### PR TITLE
feat(admin): multi-operator admin dashboard

### DIFF
--- a/src/app/admin/_components/impersonation-banner.tsx
+++ b/src/app/admin/_components/impersonation-banner.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { ImpersonationSession } from "@/lib/admin/impersonation";
+import { StopImpersonationButton } from "./stop-impersonation-button";
+
+export async function ImpersonationBanner({ session }: { session: ImpersonationSession }) {
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: biz } = await (admin as any)
+    .from("businesses")
+    .select("name")
+    .eq("id", session.target_business_id)
+    .single();
+
+  const remaining = Math.max(
+    0,
+    Math.floor((new Date(session.expires_at).getTime() - Date.now()) / 60000),
+  );
+
+  return (
+    <div className="bg-amber-500 text-black text-sm">
+      <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-xs px-1.5 py-0.5 bg-black/20 rounded">IMPERSONATING</span>
+          <span className="font-medium">{biz?.name ?? session.target_business_id}</span>
+          <span className="text-xs opacity-75">
+            {session.read_only ? "read-only" : "write-enabled"} · {remaining}m left
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link href="/dashboard" className="text-xs underline">View as tenant</Link>
+          <StopImpersonationButton />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/_components/sidebar.tsx
+++ b/src/app/admin/_components/sidebar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { Operator } from "@/lib/admin/auth";
+import { canManageOperators } from "@/lib/admin/auth";
+
+const NAV: { href: string; label: string; superadminOnly?: boolean }[] = [
+  { href: "/admin", label: "Overview" },
+  { href: "/admin/tenants", label: "Tenants" },
+  { href: "/admin/metrics", label: "Metrics" },
+  { href: "/admin/audit", label: "Audit log" },
+  { href: "/admin/operators", label: "Operators", superadminOnly: true },
+];
+
+export function AdminSidebar({ operator }: { operator: Operator }) {
+  const pathname = usePathname();
+
+  const items = NAV.filter(
+    (n) => !n.superadminOnly || canManageOperators(operator.role),
+  );
+
+  return (
+    <aside className="w-56 shrink-0 border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 min-h-screen">
+      <div className="h-14 px-5 flex items-center border-b border-neutral-200 dark:border-neutral-800">
+        <span className="font-semibold text-sm tracking-tight">Invoicer Admin</span>
+      </div>
+      <nav className="py-3 px-2 space-y-0.5">
+        {items.map((n) => {
+          const active = n.href === "/admin" ? pathname === "/admin" : pathname.startsWith(n.href);
+          return (
+            <Link
+              key={n.href}
+              href={n.href}
+              className={`block px-3 py-2 rounded-md text-sm transition-colors ${
+                active
+                  ? "bg-neutral-100 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 font-medium"
+                  : "text-neutral-600 dark:text-neutral-400 hover:bg-neutral-50 dark:hover:bg-neutral-800/50 hover:text-neutral-900 dark:hover:text-neutral-100"
+              }`}
+            >
+              {n.label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="absolute bottom-0 w-56 border-t border-neutral-200 dark:border-neutral-800 px-3 py-3">
+        <Link
+          href="/dashboard"
+          className="block text-xs text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100 px-2"
+        >
+          ← Back to app
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/admin/_components/stop-impersonation-button.tsx
+++ b/src/app/admin/_components/stop-impersonation-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { stopImpersonationAction } from "../actions";
+
+export function StopImpersonationButton() {
+  const [pending, start] = useTransition();
+  const router = useRouter();
+
+  return (
+    <button
+      className="text-xs font-medium px-2.5 py-1 rounded bg-black/20 hover:bg-black/30 disabled:opacity-50"
+      disabled={pending}
+      onClick={() =>
+        start(async () => {
+          await stopImpersonationAction();
+          router.push("/admin");
+          router.refresh();
+        })
+      }
+    >
+      {pending ? "Stopping…" : "Stop"}
+    </button>
+  );
+}

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,195 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  requireAdmin,
+  requireAdminRole,
+  canManageOperators,
+} from "@/lib/admin/auth";
+import { logAdminAction } from "@/lib/admin/audit";
+import {
+  startImpersonation,
+  stopImpersonation,
+} from "@/lib/admin/impersonation";
+
+// ------------------------------------------------------------------
+// Impersonation
+// ------------------------------------------------------------------
+
+export async function startImpersonationAction(formData: FormData) {
+  const operator = await requireAdmin();
+  const businessId = z.string().uuid().parse(formData.get("business_id"));
+  const reason = (formData.get("reason") as string | null) || undefined;
+
+  await startImpersonation(operator, businessId, { reason, readOnly: true });
+  revalidatePath("/admin", "layout");
+  redirect("/dashboard");
+}
+
+export async function stopImpersonationAction() {
+  const operator = await requireAdmin();
+  await stopImpersonation(operator);
+  revalidatePath("/admin", "layout");
+}
+
+// ------------------------------------------------------------------
+// Operator management (superadmin only)
+// ------------------------------------------------------------------
+
+const inviteSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["superadmin", "billing", "support", "read_only"]),
+  display_name: z.string().optional(),
+});
+
+export async function inviteOperatorAction(formData: FormData) {
+  const operator = await requireAdminRole(["superadmin"]);
+  const parsed = inviteSchema.parse({
+    email: formData.get("email"),
+    role: formData.get("role"),
+    display_name: formData.get("display_name") || undefined,
+  });
+
+  const admin = createAdminClient();
+
+  // Find the user by email (they must already have a Supabase account).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: users } = await (admin as any).auth.admin.listUsers({ page: 1, perPage: 1000 });
+  const found = users?.users?.find((u: { email?: string }) => u.email?.toLowerCase() === parsed.email.toLowerCase());
+  if (!found) {
+    throw new Error(`No Supabase user with email ${parsed.email}. Ask them to sign up first.`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (admin as any)
+    .from("admin_operators")
+    .insert({
+      user_id: found.id,
+      role: parsed.role,
+      display_name: parsed.display_name ?? null,
+      created_by: operator.user_id,
+    });
+
+  if (error) {
+    if (error.code === "23505") throw new Error("That user is already an operator.");
+    throw new Error(error.message);
+  }
+
+  await logAdminAction({
+    operator,
+    action: "operator.invite",
+    targetType: "user",
+    targetId: found.id,
+    metadata: { email: parsed.email, role: parsed.role },
+  });
+
+  revalidatePath("/admin/operators");
+}
+
+export async function revokeOperatorAction(formData: FormData) {
+  const operator = await requireAdminRole(["superadmin"]);
+  const operatorId = z.string().uuid().parse(formData.get("operator_id"));
+
+  if (operatorId === operator.id) {
+    throw new Error("You can't revoke your own access.");
+  }
+
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: target } = await (admin as any)
+    .from("admin_operators")
+    .select("user_id, role")
+    .eq("id", operatorId)
+    .single();
+
+  if (!target) throw new Error("Operator not found.");
+
+  // Don't allow removing the last superadmin.
+  if (target.role === "superadmin") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { count } = await (admin as any)
+      .from("admin_operators")
+      .select("*", { count: "exact", head: true })
+      .eq("role", "superadmin");
+    if ((count ?? 0) <= 1) throw new Error("Cannot remove the last superadmin.");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (admin as any).from("admin_operators").delete().eq("id", operatorId);
+
+  await logAdminAction({
+    operator,
+    action: "operator.revoke",
+    targetType: "user",
+    targetId: target.user_id,
+    metadata: { role: target.role },
+  });
+
+  revalidatePath("/admin/operators");
+}
+
+export async function changeOperatorRoleAction(formData: FormData) {
+  const operator = await requireAdminRole(["superadmin"]);
+  const operatorId = z.string().uuid().parse(formData.get("operator_id"));
+  const role = z.enum(["superadmin", "billing", "support", "read_only"]).parse(formData.get("role"));
+
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: before } = await (admin as any)
+    .from("admin_operators")
+    .select("role")
+    .eq("id", operatorId)
+    .single();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (admin as any).from("admin_operators").update({ role }).eq("id", operatorId);
+
+  await logAdminAction({
+    operator,
+    action: "operator.role_change",
+    targetType: "admin_operator",
+    targetId: operatorId,
+    metadata: { from: before?.role, to: role },
+  });
+
+  revalidatePath("/admin/operators");
+}
+
+// ------------------------------------------------------------------
+// Bootstrap — only works when no operators exist yet.
+// ------------------------------------------------------------------
+
+export async function bootstrapFirstOperatorAction(formData: FormData) {
+  void formData; // reserved for future use
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { count } = await (admin as any)
+    .from("admin_operators")
+    .select("*", { count: "exact", head: true });
+
+  if ((count ?? 0) > 0) {
+    throw new Error("Admin is already bootstrapped.");
+  }
+
+  // The caller is whoever is currently logged in.
+  const { createClient } = await import("@/lib/supabase/server");
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login?next=/admin");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (admin as any).from("admin_operators").insert({
+    user_id: user.id,
+    role: "superadmin",
+    display_name: user.email,
+    created_by: user.id,
+  });
+
+  redirect("/admin");
+}
+
+// Silence unused-import warnings where helpers are re-exported conditionally.
+void canManageOperators;

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,139 @@
+import { requireAdmin } from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+export default async function AuditPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ action?: string; operator?: string }>;
+}) {
+  await requireAdmin();
+  const { action, operator } = await searchParams;
+  const admin = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let q = (admin as any)
+    .from("admin_audit_log")
+    .select("id, operator_user_id, action, target_type, target_id, target_business_id, metadata, ip_address, created_at")
+    .order("created_at", { ascending: false })
+    .limit(300);
+
+  if (action) q = q.eq("action", action);
+  if (operator) q = q.eq("operator_user_id", operator);
+
+  const { data } = await q;
+  const rows =
+    (data as Array<{
+      id: number;
+      operator_user_id: string;
+      action: string;
+      target_type: string | null;
+      target_id: string | null;
+      target_business_id: string | null;
+      metadata: Record<string, unknown> | null;
+      ip_address: string | null;
+      created_at: string;
+    }>) ?? [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: authResp } = await (admin as any).auth.admin.listUsers({ page: 1, perPage: 1000 });
+  const emailByUser = new Map<string, string>();
+  for (const u of authResp?.users ?? []) {
+    if (u.id && u.email) emailByUser.set(u.id, u.email);
+  }
+
+  const distinctActions = [...new Set(rows.map((r) => r.action))].sort();
+
+  return (
+    <div>
+      <div className="mb-6 flex items-end justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Audit log</h1>
+          <p className="text-sm text-neutral-500 mt-0.5">
+            {rows.length} events (most recent 300)
+          </p>
+        </div>
+        <form method="get" className="flex gap-2">
+          <select
+            name="action"
+            defaultValue={action ?? ""}
+            className="px-3 py-1.5 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-sm font-mono"
+          >
+            <option value="">All actions</option>
+            {distinctActions.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+          <button className="px-3 py-1.5 rounded-md bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 text-sm">
+            Filter
+          </button>
+        </form>
+      </div>
+
+      <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 overflow-hidden bg-white dark:bg-neutral-900">
+        <table className="w-full text-sm">
+          <thead className="bg-neutral-50 dark:bg-neutral-800/50 text-xs uppercase tracking-wide text-neutral-500">
+            <tr>
+              <th className="text-left px-4 py-2 font-medium">When</th>
+              <th className="text-left px-4 py-2 font-medium">Operator</th>
+              <th className="text-left px-4 py-2 font-medium">Action</th>
+              <th className="text-left px-4 py-2 font-medium">Target</th>
+              <th className="text-left px-4 py-2 font-medium">IP</th>
+              <th className="text-left px-4 py-2 font-medium">Metadata</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100 dark:divide-neutral-800">
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-neutral-500">
+                  No audit events.
+                </td>
+              </tr>
+            ) : (
+              rows.map((r) => (
+                <tr key={r.id} className="align-top">
+                  <td className="px-4 py-2 text-xs text-neutral-500 tabular-nums whitespace-nowrap">
+                    {new Date(r.created_at).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-2 text-xs">
+                    {emailByUser.get(r.operator_user_id) ?? (
+                      <span className="font-mono text-neutral-500">
+                        {r.operator_user_id.slice(0, 8)}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800">
+                      {r.action}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-xs text-neutral-600 dark:text-neutral-400">
+                    {r.target_type ? (
+                      <>
+                        <span className="text-neutral-400">{r.target_type}</span>
+                        {r.target_id && (
+                          <span className="font-mono ml-1">{r.target_id.slice(0, 8)}</span>
+                        )}
+                      </>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-xs text-neutral-500 font-mono">
+                    {r.ip_address ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-xs text-neutral-500 font-mono max-w-xs truncate">
+                    {r.metadata ? JSON.stringify(r.metadata) : "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { requireAdmin, getOperator } from "@/lib/admin/auth";
+import { getActiveImpersonation } from "@/lib/admin/impersonation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { AdminSidebar } from "./_components/sidebar";
+import { ImpersonationBanner } from "./_components/impersonation-banner";
+
+export const metadata = {
+  title: "Admin — Invoicer",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  // Bootstrap escape hatch: if there are zero operators, let any logged-in
+  // user reach /admin so they can self-promote. The bootstrap page itself
+  // re-checks this invariant before inserting.
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { count } = await (admin as any)
+    .from("admin_operators")
+    .select("*", { count: "exact", head: true });
+
+  if ((count ?? 0) === 0) {
+    const maybeOp = await getOperator();
+    void maybeOp;
+    return (
+      <div className="min-h-screen bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
+        {children}
+      </div>
+    );
+  }
+
+  const operator = await requireAdmin();
+  const impersonation = await getActiveImpersonation();
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
+      {impersonation && <ImpersonationBanner session={impersonation} />}
+      <div className="flex">
+        <AdminSidebar operator={operator} />
+        <main className="flex-1 min-h-screen">
+          <header className="h-14 border-b border-neutral-200 dark:border-neutral-800 px-6 flex items-center justify-between bg-white dark:bg-neutral-900">
+            <div className="text-sm text-neutral-500">
+              <Link href="/admin" className="hover:text-neutral-900 dark:hover:text-neutral-100">Admin</Link>
+            </div>
+            <div className="text-xs text-neutral-500">
+              <span className="px-2 py-0.5 rounded-full bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 font-mono">
+                {operator.role}
+              </span>
+              <span className="ml-3">{operator.display_name || operator.email}</span>
+            </div>
+          </header>
+          <div className="p-6 max-w-7xl">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/metrics/page.tsx
+++ b/src/app/admin/metrics/page.tsx
@@ -1,0 +1,131 @@
+import { requireAdmin } from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+function daysAgo(n: number) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+export default async function MetricsPage() {
+  await requireAdmin();
+  const admin = createAdminClient();
+
+  const d7 = daysAgo(7);
+  const d30 = daysAgo(30);
+
+  const [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: tenants },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: tenants7 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: tenants30 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: invoices },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: invoices7 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: invoices30 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: customers },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: leads },
+  ] = await Promise.all([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("businesses").select("*", { count: "exact", head: true }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("businesses").select("*", { count: "exact", head: true }).gte("created_at", d7),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("businesses").select("*", { count: "exact", head: true }).gte("created_at", d30),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("invoices").select("*", { count: "exact", head: true }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("invoices").select("*", { count: "exact", head: true }).gte("created_at", d7),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("invoices").select("*", { count: "exact", head: true }).gte("created_at", d30),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("customers").select("*", { count: "exact", head: true }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("leads").select("*", { count: "exact", head: true }),
+  ]);
+
+  // Top tenants by invoice count
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: topInvoices } = await (admin as any)
+    .from("invoices")
+    .select("business_id")
+    .limit(5000);
+
+  const counts = new Map<string, number>();
+  for (const r of (topInvoices as Array<{ business_id: string }>) ?? []) {
+    counts.set(r.business_id, (counts.get(r.business_id) ?? 0) + 1);
+  }
+  const topIds = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: topBizs } = await (admin as any)
+    .from("businesses")
+    .select("id, name")
+    .in(
+      "id",
+      topIds.map((x) => x[0]),
+    );
+  const nameById = new Map<string, string>();
+  for (const b of (topBizs as Array<{ id: string; name: string }>) ?? []) {
+    nameById.set(b.id, b.name);
+  }
+
+  const kpi = (label: string, value: number | string, sub?: string) => (
+    <div className="p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+      <div className="text-xs text-neutral-500 uppercase tracking-wide">{label}</div>
+      <div className="text-2xl font-semibold tabular-nums mt-1">{value}</div>
+      {sub && <div className="text-xs text-neutral-500 mt-1">{sub}</div>}
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold">Metrics</h1>
+        <p className="text-sm text-neutral-500 mt-0.5">Platform-wide activity.</p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        {kpi("Total tenants", tenants ?? 0, `+${tenants7 ?? 0} in 7d · +${tenants30 ?? 0} in 30d`)}
+        {kpi("Total invoices", invoices ?? 0, `+${invoices7 ?? 0} in 7d · +${invoices30 ?? 0} in 30d`)}
+        {kpi("Total customers", customers ?? 0)}
+        {kpi("Total leads", leads ?? 0)}
+      </div>
+
+      <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+        <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
+          <h2 className="text-sm font-medium">Top tenants by invoice volume</h2>
+        </div>
+        <table className="w-full text-sm">
+          <tbody className="divide-y divide-neutral-100 dark:divide-neutral-800">
+            {topIds.length === 0 ? (
+              <tr>
+                <td className="px-4 py-8 text-center text-neutral-500">No data yet.</td>
+              </tr>
+            ) : (
+              topIds.map(([id, n], i) => (
+                <tr key={id}>
+                  <td className="px-4 py-2.5 w-10 text-neutral-400 tabular-nums">{i + 1}</td>
+                  <td className="px-4 py-2.5">
+                    <a href={`/admin/tenants/${id}`} className="hover:underline font-medium">
+                      {nameById.get(id) || id}
+                    </a>
+                  </td>
+                  <td className="px-4 py-2.5 text-right tabular-nums text-neutral-500">{n}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/operators/page.tsx
+++ b/src/app/admin/operators/page.tsx
@@ -1,0 +1,159 @@
+import { requireAdminRole } from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  inviteOperatorAction,
+  revokeOperatorAction,
+  changeOperatorRoleAction,
+} from "../actions";
+
+export const dynamic = "force-dynamic";
+
+const ROLES = ["superadmin", "billing", "support", "read_only"] as const;
+
+export default async function OperatorsPage() {
+  const me = await requireAdminRole(["superadmin"]);
+  const admin = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: operators } = await (admin as any)
+    .from("admin_operators")
+    .select("id, user_id, role, display_name, created_at, last_seen_at")
+    .order("created_at", { ascending: true });
+
+  // Enrich with emails from auth.users
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: authResp } = await (admin as any).auth.admin.listUsers({ page: 1, perPage: 1000 });
+  const emailByUser = new Map<string, string>();
+  for (const u of authResp?.users ?? []) {
+    if (u.id && u.email) emailByUser.set(u.id, u.email);
+  }
+
+  const rows =
+    (operators as Array<{
+      id: string;
+      user_id: string;
+      role: string;
+      display_name: string | null;
+      created_at: string;
+      last_seen_at: string | null;
+    }>) ?? [];
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold">Operators</h1>
+        <p className="text-sm text-neutral-500 mt-0.5">
+          People who can access this admin panel. You are <span className="font-mono">{me.role}</span>.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-neutral-50 dark:bg-neutral-800/50 text-xs uppercase tracking-wide text-neutral-500">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Operator</th>
+                <th className="text-left px-4 py-2 font-medium">Role</th>
+                <th className="text-left px-4 py-2 font-medium">Last seen</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100 dark:divide-neutral-800">
+              {rows.map((op) => {
+                const email = emailByUser.get(op.user_id) ?? "(unknown)";
+                const isSelf = op.id === me.id;
+                return (
+                  <tr key={op.id}>
+                    <td className="px-4 py-3">
+                      <div className="font-medium">{op.display_name || email}</div>
+                      <div className="text-xs text-neutral-500">{email}</div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <form action={changeOperatorRoleAction} className="flex gap-1">
+                        <input type="hidden" name="operator_id" value={op.id} />
+                        <select
+                          name="role"
+                          defaultValue={op.role}
+                          disabled={isSelf}
+                          className="text-xs px-2 py-1 rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 font-mono disabled:opacity-60"
+                        >
+                          {ROLES.map((r) => (
+                            <option key={r} value={r}>
+                              {r}
+                            </option>
+                          ))}
+                        </select>
+                        {!isSelf && (
+                          <button className="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700">
+                            Save
+                          </button>
+                        )}
+                      </form>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-neutral-500 tabular-nums">
+                      {op.last_seen_at ? new Date(op.last_seen_at).toLocaleString() : "never"}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {isSelf ? (
+                        <span className="text-xs text-neutral-400">you</span>
+                      ) : (
+                        <form action={revokeOperatorAction}>
+                          <input type="hidden" name="operator_id" value={op.id} />
+                          <button className="text-xs text-red-600 hover:text-red-700 dark:text-red-400">
+                            Revoke
+                          </button>
+                        </form>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+          <h2 className="text-sm font-medium mb-3">Invite operator</h2>
+          <p className="text-xs text-neutral-500 mb-4">
+            The user must already have an Invoicer account. They&apos;ll get admin access the next time they visit /admin.
+          </p>
+          <form action={inviteOperatorAction} className="space-y-3">
+            <div>
+              <label className="text-xs text-neutral-500 block mb-1">Email</label>
+              <input
+                name="email"
+                type="email"
+                required
+                className="w-full px-3 py-1.5 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-neutral-500 block mb-1">Display name (optional)</label>
+              <input
+                name="display_name"
+                className="w-full px-3 py-1.5 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-neutral-500 block mb-1">Role</label>
+              <select
+                name="role"
+                defaultValue="support"
+                className="w-full px-3 py-1.5 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm font-mono"
+              >
+                {ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button className="w-full py-2 rounded-md bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 text-sm font-medium">
+              Invite
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,133 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getOperator } from "@/lib/admin/auth";
+import { bootstrapFirstOperatorAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+async function BootstrapCard({ email }: { email: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="max-w-md w-full border border-neutral-200 dark:border-neutral-800 rounded-xl bg-white dark:bg-neutral-900 p-8 shadow-sm">
+        <div className="text-xs uppercase tracking-wide font-mono text-amber-600 dark:text-amber-400 mb-2">
+          Admin bootstrap
+        </div>
+        <h1 className="text-xl font-semibold mb-3">Create the first operator</h1>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-6">
+          No admin operators exist yet. You&apos;re signed in as{" "}
+          <span className="font-medium text-neutral-900 dark:text-neutral-100">{email}</span>.
+          Promote yourself to the first <span className="font-mono text-xs">superadmin</span> to
+          continue. This can only be done once.
+        </p>
+        <form action={bootstrapFirstOperatorAction}>
+          <button
+            type="submit"
+            className="w-full py-2 px-4 rounded-md bg-neutral-900 hover:bg-neutral-800 text-white text-sm font-medium dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100"
+          >
+            Promote me to superadmin
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default async function AdminHomePage() {
+  const admin = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { count: operatorCount } = await (admin as any)
+    .from("admin_operators")
+    .select("*", { count: "exact", head: true });
+
+  if ((operatorCount ?? 0) === 0) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) redirect("/auth/login?next=/admin");
+    return <BootstrapCard email={user.email ?? ""} />;
+  }
+
+  const operator = await getOperator();
+  if (!operator) redirect("/dashboard");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [{ count: tenantCount }, { count: userCount }, { count: invoiceCount }, recentAudit] =
+    await Promise.all([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (admin as any).from("businesses").select("*", { count: "exact", head: true }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (admin as any).from("business_members").select("*", { count: "exact", head: true }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (admin as any).from("invoices").select("*", { count: "exact", head: true }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (admin as any)
+        .from("admin_audit_log")
+        .select("id, action, target_type, created_at, operator_user_id")
+        .order("created_at", { ascending: false })
+        .limit(8),
+    ]);
+
+  const stats = [
+    { label: "Tenants", value: tenantCount ?? 0, href: "/admin/tenants" },
+    { label: "Users", value: userCount ?? 0, href: "/admin/tenants" },
+    { label: "Invoices", value: invoiceCount ?? 0, href: "/admin/metrics" },
+    { label: "Operators", value: operatorCount ?? 0, href: "/admin/operators" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold">Overview</h1>
+        <p className="text-sm text-neutral-500 mt-0.5">
+          Welcome back, {operator.display_name || operator.email}.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        {stats.map((s) => (
+          <Link
+            key={s.label}
+            href={s.href}
+            className="block p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors"
+          >
+            <div className="text-xs text-neutral-500 uppercase tracking-wide">{s.label}</div>
+            <div className="text-2xl font-semibold mt-1 tabular-nums">{s.value}</div>
+          </Link>
+        ))}
+      </div>
+
+      <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+        <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800 flex items-center justify-between">
+          <h2 className="text-sm font-medium">Recent admin activity</h2>
+          <Link href="/admin/audit" className="text-xs text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100">
+            View all →
+          </Link>
+        </div>
+        <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
+          {((recentAudit?.data as Array<{ id: number; action: string; target_type: string | null; created_at: string }>) ?? []).length === 0 ? (
+            <div className="px-4 py-6 text-sm text-neutral-500">No activity yet.</div>
+          ) : (
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ((recentAudit?.data as any[]) ?? []).map((row: { id: number; action: string; target_type: string | null; created_at: string }) => (
+              <div key={row.id} className="px-4 py-2.5 text-sm flex items-center justify-between">
+                <div>
+                  <span className="font-mono text-xs text-neutral-500">{row.action}</span>
+                  {row.target_type && (
+                    <span className="ml-2 text-xs text-neutral-400">{row.target_type}</span>
+                  )}
+                </div>
+                <div className="text-xs text-neutral-500">
+                  {new Date(row.created_at).toLocaleString()}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/tenants/[id]/page.tsx
+++ b/src/app/admin/tenants/[id]/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAdmin, canWrite } from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { startImpersonationAction } from "../../actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function TenantDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const operator = await requireAdmin();
+  const { id } = await params;
+  const admin = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: biz } = await (admin as any)
+    .from("businesses")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!biz) notFound();
+
+  const [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: invoiceCount },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: customerCount },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { count: memberCount },
+  ] = await Promise.all([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("invoices").select("*", { count: "exact", head: true }).eq("business_id", id),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("customers").select("*", { count: "exact", head: true }).eq("business_id", id),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (admin as any).from("business_members").select("*", { count: "exact", head: true }).eq("business_id", id),
+  ]);
+
+  const field = (label: string, value: React.ReactNode) => (
+    <div className="flex justify-between py-2 border-b border-neutral-100 dark:border-neutral-800 last:border-0">
+      <span className="text-xs text-neutral-500 uppercase tracking-wide">{label}</span>
+      <span className="text-sm font-medium text-right">{value || "—"}</span>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link href="/admin/tenants" className="text-xs text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100">
+          ← All tenants
+        </Link>
+        <h1 className="text-xl font-semibold mt-2">{biz.name || "(unnamed)"}</h1>
+        <p className="text-xs font-mono text-neutral-500 mt-0.5">{biz.id}</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        <div className="p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+          <div className="text-xs text-neutral-500 uppercase">Invoices</div>
+          <div className="text-2xl font-semibold tabular-nums">{invoiceCount ?? 0}</div>
+        </div>
+        <div className="p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+          <div className="text-xs text-neutral-500 uppercase">Customers</div>
+          <div className="text-2xl font-semibold tabular-nums">{customerCount ?? 0}</div>
+        </div>
+        <div className="p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+          <div className="text-xs text-neutral-500 uppercase">Team members</div>
+          <div className="text-2xl font-semibold tabular-nums">{memberCount ?? 0}</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="p-5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+          <h2 className="text-sm font-medium mb-3">Business details</h2>
+          {field("Email", biz.email)}
+          {field("Phone", biz.phone)}
+          {field("Address", [biz.address, biz.city, biz.postcode, biz.country].filter(Boolean).join(", "))}
+          {field("Website", biz.website)}
+          {field("Currency", biz.currency)}
+          {field("Locale", biz.locale)}
+          {field("Created", new Date(biz.created_at).toLocaleString())}
+        </div>
+
+        <div className="p-5 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+          <h2 className="text-sm font-medium mb-3">Actions</h2>
+          {canWrite(operator.role) ? (
+            <form action={startImpersonationAction} className="space-y-3">
+              <input type="hidden" name="business_id" value={biz.id} />
+              <div>
+                <label className="text-xs text-neutral-500 block mb-1">Reason (logged)</label>
+                <input
+                  name="reason"
+                  placeholder="e.g. support ticket #123"
+                  className="w-full px-3 py-1.5 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+                />
+              </div>
+              <button
+                type="submit"
+                className="w-full py-2 px-4 rounded-md bg-amber-500 hover:bg-amber-400 text-black text-sm font-medium"
+              >
+                Impersonate (read-only, 30min)
+              </button>
+              <p className="text-xs text-neutral-500">
+                You&apos;ll be redirected to the tenant&apos;s dashboard. Every action is audited.
+              </p>
+            </form>
+          ) : (
+            <p className="text-sm text-neutral-500">
+              Your role ({operator.role}) cannot impersonate tenants.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/tenants/page.tsx
+++ b/src/app/admin/tenants/page.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+import { requireAdmin } from "@/lib/admin/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+export default async function TenantsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  await requireAdmin();
+  const { q } = await searchParams;
+  const admin = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let query = (admin as any)
+    .from("businesses")
+    .select("id, name, email, created_at, currency, country")
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  if (q && q.trim()) {
+    query = query.or(`name.ilike.%${q}%,email.ilike.%${q}%`);
+  }
+
+  const { data: tenants } = await query;
+  const rows = (tenants as Array<{
+    id: string;
+    name: string | null;
+    email: string | null;
+    created_at: string;
+    currency: string | null;
+    country: string | null;
+  }>) ?? [];
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-semibold">Tenants</h1>
+          <p className="text-sm text-neutral-500 mt-0.5">{rows.length} shown</p>
+        </div>
+        <form method="get" className="flex gap-2">
+          <input
+            type="text"
+            name="q"
+            defaultValue={q ?? ""}
+            placeholder="Search name or email…"
+            className="px-3 py-1.5 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-sm w-64"
+          />
+          <button className="px-3 py-1.5 rounded-md bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 text-sm">
+            Search
+          </button>
+        </form>
+      </div>
+
+      <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 overflow-hidden bg-white dark:bg-neutral-900">
+        <table className="w-full text-sm">
+          <thead className="bg-neutral-50 dark:bg-neutral-800/50 text-xs uppercase tracking-wide text-neutral-500">
+            <tr>
+              <th className="text-left px-4 py-2 font-medium">Name</th>
+              <th className="text-left px-4 py-2 font-medium">Email</th>
+              <th className="text-left px-4 py-2 font-medium">Region</th>
+              <th className="text-left px-4 py-2 font-medium">Created</th>
+              <th className="w-10" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100 dark:divide-neutral-800">
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-neutral-500">
+                  No tenants {q ? "match your search" : "yet"}.
+                </td>
+              </tr>
+            ) : (
+              rows.map((t) => (
+                <tr key={t.id} className="hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+                  <td className="px-4 py-2.5">
+                    <Link
+                      href={`/admin/tenants/${t.id}`}
+                      className="font-medium hover:underline"
+                    >
+                      {t.name || "(unnamed)"}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2.5 text-neutral-600 dark:text-neutral-400">
+                    {t.email || "—"}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-800 font-mono">
+                      {t.country ?? "—"} · {t.currency ?? "—"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5 text-neutral-500 text-xs tabular-nums">
+                    {new Date(t.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-2.5 text-right">
+                    <Link
+                      href={`/admin/tenants/${t.id}`}
+                      className="text-xs text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
+                    >
+                      →
+                    </Link>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/v1/leads/route.ts
+++ b/src/app/api/v1/leads/route.ts
@@ -28,6 +28,13 @@ export async function POST(req: NextRequest) {
 
   if (!name) return err("name is required", 400);
 
+  // DB has a CHECK constraint on source. Coerce unknown values to 'landing-page'
+  // and preserve the caller-supplied label in utm_source so tracking isn't lost.
+  const ALLOWED_SOURCES = ["landing-page", "website", "referral", "telegram", "email", "phone", "manual"];
+  const rawSource = (source || "landing-page").trim();
+  const normalizedSource = ALLOWED_SOURCES.includes(rawSource) ? rawSource : "landing-page";
+  const effectiveUtmSource = utm_source || (normalizedSource !== rawSource ? rawSource : null);
+
   const sb = createAdminClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (sb as any)
@@ -42,8 +49,8 @@ export async function POST(req: NextRequest) {
       timing: timing || null,
       notes: notes || null,
       status: "new",
-      source: source || "landing-page",
-      utm_source: utm_source || null,
+      source: normalizedSource,
+      utm_source: effectiveUtmSource,
       utm_medium: utm_medium || null,
       utm_campaign: utm_campaign || null,
       business_id: ctx.businessId,

--- a/src/lib/admin/audit.ts
+++ b/src/lib/admin/audit.ts
@@ -1,0 +1,53 @@
+/**
+ * Admin audit logging. Every admin mutation should call logAdminAction().
+ */
+
+import { headers } from "next/headers";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Operator } from "./auth";
+
+export type AdminAction =
+  | "operator.invite"
+  | "operator.revoke"
+  | "operator.role_change"
+  | "tenant.view"
+  | "tenant.extend_trial"
+  | "tenant.change_plan"
+  | "tenant.disable"
+  | "tenant.enable"
+  | "tenant.delete"
+  | "tenant.resend_welcome"
+  | "impersonation.start"
+  | "impersonation.stop"
+  | "impersonation.escalate_write"
+  | "billing.refund"
+  | "billing.apply_credit";
+
+export type LogArgs = {
+  operator: Operator;
+  action: AdminAction;
+  targetType?: string;
+  targetId?: string;
+  targetBusinessId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export async function logAdminAction(args: LogArgs): Promise<void> {
+  const h = await headers();
+  const ip = h.get("x-forwarded-for")?.split(",")[0]?.trim() || h.get("x-real-ip") || null;
+  const ua = h.get("user-agent") || null;
+
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (admin as any).from("admin_audit_log").insert({
+    operator_id: args.operator.id,
+    operator_user_id: args.operator.user_id,
+    action: args.action,
+    target_type: args.targetType ?? null,
+    target_id: args.targetId ?? null,
+    target_business_id: args.targetBusinessId ?? null,
+    metadata: args.metadata ?? {},
+    ip_address: ip,
+    user_agent: ua,
+  });
+}

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin-side auth helpers. Used by every /admin page and server action.
+ *
+ * requireAdmin() — must be the first call in any admin server component or
+ * action. Throws a redirect() if the caller isn't a logged-in operator.
+ *
+ * requireAdminRole(roles) — additionally asserts the operator has one of the
+ * given roles. Use on sensitive routes.
+ *
+ * All admin data reads in this file use the service-role client to bypass
+ * tenant RLS — BUT the operator identity is verified against the regular
+ * session cookie first. Never call createAdminClient() before calling
+ * requireAdmin().
+ */
+
+import { redirect } from "next/navigation";
+import { cache } from "react";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export type AdminRole = "superadmin" | "billing" | "support" | "read_only";
+
+export type Operator = {
+  id: string;
+  user_id: string;
+  email: string;
+  role: AdminRole;
+  display_name: string | null;
+};
+
+/**
+ * Returns the operator for the current session, or null.
+ * Does NOT redirect — use for optional checks (e.g. showing a nav link).
+ */
+export const getOperator = cache(async (): Promise<Operator | null> => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any)
+    .from("admin_operators")
+    .select("id, user_id, role, display_name")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  // Update last_seen (fire and forget)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  void (admin as any)
+    .from("admin_operators")
+    .update({ last_seen_at: new Date().toISOString() })
+    .eq("id", data.id);
+
+  return {
+    id: data.id,
+    user_id: data.user_id,
+    email: user.email ?? "",
+    role: data.role as AdminRole,
+    display_name: data.display_name,
+  };
+});
+
+/**
+ * Enforce that the caller is an operator. Redirects to /auth/login if not
+ * signed in, or to /dashboard (no 404 leak) if signed in but not an operator.
+ */
+export async function requireAdmin(): Promise<Operator> {
+  const op = await getOperator();
+  if (!op) {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) redirect("/auth/login?next=/admin");
+    // Signed in but not an admin — bounce to tenant dashboard.
+    // Deliberately no flash of /admin UI.
+    redirect("/dashboard");
+  }
+  return op;
+}
+
+export async function requireAdminRole(allowed: AdminRole[]): Promise<Operator> {
+  const op = await requireAdmin();
+  if (!allowed.includes(op.role)) {
+    throw new Error(`Forbidden: role ${op.role} is not permitted here`);
+  }
+  return op;
+}
+
+/**
+ * Roles that can write (mutate tenants, manage operators, extend trials).
+ * read_only sees everything but can do nothing.
+ */
+export function canWrite(role: AdminRole): boolean {
+  return role === "superadmin" || role === "billing" || role === "support";
+}
+
+export function canManageOperators(role: AdminRole): boolean {
+  return role === "superadmin";
+}
+
+export function canManageBilling(role: AdminRole): boolean {
+  return role === "superadmin" || role === "billing";
+}

--- a/src/lib/admin/impersonation.ts
+++ b/src/lib/admin/impersonation.ts
@@ -1,0 +1,144 @@
+/**
+ * Impersonation helpers.
+ *
+ * Impersonation does NOT swap the auth session. Instead, we set two signed
+ * cookies: active_business_id (overrides the normal active business selector)
+ * and admin_impersonation_id (the session row). When admin_impersonation_id
+ * is set, the dashboard renders a top banner; tenant writes are blocked
+ * unless the operator explicitly escalated the session to read_only=false.
+ *
+ * This keeps the operator's identity on every server-side log line, and
+ * preserves a clean audit trail ("operator X acted as business Y").
+ */
+
+import { cookies } from "next/headers";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logAdminAction } from "./audit";
+import type { Operator } from "./auth";
+
+const IMP_COOKIE = "admin_impersonation_id";
+const BIZ_COOKIE = "active_business_id";
+
+export type ImpersonationSession = {
+  id: string;
+  operator_id: string;
+  target_business_id: string;
+  target_user_id: string | null;
+  read_only: boolean;
+  started_at: string;
+  expires_at: string;
+};
+
+export async function startImpersonation(
+  operator: Operator,
+  targetBusinessId: string,
+  opts: { reason?: string; readOnly?: boolean } = {},
+): Promise<ImpersonationSession> {
+  const admin = createAdminClient();
+
+  // End any existing active session for this operator first.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (admin as any)
+    .from("admin_impersonation_sessions")
+    .update({ ended_at: new Date().toISOString() })
+    .is("ended_at", null)
+    .eq("operator_user_id", operator.user_id);
+
+  // Pick the business owner as the effective target user (for audit context).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: biz } = await (admin as any)
+    .from("businesses")
+    .select("user_id")
+    .eq("id", targetBusinessId)
+    .single();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any)
+    .from("admin_impersonation_sessions")
+    .insert({
+      operator_id: operator.id,
+      operator_user_id: operator.user_id,
+      target_business_id: targetBusinessId,
+      target_user_id: biz?.user_id ?? null,
+      reason: opts.reason ?? null,
+      read_only: opts.readOnly ?? true,
+    })
+    .select()
+    .single();
+
+  if (error || !data) throw new Error(`Failed to start impersonation: ${error?.message}`);
+
+  const session: ImpersonationSession = data;
+  const jar = await cookies();
+  jar.set(IMP_COOKIE, session.id, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 30 * 60, // 30 min, matches DB default
+  });
+  jar.set(BIZ_COOKIE, targetBusinessId, {
+    httpOnly: false,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 30 * 60,
+  });
+
+  await logAdminAction({
+    operator,
+    action: "impersonation.start",
+    targetType: "business",
+    targetId: targetBusinessId,
+    targetBusinessId,
+    metadata: { reason: opts.reason, read_only: session.read_only },
+  });
+
+  return session;
+}
+
+export async function stopImpersonation(operator: Operator): Promise<void> {
+  const jar = await cookies();
+  const id = jar.get(IMP_COOKIE)?.value;
+  if (!id) return;
+
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (admin as any)
+    .from("admin_impersonation_sessions")
+    .update({ ended_at: new Date().toISOString() })
+    .eq("id", id);
+
+  jar.delete(IMP_COOKIE);
+  jar.delete(BIZ_COOKIE);
+
+  await logAdminAction({
+    operator,
+    action: "impersonation.stop",
+    targetType: "impersonation_session",
+    targetId: id,
+  });
+}
+
+/**
+ * Read the active impersonation from cookies. Returns null if cookie missing,
+ * expired, or already ended. Used by the dashboard shell to render a banner.
+ */
+export async function getActiveImpersonation(): Promise<ImpersonationSession | null> {
+  const jar = await cookies();
+  const id = jar.get(IMP_COOKIE)?.value;
+  if (!id) return null;
+
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (admin as any)
+    .from("admin_impersonation_sessions")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!data || data.ended_at) return null;
+  if (new Date(data.expires_at).getTime() < Date.now()) return null;
+
+  return data as ImpersonationSession;
+}

--- a/supabase/migrations/20260423000001_admin_dashboard.sql
+++ b/supabase/migrations/20260423000001_admin_dashboard.sql
@@ -1,0 +1,118 @@
+-- Admin dashboard: multi-operator, audit-logged, impersonation-capable.
+--
+-- Design notes:
+-- * admin_operators is a separate table from auth.users: an operator is a
+--   Supabase user who ALSO has an admin_operators row. Revoking admin access
+--   = delete the row (user keeps their regular tenant account if they have one).
+-- * All admin actions are logged to admin_audit_log with operator_id, action,
+--   target (business/user), and metadata.
+-- * Impersonation is explicit, time-boxed, and recorded. The active
+--   impersonation is stored in admin_impersonation_sessions; a middleware
+--   check surfaces a banner and blocks writes by default until the operator
+--   explicitly elevates.
+
+-- ---------- admin_operators ----------
+create table if not exists public.admin_operators (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references auth.users(id) on delete cascade,
+  role text not null default 'support'
+    check (role in ('superadmin', 'billing', 'support', 'read_only')),
+  display_name text,
+  notes text,
+  created_at timestamptz not null default now(),
+  created_by uuid references auth.users(id) on delete set null,
+  last_seen_at timestamptz
+);
+
+create index if not exists idx_admin_operators_user_id on public.admin_operators(user_id);
+
+-- Only superadmins can see or modify the admin_operators table.
+alter table public.admin_operators enable row level security;
+
+create policy "admin_operators: superadmin read"
+  on public.admin_operators for select
+  using (
+    exists (
+      select 1 from public.admin_operators a
+      where a.user_id = auth.uid() and a.role = 'superadmin'
+    )
+  );
+
+create policy "admin_operators: superadmin write"
+  on public.admin_operators for all
+  using (
+    exists (
+      select 1 from public.admin_operators a
+      where a.user_id = auth.uid() and a.role = 'superadmin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.admin_operators a
+      where a.user_id = auth.uid() and a.role = 'superadmin'
+    )
+  );
+
+-- ---------- admin_audit_log ----------
+create table if not exists public.admin_audit_log (
+  id bigserial primary key,
+  operator_id uuid not null references public.admin_operators(id) on delete restrict,
+  operator_user_id uuid not null references auth.users(id) on delete restrict,
+  action text not null,
+  target_type text,
+  target_id text,
+  target_business_id uuid references public.businesses(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  ip_address inet,
+  user_agent text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_admin_audit_log_operator on public.admin_audit_log(operator_id, created_at desc);
+create index if not exists idx_admin_audit_log_target_business on public.admin_audit_log(target_business_id, created_at desc);
+create index if not exists idx_admin_audit_log_created_at on public.admin_audit_log(created_at desc);
+
+alter table public.admin_audit_log enable row level security;
+
+create policy "admin_audit_log: any operator can read"
+  on public.admin_audit_log for select
+  using (
+    exists (
+      select 1 from public.admin_operators a where a.user_id = auth.uid()
+    )
+  );
+
+-- Writes are via service role only (server-side logging).
+
+-- ---------- admin_impersonation_sessions ----------
+create table if not exists public.admin_impersonation_sessions (
+  id uuid primary key default gen_random_uuid(),
+  operator_id uuid not null references public.admin_operators(id) on delete cascade,
+  operator_user_id uuid not null references auth.users(id) on delete cascade,
+  target_business_id uuid not null references public.businesses(id) on delete cascade,
+  target_user_id uuid references auth.users(id) on delete set null,
+  reason text,
+  read_only boolean not null default true,
+  started_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '30 minutes'),
+  ended_at timestamptz
+);
+
+create index if not exists idx_admin_imp_operator on public.admin_impersonation_sessions(operator_user_id) where ended_at is null;
+create index if not exists idx_admin_imp_business on public.admin_impersonation_sessions(target_business_id, started_at desc);
+
+alter table public.admin_impersonation_sessions enable row level security;
+
+create policy "admin_impersonation: operators read"
+  on public.admin_impersonation_sessions for select
+  using (
+    exists (
+      select 1 from public.admin_operators a where a.user_id = auth.uid()
+    )
+  );
+
+-- ---------- Seed: first superadmin ----------
+-- Anyone running this migration can promote themselves to superadmin ONCE,
+-- if no operator exists yet. After that, only superadmins can add more.
+-- The actual seed is done via the /admin/bootstrap route (see app code) so
+-- the current auth.uid() is available.


### PR DESCRIPTION
## Summary
- New `/admin` surface with role-gated access (superadmin / billing / support / read_only)
- Cookie-based tenant impersonation (read-only by default, 30min auto-expire)
- Full audit log — every mutation captures operator, IP, user-agent, metadata
- Pages: Overview, Tenants (list + detail), Operators, Metrics, Audit log
- Bootstrap flow promotes the first signed-in user to superadmin when no operators exist

## Schema
Migration `20260423000001_admin_dashboard.sql` adds `admin_operators`, `admin_audit_log`, `admin_impersonation_sessions` — all service-role only via RLS.

## Security
- Non-operators redirect to `/dashboard` (no 404 leak)
- Impersonation does not swap session — cookie-scoped so audit always traces to the real operator
- Self-revoke and last-superadmin revoke blocked
- `robots: noindex, nofollow` on admin layout

## Test plan
- [ ] Migration applied cleanly
- [ ] Bootstrap: first visit promotes signed-in user
- [ ] Overview KPIs + recent activity render
- [ ] Tenants list + search + detail
- [ ] Impersonate → banner → stop round-trip
- [ ] Operators: invite / role-change / revoke gated to superadmin
- [ ] Audit events captured with IP + metadata