### PR TITLE
feat(crm): unified contacts with lead → contact → customer lifecycle

### DIFF
--- a/src/app/(dashboard)/contacts/page.tsx
+++ b/src/app/(dashboard)/contacts/page.tsx
@@ -1,0 +1,7 @@
+import { listContacts } from "@/lib/actions/contacts";
+import { ContactsClient } from "@/components/contacts/contacts-client";
+
+export default async function ContactsPage() {
+  const contacts = await listContacts();
+  return <ContactsClient contacts={contacts} />;
+}

--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -81,7 +81,7 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
     }
     if (workOrder.booker_contact_id) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data } = await (supabase as any).from("contacts").select("id, name, email, phone, role").eq("id", workOrder.booker_contact_id).maybeSingle();
+      const { data } = await (supabase as any).from("account_contacts").select("id, name, email, phone, role").eq("id", workOrder.booker_contact_id).maybeSingle();
       bookerContact = data;
     }
 

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -9,7 +9,7 @@ import { createInvoice, updateInvoice, sendInvoiceEmail, addPayment } from "@/li
 import { getProducts, createProduct } from "@/lib/actions/products";
 import { createReport } from "@/lib/actions/reports";
 import { createSite } from "@/lib/actions/sites";
-import { createContact } from "@/lib/actions/contacts";
+import { createContact } from "@/lib/actions/account-contacts";
 import { createBillingProfile, updateBillingProfile, archiveBillingProfile, setSiteBilling } from "@/lib/actions/billing-profiles";
 import { enableWorkOrderShareLink, disableWorkOrderShareLink, invoiceUnbilledForWorkOrder } from "@/lib/actions/work-orders";
 import { updateWorkOrder } from "@/lib/actions/work-orders";
@@ -1131,7 +1131,7 @@ async function executeTool(
 
     case "search_contacts": {
       const sb = await getRawSupabase();
-      let q = sb.from("contacts")
+      let q = sb.from("account_contacts")
         .select("id, account_id, name, email, phone, role")
         .eq("business_id", ctx.businessId)
         .eq("archived", false)

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  Plus, Mail, Phone, Building2, Search, MoreHorizontal,
+  Trash2, TrendingUp, User,
+} from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
+  DropdownMenuSeparator, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  createContact, updateContact, archiveContact, promoteContactToCustomer,
+} from "@/lib/actions/contacts";
+import type { Contact, LifecycleStage } from "@/types/database";
+
+const STAGE_BADGE: Record<LifecycleStage, string> = {
+  lead:     "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  contact:  "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  customer: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+};
+
+const STAGES: LifecycleStage[] = ["lead", "contact", "customer"];
+
+type Form = {
+  name: string;
+  email: string;
+  phone: string;
+  company: string;
+  notes: string;
+  tags: string;
+  lifecycle_stage: LifecycleStage;
+};
+
+const EMPTY: Form = { name: "", email: "", phone: "", company: "", notes: "", tags: "", lifecycle_stage: "contact" };
+
+function formToPayload(f: Form) {
+  return {
+    name: f.name,
+    email: f.email || null,
+    phone: f.phone || null,
+    company: f.company || null,
+    notes: f.notes || null,
+    tags: f.tags ? f.tags.split(",").map((t) => t.trim()).filter(Boolean) : [],
+    lifecycle_stage: f.lifecycle_stage,
+  };
+}
+
+export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
+  const router = useRouter();
+  const [contacts, setContacts] = useState(initial);
+  const [search, setSearch] = useState("");
+  const [stageFilter, setStageFilter] = useState<LifecycleStage | "all">("all");
+  const [showAdd, setShowAdd] = useState(false);
+  const [editing, setEditing] = useState<Contact | null>(null);
+  const [form, setForm] = useState<Form>(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [promoting, setPromoting] = useState<string | null>(null);
+
+  const filtered = contacts.filter((c) => {
+    if (stageFilter !== "all" && c.lifecycle_stage !== stageFilter) return false;
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return `${c.name} ${c.email ?? ""} ${c.phone ?? ""} ${c.company ?? ""}`.toLowerCase().includes(q);
+  });
+
+  const counts = {
+    total: contacts.length,
+    lead: contacts.filter((c) => c.lifecycle_stage === "lead").length,
+    contact: contacts.filter((c) => c.lifecycle_stage === "contact").length,
+    customer: contacts.filter((c) => c.lifecycle_stage === "customer").length,
+  };
+
+  const handleAdd = async () => {
+    if (!form.name.trim()) { toast.error("Name is required"); return; }
+    setSaving(true);
+    try {
+      const c = await createContact(formToPayload(form));
+      setContacts((prev) => [c, ...prev]);
+      setForm(EMPTY);
+      setShowAdd(false);
+      toast.success("Contact added");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to add contact");
+    }
+    setSaving(false);
+  };
+
+  const handleEditSave = async () => {
+    if (!editing) return;
+    setSaving(true);
+    try {
+      const c = await updateContact(editing.id, formToPayload(form));
+      setContacts((prev) => prev.map((x) => (x.id === c.id ? c : x)));
+      setEditing(null);
+      toast.success("Contact updated");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update");
+    }
+    setSaving(false);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    try {
+      await archiveContact(deleteId);
+      setContacts((prev) => prev.filter((c) => c.id !== deleteId));
+      toast.success("Contact archived");
+    } catch { toast.error("Failed to archive"); }
+    setDeleteId(null);
+  };
+
+  const handlePromote = async (id: string) => {
+    setPromoting(id);
+    try {
+      const { contact, customerId } = await promoteContactToCustomer(id);
+      setContacts((prev) => prev.map((c) => (c.id === id ? contact : c)));
+      toast.success("Promoted to customer");
+      router.push(`/customers/${customerId}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Promotion failed");
+    } finally {
+      setPromoting(null);
+    }
+  };
+
+  const startEdit = (c: Contact) => {
+    setEditing(c);
+    setForm({
+      name: c.name,
+      email: c.email ?? "",
+      phone: c.phone ?? "",
+      company: c.company ?? "",
+      notes: c.notes ?? "",
+      tags: c.tags.join(", "),
+      lifecycle_stage: c.lifecycle_stage,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Contacts</h1>
+          <p className="text-muted-foreground text-sm mt-0.5">
+            {counts.total} total · {counts.lead} leads · {counts.contact} contacts · {counts.customer} customers
+          </p>
+        </div>
+        <Button onClick={() => { setForm(EMPTY); setShowAdd(true); }}>
+          <Plus className="h-4 w-4 mr-2" /> Add Contact
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search contacts..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <Select value={stageFilter} onValueChange={(v) => setStageFilter(v as LifecycleStage | "all")}>
+          <SelectTrigger className="w-[180px]"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All stages</SelectItem>
+            {STAGES.map((s) => (
+              <SelectItem key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* List */}
+      {filtered.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            No contacts {search || stageFilter !== "all" ? "match your filter" : "yet — add one or promote a lead"}.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {filtered.map((c) => (
+            <Card key={c.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-1">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <User className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <span className="font-medium truncate">{c.name}</span>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => startEdit(c)}>Edit</DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => handlePromote(c.id)}
+                        disabled={!!c.customer_id || promoting === c.id}
+                      >
+                        <TrendingUp className="h-3.5 w-3.5 mr-2" />
+                        {c.customer_id ? "Customer ✓" : "Promote to customer"}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => setDeleteId(c.id)} className="text-destructive focus:text-destructive">
+                        <Trash2 className="h-3.5 w-3.5 mr-2" /> Archive
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Badge className={STAGE_BADGE[c.lifecycle_stage]} variant="secondary">
+                    {c.lifecycle_stage}
+                  </Badge>
+                  {c.tags.map((t) => (
+                    <Badge key={t} variant="outline" className="text-xs">{t}</Badge>
+                  ))}
+                </div>
+
+                <div className="space-y-1">
+                  {c.company && (
+                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <Building2 className="h-3 w-3 shrink-0" />
+                      <span className="truncate">{c.company}</span>
+                    </div>
+                  )}
+                  {c.email && (
+                    <a href={`mailto:${c.email}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+                      <Mail className="h-3 w-3 shrink-0" />
+                      <span className="truncate">{c.email}</span>
+                    </a>
+                  )}
+                  {c.phone && (
+                    <a href={`tel:${c.phone.replace(/\s/g, "")}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+                      <Phone className="h-3 w-3 shrink-0" />
+                      <span className="truncate">{c.phone}</span>
+                    </a>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Add / Edit Dialog */}
+      <Dialog
+        open={showAdd || !!editing}
+        onOpenChange={(o) => { if (!o) { setShowAdd(false); setEditing(null); } }}
+      >
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{editing ? "Edit Contact" : "Add Contact"}</DialogTitle>
+          </DialogHeader>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-2">
+            <div className="col-span-2 space-y-1.5">
+              <Label>Name *</Label>
+              <Input value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Email</Label>
+              <Input value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Phone</Label>
+              <Input value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Company</Label>
+              <Input value={form.company} onChange={(e) => setForm((f) => ({ ...f, company: e.target.value }))} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Stage</Label>
+              <Select value={form.lifecycle_stage} onValueChange={(v) => setForm((f) => ({ ...f, lifecycle_stage: v as LifecycleStage }))}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {STAGES.map((s) => (
+                    <SelectItem key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="col-span-2 space-y-1.5">
+              <Label>Tags (comma-separated)</Label>
+              <Input value={form.tags} onChange={(e) => setForm((f) => ({ ...f, tags: e.target.value }))} placeholder="vip, follow-up" />
+            </div>
+            <div className="col-span-2 space-y-1.5">
+              <Label>Notes</Label>
+              <Textarea value={form.notes} onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))} rows={3} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setShowAdd(false); setEditing(null); }}>Cancel</Button>
+            <Button onClick={editing ? handleEditSave : handleAdd} disabled={saving}>
+              {saving ? "Saving..." : editing ? "Save Changes" : "Add Contact"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={!!deleteId} onOpenChange={(o) => { if (!o) setDeleteId(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Archive contact?</AlertDialogTitle>
+            <AlertDialogDescription>You can restore it from the database if needed.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">Archive</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -23,6 +23,7 @@ const navItems = [
   { label: "Schedule",    href: "/schedule",    icon: CalendarDays },
   { label: "Recurring",   href: "/recurring",   icon: Repeat },
   { label: "Leads",       href: "/leads",       icon: UserPlus },
+  { label: "Contacts",    href: "/contacts",    icon: Users2 },
   { label: "Reports",     href: "/reports",     icon: ClipboardList },
   { label: "Work Orders", href: "/work-orders", icon: Wrench },
   { label: "Messages",    href: "/messages",    icon: MessageSquare },

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -27,6 +27,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useRouter } from "next/navigation";
 import { updateLeadStatus, deleteLead, createLead, updateLead, convertLeadToCustomer, convertLeadToQuote, convertLeadToWorkOrder } from "@/lib/actions/leads";
+import { addLeadAsContact } from "@/lib/actions/contacts";
 import type { Lead, LeadStatus, LeadSource } from "@/types/database";
 
 const COLUMNS: { status: LeadStatus; label: string; color: string; dot: string }[] = [
@@ -140,6 +141,19 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
       toast.success("Lead added");
     } catch { toast.error("Failed to add lead"); }
     setSaving(false);
+  };
+
+  const handleAddAsContact = async (id: string) => {
+    setConverting(id);
+    try {
+      await addLeadAsContact(id);
+      toast.success("Added as contact");
+      router.push("/contacts");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to add as contact");
+    } finally {
+      setConverting(null);
+    }
   };
 
   const handleConvert = async (id: string, target: "customer" | "quote" | "work_order") => {
@@ -290,6 +304,7 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
                       onDelete={() => setDeleteId(lead.id)}
                       onEdit={() => { setEditLead(lead); setEditForm({ name: lead.name, phone: lead.phone, email: lead.email, suburb: lead.suburb, service: lead.service, property_type: lead.property_type, timing: lead.timing, notes: lead.notes }); }}
                       onConvert={(target) => handleConvert(lead.id, target)}
+                      onAddAsContact={() => handleAddAsContact(lead.id)}
                     />
                   </div>
                 ))}
@@ -433,6 +448,7 @@ function LeadCard({
   onDelete,
   onEdit,
   onConvert,
+  onAddAsContact,
 }: {
   lead: Lead;
   converting: boolean;
@@ -440,6 +456,7 @@ function LeadCard({
   onDelete: () => void;
   onEdit: () => void;
   onConvert: (target: "customer" | "quote" | "work_order") => void;
+  onAddAsContact: () => void;
 }) {
   const NEXT_STATUS: Partial<Record<LeadStatus, LeadStatus>> = {
     new: "contacted",
@@ -469,6 +486,9 @@ function LeadCard({
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={onEdit}>Edit</DropdownMenuItem>
             <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onAddAsContact} disabled={converting}>
+              Add as contact
+            </DropdownMenuItem>
             <DropdownMenuItem onClick={() => onConvert("customer")} disabled={converting || !!lead.customer_id}>
               Convert to customer{lead.customer_id ? " ✓" : ""}
             </DropdownMenuItem>

--- a/src/components/work-orders/work-order-new-client.tsx
+++ b/src/components/work-orders/work-order-new-client.tsx
@@ -16,9 +16,9 @@ import { SearchableSelect } from "@/components/ui/searchable-select";
 import { AddressSelect } from "@/components/addresses/address-select";
 import { createWorkOrder } from "@/lib/actions/work-orders";
 import { getSitesForAccount, getSite } from "@/lib/actions/sites";
-import { getContactsForAccount } from "@/lib/actions/contacts";
+import { getContactsForAccount } from "@/lib/actions/account-contacts";
 import { getBillingProfilesForAccount, getSiteBilling } from "@/lib/actions/billing-profiles";
-import type { Customer, MemberProfile, Site, Contact, BillingProfile } from "@/types/database";
+import type { Customer, MemberProfile, Site, AccountContact, BillingProfile } from "@/types/database";
 
 const AVATAR_COLORS = [
   "bg-blue-500","bg-violet-500","bg-pink-500","bg-orange-500",
@@ -61,7 +61,7 @@ export function WorkOrderNewClient({
 
   // Account-driven selectors
   const [sites, setSites] = useState<Site[]>([]);
-  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [contacts, setContacts] = useState<AccountContact[]>([]);
   const [billingProfiles, setBillingProfiles] = useState<BillingProfile[]>([]);
   const [siteId, setSiteId] = useState<string>(defaultSiteId ?? "");
   const [bookerContactId, setBookerContactId] = useState<string>("");

--- a/src/lib/actions/account-contacts.ts
+++ b/src/lib/actions/account-contacts.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import type { AccountContact, AccountContactRole } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+async function ctx() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, user, businessId };
+}
+
+export async function getContactsForAccount(accountId: string): Promise<AccountContact[]> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "account_contacts")
+    .select("*")
+    .eq("account_id", accountId)
+    .eq("business_id", businessId)
+    .eq("archived", false)
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+  return data as AccountContact[];
+}
+
+export async function getContact(id: string): Promise<AccountContact | null> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "account_contacts")
+    .select("*")
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .maybeSingle();
+  if (error) throw error;
+  return data as AccountContact | null;
+}
+
+export type AccountContactPayload = {
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  role?: AccountContactRole;
+  notes?: string | null;
+};
+
+export async function createContact(accountId: string, payload: AccountContactPayload): Promise<AccountContact> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "account_contacts")
+    .insert({ account_id: accountId, business_id: businessId, role: 'other', ...payload })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath(`/customers/${accountId}`);
+  return data as AccountContact;
+}
+
+export async function updateContact(id: string, payload: Partial<AccountContactPayload>): Promise<AccountContact> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "account_contacts")
+    .update(payload)
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .select()
+    .single();
+  if (error) throw error;
+  if (data) revalidatePath(`/customers/${(data as AccountContact).account_id}`);
+  return data as AccountContact;
+}
+
+export async function archiveContact(id: string): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  await tbl(supabase, "account_contacts").update({ archived: true }).eq("id", id).eq("business_id", businessId);
+}

--- a/src/lib/actions/contacts.ts
+++ b/src/lib/actions/contacts.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
-import type { Contact, ContactRole } from "@/types/database";
+import type { Contact, LifecycleStage } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
@@ -16,14 +16,25 @@ async function ctx() {
   return { supabase, user, businessId };
 }
 
-export async function getContactsForAccount(accountId: string): Promise<Contact[]> {
+export type ContactPayload = {
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  company?: string | null;
+  notes?: string | null;
+  tags?: string[];
+  lifecycle_stage?: LifecycleStage;
+};
+
+export async function listContacts(opts?: { stage?: LifecycleStage }): Promise<Contact[]> {
   const { supabase, businessId } = await ctx();
-  const { data, error } = await tbl(supabase, "contacts")
+  let q = tbl(supabase, "contacts")
     .select("*")
-    .eq("account_id", accountId)
     .eq("business_id", businessId)
     .eq("archived", false)
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: false });
+  if (opts?.stage) q = q.eq("lifecycle_stage", opts.stage);
+  const { data, error } = await q;
   if (error) throw error;
   return data as Contact[];
 }
@@ -39,22 +50,23 @@ export async function getContact(id: string): Promise<Contact | null> {
   return data as Contact | null;
 }
 
-export type ContactPayload = {
-  name: string;
-  email?: string | null;
-  phone?: string | null;
-  role?: ContactRole;
-  notes?: string | null;
-};
-
-export async function createContact(accountId: string, payload: ContactPayload): Promise<Contact> {
+export async function createContact(payload: ContactPayload): Promise<Contact> {
   const { supabase, businessId } = await ctx();
   const { data, error } = await tbl(supabase, "contacts")
-    .insert({ account_id: accountId, business_id: businessId, role: 'other', ...payload })
+    .insert({
+      business_id: businessId,
+      lifecycle_stage: payload.lifecycle_stage ?? "contact",
+      tags: payload.tags ?? [],
+      name: payload.name,
+      email: payload.email ?? null,
+      phone: payload.phone ?? null,
+      company: payload.company ?? null,
+      notes: payload.notes ?? null,
+    })
     .select()
     .single();
   if (error) throw error;
-  revalidatePath(`/customers/${accountId}`);
+  revalidatePath("/contacts");
   return data as Contact;
 }
 
@@ -67,11 +79,100 @@ export async function updateContact(id: string, payload: Partial<ContactPayload>
     .select()
     .single();
   if (error) throw error;
-  if (data) revalidatePath(`/customers/${(data as Contact).account_id}`);
+  revalidatePath("/contacts");
+  revalidatePath(`/contacts/${id}`);
   return data as Contact;
 }
 
 export async function archiveContact(id: string): Promise<void> {
   const { supabase, businessId } = await ctx();
-  await tbl(supabase, "contacts").update({ archived: true }).eq("id", id).eq("business_id", businessId);
+  const { error } = await tbl(supabase, "contacts")
+    .update({ archived: true })
+    .eq("id", id)
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/contacts");
+}
+
+/** Promote a lead into a contact (lifecycle_stage='contact'). Idempotent — returns existing if already promoted. */
+export async function addLeadAsContact(leadId: string): Promise<Contact> {
+  const { supabase, businessId } = await ctx();
+
+  const existing = await tbl(supabase, "contacts")
+    .select("*")
+    .eq("business_id", businessId)
+    .eq("source_lead_id", leadId)
+    .maybeSingle();
+  if (existing.data) return existing.data as Contact;
+
+  const { data: lead, error: leadErr } = await tbl(supabase, "leads")
+    .select("id, name, email, phone, notes")
+    .eq("id", leadId)
+    .eq("business_id", businessId)
+    .single();
+  if (leadErr) throw leadErr;
+  if (!lead) throw new Error("Lead not found");
+
+  const { data, error } = await tbl(supabase, "contacts")
+    .insert({
+      business_id: businessId,
+      name: lead.name,
+      email: lead.email ?? null,
+      phone: lead.phone ?? null,
+      notes: lead.notes ?? null,
+      source_lead_id: lead.id,
+      lifecycle_stage: "contact",
+      tags: [],
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/contacts");
+  revalidatePath("/leads");
+  return data as Contact;
+}
+
+/** Promote a contact to a customer. Creates customer row, links it back. Idempotent. */
+export async function promoteContactToCustomer(contactId: string): Promise<{ contact: Contact; customerId: string }> {
+  const { supabase, user, businessId } = await ctx();
+
+  const { data: contact, error: cErr } = await tbl(supabase, "contacts")
+    .select("*")
+    .eq("id", contactId)
+    .eq("business_id", businessId)
+    .single();
+  if (cErr) throw cErr;
+  if (!contact) throw new Error("Contact not found");
+
+  if (contact.customer_id) {
+    return { contact: contact as Contact, customerId: contact.customer_id as string };
+  }
+
+  const { data: customer, error: custErr } = await tbl(supabase, "customers")
+    .insert({
+      business_id: businessId,
+      user_id: user.id,
+      name: contact.name,
+      email: contact.email,
+      phone: contact.phone,
+      company: contact.company,
+      notes: contact.notes,
+      account_type: "individual",
+    })
+    .select("id")
+    .single();
+  if (custErr) throw custErr;
+
+  const { data: updated, error: upErr } = await tbl(supabase, "contacts")
+    .update({ customer_id: customer.id, lifecycle_stage: "customer" })
+    .eq("id", contactId)
+    .eq("business_id", businessId)
+    .select()
+    .single();
+  if (upErr) throw upErr;
+
+  revalidatePath("/contacts");
+  revalidatePath(`/contacts/${contactId}`);
+  revalidatePath("/customers");
+  return { contact: updated as Contact, customerId: customer.id };
 }

--- a/src/lib/actions/customer-hub.ts
+++ b/src/lib/actions/customer-hub.ts
@@ -19,10 +19,10 @@ import {
 } from "@/lib/actions/sites";
 import {
   getContactsForAccount, createContact, updateContact, archiveContact,
-} from "@/lib/actions/contacts";
+} from "@/lib/actions/account-contacts";
 import type {
   CustomerProperty, CustomerContact, CustomerNote,
-  Site, Contact, ContactRole,
+  Site, AccountContact, AccountContactRole,
 } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,7 +46,7 @@ function siteToProperty(s: Site): CustomerProperty {
   };
 }
 
-function contactToCustomerContact(c: Contact): CustomerContact {
+function contactToCustomerContact(c: AccountContact): CustomerContact {
   return {
     id: c.id,
     business_id: c.business_id,
@@ -116,7 +116,7 @@ export async function createCustomerContact(
   customerId: string,
   payload: { name: string; role?: string; email?: string; phone?: string; is_primary?: boolean; notes?: string }
 ): Promise<CustomerContact> {
-  const role: ContactRole = payload.is_primary ? 'primary' : (payload.role as ContactRole) || 'other';
+  const role: AccountContactRole = payload.is_primary ? 'primary' : (payload.role as AccountContactRole) || 'other';
   const c = await createContact(customerId, {
     name: payload.name,
     email: payload.email ?? null,

--- a/src/lib/ai/resolvers.ts
+++ b/src/lib/ai/resolvers.ts
@@ -136,7 +136,7 @@ export async function resolveContact(query: string, accountId?: string): Promise
   const { supabase, businessId } = await ctx();
   const q = query.trim();
   if (!q) return { match: null, candidates: [], ambiguous: false };
-  let req = tbl(supabase, "contacts")
+  let req = tbl(supabase, "account_contacts")
     .select("id, account_id, name, email, phone, role")
     .eq("business_id", businessId)
     .eq("archived", false)

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -457,7 +457,9 @@ export interface CustomerNote {
 // Note: the `customers` table is the "Account" backing — no rename.
 
 export type AccountType = 'individual' | 'property_mgmt' | 'commercial' | 'strata' | 'other';
-export type ContactRole = 'owner' | 'pm' | 'tenant' | 'super' | 'primary' | 'accounts' | 'other';
+export type AccountContactRole = 'owner' | 'pm' | 'tenant' | 'super' | 'primary' | 'accounts' | 'other';
+/** @deprecated Use AccountContactRole. */
+export type ContactRole = AccountContactRole;
 export type SiteContactRole = 'tenant' | 'super' | 'owner_onsite' | 'primary' | 'other';
 
 export interface Site {
@@ -479,15 +481,36 @@ export interface Site {
   updated_at: string;
 }
 
-export interface Contact {
+/** A person attached to a customer account (PM, tenant, primary, etc). */
+export interface AccountContact {
   id: string;
   business_id: string;
   account_id: string;
   name: string;
   email: string | null;
   phone: string | null;
-  role: ContactRole;
+  role: AccountContactRole;
   notes: string | null;
+  archived: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export type LifecycleStage = 'lead' | 'contact' | 'customer';
+
+/** Top-level CRM contact. Lifecycle: lead -> contact -> customer. */
+export interface Contact {
+  id: string;
+  business_id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  company: string | null;
+  notes: string | null;
+  lifecycle_stage: LifecycleStage;
+  source_lead_id: string | null;
+  customer_id: string | null;
+  tags: string[];
   archived: boolean;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20260428000001_unified_contacts.sql
+++ b/supabase/migrations/20260428000001_unified_contacts.sql
@@ -1,0 +1,81 @@
+-- Unified CRM contacts.
+--
+-- Step 1: rename the existing per-account `contacts` table to `account_contacts`
+--         (its real job — people attached to a customer account: PMs, tenants, etc).
+-- Step 2: create a new top-level `contacts` table for the CRM lifecycle:
+--         lead -> contact -> customer.
+--
+-- Existing FKs that pointed at the old `contacts(id)` get re-pointed to
+-- `account_contacts(id)` automatically because Postgres preserves the FK
+-- through a table rename, but the FK column names already mention "contact"
+-- so we leave them as-is for now. (work_orders.booker_contact_id, site_contacts.contact_id)
+
+-- ============================================================
+-- 1. RENAME existing contacts -> account_contacts
+-- ============================================================
+ALTER TABLE public.contacts RENAME TO account_contacts;
+
+ALTER INDEX IF EXISTS contacts_account_idx  RENAME TO account_contacts_account_idx;
+ALTER INDEX IF EXISTS contacts_business_idx RENAME TO account_contacts_business_idx;
+
+ALTER TRIGGER contacts_updated_at ON public.account_contacts RENAME TO account_contacts_updated_at;
+
+DROP POLICY IF EXISTS "contacts_all" ON public.account_contacts;
+CREATE POLICY "account_contacts_all" ON public.account_contacts FOR ALL
+  USING (business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION
+    SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ))
+  WITH CHECK (business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION
+    SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ));
+
+-- ============================================================
+-- 2. NEW unified contacts table for the CRM lifecycle
+-- ============================================================
+CREATE TABLE public.contacts (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id     UUID        NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name            TEXT        NOT NULL,
+  email           TEXT,
+  phone           TEXT,
+  company         TEXT,
+  notes           TEXT,
+  -- lifecycle: 'lead' (just imported), 'contact' (working with), 'customer' (promoted, has customer_id)
+  lifecycle_stage TEXT        NOT NULL DEFAULT 'contact'
+                              CHECK (lifecycle_stage IN ('lead','contact','customer')),
+  -- where this contact came from / was promoted to
+  source_lead_id  UUID        REFERENCES public.leads(id)     ON DELETE SET NULL,
+  customer_id     UUID        REFERENCES public.customers(id) ON DELETE SET NULL,
+  -- simple tag bag — opportunities/pipelines/custom-fields land in later migrations
+  tags            TEXT[]      NOT NULL DEFAULT '{}',
+  archived        BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX contacts_business_idx       ON public.contacts (business_id) WHERE NOT archived;
+CREATE INDEX contacts_lifecycle_idx      ON public.contacts (business_id, lifecycle_stage) WHERE NOT archived;
+CREATE INDEX contacts_source_lead_idx    ON public.contacts (source_lead_id) WHERE source_lead_id IS NOT NULL;
+CREATE INDEX contacts_customer_id_idx    ON public.contacts (customer_id)    WHERE customer_id    IS NOT NULL;
+CREATE UNIQUE INDEX contacts_one_per_lead     ON public.contacts (source_lead_id) WHERE source_lead_id IS NOT NULL;
+CREATE UNIQUE INDEX contacts_one_per_customer ON public.contacts (customer_id)    WHERE customer_id    IS NOT NULL;
+
+CREATE TRIGGER contacts_updated_at BEFORE UPDATE ON public.contacts
+  FOR EACH ROW EXECUTE PROCEDURE public.handle_updated_at();
+
+ALTER TABLE public.contacts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "contacts_all" ON public.contacts FOR ALL
+  USING (business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION
+    SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ))
+  WITH CHECK (business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION
+    SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ));


### PR DESCRIPTION
## Summary
- Renames existing `contacts` → `account_contacts` (per-account: PMs/tenants/supers)
- New top-level `contacts` table with `lifecycle_stage` (lead → contact → customer), `source_lead_id`, `customer_id`, tags
- Server actions: list/get/create/update/archive + `addLeadAsContact` + `promoteContactToCustomer` (idempotent — creates customer row, links it back)
- New `/contacts` route with stage filter and tag chips
- "Add as contact" action on the leads kanban card menu

Closes #44

## Test plan
- [ ] Migration applied to remote DB (done — `20260428000001_unified_contacts`)
- [ ] `npx tsc --noEmit` clean (done)
- [ ] Visit `/contacts`, add a contact, edit it, archive it
- [ ] On `/leads`, "Add as contact" creates a contact with `source_lead_id` set
- [ ] On `/contacts`, "Promote to customer" creates a customer row and links `customer_id`
- [ ] Booker contact picker on work-order create still works (uses `account_contacts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)