### PR TITLE
fix(fonts): unblock build by dropping weight from Fraunces

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,6 @@ const fraunces = Fraunces({
   variable: "--font-display",
   display: "swap",
   style: ["normal", "italic"],
-  weight: ["400", "500", "600"],
   axes: ["opsz", "SOFT"],
 });
 


### PR DESCRIPTION
Next 16 rejected the combination of explicit weights + axes on Fraunces (`Axes can only be defined for variable fonts when weight is nonexistent or set to variable`). Removing the weight array keeps the variable-font axes (opsz, SOFT) and the production build now succeeds.