### PR TITLE
chore(layout): one canonical content frame for every page

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -37,7 +37,7 @@ export default async function AgentsPage() {
   const installs = await listAgentInstalls();
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-8">
+    <div className="">
       <AgentsStore installs={installs} />
     </div>
   );

--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -49,7 +49,7 @@ export default async function TasksPage() {
   const contacts = (contactsRes.data ?? []) as { id: string; name: string; company: string | null }[];
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div>
       <div className="mb-6">
         <h1 className="text-2xl font-semibold tracking-tight">Tasks</h1>
         <p className="text-sm text-neutral-500 mt-0.5">

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -157,7 +157,7 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
   };
 
   return (
-    <div className="max-w-5xl mx-auto space-y-10">
+    <div className="space-y-10">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-6 pb-2">
         <div className="space-y-2">

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -57,7 +57,7 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
   };
 
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
+    <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Customers</h1>

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -71,8 +71,8 @@ export function DashboardClient({ stats, currency = "GBP", todayJobs }: Dashboar
   const peakIdx = monthly.reduce((acc, m, i) => (m.revenue > monthly[acc].revenue ? i : acc), 0);
 
   return (
-    <div className="min-h-full">
-      <div className="max-w-[1500px] mx-auto">
+    <div>
+      <div>
 
         {/* ── Top bar ──────────────────────────────────────────────────── */}
         <motion.div

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -60,7 +60,7 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
   };
 
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
+    <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Invoices</h1>

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -47,8 +47,10 @@ export function DashboardShell({ business, businesses, user, userRole, children 
             business={business}
             onMenuClick={() => setSidebarOpen((o) => !o)}
           />
-          <main className="app-content flex-1 overflow-auto p-4 md:p-6 lg:p-8">
-            {children}
+          <main className="app-content flex-1 overflow-auto">
+            <div className="max-w-7xl mx-auto w-full p-5 sm:p-6 lg:p-8">
+              {children}
+            </div>
           </main>
         </div>
       </div>

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -77,7 +77,7 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
   };
 
   return (
-    <div className="space-y-6 max-w-4xl mx-auto">
+    <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Products & Services</h1>

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -53,7 +53,7 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
   };
 
   return (
-    <div className="space-y-6 max-w-6xl mx-auto">
+    <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Quotes</h1>

--- a/src/components/team/team-page-client.tsx
+++ b/src/components/team/team-page-client.tsx
@@ -298,7 +298,7 @@ export function TeamPageClient({ profiles: initialProfiles, members, userRole, c
   };
 
   return (
-    <div className="space-y-6 max-w-4xl">
+    <div className="space-y-6 ">
       {/* Header */}
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-center justify-between gap-4">
         <div>


### PR DESCRIPTION
Standardize content width app-wide. Pages were declaring their own max-w independently (4xl/5xl/6xl/7xl/[1500px]/none), causing visible shifts on navigation. Moved the constraint into the dashboard shell's <main> wrapper with uniform max-w-7xl mx-auto + p-5/sm:p-6/lg:p-8. Stripped redundant wrappers from list pages; left narrow form pages alone since they clamp tighter intentionally.