### PR TITLE
feat(worker-role): isolated worker role with RLS hardening

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,9 +1,52 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { isWorker, type Role } from "@/lib/permissions";
 import { getDashboardStats } from "@/lib/actions/invoices";
 import { getBusiness } from "@/lib/actions/business";
-import { getTodayWorkOrders } from "@/lib/actions/work-orders";
+import { getTodayWorkOrders, getWorkOrders } from "@/lib/actions/work-orders";
 import { DashboardClient } from "@/components/dashboard/dashboard-client";
+import { WorkerDashboard } from "@/components/dashboard/worker-dashboard";
 
 export default async function DashboardPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any;
+  const businessId = await getActiveBizId(sb, user.id);
+
+  // Resolve role
+  const { data: biz } = await sb.from("businesses").select("user_id").eq("id", businessId).single();
+  let role: Role = "owner";
+  if (biz?.user_id !== user.id) {
+    const { data: m } = await sb
+      .from("business_members")
+      .select("role")
+      .eq("business_id", businessId)
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .maybeSingle();
+    role = (m?.role ?? "viewer") as Role;
+  }
+
+  if (isWorker(role)) {
+    const [business, todayJobs, allJobs] = await Promise.all([
+      getBusiness().catch(() => null),
+      getTodayWorkOrders().catch(() => []),
+      getWorkOrders().catch(() => []),
+    ]);
+    return (
+      <WorkerDashboard
+        userEmail={user.email ?? ""}
+        businessName={business?.name ?? "your team"}
+        todayJobs={todayJobs}
+        allJobs={allJobs}
+      />
+    );
+  }
+
   const [stats, business, todayJobs] = await Promise.all([
     getDashboardStats(),
     getBusiness(),

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,8 +1,8 @@
 import { redirect } from "next/navigation";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { DashboardShell } from "@/components/layout/dashboard-shell";
-import type { Role } from "@/lib/permissions";
+import { isWorker, isPathAllowedForWorker, type Role } from "@/lib/permissions";
 import type { Business } from "@/types/database";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -43,6 +43,20 @@ export default async function DashboardLayout({ children }: { children: React.Re
   if (!isOwnerOfBiz) {
     const membership = memberships.find((m) => m.business_id === business.id);
     userRole = (membership?.role ?? "viewer") as Role;
+  }
+
+  // Idempotent profile link: if a member_profile exists for this user's email
+  // in the active business, point its user_id at the auth user.
+  // Best-effort — the function is SECURITY DEFINER and a no-op if nothing matches.
+  await sb.rpc("link_my_member_profile").catch(() => undefined);
+
+  // Redirect workers away from pages they shouldn't see
+  if (isWorker(userRole)) {
+    const h = await headers();
+    const path = h.get("x-pathname") ?? h.get("x-invoke-path") ?? "/dashboard";
+    if (!isPathAllowedForWorker(path)) {
+      redirect("/work-orders");
+    }
   }
 
   return (

--- a/src/components/dashboard/worker-dashboard.tsx
+++ b/src/components/dashboard/worker-dashboard.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import {
+  Wrench, MapPin, Clock, CheckCircle, ArrowRight, Calendar, AlertTriangle,
+} from "@/components/ui/icons";
+import { Badge } from "@/components/ui/badge";
+import type { WorkOrderWithCustomer, WorkOrderStatus } from "@/types/database";
+
+const STATUS_PILL: Record<WorkOrderStatus, string> = {
+  draft:       "bg-neutral-100 text-neutral-700",
+  assigned:    "bg-blue-100 text-blue-700",
+  in_progress: "bg-amber-100 text-amber-800",
+  submitted:   "bg-violet-100 text-violet-700",
+  reviewed:    "bg-yellow-100 text-yellow-800",
+  completed:   "bg-lime-200 text-lime-900",
+  cancelled:   "bg-rose-100 text-rose-700",
+};
+
+interface WorkerDashboardProps {
+  userEmail: string;
+  businessName: string;
+  todayJobs: WorkOrderWithCustomer[];
+  allJobs: WorkOrderWithCustomer[];
+}
+
+export function WorkerDashboard({ userEmail, businessName, todayJobs, allJobs }: WorkerDashboardProps) {
+  const todayStr = new Date().toISOString().split("T")[0];
+  const now = new Date();
+  const hour = now.getHours();
+  const greeting = hour < 5 ? "Late night" : hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
+  const todayLabel = now.toLocaleDateString("en-AU", { weekday: "long", day: "numeric", month: "long" });
+
+  const onSite      = allJobs.filter((j) => j.status === "in_progress");
+  const upcoming    = allJobs.filter((j) => j.scheduled_date && j.scheduled_date > todayStr && ["assigned", "draft"].includes(j.status));
+  const needsAction = todayJobs.filter((j) => j.status === "assigned" || j.status === "in_progress");
+  const completedThisWeek = allJobs.filter((j) => {
+    if (!j.completed_at) return false;
+    const d = new Date(j.completed_at);
+    const week = new Date(); week.setDate(week.getDate() - 7);
+    return d > week;
+  });
+
+  return (
+    <div>
+      {/* Hero */}
+      <motion.section
+        initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}
+        className="mb-8"
+      >
+        <div className="flex items-center gap-2 mb-3">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-foreground/5 text-[11px] font-medium text-foreground/70">
+            <Calendar className="w-3 h-3" /> {todayLabel}
+          </span>
+        </div>
+        <h1 className="font-display text-4xl sm:text-5xl font-medium tracking-tight leading-[1.05]">
+          {greeting}.
+        </h1>
+        <p className="mt-2 text-sm sm:text-base text-muted-foreground max-w-xl">
+          {needsAction.length === 0
+            ? "Nothing on your plate today — enjoy the breathing room."
+            : `You have ${needsAction.length} ${needsAction.length === 1 ? "job" : "jobs"} to take care of today${onSite.length ? ` (${onSite.length} on site)` : ""}.`}
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground/70">
+          Working with <span className="font-medium text-foreground/80">{businessName}</span> as <span className="font-mono">{userEmail}</span>
+        </p>
+      </motion.section>
+
+      {/* KPI strip */}
+      <motion.section
+        initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.05 }}
+        className="grid grid-cols-2 lg:grid-cols-4 gap-px bg-border/60 rounded-2xl overflow-hidden border border-border/60 mb-8"
+      >
+        <Stat icon={<Wrench className="w-3.5 h-3.5" />} label="Today" value={needsAction.length} hint={needsAction.length === 1 ? "job" : "jobs"} accent="text-amber-600" />
+        <Stat icon={<Clock className="w-3.5 h-3.5" />} label="On site now" value={onSite.length} hint={onSite.length === 1 ? "active" : "active"} accent="text-emerald-600" />
+        <Stat icon={<Calendar className="w-3.5 h-3.5" />} label="Upcoming" value={upcoming.length} hint={upcoming.length === 1 ? "scheduled" : "scheduled"} accent="text-blue-600" />
+        <Stat icon={<CheckCircle className="w-3.5 h-3.5" />} label="Done this week" value={completedThisWeek.length} hint={completedThisWeek.length === 1 ? "complete" : "complete"} accent="text-violet-600" />
+      </motion.section>
+
+      {/* Jobs */}
+      <motion.section
+        initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.1 }}
+        className="rounded-[28px] bg-card border border-black/5 overflow-hidden"
+      >
+        <div className="flex items-center justify-between px-7 pt-6 pb-4">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center">
+              <Wrench className="w-4 h-4" />
+            </div>
+            <span className="text-sm font-medium">Today&apos;s jobs</span>
+            {todayJobs.length > 0 && (
+              <span className="ml-2 px-2 py-0.5 rounded-full bg-lime-300 text-lime-950 text-[10px] font-bold">
+                {todayJobs.length}
+              </span>
+            )}
+          </div>
+          <Link href="/work-orders" className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1">
+            All jobs <ArrowRight className="w-3 h-3" />
+          </Link>
+        </div>
+
+        {todayJobs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-14 px-6 text-center">
+            <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-3">
+              <Wrench className="w-5 h-5 text-muted-foreground" />
+            </div>
+            <p className="text-sm font-medium">No jobs assigned to you today</p>
+            <p className="text-xs text-muted-foreground mt-1">Upcoming jobs will appear here when scheduled</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border/60">
+            {todayJobs.map((job) => <JobRow key={job.id} job={job} />)}
+          </div>
+        )}
+      </motion.section>
+
+      {/* Upcoming */}
+      {upcoming.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.15 }}
+          className="rounded-[28px] bg-card border border-black/5 overflow-hidden mt-5"
+        >
+          <div className="flex items-center justify-between px-7 pt-6 pb-4">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center">
+                <Calendar className="w-4 h-4" />
+              </div>
+              <span className="text-sm font-medium">Upcoming</span>
+            </div>
+            <Link href="/schedule" className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1">
+              Schedule <ArrowRight className="w-3 h-3" />
+            </Link>
+          </div>
+          <div className="divide-y divide-border/60">
+            {upcoming.slice(0, 6).map((job) => <JobRow key={job.id} job={job} showDate />)}
+          </div>
+        </motion.section>
+      )}
+
+      {needsAction.some((j) => j.status === "in_progress") && (
+        <motion.div
+          initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.2 }}
+          className="mt-5 flex items-center gap-3 px-5 py-3.5 rounded-2xl bg-amber-100 dark:bg-amber-950/40"
+        >
+          <div className="w-9 h-9 rounded-full bg-amber-200 dark:bg-amber-900/50 flex items-center justify-center flex-shrink-0">
+            <AlertTriangle className="w-4 h-4 text-amber-800 dark:text-amber-300" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-amber-900 dark:text-amber-200 leading-tight">
+              You have jobs in progress
+            </p>
+            <p className="text-xs text-amber-800/70 dark:text-amber-300/70">Don&apos;t forget to submit them with photos when you&apos;re done</p>
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  icon, label, value, hint, accent,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  hint: string;
+  accent: string;
+}) {
+  return (
+    <div className="bg-card p-5 sm:p-6">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">{label}</span>
+        <span className={accent}>{icon}</span>
+      </div>
+      <div className="font-display text-3xl font-medium tracking-tight tabular-nums leading-none">
+        {value}
+        <span className="text-sm font-normal text-muted-foreground ml-1">{hint}</span>
+      </div>
+    </div>
+  );
+}
+
+function JobRow({ job, showDate }: { job: WorkOrderWithCustomer; showDate?: boolean }) {
+  return (
+    <Link href={`/work-orders/${job.id}`}>
+      <div className="flex items-center gap-3 px-7 py-4 hover:bg-muted/40 transition-colors group">
+        <div className="w-10 h-10 rounded-full bg-violet-100 flex items-center justify-center flex-shrink-0">
+          <Wrench className="w-4 h-4 text-violet-700" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="text-sm font-medium truncate">{job.title}</p>
+            <Badge className={`${STATUS_PILL[job.status]} text-[10px] border-0 rounded-full`}>
+              {job.status.replace("_", " ")}
+            </Badge>
+            {showDate && job.scheduled_date && (
+              <span className="text-[11px] text-muted-foreground">· {job.scheduled_date}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-3 mt-1 text-[11px] text-muted-foreground">
+            <span className="font-mono">{job.number}</span>
+            {job.property_address && (
+              <span className="flex items-center gap-1 truncate">
+                <MapPin className="w-3 h-3 flex-shrink-0" />{job.property_address}
+              </span>
+            )}
+            {!showDate && job.start_time && (
+              <span className="flex items-center gap-1 flex-shrink-0">
+                <Clock className="w-3 h-3" />{job.start_time}
+              </span>
+            )}
+          </div>
+        </div>
+        <ArrowRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-foreground group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+      </div>
+    </Link>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -10,27 +10,29 @@ import {
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
 import type { Role } from "@/lib/permissions";
-import { canManageSettings, ROLE_LABELS } from "@/lib/permissions";
+import { canManageSettings, isWorker, ROLE_LABELS } from "@/lib/permissions";
 import Image from "next/image";
 import { BusinessSwitcher } from "@/components/business/business-switcher";
 
-const navItems = [
-  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-  { label: "Invoices",  href: "/invoices",  icon: FileText },
-  { label: "Quotes",    href: "/quotes",    icon: FileCheck },
-  { label: "Customers", href: "/customers", icon: Users },
-  { label: "Products",  href: "/products",  icon: Package },
-  { label: "Tasks",       href: "/tasks",       icon: Columns3 },
-  { label: "Schedule",    href: "/schedule",    icon: CalendarDays },
-  { label: "Recurring",   href: "/recurring",   icon: Repeat },
-  { label: "Leads",       href: "/leads",       icon: UserPlus },
-  { label: "Contacts",    href: "/contacts",    icon: Users2 },
-  { label: "Reports",     href: "/reports",     icon: ClipboardList },
-  { label: "Work Orders", href: "/work-orders", icon: Wrench },
-  { label: "Messages",    href: "/messages",    icon: MessageSquare },
-  { label: "Team",        href: "/team",        icon: Users2 },
-  { label: "Agents",      href: "/agents",      icon: Bot },
-  { label: "Help",        href: "/help",        icon: HelpCircle },
+type NavItem = { label: string; href: string; icon: typeof LayoutDashboard; worker?: boolean };
+
+const navItems: NavItem[] = [
+  { label: "Dashboard",   href: "/dashboard",   icon: LayoutDashboard, worker: true  },
+  { label: "Invoices",    href: "/invoices",    icon: FileText                       },
+  { label: "Quotes",      href: "/quotes",      icon: FileCheck                      },
+  { label: "Customers",   href: "/customers",   icon: Users                          },
+  { label: "Products",    href: "/products",    icon: Package                        },
+  { label: "Tasks",       href: "/tasks",       icon: Columns3                       },
+  { label: "Work Orders", href: "/work-orders", icon: Wrench,         worker: true  },
+  { label: "Schedule",    href: "/schedule",    icon: CalendarDays,   worker: true  },
+  { label: "Recurring",   href: "/recurring",   icon: Repeat                         },
+  { label: "Leads",       href: "/leads",       icon: UserPlus                       },
+  { label: "Contacts",    href: "/contacts",    icon: Users2                         },
+  { label: "Reports",     href: "/reports",     icon: ClipboardList                  },
+  { label: "Messages",    href: "/messages",    icon: MessageSquare                  },
+  { label: "Team",        href: "/team",        icon: Users2                         },
+  { label: "Agents",      href: "/agents",      icon: Bot                            },
+  { label: "Help",        href: "/help",        icon: HelpCircle,     worker: true  },
 ];
 
 interface AppSidebarProps {
@@ -43,6 +45,8 @@ interface AppSidebarProps {
 
 export function AppSidebar({ business, businesses, userRole, open, onClose }: AppSidebarProps) {
   const pathname = usePathname();
+  const workerView = isWorker(userRole);
+  const visibleNav = workerView ? navItems.filter((n) => n.worker) : navItems;
 
   const isActive = (href: string) =>
     href === "/dashboard" ? pathname === "/dashboard" : pathname.startsWith(href);
@@ -101,7 +105,7 @@ export function AppSidebar({ business, businesses, userRole, open, onClose }: Ap
           Menu
         </p>
         <ul className="space-y-0.5">
-          {navItems.map((item, i) => (
+          {visibleNav.map((item, i) => (
             <li key={item.href}>
               <motion.div
                 initial={{ opacity: 0, x: -12 }}

--- a/src/components/settings/team-settings.tsx
+++ b/src/components/settings/team-settings.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
-import { Loader2, UserPlus, Trash2, Crown, ShieldCheck, Pencil, Eye, Link2 } from "@/components/ui/icons";
+import { Loader2, UserPlus, Trash2, Crown, ShieldCheck, Pencil, Eye, Link2, Wrench } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,6 +19,7 @@ const ROLE_ICONS: Record<Role, React.ElementType> = {
   admin:  ShieldCheck,
   editor: Pencil,
   viewer: Eye,
+  worker: Wrench,
 };
 
 const ROLE_COLORS: Record<Role, string> = {
@@ -26,6 +27,7 @@ const ROLE_COLORS: Record<Role, string> = {
   admin:  "bg-purple-100 text-purple-800 border-purple-200",
   editor: "bg-blue-100 text-blue-800 border-blue-200",
   viewer: "bg-slate-100 text-slate-600 border-slate-200",
+  worker: "bg-lime-200 text-lime-900 border-lime-300",
 };
 
 interface TeamSettingsProps {
@@ -104,8 +106,8 @@ export function TeamSettings({ members: initialMembers, ownerEmail, userRole }: 
 
   // Selectable roles depend on caller's role
   const selectableRoles: MemberRole[] = isOwner(userRole)
-    ? ["admin", "editor", "viewer"]
-    : ["editor", "viewer"];
+    ? ["admin", "editor", "viewer", "worker"]
+    : ["editor", "viewer", "worker"];
 
   return (
     <div className="space-y-6">
@@ -255,7 +257,7 @@ export function TeamSettings({ members: initialMembers, ownerEmail, userRole }: 
         </CardHeader>
         <CardContent>
           <div className="grid gap-3 text-sm">
-            {(["owner", "admin", "editor", "viewer"] as Role[]).map((r) => (
+            {(["owner", "admin", "editor", "viewer", "worker"] as Role[]).map((r) => (
               <div key={r} className="flex items-start gap-3">
                 <RoleBadge role={r} />
                 <p className="text-muted-foreground text-xs mt-0.5">{ROLE_DESCRIPTIONS[r]}</p>
@@ -283,4 +285,5 @@ const ROLE_DESCRIPTIONS: Record<Role, string> = {
   admin:  "Full data access (invoices, quotes, customers, products, reports) and can manage the team. Cannot delete the business.",
   editor: "Can create, edit, and delete invoices, quotes, customers, products, and reports. Cannot access settings.",
   viewer: "Read-only. Can view everything but cannot create or change anything.",
+  worker: "Field worker. Sees only the work orders assigned to them — no invoices, quotes, customers, or financials.",
 };

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -19,9 +19,32 @@ export function isOwner(role: Role): boolean {
   return role === 'owner';
 }
 
+export function isWorker(role: Role): boolean {
+  return role === 'worker';
+}
+
+/** Tables/pages a worker should never see (financials, customers, leads, etc.). */
+export function canSeeFinancials(role: Role): boolean {
+  return role !== 'worker';
+}
+
+/** Routes the sidebar should hide and pages should redirect away from for workers. */
+export const WORKER_ALLOWED_PATHS = [
+  "/dashboard",
+  "/work-orders",
+  "/schedule",
+  "/help",
+  "/settings/profile",
+] as const;
+
+export function isPathAllowedForWorker(path: string): boolean {
+  return WORKER_ALLOWED_PATHS.some((p) => path === p || path.startsWith(p + "/") || path.startsWith(p + "?"));
+}
+
 export const ROLE_LABELS: Record<Role, string> = {
   owner:  'Owner',
   admin:  'Admin',
   editor: 'Editor',
   viewer: 'Viewer',
+  worker: 'Worker',
 };

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -3,7 +3,11 @@ import { NextResponse, type NextRequest } from "next/server";
 import type { Database } from "@/types/database";
 
 export async function updateSession(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request });
+  // Forward the URL path as a header so server components / layouts can make
+  // routing decisions (workers get redirected away from non-allowed paths).
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", request.nextUrl.pathname);
+  let supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
 
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -17,7 +21,7 @@ export async function updateSession(request: NextRequest) {
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
           );
-          supabaseResponse = NextResponse.next({ request });
+          supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
           );

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -865,7 +865,7 @@ export interface BusinessApiKey {
   revoked_at: string | null;
 }
 
-export type MemberRole = 'admin' | 'editor' | 'viewer';
+export type MemberRole = 'admin' | 'editor' | 'viewer' | 'worker';
 export type MemberStatus = 'pending' | 'active';
 
 export interface BusinessMember {

--- a/supabase/migrations/20260430000001_worker_role_and_isolation.sql
+++ b/supabase/migrations/20260430000001_worker_role_and_isolation.sql
@@ -1,0 +1,260 @@
+-- ============================================================================
+-- Worker role + data isolation
+--
+-- Adds 'worker' as a member role. Workers belong to a business but only see
+-- work orders assigned to them; everything else is hidden at the RLS layer so
+-- direct API calls can't leak data either. Member profiles auto-link to auth
+-- users on first login so a worker's existing profile lights up automatically.
+-- Idempotent — safe to re-run.
+-- ============================================================================
+
+-- ─── 1. Allow 'worker' in business_members.role ────────────────────────────
+ALTER TABLE public.business_members
+  DROP CONSTRAINT IF EXISTS business_members_role_check;
+ALTER TABLE public.business_members
+  ADD  CONSTRAINT business_members_role_check
+  CHECK (role IN ('admin', 'editor', 'viewer', 'worker'));
+
+-- ─── 2. Helper: is the caller a worker in this business? ───────────────────
+-- SECURITY DEFINER so the lookup always sees business_members regardless of
+-- the calling user's RLS view (avoids recursion in policies that reference
+-- business_members itself).
+CREATE OR REPLACE FUNCTION public.is_business_worker(biz_id UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.business_members
+    WHERE business_id = biz_id
+      AND user_id     = auth.uid()
+      AND status      = 'active'
+      AND role        = 'worker'
+  );
+$$;
+
+-- ─── 3. Helper: profile ids that belong to the calling worker ──────────────
+-- Used by work_orders policies. SECURITY DEFINER so we can read the profile.
+CREATE OR REPLACE FUNCTION public.my_member_profile_ids(biz_id UUID)
+RETURNS SETOF UUID
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM public.member_profiles
+  WHERE business_id = biz_id
+    AND user_id     = auth.uid();
+$$;
+
+-- ─── 4. Auto-link member_profiles to the caller by matching email ──────────
+-- Mirrors activate_pending_memberships() — call on every dashboard load.
+CREATE OR REPLACE FUNCTION public.link_my_member_profile()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.member_profiles
+  SET    user_id = auth.uid()
+  WHERE  user_id IS NULL
+    AND  lower(email) = lower((SELECT email FROM auth.users WHERE id = auth.uid()));
+END;
+$$;
+
+-- ─── 5. Tighten RLS on sensitive tables: deny workers ──────────────────────
+-- Pattern: drop the existing "owners OR active members" policy and replace
+-- with the same predicate AND NOT is_business_worker(business_id).
+
+-- helper macro is ugly in plain SQL, so we just spell each table out
+
+-- customers ─────
+DROP POLICY IF EXISTS "Business members can manage customers" ON public.customers;
+CREATE POLICY "customers_no_workers" ON public.customers
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- products
+DROP POLICY IF EXISTS "Business members can manage products" ON public.products;
+CREATE POLICY "products_no_workers" ON public.products
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- invoices
+DROP POLICY IF EXISTS "Business members can manage invoices" ON public.invoices;
+CREATE POLICY "invoices_no_workers" ON public.invoices
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- quotes
+DROP POLICY IF EXISTS "Business members can manage quotes" ON public.quotes;
+CREATE POLICY "quotes_no_workers" ON public.quotes
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- payments
+DROP POLICY IF EXISTS "Business members can manage payments" ON public.payments;
+CREATE POLICY "payments_no_workers" ON public.payments
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- reports
+DROP POLICY IF EXISTS "Business members can manage reports" ON public.reports;
+CREATE POLICY "reports_no_workers" ON public.reports
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ─── 6. work_orders: workers see only their own ───────────────────────────
+-- Replace the broad policy with two: a non-worker FOR ALL policy, and a
+-- worker-only FOR SELECT/UPDATE policy that restricts to assigned rows.
+DROP POLICY IF EXISTS "work_orders_all" ON public.work_orders;
+
+CREATE POLICY "work_orders_non_worker_all" ON public.work_orders
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- Workers can SELECT only assigned rows
+CREATE POLICY "work_orders_worker_select" ON public.work_orders
+  FOR SELECT
+  USING (
+    public.is_business_worker(business_id)
+    AND (
+      assigned_to_profile_id IN (SELECT public.my_member_profile_ids(business_id))
+      OR id IN (
+        SELECT work_order_id FROM public.work_order_assignments
+        WHERE member_profile_id IN (SELECT public.my_member_profile_ids(business_id))
+      )
+    )
+  );
+
+-- Workers can UPDATE their assigned rows (for status submit, photos, etc.)
+CREATE POLICY "work_orders_worker_update" ON public.work_orders
+  FOR UPDATE
+  USING (
+    public.is_business_worker(business_id)
+    AND (
+      assigned_to_profile_id IN (SELECT public.my_member_profile_ids(business_id))
+      OR id IN (
+        SELECT work_order_id FROM public.work_order_assignments
+        WHERE member_profile_id IN (SELECT public.my_member_profile_ids(business_id))
+      )
+    )
+  );
+
+-- ─── 7. work_order_assignments: workers see their own rows ─────────────────
+DO $$ BEGIN
+  CREATE POLICY "woa_worker_select" ON public.work_order_assignments
+    FOR SELECT
+    USING (
+      public.is_business_worker(business_id)
+      AND member_profile_id IN (SELECT public.my_member_profile_ids(business_id))
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
Workers belong to a business but only see jobs assigned to them — and the database (not just the app) enforces it so direct API calls can't leak data.

## How a team member sees their work now
1. **Owner adds them via Settings → Team** with the new **Worker** role and their email.
2. They get the existing invite email → register at \`/auth/register\` → land on the dashboard.
3. On every dashboard load \`link_my_member_profile()\` lights up their existing \`member_profiles\` row by matching email — so any work orders you already assigned to that profile become visible immediately.
4. They see a **worker-only dashboard**: today's jobs, upcoming, on-site, done-this-week.
5. Sidebar shows only Dashboard / Work Orders / Schedule / Help.
6. \`/work-orders\` lists only their assigned jobs. RLS would also reject any direct API call to invoices, customers, etc.

## What changed

### Migration \`20260430000001_worker_role_and_isolation.sql\`
- \`business_members.role\` accepts \`'worker'\`
- \`is_business_worker(biz_id)\` and \`my_member_profile_ids(biz_id)\` SECURITY DEFINER helpers
- \`link_my_member_profile()\` RPC (idempotent, mirrors \`activate_pending_memberships\`)
- Customers / products / invoices / quotes / payments / reports policies tightened to deny workers
- work_orders split into a **non-worker FOR ALL** policy and a **worker-only FOR SELECT/UPDATE** policy that requires \`assigned_to_profile_id\` (or a matching \`work_order_assignments\` row) to belong to the caller
- \`work_order_assignments\`: workers see only their own rows

### App
- \`MemberRole\` adds \`'worker'\`; \`ROLE_LABELS\`, \`isWorker\`, \`canSeeFinancials\`, \`isPathAllowedForWorker\` helpers
- Sidebar filters nav items for workers
- Dashboard layout calls \`link_my_member_profile()\` and redirects workers away from non-allowed paths using \`x-pathname\` forwarded by the proxy
- New \`<WorkerDashboard>\` with greeting, 4-up KPI strip, today's jobs, and upcoming list
- Team Settings: 'Worker' selectable with description and lime pill

## ⚠️ Before deploy
Apply the SQL migration in **Supabase → SQL editor** (or via psql against the session pooler). The RLS hardening is the critical half of the security model.

## Test plan
- [ ] Apply the migration on the project DB
- [ ] In Settings → Team add a worker with an email
- [ ] Have them register; confirm they land on the worker dashboard
- [ ] Confirm sidebar hides Invoices / Quotes / Customers / Reports / Team / Agents
- [ ] Manually visit \`/invoices\` as the worker → redirected to \`/work-orders\`
- [ ] Confirm \`/work-orders\` shows only jobs you assigned to them
- [ ] In a separate session as owner, query invoices via the public REST API with the worker's session token — should return empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)