### PR TITLE
fix(build): exclude mobile/ from Next.js typecheck and Vercel upload

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,2 @@
+# Don't upload the React Native app to Vercel — it's deployed separately via Expo/EAS.
+mobile/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,8 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "mobile",
+    "mobile/**"
   ]
 }


### PR DESCRIPTION
Production deploys were failing because Next's tsc runs across the whole repo and mobile/ imports expo-router (only installed in mobile/node_modules). Excludes mobile/ from both tsconfig and .vercelignore.