### PR TITLE
fix(forms): loading state + auto-fill address on customer change

### DIFF
--- a/src/components/addresses/address-select.tsx
+++ b/src/components/addresses/address-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MapPin, Plus } from "@/components/ui/icons";
+import { MapPin, Plus, Loader2 } from "@/components/ui/icons";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -42,23 +42,44 @@ export function AddressSelect({
   sites: sitesProp,
   label = "Address",
 }: AddressSelectProps) {
-  const [sites, setSites] = useState<Site[]>(sitesProp ?? []);
+  const [sites, setSites]       = useState<Site[]>(sitesProp ?? []);
+  const [loading, setLoading]   = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
 
   // Fetch sites when the customer changes (unless caller passes them).
   useEffect(() => {
-    if (sitesProp) { setSites(sitesProp); return; }
-    if (!customer?.id) { setSites([]); return; }
+    if (sitesProp) { setSites(sitesProp); setLoading(false); return; }
+    if (!customer?.id) { setSites([]); setLoading(false); return; }
+
     let cancelled = false;
+    setLoading(true);
     (async () => {
       try {
         const data = await getSitesForAccount(customer.id);
-        if (!cancelled) setSites(data);
+        if (cancelled) return;
+        setSites(data);
+
+        // If the user hasn't picked an address yet, auto-fill with the most
+        // sensible default so they don't reach for "Custom address" while
+        // we're still resolving real ones. Prefer primary, else single site.
+        const noUserPick = !value.property_address && !value.site_id;
+        if (noUserPick) {
+          const customerAddr = customerAddress(customer);
+          if (customerAddr) {
+            onChange({ site_id: null, property_address: customerAddr });
+          } else if (data.length === 1) {
+            onChange({ site_id: data[0].id, property_address: siteAddress(data[0]) });
+          }
+        }
       } catch {
         if (!cancelled) setSites([]);
+      } finally {
+        if (!cancelled) setLoading(false);
       }
     })();
     return () => { cancelled = true; };
+    // value is intentionally excluded — we only auto-fill on customer change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customer?.id, sitesProp]);
 
   const customerAddr = customer ? customerAddress(customer) : "";
@@ -108,12 +129,24 @@ export function AddressSelect({
 
   return (
     <div className="space-y-1.5">
-      <Label className="flex items-center gap-1"><MapPin className="h-3.5 w-3.5" /> {label}</Label>
+      <Label className="flex items-center gap-1.5">
+        <MapPin className="h-3.5 w-3.5" /> {label}
+        {loading && (
+          <span className="ml-1 inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading addresses…
+          </span>
+        )}
+      </Label>
       <SearchableSelect
         items={items}
         value={selectedKey}
         onValueChange={handleSelect}
-        placeholder={customer ? "Select address" : "Select a customer first"}
+        placeholder={
+          !customer ? "Select a customer first"
+          : loading  ? "Loading addresses…"
+          : "Select address"
+        }
         searchPlaceholder="Search addresses..."
         disabled={!customer}
         allowNone

--- a/src/components/work-orders/work-order-new-client.tsx
+++ b/src/components/work-orders/work-order-new-client.tsx
@@ -63,6 +63,7 @@ export function WorkOrderNewClient({
   const [sites, setSites] = useState<Site[]>([]);
   const [contacts, setContacts] = useState<AccountContact[]>([]);
   const [billingProfiles, setBillingProfiles] = useState<BillingProfile[]>([]);
+  const [accountLoading, setAccountLoading] = useState(false);
   const [siteId, setSiteId] = useState<string>(defaultSiteId ?? "");
   const [bookerContactId, setBookerContactId] = useState<string>("");
   const [onsiteContactId, setOnsiteContactId] = useState<string>("");
@@ -75,8 +76,10 @@ export function WorkOrderNewClient({
     if (!accountId) {
       setSites([]); setContacts([]); setBillingProfiles([]);
       setSiteId(""); setBookerContactId(""); setOnsiteContactId(""); setBillingProfileId("");
+      setAccountLoading(false);
       return;
     }
+    setAccountLoading(true);
     (async () => {
       try {
         const [s, c, b] = await Promise.all([
@@ -101,6 +104,8 @@ export function WorkOrderNewClient({
         if (!siteId && s.length === 1) setSiteId(s[0].id);
       } catch (e) {
         console.error("Failed to load account context", e);
+      } finally {
+        if (!cancelled) setAccountLoading(false);
       }
     })();
     return () => { cancelled = true; };
@@ -227,6 +232,13 @@ export function WorkOrderNewClient({
                 label="Property address"
               />
             </div>
+
+            {accountSelected && accountLoading && contacts.length === 0 && billingProfiles.length === 0 && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground rounded-xl bg-muted/40 border border-border px-3 py-2.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Loading customer details…
+              </div>
+            )}
 
             {accountSelected && contacts.length > 0 && (
               <>


### PR DESCRIPTION
Quote / invoice / work-order forms were silently 'empty' between selecting a customer and the address fetch resolving. Adds a Loader2 hint + 'Loading addresses…' placeholder, and auto-fills the customer's primary address (or the only site) once data lands. Also adds an inline 'Loading customer details…' pill on the new-WO form while contacts/billing are fetching.