### PR TITLE
feat(design): adopt the Connected Hub look

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,56 +121,57 @@
   }
 }
 
-/* ─── Flux theme (active) ─────────────────────────────────────
-   Cream-lime canvas, white rounded cards, lime + lavender accents.
-   Inspired by the flux dashboard reference. Active globally via
+/* ─── Connected Hub theme (active) ────────────────────────────
+   Warm off-white canvas, pure white cards, deep-teal accent —
+   modern SaaS for trades contractors. Adapted from the
+   Connected Hub design handoff. Active globally via
    <html data-theme="console"> in app/layout.tsx.
 */
 [data-theme="console"] {
-  /* Light: cream-lime canvas, pure white cards */
-  --background: 73 45% 86%;          /* #eaf0c8 */
-  --foreground: 0 0% 8%;              /* near-black */
-  --card: 0 0% 100%;                  /* pure white */
-  --card-foreground: 0 0% 8%;
+  /* Light: warm off-white canvas, white cards */
+  --background: 60 9% 98%;            /* #fafaf7 */
+  --foreground: 60 5% 9%;             /* #1a1a17 */
+  --card: 0 0% 100%;
+  --card-foreground: 60 5% 9%;
   --popover: 0 0% 100%;
-  --popover-foreground: 0 0% 8%;
-  --primary: 0 0% 9%;                 /* near-black CTAs */
+  --popover-foreground: 60 5% 9%;
+  --primary: 191 38% 36%;             /* deep teal — oklch(0.55 0.08 195) ish */
   --primary-foreground: 0 0% 100%;
-  --secondary: 0 0% 96%;
-  --secondary-foreground: 0 0% 9%;
-  --muted: 0 0% 96%;
-  --muted-foreground: 0 0% 42%;
-  --accent: 73 78% 60%;               /* lime #c4eb4a */
-  --accent-foreground: 0 0% 9%;
-  --destructive: 0 72% 51%;
+  --secondary: 50 22% 95%;            /* surface-2 */
+  --secondary-foreground: 60 5% 9%;
+  --muted: 50 22% 95%;
+  --muted-foreground: 50 4% 40%;      /* #6b6a62 */
+  --accent: 191 38% 36%;              /* same teal as primary */
+  --accent-foreground: 0 0% 100%;
+  --destructive: 18 75% 50%;          /* status-overdue terracotta */
   --destructive-foreground: 0 0% 100%;
-  --border: 0 0% 92%;                 /* hairline */
-  --input: 0 0% 92%;
-  --ring: 73 78% 60%;
-  --radius: 1rem;                     /* big-bubble defaults */
+  --border: 50 17% 88%;               /* #e5e3d9 */
+  --input: 50 17% 88%;
+  --ring: 191 38% 36%;
+  --radius: 0.625rem;                 /* 10px → matches the prototype's --r-md */
 }
 
 .dark [data-theme="console"],
 [data-theme="console"].dark {
-  --background: 0 0% 6%;
-  --foreground: 0 0% 95%;
-  --card: 0 0% 9%;
-  --card-foreground: 0 0% 95%;
-  --popover: 0 0% 9%;
-  --popover-foreground: 0 0% 95%;
-  --primary: 0 0% 96%;
-  --primary-foreground: 0 0% 9%;
-  --secondary: 0 0% 14%;
-  --secondary-foreground: 0 0% 95%;
-  --muted: 0 0% 14%;
-  --muted-foreground: 0 0% 65%;
-  --accent: 73 78% 60%;
-  --accent-foreground: 0 0% 9%;
-  --destructive: 0 72% 55%;
+  --background: 60 4% 8%;
+  --foreground: 50 17% 92%;
+  --card: 60 4% 11%;
+  --card-foreground: 50 17% 92%;
+  --popover: 60 4% 11%;
+  --popover-foreground: 50 17% 92%;
+  --primary: 191 50% 55%;             /* lighter teal for dark mode contrast */
+  --primary-foreground: 60 4% 8%;
+  --secondary: 60 4% 16%;
+  --secondary-foreground: 50 17% 92%;
+  --muted: 60 4% 16%;
+  --muted-foreground: 50 8% 65%;
+  --accent: 191 50% 55%;
+  --accent-foreground: 60 4% 8%;
+  --destructive: 18 75% 55%;
   --destructive-foreground: 0 0% 100%;
-  --border: 0 0% 16%;
-  --input: 0 0% 16%;
-  --ring: 73 78% 60%;
+  --border: 60 4% 19%;
+  --input: 60 4% 19%;
+  --ring: 191 50% 55%;
 }
 
 [data-theme="console"] {
@@ -268,6 +269,10 @@
 }
 
 /* ─── Accent colour overrides ─────────────────────────────── */
+:root[data-accent="teal"] {
+  --primary: 191 38% 36%; --ring: 191 38% 36%; --accent: 191 38% 36%;
+  --sidebar-primary: 191 50% 45%; --sidebar-ring: 191 50% 45%;
+}
 :root[data-accent="blue"] {
   --primary: 221 83% 53%; --ring: 221 83% 53%;
   --sidebar-primary: 217 91% 60%; --sidebar-ring: 217 91% 60%;

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -15,24 +15,41 @@ import Image from "next/image";
 import { BusinessSwitcher } from "@/components/business/business-switcher";
 
 type NavItem = { label: string; href: string; icon: typeof LayoutDashboard; worker?: boolean };
+type NavSection = { section: string; items: NavItem[] };
 
-const navItems: NavItem[] = [
-  { label: "Dashboard",   href: "/dashboard",   icon: LayoutDashboard, worker: true  },
-  { label: "Invoices",    href: "/invoices",    icon: FileText                       },
-  { label: "Quotes",      href: "/quotes",      icon: FileCheck                      },
-  { label: "Customers",   href: "/customers",   icon: Users                          },
-  { label: "Products",    href: "/products",    icon: Package                        },
-  { label: "Tasks",       href: "/tasks",       icon: Columns3                       },
-  { label: "Work Orders", href: "/work-orders", icon: Wrench,         worker: true  },
-  { label: "Schedule",    href: "/schedule",    icon: CalendarDays,   worker: true  },
-  { label: "Recurring",   href: "/recurring",   icon: Repeat                         },
-  { label: "Leads",       href: "/leads",       icon: UserPlus                       },
-  { label: "Contacts",    href: "/contacts",    icon: Users2                         },
-  { label: "Reports",     href: "/reports",     icon: ClipboardList                  },
-  { label: "Messages",    href: "/messages",    icon: MessageSquare                  },
-  { label: "Team",        href: "/team",        icon: Users2                         },
-  { label: "Agents",      href: "/agents",      icon: Bot                            },
-  { label: "Help",        href: "/help",        icon: HelpCircle,     worker: true  },
+const navSections: NavSection[] = [
+  { section: "Workspace", items: [
+    { label: "Dashboard",  href: "/dashboard",  icon: LayoutDashboard, worker: true },
+    { label: "Messages",   href: "/messages",   icon: MessageSquare                 },
+    { label: "Tasks",      href: "/tasks",      icon: Columns3                      },
+  ]},
+  { section: "Sales", items: [
+    { label: "Leads",      href: "/leads",      icon: UserPlus                      },
+    { label: "Quotes",     href: "/quotes",     icon: FileCheck                     },
+    { label: "Invoices",   href: "/invoices",   icon: FileText                      },
+    { label: "Recurring",  href: "/recurring",  icon: Repeat                        },
+  ]},
+  { section: "Service", items: [
+    { label: "Work Orders", href: "/work-orders", icon: Wrench,        worker: true },
+    { label: "Schedule",    href: "/schedule",    icon: CalendarDays,  worker: true },
+  ]},
+  { section: "Contacts", items: [
+    { label: "Customers",  href: "/customers",  icon: Users                         },
+    { label: "Contacts",   href: "/contacts",   icon: Users2                        },
+  ]},
+  { section: "Catalog", items: [
+    { label: "Products",   href: "/products",   icon: Package                       },
+  ]},
+  { section: "Workforce", items: [
+    { label: "Team",       href: "/team",       icon: Users2                        },
+    { label: "Agents",     href: "/agents",     icon: Bot                           },
+  ]},
+  { section: "Insights", items: [
+    { label: "Reports",    href: "/reports",    icon: ClipboardList                 },
+  ]},
+  { section: "Account", items: [
+    { label: "Help",       href: "/help",       icon: HelpCircle,    worker: true   },
+  ]},
 ];
 
 interface AppSidebarProps {
@@ -46,7 +63,9 @@ interface AppSidebarProps {
 export function AppSidebar({ business, businesses, userRole, open, onClose }: AppSidebarProps) {
   const pathname = usePathname();
   const workerView = isWorker(userRole);
-  const visibleNav = workerView ? navItems.filter((n) => n.worker) : navItems;
+  const visibleSections = navSections
+    .map((s) => ({ ...s, items: workerView ? s.items.filter((i) => i.worker) : s.items }))
+    .filter((s) => s.items.length > 0);
 
   const isActive = (href: string) =>
     href === "/dashboard" ? pathname === "/dashboard" : pathname.startsWith(href);
@@ -100,64 +119,68 @@ export function AppSidebar({ business, businesses, userRole, open, onClose }: Ap
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 px-2 py-3 overflow-y-auto">
-        <p className="px-2 mb-2 text-[10px] font-semibold uppercase tracking-widest text-sidebar-foreground/40">
-          Menu
-        </p>
-        <ul className="space-y-0.5">
-          {visibleNav.map((item, i) => (
-            <li key={item.href}>
-              <motion.div
-                initial={{ opacity: 0, x: -12 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: 0.22, delay: i * 0.04, ease: "easeOut" }}
-              >
-                <Link
-                  href={item.href}
-                  onClick={onClose}
-                  className={cn(
-                    "relative flex items-center gap-3 px-3.5 py-2.5 rounded-full text-sm transition-colors duration-150",
-                    isActive(item.href)
-                      ? "text-sidebar-foreground font-semibold"
-                      : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/60"
-                  )}
+      <nav className="flex-1 px-3 py-2 overflow-y-auto">
+        {visibleSections.map((group, gi) => (
+          <div key={group.section} className={cn("flex flex-col gap-px", gi > 0 && "mt-2")}>
+            <p className="px-2 pt-2.5 pb-1 text-[10.5px] font-semibold uppercase tracking-[0.06em] text-sidebar-foreground/45">
+              {group.section}
+            </p>
+            {group.items.map((item, i) => {
+              const active = isActive(item.href);
+              return (
+                <motion.div
+                  key={item.href}
+                  initial={{ opacity: 0, x: -8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.18, delay: (gi * 4 + i) * 0.02, ease: "easeOut" }}
                 >
-                  {isActive(item.href) && (
-                    <motion.div
-                      layoutId="sidebar-active"
-                      className="absolute inset-0 bg-sidebar-accent rounded-full ring-1 ring-white/5"
-                      transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                    />
-                  )}
-                  <item.icon className={cn(
-                    "w-4 h-4 relative z-10 flex-shrink-0",
-                    isActive(item.href) ? "text-sidebar-foreground" : "text-sidebar-foreground/50"
-                  )} />
-                  <span className="relative z-10">{item.label}</span>
-                </Link>
-              </motion.div>
-            </li>
-          ))}
-        </ul>
+                  <Link
+                    href={item.href}
+                    onClick={onClose}
+                    className={cn(
+                      "relative flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-150",
+                      active
+                        ? "bg-sidebar-accent text-sidebar-foreground font-semibold"
+                        : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium"
+                    )}
+                  >
+                    {active && (
+                      <motion.span
+                        layoutId="sidebar-active-rail"
+                        className="absolute -left-2 top-1.5 bottom-1.5 w-0.5 rounded-full bg-sidebar-primary"
+                        transition={{ type: "spring", stiffness: 380, damping: 30 }}
+                      />
+                    )}
+                    <item.icon className={cn(
+                      "w-4 h-4 flex-shrink-0",
+                      active ? "text-sidebar-foreground" : "text-sidebar-foreground/55"
+                    )} />
+                    <span>{item.label}</span>
+                  </Link>
+                </motion.div>
+              );
+            })}
+          </div>
+        ))}
       </nav>
 
       {/* Footer */}
-      <div className="px-2 pb-4 pt-3 space-y-2">
+      <div className="px-3 pb-3 pt-2 border-t border-sidebar-border space-y-px">
         {canManageSettings(userRole) && (
           <Link
             href="/settings"
             onClick={onClose}
             className={cn(
-              "relative flex items-center gap-3 px-3.5 py-2.5 rounded-full text-sm transition-colors duration-150",
+              "relative flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-150",
               pathname.startsWith("/settings")
-                ? "text-sidebar-foreground font-semibold"
-                : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/60"
+                ? "bg-sidebar-accent text-sidebar-foreground font-semibold"
+                : "text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium"
             )}
           >
             {pathname.startsWith("/settings") && (
-              <motion.div
-                layoutId="sidebar-active"
-                className="absolute inset-0 bg-sidebar-accent rounded-full ring-1 ring-white/5"
+              <motion.span
+                layoutId="sidebar-active-rail"
+                className="absolute -left-2 top-1.5 bottom-1.5 w-0.5 rounded-full bg-sidebar-primary"
                 transition={{ type: "spring", stiffness: 380, damping: 30 }}
               />
             )}

--- a/src/components/layout/appearance-provider.tsx
+++ b/src/components/layout/appearance-provider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 
 export const ACCENT_PRESETS = [
+  { key: "teal",    label: "Teal",    hex: "#3a847e" },
   { key: "blue",    label: "Blue",    hex: "#2563eb" },
   { key: "violet",  label: "Violet",  hex: "#7c3aed" },
   { key: "emerald", label: "Emerald", hex: "#059669" },
@@ -23,6 +24,24 @@ export const PATTERN_PRESETS = [
 // sidebarBg / sidebarFg / sidebarAccent used only for preview rendering —
 // the real values live in CSS. All combos pass WCAG AA (≥4.5:1).
 export const SIDEBAR_THEMES = [
+  {
+    key: "light",
+    label: "Light",
+    dark: false,
+    sidebarBg: "#ffffff",
+    sidebarFg: "#1a1a17",
+    sidebarAccent: "#f5f4ef",
+    dot: "#3a847e",
+  },
+  {
+    key: "soft",
+    label: "Soft",
+    dark: false,
+    sidebarBg: "#fafaf7",
+    sidebarFg: "#1a1a17",
+    sidebarAccent: "#ecebe4",
+    dot: "#3a847e",
+  },
   {
     key: "dark-navy",
     label: "Dark Navy",
@@ -86,24 +105,6 @@ export const SIDEBAR_THEMES = [
     sidebarAccent: "#2d3748",
     dot: "#94a3b8",
   },
-  {
-    key: "light",
-    label: "Light",
-    dark: false,
-    sidebarBg: "#ffffff",
-    sidebarFg: "#0f172a",
-    sidebarAccent: "#f1f5f9",
-    dot: "#2563eb",
-  },
-  {
-    key: "soft",
-    label: "Soft",
-    dark: false,
-    sidebarBg: "#f0f4f8",
-    sidebarFg: "#1e293b",
-    sidebarAccent: "#e2e8f0",
-    dot: "#7c3aed",
-  },
 ] as const;
 
 interface AppearanceContextValue {
@@ -116,9 +117,9 @@ interface AppearanceContextValue {
 }
 
 const AppearanceContext = createContext<AppearanceContextValue>({
-  accentColor: "blue",
+  accentColor: "teal",
   bgPattern: "none",
-  sidebarTheme: "dark-navy",
+  sidebarTheme: "light",
   setAccentColor: () => {},
   setBgPattern: () => {},
   setSidebarTheme: () => {},
@@ -132,7 +133,7 @@ export function AppearanceProvider({
   children,
   accentColor: initialAccent = "blue",
   bgPattern: initialPattern = "none",
-  sidebarTheme: initialTheme = "dark-navy",
+  sidebarTheme: initialTheme = "light",
 }: {
   children: React.ReactNode;
   accentColor?: string;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,25 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:opacity-90",
+        default: "bg-primary text-primary-foreground hover:bg-[hsl(var(--primary)/0.92)]",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-black/10 bg-card hover:bg-muted",
+          "border border-border bg-card hover:bg-muted",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-muted hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-5 py-2",
-        sm: "h-9 px-4",
-        lg: "h-11 px-7",
-        icon: "h-10 w-10",
+        default: "h-9 px-3 py-1.5",
+        sm:      "h-8 px-2.5 text-xs",
+        lg:      "h-10 px-4",
+        icon:    "h-9 w-9",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-2xl border border-black/5 bg-card text-card-foreground",
+      "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-xl border border-input bg-card px-3.5 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-card px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-xl border border-input bg-card px-3.5 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-card px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-2xl border border-input bg-card px-3.5 py-2.5 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-card px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}


### PR DESCRIPTION
Picks up the design handoff: warm off-white canvas, deep-teal accent, grouped sidebar with section labels and a teal left-rail active state, default sidebar flipped to 'light'. Existing accent / sidebar-theme / bg-pattern customisation is preserved — the prototype's tweaks panel was redundant and skipped.