### PR TITLE
feat(design): Connected Hub patterns — dashboard rebuild + table-style lists

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -333,3 +333,388 @@
     linear-gradient(90deg, hsl(var(--border) / 0.25) 1px, transparent 1px);
   background-size: 64px 64px, 64px 64px, 16px 16px, 16px 16px;
 }
+
+/* ─── Connected Hub utility classes ────────────────────────────
+   Scoped utility set lifted from the design handoff; bound to our
+   HSL token vars so accent / sidebar / theme customisation drives
+   everything. Pages opt-in by adding the class names below.
+*/
+
+/* Page header */
+.ch-page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.ch-page-title {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: hsl(var(--foreground));
+  margin: 0;
+}
+.ch-page-subtitle {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+  margin: 4px 0 0;
+}
+.ch-page-actions { display: flex; align-items: center; gap: 8px; }
+
+/* KPI grid + stat */
+.ch-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.ch-stat {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ch-stat-label {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ch-stat-value {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--foreground));
+}
+.ch-stat-meta {
+  font-size: 11.5px;
+  color: hsl(var(--muted-foreground));
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ch-stat-delta { font-weight: 600; font-variant-numeric: tabular-nums; }
+.ch-stat-delta.up   { color: hsl(150 60% 38%); }
+.ch-stat-delta.down { color: hsl(0 70% 50%); }
+
+/* Tables */
+.ch-table-wrap {
+  overflow-x: auto;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 14px;
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.04);
+}
+.ch-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.ch-table th {
+  text-align: left;
+  padding: 10px 16px;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid hsl(var(--border));
+  background: hsl(var(--muted));
+  white-space: nowrap;
+}
+.ch-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid hsl(var(--border));
+  vertical-align: middle;
+}
+.ch-table tr:last-child td { border-bottom: none; }
+.ch-table tbody tr {
+  transition: background 0.08s;
+  cursor: pointer;
+}
+.ch-table tbody tr:hover { background: hsl(var(--muted) / 0.6); }
+.ch-table .num   { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--font-mono, ui-monospace, monospace); }
+.ch-table .ref   { font-family: var(--font-mono, ui-monospace, monospace); font-size: 12px; color: hsl(var(--muted-foreground)); }
+
+/* Status pills */
+.ch-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.ch-pill::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.ch-pill.no-dot::before { display: none; }
+.ch-pill.paid,
+.ch-pill.completed,
+.ch-pill.accepted   { background: hsl(150 50% 95%); color: hsl(150 60% 32%); }
+.ch-pill.pending,
+.ch-pill.in-progress { background: hsl(40 80% 95%); color: hsl(35 75% 38%); }
+.ch-pill.overdue,
+.ch-pill.cancelled  { background: hsl(0 70% 96%); color: hsl(0 70% 45%); }
+.ch-pill.draft      { background: hsl(220 14% 95%); color: hsl(220 10% 40%); }
+.ch-pill.scheduled  { background: hsl(280 40% 96%); color: hsl(280 40% 40%); }
+.ch-pill.sent       { background: hsl(var(--primary) / 0.12); color: hsl(var(--primary)); }
+.ch-pill.partial    { background: hsl(40 80% 95%); color: hsl(35 75% 38%); }
+.ch-pill.declined,
+.ch-pill.rejected   { background: hsl(220 14% 95%); color: hsl(220 10% 40%); }
+.ch-pill.new        { background: hsl(var(--primary) / 0.12); color: hsl(var(--primary)); }
+.ch-pill.contacted  { background: hsl(220 80% 95%); color: hsl(220 70% 45%); }
+.ch-pill.quoted     { background: hsl(280 40% 96%); color: hsl(280 40% 40%); }
+.ch-pill.won        { background: hsl(150 50% 95%); color: hsl(150 60% 32%); }
+.ch-pill.lost       { background: hsl(0 70% 96%); color: hsl(0 70% 45%); }
+.ch-pill.active     { background: hsl(150 50% 95%); color: hsl(150 60% 32%); }
+.ch-pill.archived   { background: hsl(220 14% 95%); color: hsl(220 10% 40%); }
+
+/* Tabs */
+.ch-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid hsl(var(--border));
+  margin-bottom: 16px;
+  overflow-x: auto;
+}
+.ch-tab {
+  padding: 9px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.12s, border-color 0.12s;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  cursor: pointer;
+}
+.ch-tab:hover { color: hsl(var(--foreground)); }
+.ch-tab.active {
+  color: hsl(var(--foreground));
+  border-bottom-color: hsl(var(--primary));
+  font-weight: 600;
+}
+.ch-tab .count {
+  font-size: 11px;
+  background: hsl(var(--muted));
+  padding: 1px 6px;
+  border-radius: 8px;
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
+}
+
+/* Filter chips */
+.ch-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.ch-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  font-weight: 500;
+  transition: background 0.12s, border-color 0.12s;
+  cursor: pointer;
+}
+.ch-filter-chip:hover { background: hsl(var(--muted)); }
+.ch-filter-chip.active {
+  background: hsl(var(--primary) / 0.1);
+  border-color: hsl(var(--primary) / 0.4);
+  color: hsl(var(--primary));
+}
+
+/* Bar chart */
+.ch-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 140px;
+  padding: 8px 0;
+}
+.ch-bar-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.ch-bar {
+  width: 100%;
+  max-width: 32px;
+  background: hsl(var(--muted));
+  border-radius: 4px 4px 0 0;
+  transition: background 0.18s;
+}
+.ch-bar.primary { background: hsl(var(--primary)); }
+.ch-bar.primary:hover { background: hsl(var(--primary) / 0.85); }
+.ch-bar-label {
+  font-size: 10.5px;
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
+}
+
+/* Sparkline */
+.ch-spark      { stroke: hsl(var(--primary)); stroke-width: 2; fill: none; }
+.ch-spark-fill { fill: hsl(var(--primary)); opacity: 0.08; }
+
+/* Schedule items */
+.ch-schedule-item {
+  display: grid;
+  grid-template-columns: 60px 4px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 4px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.08s;
+}
+.ch-schedule-item:hover { background: hsl(var(--muted) / 0.6); }
+.ch-schedule-time {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+.ch-schedule-bar {
+  width: 4px;
+  height: 32px;
+  border-radius: 2px;
+  background: hsl(var(--primary));
+}
+.ch-schedule-content { min-width: 0; }
+.ch-schedule-title { font-size: 13px; font-weight: 600; }
+.ch-schedule-meta {
+  font-size: 11.5px;
+  color: hsl(var(--muted-foreground));
+  margin-top: 2px;
+}
+.ch-schedule-day {
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 4px 0;
+}
+
+/* Activity items */
+.ch-activity-item {
+  display: flex;
+  gap: 10px;
+  padding: 8px 4px;
+  align-items: flex-start;
+}
+.ch-activity-icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.ch-activity-content { font-size: 12.5px; min-width: 0; }
+.ch-activity-meta {
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+  margin-top: 2px;
+}
+
+/* Quick actions */
+.ch-quick-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.ch-quick-action {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  background: hsl(var(--muted) / 0.4);
+  border: 1px solid transparent;
+  border-radius: 10px;
+  text-align: left;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  width: 100%;
+}
+.ch-quick-action:hover {
+  background: hsl(var(--card));
+  border-color: hsl(var(--border));
+}
+.ch-quick-action-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: hsl(var(--primary) / 0.12);
+  color: hsl(var(--primary));
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.ch-quick-action-meta {
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+  font-weight: 400;
+  margin-top: 2px;
+}
+
+/* 2-col grid for dashboard */
+.ch-grid-2 {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 16px;
+}
+@media (max-width: 1100px) { .ch-grid-2 { grid-template-columns: 1fr; } }
+
+/* Empty state */
+.ch-empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+}
+.ch-empty h4 { color: hsl(var(--foreground)); margin: 0 0 6px; font-size: 14px; }
+.ch-empty p  { margin: 0 0 12px; font-size: 13px; }
+
+/* Mono utility for tabular figures */
+.ch-mono { font-family: var(--font-mono, ui-monospace, monospace); font-feature-settings: "tnum"; }
+.ch-tnum { font-variant-numeric: tabular-nums; }

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -1,47 +1,61 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Plus, Search, Users, Mail, Phone, Building2, MoreHorizontal, Archive, Trash2, Upload } from "@/components/ui/icons";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/layout/page-header";
 import { deleteCustomer, updateCustomer, bulkImportCustomers } from "@/lib/actions/customers";
 import { BulkImportModal } from "@/components/shared/bulk-import-modal";
 import type { Customer } from "@/types/database";
 
 const CUSTOMER_COLUMNS = [
-  { key: "name", label: "Name", required: true },
-  { key: "email", label: "Email" },
-  { key: "phone", label: "Phone" },
-  { key: "company", label: "Company" },
-  { key: "address", label: "Address" },
-  { key: "city", label: "City" },
+  { key: "name",     label: "Name", required: true },
+  { key: "email",    label: "Email" },
+  { key: "phone",    label: "Phone" },
+  { key: "company",  label: "Company" },
+  { key: "address",  label: "Address" },
+  { key: "city",     label: "City" },
   { key: "postcode", label: "Postcode" },
-  { key: "country", label: "Country" },
-  { key: "notes", label: "Notes" },
+  { key: "country",  label: "Country" },
+  { key: "notes",    label: "Notes" },
 ] as const;
 
+function initials(name: string) {
+  return name.split(/\s+/).map((p) => p[0]).filter(Boolean).join("").toUpperCase().slice(0, 2);
+}
+
 export function CustomersClient({ customers: initial }: { customers: Customer[] }) {
+  const router = useRouter();
   const [customers, setCustomers] = useState(initial);
   const [search, setSearch] = useState("");
+  const [tab, setTab] = useState<"active" | "archived" | "all">("active");
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
 
-  const filtered = customers.filter((c) =>
-    `${c.name} ${c.email} ${c.company}`.toLowerCase().includes(search.toLowerCase())
-  );
+  const filtered = useMemo(() => customers.filter((c) => {
+    const matchSearch = `${c.name} ${c.email ?? ""} ${c.company ?? ""}`.toLowerCase().includes(search.toLowerCase());
+    const matchTab    = tab === "all" || (tab === "active" ? !c.archived : !!c.archived);
+    return matchSearch && matchTab;
+  }), [customers, search, tab]);
+
+  const counts = useMemo(() => ({
+    all:      customers.length,
+    active:   customers.filter((c) => !c.archived).length,
+    archived: customers.filter((c) =>  c.archived).length,
+    withEmail: customers.filter((c) => !!c.email).length,
+    withCompany: customers.filter((c) => !!c.company).length,
+  }), [customers]);
 
   const handleArchive = async (id: string) => {
     try {
       await updateCustomer(id, { archived: true });
-      setCustomers((prev) => prev.filter((c) => c.id !== id));
+      setCustomers((prev) => prev.map((c) => c.id === id ? { ...c, archived: true } : c));
       toast.success("Customer archived");
     } catch { toast.error("Failed to archive"); }
   };
@@ -57,93 +71,157 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
   };
 
   return (
-    <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Customers</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{customers.length} customer{customers.length !== 1 ? "s" : ""}</p>
-        </div>
-        <div className="flex items-center gap-2 w-full sm:w-auto">
-          <Button size="sm" variant="outline" className="gap-1.5 flex-1 sm:flex-initial" onClick={() => setShowImport(true)}>
-            <Upload className="w-3.5 h-3.5" /> Import CSV
-          </Button>
-          <Link href="/customers/new" className="flex-1 sm:flex-initial">
-            <Button size="sm" className="gap-1.5 w-full sm:w-auto"><Plus className="w-3.5 h-3.5" /> Add customer</Button>
-          </Link>
-        </div>
-      </motion.div>
+    <div>
+      <PageHeader
+        title="Customers"
+        subtitle={`${counts.active} active · ${counts.archived} archived`}
+        actions={
+          <>
+            <button
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+              onClick={() => setShowImport(true)}
+            >
+              <Upload className="w-3.5 h-3.5" /> Import CSV
+            </button>
+            <Link href="/customers/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+                <Plus className="w-3.5 h-3.5" /> Add customer
+              </button>
+            </Link>
+          </>
+        }
+      />
 
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <Input className="pl-9" placeholder="Search customers..." value={search} onChange={(e) => setSearch(e.target.value)} />
+      <div className="ch-stat-grid">
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Users className="w-3.5 h-3.5" /><span>Total</span></div>
+          <div className="ch-stat-value">{counts.all}</div>
+          <div className="ch-stat-meta">{counts.active} active</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Mail className="w-3.5 h-3.5" /><span>With email</span></div>
+          <div className="ch-stat-value">{counts.withEmail}</div>
+          <div className="ch-stat-meta">reachable</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Building2 className="w-3.5 h-3.5" /><span>Companies</span></div>
+          <div className="ch-stat-value">{counts.withCompany}</div>
+          <div className="ch-stat-meta">B2B accounts</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Archive className="w-3.5 h-3.5" /><span>Archived</span></div>
+          <div className="ch-stat-value">{counts.archived}</div>
+          <div className="ch-stat-meta">hidden by default</div>
+        </div>
+      </div>
+
+      <div className="ch-tabs">
+        <button className={`ch-tab ${tab === "active"   ? "active" : ""}`} onClick={() => setTab("active")}>
+          Active <span className="count">{counts.active}</span>
+        </button>
+        <button className={`ch-tab ${tab === "archived" ? "active" : ""}`} onClick={() => setTab("archived")}>
+          Archived <span className="count">{counts.archived}</span>
+        </button>
+        <button className={`ch-tab ${tab === "all"      ? "active" : ""}`} onClick={() => setTab("all")}>
+          All <span className="count">{counts.all}</span>
+        </button>
+      </div>
+
+      <div className="ch-filter-bar">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input placeholder="Search customers..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-9" />
+        </div>
       </div>
 
       {filtered.length === 0 ? (
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center py-20">
-          <Users className="w-12 h-12 text-muted-foreground/30 mx-auto mb-3" />
-          <h3 className="font-medium mb-1">No customers found</h3>
-          <p className="text-sm text-muted-foreground mb-4">{search ? "Try a different search" : "Add your first customer to get started"}</p>
-          {!search && <Link href="/customers/new"><Button size="sm">Add customer</Button></Link>}
-        </motion.div>
+        <div className="ch-empty">
+          <Users className="w-10 h-10 text-muted-foreground/30 mx-auto mb-3" />
+          <h4>No customers found</h4>
+          <p>{search ? "Try a different search." : "Add your first customer to get started."}</p>
+          {!search && (
+            <Link href="/customers/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium">
+                <Plus className="w-3 h-3" /> Add customer
+              </button>
+            </Link>
+          )}
+        </div>
       ) : (
-        <motion.div className="grid gap-3" initial="hidden" animate="show" variants={{ show: { transition: { staggerChildren: 0.05 } } }}>
-          {filtered.map((customer) => (
-            <motion.div key={customer.id} variants={{ hidden: { opacity: 0, y: 12 }, show: { opacity: 1, y: 0 } }}>
-              <Card className="hover:shadow-sm transition-shadow">
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-4">
-                    <Avatar className="h-10 w-10 flex-shrink-0">
-                      <AvatarFallback className="bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 font-medium text-sm">
-                        {customer.name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="flex-1 min-w-0">
-                      <Link href={`/customers/${customer.id}`} className="font-medium hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                        {customer.name}
-                      </Link>
-                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1">
+        <motion.div
+          initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}
+          className="ch-table-wrap"
+        >
+          <table className="ch-table">
+            <thead>
+              <tr>
+                <th>Customer</th>
+                <th>Email</th>
+                <th>Phone</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((customer) => (
+                <tr key={customer.id} onClick={() => router.push(`/customers/${customer.id}`)}>
+                  <td>
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="w-7 h-7 rounded-full bg-[hsl(var(--primary)/0.12)] text-[hsl(var(--primary))] flex items-center justify-center font-semibold text-[11px] flex-shrink-0">
+                        {initials(customer.name)}
+                      </div>
+                      <div className="min-w-0">
+                        <div className="font-semibold truncate">{customer.name}</div>
                         {customer.company && (
-                          <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <Building2 className="w-3 h-3" />{customer.company}
-                          </span>
-                        )}
-                        {customer.email && (
-                          <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <Mail className="w-3 h-3" />{customer.email}
-                          </span>
-                        )}
-                        {customer.phone && (
-                          <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <Phone className="w-3 h-3" />{customer.phone}
-                          </span>
+                          <div className="text-[11.5px] text-muted-foreground truncate inline-flex items-center gap-1">
+                            <Building2 className="w-3 h-3" /> {customer.company}
+                          </div>
                         )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-2 flex-shrink-0">
-                      {customer.archived && <Badge variant="secondary" className="text-xs">Archived</Badge>}
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-8 w-8"><MoreHorizontal className="w-4 h-4" /></Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem asChild><Link href={`/customers/${customer.id}`}>View details</Link></DropdownMenuItem>
-                          <DropdownMenuItem asChild><Link href={`/invoices/new?customer=${customer.id}`}>New invoice</Link></DropdownMenuItem>
-                          <DropdownMenuItem asChild><Link href={`/quotes/new?customer=${customer.id}`}>New quote</Link></DropdownMenuItem>
-                          <DropdownMenuSeparator />
+                  </td>
+                  <td className="text-muted-foreground">
+                    {customer.email ? (
+                      <span className="inline-flex items-center gap-1.5"><Mail className="w-3 h-3" /> {customer.email}</span>
+                    ) : "—"}
+                  </td>
+                  <td className="text-muted-foreground">
+                    {customer.phone ? (
+                      <span className="inline-flex items-center gap-1.5"><Phone className="w-3 h-3" /> {customer.phone}</span>
+                    ) : "—"}
+                  </td>
+                  <td>
+                    <span className={`ch-pill ${customer.archived ? "archived" : "active"}`}>
+                      {customer.archived ? "archived" : "active"}
+                    </span>
+                  </td>
+                  <td className="text-right" onClick={(e) => e.stopPropagation()}>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted">
+                          <MoreHorizontal className="w-4 h-4" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem asChild><Link href={`/customers/${customer.id}`}>View details</Link></DropdownMenuItem>
+                        <DropdownMenuItem asChild><Link href={`/invoices/new?customer=${customer.id}`}>New invoice</Link></DropdownMenuItem>
+                        <DropdownMenuItem asChild><Link href={`/quotes/new?customer=${customer.id}`}>New quote</Link></DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        {!customer.archived && (
                           <DropdownMenuItem onClick={() => handleArchive(customer.id)} className="gap-2">
                             <Archive className="w-3.5 h-3.5" />Archive
                           </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setDeleteId(customer.id)} className="text-destructive gap-2">
-                            <Trash2 className="w-3.5 h-3.5" />Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
+                        )}
+                        <DropdownMenuItem onClick={() => setDeleteId(customer.id)} className="text-destructive gap-2">
+                          <Trash2 className="w-3.5 h-3.5" />Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </motion.div>
       )}
 

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -1,35 +1,23 @@
 "use client";
 
-import { motion, type Variants } from "framer-motion";
+import Link from "next/link";
+import { motion } from "framer-motion";
 import {
   TrendingUp, Clock, AlertTriangle, CheckCircle, Plus, FileText,
-  Wrench, MapPin, User, ArrowRight, FileCheck, UserPlus,
-  MoreHorizontal,
+  Wrench, MapPin, User, ArrowRight, FileCheck, UserPlus, ChevronRight,
+  DollarSign,
 } from "@/components/ui/icons";
-import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
 import { formatCurrency, getStatusColor } from "@/lib/utils";
-import { AnimatedCounter } from "./animated-counter";
 import type { WorkOrderWithCustomer, WorkOrderStatus } from "@/types/database";
 
-const JOB_STATUS_STYLES: Record<WorkOrderStatus, string> = {
-  draft:       "bg-neutral-100 text-neutral-700",
-  assigned:    "bg-blue-100 text-blue-700",
-  in_progress: "bg-amber-100 text-amber-800",
-  submitted:   "bg-violet-100 text-violet-700",
-  reviewed:    "bg-yellow-100 text-yellow-800",
-  completed:   "bg-lime-200 text-lime-900",
-  cancelled:   "bg-rose-100 text-rose-700",
-};
-
-const fadeUp: Variants = {
-  hidden: { opacity: 0, y: 14 },
-  show:   { opacity: 1, y: 0, transition: { duration: 0.45, ease: [0.22, 1, 0.36, 1] } },
-};
-
-const stagger: Variants = {
-  hidden: {},
-  show:   { transition: { staggerChildren: 0.06 } },
+const STATUS_TO_PILL: Record<WorkOrderStatus, string> = {
+  draft:       "draft",
+  assigned:    "scheduled",
+  in_progress: "in-progress",
+  submitted:   "pending",
+  reviewed:    "pending",
+  completed:   "completed",
+  cancelled:   "cancelled",
 };
 
 interface DashboardClientProps {
@@ -45,6 +33,7 @@ interface DashboardClientProps {
       status?: string;
       total?: number;
       due_date?: string;
+      issue_date?: string;
       customers?: { name?: string } | null;
     }>;
     monthlyData: Array<{ month: string; revenue: number; invoiced: number }>;
@@ -52,534 +41,368 @@ interface DashboardClientProps {
   currency?: string;
 }
 
+function fmtShort(n: number, currency: string) {
+  if (Math.abs(n) >= 1000) {
+    return (n / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 }).replace(/\.0$/, "") + "k " + currency;
+  }
+  return formatCurrency(n, currency);
+}
+
 export function DashboardClient({ stats, currency = "GBP", todayJobs }: DashboardClientProps) {
-  const todayStr  = new Date().toISOString().split("T")[0];
+  const todayStr = new Date().toISOString().split("T")[0];
   const now = new Date();
-  const dateLabel = now.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
+  const hour = now.getHours();
+  const greeting = hour < 5 ? "Late night" : hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
+
+  const monthly = stats.monthlyData.slice(-6);
+  const maxBar  = Math.max(...monthly.map((m) => m.revenue), 1);
+  const totalBilled = monthly.reduce((s, m) => s + m.revenue, 0);
+  const sparkData = monthly.map((m) => m.revenue);
 
   const scheduledToday = todayJobs.filter((j) => j.scheduled_date === todayStr);
-  const onSite         = todayJobs.filter((j) => j.status === "in_progress");
-  const needsReview    = todayJobs.filter((j) => j.status === "submitted");
+  const tomorrowStr = (() => {
+    const t = new Date(); t.setDate(t.getDate() + 1);
+    return t.toISOString().split("T")[0];
+  })();
+  const tomorrow = todayJobs.filter((j) => j.scheduled_date === tomorrowStr);
 
-  const total = Math.max(stats.totalRevenue + stats.outstanding + stats.overdue, 1);
-  const paidPct = Math.round((stats.totalRevenue / total) * 100);
-  const outPct  = Math.round((stats.outstanding / total) * 100);
-  const overPct = Math.max(0, 100 - paidPct - outPct);
-
-  const monthly = stats.monthlyData.slice(-7);
-  const maxBar = Math.max(...monthly.map((m) => Math.max(m.revenue, m.invoiced)), 1);
-  const peakIdx = monthly.reduce((acc, m, i) => (m.revenue > monthly[acc].revenue ? i : acc), 0);
+  // Compute deltas vs the prior month for the headline KPI
+  const lastMonth = monthly[monthly.length - 2]?.revenue ?? 0;
+  const thisMonth = monthly[monthly.length - 1]?.revenue ?? 0;
+  const monthDelta = lastMonth > 0 ? ((thisMonth - lastMonth) / lastMonth) * 100 : 0;
 
   return (
     <div>
-      <div>
-
-        {/* ── Top bar ──────────────────────────────────────────────────── */}
-        <motion.div
-          initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}
-          className="flex items-center justify-between gap-3 mb-6"
-        >
-          <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400">
-            <span className="font-medium text-neutral-900 dark:text-neutral-100">Overview</span>
-            <span className="text-neutral-400">·</span>
-            <span>{dateLabel}</span>
-          </div>
-          {needsReview.length > 0 && (
-            <Link
-              href="/work-orders"
-              className="relative inline-flex items-center gap-2 pl-2 pr-4 py-1.5 rounded-full bg-white dark:bg-neutral-900 border border-black/5 dark:border-white/5 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
-            >
-              <span className="w-7 h-7 rounded-full bg-lime-300 text-lime-950 text-xs font-bold flex items-center justify-center">
-                {needsReview.length}
-              </span>
-              <span className="text-neutral-700 dark:text-neutral-200">need review</span>
-            </Link>
-          )}
-        </motion.div>
-
-        {/* ── Title row ────────────────────────────────────────────────── */}
-        <motion.div
-          initial={{ opacity: 0, y: -6 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.05 }}
-          className="flex items-end justify-between gap-4 mb-7 flex-wrap"
-        >
-          <div>
-            <h1 className="font-display text-5xl sm:text-6xl font-semibold tracking-tight leading-none text-neutral-900 dark:text-neutral-50">
-              Dashboard
-            </h1>
-            <p className="text-sm sm:text-base text-neutral-600 dark:text-neutral-400 mt-2">
-              Take control of your business today!
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Link href="/quotes/new" className="px-4 py-2.5 rounded-full bg-white dark:bg-neutral-900 border border-black/5 dark:border-white/10 text-sm font-medium text-neutral-800 dark:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors flex items-center gap-1.5">
-              <FileCheck className="w-3.5 h-3.5" /> New quote
-            </Link>
-            <Link href="/invoices/new" className="px-4 py-2.5 rounded-full bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 text-sm font-medium hover:opacity-90 transition-opacity flex items-center gap-1.5">
+      {/* Page header */}
+      <motion.div
+        initial={{ opacity: 0, y: -6 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}
+        className="ch-page-header"
+      >
+        <div>
+          <h1 className="ch-page-title">{greeting}.</h1>
+          <p className="ch-page-subtitle">Here&apos;s what&apos;s happening today.</p>
+        </div>
+        <div className="ch-page-actions">
+          <Link href="/reports">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium text-foreground hover:bg-muted transition-colors">
+              <TrendingUp className="w-3.5 h-3.5" /> View reports
+            </button>
+          </Link>
+          <Link href="/invoices/new">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
               <Plus className="w-3.5 h-3.5" /> New invoice
-            </Link>
+            </button>
+          </Link>
+        </div>
+      </motion.div>
+
+      {/* Overdue strip */}
+      {stats.overdue > 0 && (
+        <Link href="/invoices?status=overdue" className="block mb-5">
+          <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200/60 dark:border-rose-900/40 hover:bg-rose-100/60 dark:hover:bg-rose-950/50 transition-colors">
+            <div className="w-9 h-9 rounded-full bg-rose-100 dark:bg-rose-900/50 flex items-center justify-center flex-shrink-0">
+              <AlertTriangle className="w-4 h-4 text-rose-700 dark:text-rose-300" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-rose-900 dark:text-rose-200 leading-tight">
+                {formatCurrency(stats.overdue, currency)} overdue
+              </p>
+              <p className="text-xs text-rose-700/80 dark:text-rose-300/70">Send reminders to bring these in</p>
+            </div>
+            <ArrowRight className="w-4 h-4 text-rose-700 dark:text-rose-300" />
           </div>
-        </motion.div>
+        </Link>
+      )}
 
-        {/* ── Overdue strip ────────────────────────────────────────────── */}
-        {stats.overdue > 0 && (
-          <motion.div
-            initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.35 }}
-            className="mb-5"
-          >
-            <Link href="/invoices?status=overdue" className="group flex items-center gap-3 px-5 py-3.5 rounded-2xl bg-rose-100 dark:bg-rose-950/40 hover:bg-rose-200/60 dark:hover:bg-rose-950/60 transition-colors">
-              <div className="w-9 h-9 rounded-full bg-rose-200 dark:bg-rose-900/50 flex items-center justify-center flex-shrink-0">
-                <AlertTriangle className="w-4 h-4 text-rose-700 dark:text-rose-300" />
+      {/* KPI grid */}
+      <motion.div
+        initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3, delay: 0.05 }}
+        className="ch-stat-grid"
+      >
+        <StatCard
+          icon={<DollarSign className="w-3.5 h-3.5" />}
+          label={`Revenue (${monthly[monthly.length - 1]?.month ?? "this month"})`}
+          value={fmtShort(thisMonth, currency)}
+          delta={Math.round(monthDelta * 10) / 10}
+          sub="vs last month"
+          spark={sparkData}
+        />
+        <StatCard
+          icon={<Clock className="w-3.5 h-3.5" />}
+          label="Outstanding"
+          value={fmtShort(stats.outstanding, currency)}
+          sub={`${stats.recentInvoices.length} recent invoices`}
+        />
+        <StatCard
+          icon={<AlertTriangle className="w-3.5 h-3.5" />}
+          label="Overdue"
+          value={fmtShort(stats.overdue, currency)}
+          sub={stats.overdue > 0 ? "needs follow-up" : "all clear"}
+        />
+        <StatCard
+          icon={<CheckCircle className="w-3.5 h-3.5" />}
+          label="Paid this month"
+          value={fmtShort(stats.paidThisMonth, currency)}
+          sub="settled invoices"
+        />
+      </motion.div>
+
+      {/* 2-col layout */}
+      <div className="ch-grid-2">
+        {/* LEFT */}
+        <div className="flex flex-col gap-4">
+          {/* Revenue, last 6 months */}
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <div>
+                <h3 className="text-sm font-semibold">Revenue, last 6 months</h3>
+                <p className="text-xs text-muted-foreground mt-0.5">Paid invoices, trailing</p>
               </div>
-              <div className="flex-1 min-w-0">
-                <p className="font-display text-lg font-semibold text-rose-900 dark:text-rose-200 leading-tight">
-                  {formatCurrency(stats.overdue, currency)} overdue
-                </p>
-                <p className="text-xs text-rose-700/80 dark:text-rose-300/70">Send reminders to bring these in</p>
-              </div>
-              <ArrowRight className="w-4 h-4 text-rose-700 dark:text-rose-300 group-hover:translate-x-0.5 transition-transform" />
-            </Link>
-          </motion.div>
-        )}
-
-        {/* ── Main grid: Revenue Mix (left 2/3) + side stack (right 1/3) ── */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-
-          {/* ── LEFT: big Revenue Mix card ──────────────────────────── */}
-          <motion.div
-            variants={fadeUp} initial="hidden" animate="show"
-            className="lg:col-span-2 rounded-[28px] bg-white dark:bg-neutral-900 p-7 sm:p-8 border border-black/5 dark:border-white/5"
-          >
-            <CardHeader
-              icon={<TrendingUp className="w-4 h-4" />}
-              label="Revenue mix"
-              chip={<DeltaChip value="+5%" positive />}
-            />
-
-            <div className="flex items-baseline gap-3 mt-3">
-              <div className="font-display text-4xl sm:text-5xl font-semibold tracking-tight tabular-nums text-neutral-900 dark:text-neutral-50">
-                <AnimatedCounter value={stats.totalRevenue} format="currency" currency={currency} />
-              </div>
-              <span className="text-sm text-neutral-500">paid lifetime</span>
             </div>
-
-            {/* Bubble chart */}
-            <div className="mt-6 mb-7 flex justify-center">
-              <BubbleChart
-                paid={stats.totalRevenue}
-                outstanding={stats.outstanding}
-                overdue={stats.overdue}
-                currency={currency}
-              />
-            </div>
-
-            {/* Progress bars */}
-            <div className="space-y-4">
-              <ProgressRow label="Paid"        pct={paidPct} value={stats.totalRevenue} currency={currency} barClass="bg-violet-300" />
-              <ProgressRow label="Outstanding" pct={outPct}  value={stats.outstanding}  currency={currency} barClass="bg-neutral-900 dark:bg-neutral-100" />
-              <ProgressRow label="Overdue"     pct={overPct} value={stats.overdue}      currency={currency} barClass="bg-lime-300" />
-            </div>
-          </motion.div>
-
-          {/* ── RIGHT column ──────────────────────────────────────── */}
-          <motion.div variants={stagger} initial="hidden" animate="show" className="space-y-5">
-
-            {/* 2x1 small KPIs */}
-            <div className="grid grid-cols-2 gap-5">
-              <motion.div variants={fadeUp}>
-                <SmallKpi
-                  icon={<Clock className="w-3.5 h-3.5" />}
-                  label="Outstanding"
-                  value={stats.outstanding}
-                  currency={currency}
-                  hintTop="Avg"
-                  hintBottom={`${stats.recentInvoices.length} invoices`}
-                  href="/invoices"
-                />
-              </motion.div>
-              <motion.div variants={fadeUp}>
-                <SmallKpi
-                  icon={<CheckCircle className="w-3.5 h-3.5" />}
-                  label="This month"
-                  value={stats.paidThisMonth}
-                  currency={currency}
-                  hintTop="Paid"
-                  hintBottom="this period"
-                  href="/invoices?status=paid"
-                />
-              </motion.div>
-            </div>
-
-            {/* Activity */}
-            <motion.div variants={fadeUp}>
-              <Link
-                href="/work-orders"
-                className="block rounded-[24px] bg-white dark:bg-neutral-900 p-6 border border-black/5 dark:border-white/5 hover:shadow-sm transition-shadow"
-              >
-                <CardHeader
-                  icon={<Wrench className="w-4 h-4" />}
-                  label="Activity"
-                />
-                <div className="flex items-end justify-between mt-2">
-                  <div className="font-display text-3xl font-semibold tracking-tight tabular-nums text-neutral-900 dark:text-neutral-50">
-                    {scheduledToday.length}
-                    <span className="text-sm font-normal text-neutral-500 ml-1">jobs</span>
+            <div className="p-4">
+              <div className="ch-bars">
+                {monthly.map((m) => (
+                  <div key={m.month} className="ch-bar-col">
+                    <div
+                      className="ch-bar primary"
+                      style={{ height: `${(m.revenue / maxBar) * 100}%` }}
+                      title={formatCurrency(m.revenue, currency)}
+                    />
+                    <div className="ch-bar-label">{m.month}</div>
                   </div>
-                  <div className="text-right">
-                    <p className="text-[10px] uppercase tracking-wider text-neutral-500">On site</p>
-                    <p className="text-sm font-medium">{onSite.length} active</p>
-                  </div>
-                </div>
-              </Link>
-            </motion.div>
-
-          </motion.div>
-
-          {/* ── DARK Cash Flow card (full bottom) ─────────────────── */}
-          <motion.div
-            variants={fadeUp} initial="hidden" animate="show"
-            className="lg:col-span-3 rounded-[28px] bg-neutral-950 dark:bg-neutral-900 text-neutral-100 p-7 sm:p-8 border border-black/10"
-          >
-            <div className="flex items-center justify-between mb-5">
-              <CardHeader
-                icon={<Clock className="w-4 h-4" />}
-                label="Cash flow"
-                dark
-              />
-              <button className="px-3.5 py-1.5 rounded-full bg-white/10 hover:bg-white/15 transition-colors text-xs font-medium flex items-center gap-1.5">
-                Monthly <span className="opacity-60">▾</span>
-              </button>
-            </div>
-
-            <div className="flex flex-wrap items-baseline gap-x-8 gap-y-2 mb-7">
-              <div className="flex items-center gap-2.5">
-                <span className="w-1 h-7 rounded-full bg-lime-300" />
-                <div>
-                  <div className="font-display text-2xl sm:text-3xl font-semibold tabular-nums leading-none">
-                    {formatCurrency(stats.paidThisMonth, currency)}
-                  </div>
-                  <p className="text-[11px] text-neutral-400 mt-1">Paid this month</p>
-                </div>
+                ))}
               </div>
-              <div className="flex items-center gap-2.5">
-                <span className="w-1 h-7 rounded-full bg-violet-300" />
-                <div>
-                  <div className="font-display text-2xl sm:text-3xl font-semibold tabular-nums leading-none">
-                    {formatCurrency(stats.outstanding, currency)}
-                  </div>
-                  <p className="text-[11px] text-neutral-400 mt-1">Outstanding</p>
-                </div>
+              <div className="flex items-center justify-between pt-3 mt-2 border-t border-border">
+                <span className="text-xs text-muted-foreground">Total billed</span>
+                <span className="text-sm font-semibold ch-mono">{formatCurrency(totalBilled, currency)}</span>
               </div>
             </div>
+          </div>
 
-            {/* Mini bar chart */}
-            <div className="grid grid-cols-7 gap-2 sm:gap-3 h-40 items-end">
-              {monthly.map((m, i) => {
-                const isPeak = i === peakIdx;
-                const revH = (m.revenue / maxBar) * 100;
-                const invH = (m.invoiced / maxBar) * 100;
-                return (
-                  <div key={m.month} className="flex flex-col items-center gap-2">
-                    <div className="flex items-end gap-1 h-32 w-full justify-center">
-                      <div
-                        className={`w-3 sm:w-4 rounded-full ${isPeak ? "bg-lime-300" : "bg-white/10"}`}
-                        style={{ height: `${Math.max(revH, 6)}%` }}
-                      />
-                      <div
-                        className={`w-3 sm:w-4 rounded-full ${isPeak ? "bg-violet-300" : "bg-white/10"}`}
-                        style={{ height: `${Math.max(invH, 6)}%` }}
-                      />
-                    </div>
-                    <span className={`text-[11px] ${isPeak ? "text-white font-medium" : "text-neutral-500"}`}>
-                      {m.month}{isPeak ? " ↗" : ""}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </motion.div>
-
-          {/* ── Jobs (left) and Recent Invoices (right) ──────────── */}
-          <motion.div variants={fadeUp} initial="hidden" animate="show" className="lg:col-span-2 rounded-[28px] bg-white dark:bg-neutral-900 border border-black/5 dark:border-white/5 overflow-hidden">
-            <div className="flex items-center justify-between px-7 pt-6 pb-4">
-              <CardHeader icon={<Wrench className="w-4 h-4" />} label="Today's jobs" />
-              <Link href="/work-orders" className="text-xs text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors flex items-center gap-1">
-                View all <ArrowRight className="w-3 h-3" />
-              </Link>
-            </div>
-            {todayJobs.length === 0 ? (
-              <EmptyState icon={Wrench} title="Nothing scheduled today" hint="A clean slate to plan ahead" action={{ href: "/work-orders/new", label: "Schedule a job" }} />
-            ) : (
-              <div className="divide-y divide-neutral-100 dark:divide-white/5">
-                {todayJobs.slice(0, 5).map((job) => <JobRow key={job.id} job={job} />)}
-              </div>
-            )}
-          </motion.div>
-
-          <motion.div variants={fadeUp} initial="hidden" animate="show" className="rounded-[28px] bg-white dark:bg-neutral-900 border border-black/5 dark:border-white/5 overflow-hidden">
-            <div className="flex items-center justify-between px-6 pt-6 pb-4">
-              <CardHeader icon={<FileText className="w-4 h-4" />} label="Recent" />
-              <Link href="/invoices" className="text-xs text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors flex items-center gap-1">
-                View all <ArrowRight className="w-3 h-3" />
+          {/* Recent invoices */}
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <h3 className="text-sm font-semibold">Recent invoices</h3>
+              <Link href="/invoices" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                View all <ChevronRight className="w-3 h-3" />
               </Link>
             </div>
             {stats.recentInvoices.length === 0 ? (
-              <EmptyState icon={FileText} title="No invoices yet" action={{ href: "/invoices/new", label: "Create first" }} />
+              <div className="ch-empty">
+                <h4>No invoices yet</h4>
+                <p>Create your first invoice to get started.</p>
+                <Link href="/invoices/new">
+                  <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium hover:opacity-90">
+                    <Plus className="w-3 h-3" /> New invoice
+                  </button>
+                </Link>
+              </div>
             ) : (
-              <div className="divide-y divide-neutral-100 dark:divide-white/5">
-                {stats.recentInvoices.slice(0, 5).map((invoice, i) => (
-                  <Link key={invoice.id ?? i} href={`/invoices/${invoice.id}`}>
-                    <div className="flex items-center justify-between px-6 py-3.5 hover:bg-neutral-50 dark:hover:bg-white/[0.02] transition-colors">
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium truncate">{invoice.customers?.name ?? "No client"}</p>
-                        <p className="text-[11px] text-neutral-500 font-mono mt-0.5">{invoice.number}</p>
+              <div className="overflow-x-auto">
+                <table className="ch-table">
+                  <thead>
+                    <tr>
+                      <th>Invoice</th>
+                      <th>Customer</th>
+                      <th>Issued</th>
+                      <th>Status</th>
+                      <th className="num">Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stats.recentInvoices.slice(0, 5).map((inv, i) => (
+                      <tr key={inv.id ?? i} onClick={() => inv.id && (window.location.href = `/invoices/${inv.id}`)}>
+                        <td><span className="ref">{inv.number ?? "—"}</span></td>
+                        <td>{inv.customers?.name ?? "—"}</td>
+                        <td className="text-muted-foreground">{inv.issue_date ?? inv.due_date ?? ""}</td>
+                        <td><span className={`ch-pill ${statusForPill(inv.status)}`}>{inv.status}</span></td>
+                        <td className="num font-semibold">{formatCurrency(inv.total ?? 0, currency)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* RIGHT */}
+        <div className="flex flex-col gap-4">
+          {/* Quick actions */}
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="px-4 py-3 border-b border-border">
+              <h3 className="text-sm font-semibold">Quick actions</h3>
+            </div>
+            <div className="p-4">
+              <div className="ch-quick-actions">
+                <QuickAction href="/invoices/new" icon={<FileText className="w-4 h-4" />} label="New invoice" meta="Bill a customer" />
+                <QuickAction href="/quotes/new"   icon={<FileCheck className="w-4 h-4" />} label="New quote"   meta="Send an estimate" />
+                <QuickAction href="/work-orders/new" icon={<Wrench className="w-4 h-4" />} label="Work order"  meta="Schedule a job" />
+                <QuickAction href="/customers/new"   icon={<UserPlus className="w-4 h-4" />} label="Add customer" meta="New contact" />
+              </div>
+            </div>
+          </div>
+
+          {/* Today's schedule */}
+          <div className="rounded-xl border border-border bg-card shadow-sm">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <div>
+                <h3 className="text-sm font-semibold">Today&apos;s schedule</h3>
+                <p className="text-xs text-muted-foreground mt-0.5">{now.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" })}</p>
+              </div>
+              <Link href="/work-orders" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                All jobs <ChevronRight className="w-3 h-3" />
+              </Link>
+            </div>
+            <div className="p-2">
+              {scheduledToday.length === 0 ? (
+                <div className="ch-empty"><h4>Nothing scheduled today</h4><p>Add a work order to fill your day.</p></div>
+              ) : (
+                scheduledToday.slice(0, 6).map((wo) => <ScheduleRow key={wo.id} wo={wo} />)
+              )}
+              {tomorrow.length > 0 && (
+                <>
+                  <div className="border-t border-border my-2" />
+                  <div className="ch-schedule-day px-1">Tomorrow</div>
+                  {tomorrow.slice(0, 3).map((wo) => <ScheduleRow key={wo.id} wo={wo} />)}
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Activity */}
+          {stats.recentInvoices.length > 0 && (
+            <div className="rounded-xl border border-border bg-card shadow-sm">
+              <div className="px-4 py-3 border-b border-border">
+                <h3 className="text-sm font-semibold">Activity</h3>
+              </div>
+              <div className="p-2">
+                {stats.recentInvoices.slice(0, 5).map((inv, i) => (
+                  <Link key={inv.id ?? i} href={`/invoices/${inv.id}`}>
+                    <div className="ch-activity-item">
+                      <div className="ch-activity-icon">
+                        <FileText className="w-3.5 h-3.5" />
                       </div>
-                      <div className="text-right ml-3 flex-shrink-0">
-                        <p className="font-display text-base font-semibold tabular-nums">{formatCurrency(invoice.total ?? 0, currency)}</p>
-                        <Badge variant="secondary" className={`text-[10px] mt-0.5 border-0 ${getStatusColor(invoice.status ?? "draft")}`}>
-                          {invoice.status}
-                        </Badge>
+                      <div className="ch-activity-content">
+                        <div>
+                          Invoice <span className="font-semibold">{inv.number}</span> {inv.status === "paid" ? "paid" : "sent"}
+                          {" "}<span className="ch-mono font-semibold">· {formatCurrency(inv.total ?? 0, currency)}</span>
+                        </div>
+                        <div className="ch-activity-meta">{inv.customers?.name ?? "No client"}</div>
                       </div>
                     </div>
                   </Link>
                 ))}
               </div>
-            )}
-          </motion.div>
-
-          {/* ── Quick actions row ────────────────────────────────── */}
-          <motion.div variants={fadeUp} initial="hidden" animate="show" className="lg:col-span-3 rounded-[28px] bg-white dark:bg-neutral-900 p-6 border border-black/5 dark:border-white/5">
-            <div className="flex items-center justify-between mb-4">
-              <CardHeader icon={<Plus className="w-4 h-4" />} label="Quick add" />
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              <QuickLink href="/customers/new" icon={UserPlus} label="Customer" />
-              <QuickLink href="/invoices/new" icon={FileText} label="Invoice" />
-              <QuickLink href="/quotes/new" icon={FileCheck} label="Quote" />
-              <QuickLink href="/work-orders/new" icon={Wrench} label="Job" />
-            </div>
-          </motion.div>
+          )}
         </div>
       </div>
     </div>
   );
 }
 
-// ── Sub-components ───────────────────────────────────────────────────────────
+// ── Sub-components ──────────────────────────────────────────────────────────
 
-function CardHeader({
-  icon, label, chip, dark,
+function statusForPill(status?: string) {
+  if (!status) return "draft";
+  return getStatusColor(status).includes("green") ? "paid"
+       : getStatusColor(status).includes("yellow") ? "pending"
+       : status; // pass through; matches our .ch-pill.* classes
+}
+
+function StatCard({
+  icon, label, value, delta, sub, spark,
 }: {
   icon: React.ReactNode;
   label: string;
-  chip?: React.ReactNode;
-  dark?: boolean;
+  value: string;
+  delta?: number;
+  sub: string;
+  spark?: number[];
 }) {
+  const up = (delta ?? 0) >= 0;
   return (
-    <div className="flex items-center gap-2">
-      <div className={`w-8 h-8 rounded-full flex items-center justify-center ${dark ? "bg-white/10 text-white/80" : "bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300"}`}>
+    <div className="ch-stat">
+      <div className="ch-stat-label">
         {icon}
-      </div>
-      <span className={`text-sm font-medium ${dark ? "text-white" : "text-neutral-900 dark:text-neutral-100"}`}>
-        {label}
-      </span>
-      <div className="ml-auto flex items-center gap-2">
-        {chip}
-        <button className={`w-7 h-7 rounded-full flex items-center justify-center transition-colors ${dark ? "text-white/40 hover:text-white/80 hover:bg-white/5" : "text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"}`}>
-          <MoreHorizontal className="w-4 h-4" />
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function DeltaChip({ value, positive }: { value: string; positive?: boolean }) {
-  return (
-    <span className={`px-2 py-0.5 rounded-full text-[10px] font-bold ${positive ? "bg-lime-300 text-lime-950" : "bg-rose-200 text-rose-900"}`}>
-      {value}
-    </span>
-  );
-}
-
-function SmallKpi({
-  icon, label, value, currency, hintTop, hintBottom, href,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: number;
-  currency: string;
-  hintTop: string;
-  hintBottom: string;
-  href: string;
-}) {
-  return (
-    <Link href={href} className="block rounded-[24px] bg-white dark:bg-neutral-900 p-5 border border-black/5 dark:border-white/5 hover:shadow-sm transition-shadow h-full">
-      <div className="flex items-center gap-2 mb-3">
-        <div className="w-7 h-7 rounded-full bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center text-neutral-700 dark:text-neutral-300">
-          {icon}
-        </div>
-        <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300">{label}</span>
+        <span>{label}</span>
       </div>
       <div className="flex items-end justify-between gap-2">
-        <div className="font-display text-2xl font-semibold tracking-tight tabular-nums leading-none text-neutral-900 dark:text-neutral-50 truncate">
-          <AnimatedCounter value={value} format="currency" currency={currency} />
-        </div>
-        <div className="text-right flex-shrink-0">
-          <p className="text-[10px] uppercase tracking-wider text-neutral-500">{hintTop}</p>
-          <p className="text-[11px] text-neutral-700 dark:text-neutral-300">{hintBottom}</p>
-        </div>
+        <div className="ch-stat-value">{value}</div>
+        {spark && spark.length > 1 && <Sparkline data={spark} />}
       </div>
+      <div className="ch-stat-meta">
+        {delta != null && (
+          <>
+            <TrendingUp className={`w-3 h-3 ${up ? "text-emerald-600" : "text-rose-600 rotate-180"}`} />
+            <span className={`ch-stat-delta ${up ? "up" : "down"}`}>{up ? "+" : ""}{delta}%</span>
+          </>
+        )}
+        <span>{sub}</span>
+      </div>
+    </div>
+  );
+}
+
+function Sparkline({ data, width = 96, height = 28 }: { data: number[]; width?: number; height?: number }) {
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const pts = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * width;
+    const y = height - ((v - min) / range) * (height - 4) - 2;
+    return [x, y];
+  });
+  const d = pts.map((p, i) => (i === 0 ? "M" : "L") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ");
+  const fillD = d + ` L ${width} ${height} L 0 ${height} Z`;
+  return (
+    <svg width={width} height={height} className="block">
+      <path d={fillD} className="ch-spark-fill" />
+      <path d={d} className="ch-spark" />
+    </svg>
+  );
+}
+
+function QuickAction({ href, icon, label, meta }: { href: string; icon: React.ReactNode; label: string; meta: string }) {
+  return (
+    <Link href={href}>
+      <button className="ch-quick-action">
+        <div className="ch-quick-action-icon">{icon}</div>
+        <div className="min-w-0">
+          <div>{label}</div>
+          <div className="ch-quick-action-meta">{meta}</div>
+        </div>
+      </button>
     </Link>
   );
 }
 
-function ProgressRow({
-  label, pct, value, currency, barClass,
-}: {
-  label: string;
-  pct: number;
-  value: number;
-  currency: string;
-  barClass: string;
-}) {
+function ScheduleRow({ wo }: { wo: WorkOrderWithCustomer }) {
+  const time = wo.start_time ? wo.start_time.slice(0, 5) : "—";
+  const barColor =
+    wo.status === "in_progress" ? "hsl(35 75% 50%)" :
+    wo.status === "submitted"   ? "hsl(280 50% 55%)" :
+    "hsl(var(--primary))";
   return (
-    <div>
-      <div className="flex items-baseline justify-between mb-1.5">
-        <div className="flex items-baseline gap-2">
-          <span className="font-display text-xl font-semibold tabular-nums text-neutral-900 dark:text-neutral-50">{pct}<span className="text-xs text-neutral-500 ml-0.5">%</span></span>
-          <span className="text-xs text-neutral-500">{label}</span>
-        </div>
-        <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300 tabular-nums">{formatCurrency(value, currency)}</span>
-      </div>
-      <div className="h-2.5 rounded-full bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
-        <div className={`h-full rounded-full ${barClass} transition-all duration-700`} style={{ width: `${Math.max(pct, 2)}%` }} />
-      </div>
-    </div>
-  );
-}
-
-function BubbleChart({
-  paid, outstanding, overdue, currency,
-}: {
-  paid: number;
-  outstanding: number;
-  overdue: number;
-  currency: string;
-}) {
-  // Sizes proportional to sqrt(value), normalized
-  const max = Math.max(paid, outstanding, overdue, 1);
-  const r = (v: number, base = 60) => Math.max(28, Math.sqrt(v / max) * base);
-  const rPaid = r(paid, 80);
-  const rOut  = r(outstanding, 70);
-  const rOver = r(overdue, 60);
-  const fmt = (v: number) => {
-    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-    if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
-    return formatCurrency(v, currency).replace(/\.\d+/, "");
-  };
-
-  return (
-    <div className="relative w-full max-w-[420px] h-[260px]">
-      {/* Paid — large, lavender, left */}
-      <div
-        className="absolute rounded-full bg-violet-300 flex flex-col items-center justify-center text-violet-950 font-semibold"
-        style={{
-          width: rPaid * 2, height: rPaid * 2,
-          left: "8%", top: "20%",
-        }}
-      >
-        <span className="font-display text-2xl tabular-nums">{fmt(paid)}</span>
-        <span className="text-[11px] font-normal opacity-80">paid</span>
-      </div>
-      {/* Outstanding — medium, dark, top right */}
-      <div
-        className="absolute rounded-full bg-neutral-900 dark:bg-neutral-100 flex flex-col items-center justify-center text-white dark:text-neutral-900 font-semibold"
-        style={{
-          width: rOut * 2, height: rOut * 2,
-          right: "8%", top: "8%",
-        }}
-      >
-        <span className="font-display text-xl tabular-nums">{fmt(outstanding)}</span>
-        <span className="text-[10px] font-normal opacity-70">outstanding</span>
-      </div>
-      {/* Overdue — small, lime, bottom center */}
-      <div
-        className="absolute rounded-full bg-lime-300 flex flex-col items-center justify-center text-lime-950 font-semibold"
-        style={{
-          width: rOver * 2, height: rOver * 2,
-          left: "44%", bottom: "4%",
-        }}
-      >
-        <span className="font-display text-lg tabular-nums">{fmt(overdue)}</span>
-        <span className="text-[10px] font-normal opacity-80">overdue</span>
-      </div>
-    </div>
-  );
-}
-
-function QuickLink({ href, icon: Icon, label }: { href: string; icon: React.ComponentType<{ className?: string }>; label: string }) {
-  return (
-    <Link href={href} className="group flex items-center gap-2.5 px-4 py-3 rounded-2xl bg-neutral-50 dark:bg-neutral-800/50 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors">
-      <div className="w-8 h-8 rounded-full bg-white dark:bg-neutral-900 flex items-center justify-center group-hover:bg-lime-300 group-hover:text-lime-950 transition-colors">
-        <Icon className="w-3.5 h-3.5" />
-      </div>
-      <span className="text-sm font-medium text-neutral-800 dark:text-neutral-200">{label}</span>
-    </Link>
-  );
-}
-
-function EmptyState({
-  icon: Icon, title, hint, action,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  hint?: string;
-  action?: { href: string; label: string };
-}) {
-  return (
-    <div className="flex flex-col items-center justify-center py-14 px-6 text-center">
-      <div className="w-12 h-12 rounded-full bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center mb-3">
-        <Icon className="w-5 h-5 text-neutral-500" />
-      </div>
-      <p className="text-sm font-medium text-neutral-800 dark:text-neutral-200">{title}</p>
-      {hint && <p className="text-xs text-neutral-500 mt-1">{hint}</p>}
-      {action && (
-        <Link href={action.href} className="mt-4 px-4 py-2 rounded-full bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 text-xs font-medium hover:opacity-90 transition-opacity flex items-center gap-1.5">
-          <Plus className="w-3 h-3" /> {action.label}
-        </Link>
-      )}
-    </div>
-  );
-}
-
-function JobRow({ job }: { job: WorkOrderWithCustomer }) {
-  return (
-    <Link href={`/work-orders/${job.id}`}>
-      <div className="flex items-center gap-3 px-7 py-4 hover:bg-neutral-50 dark:hover:bg-white/[0.02] transition-colors group">
-        <div className="w-10 h-10 rounded-full bg-violet-100 dark:bg-violet-950/40 flex items-center justify-center flex-shrink-0">
-          <Wrench className="w-4 h-4 text-violet-700 dark:text-violet-300" />
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <p className="text-sm font-medium truncate">{job.title}</p>
-            <Badge className={`${JOB_STATUS_STYLES[job.status]} text-[10px] border-0 rounded-full`}>
-              {job.status.replace("_", " ")}
-            </Badge>
-          </div>
-          <div className="flex items-center gap-3 mt-1 text-[11px] text-neutral-500">
-            <span className="font-mono">{job.number}</span>
-            {job.property_address && (
-              <span className="flex items-center gap-1 truncate">
-                <MapPin className="w-3 h-3 flex-shrink-0" />{job.property_address}
-              </span>
-            )}
-            {job.assigned_to_email && (
-              <span className="flex items-center gap-1 flex-shrink-0">
-                <User className="w-3 h-3" />{job.assigned_to_email}
+    <Link href={`/work-orders/${wo.id}`} className="block">
+      <div className="ch-schedule-item">
+        <div className="ch-schedule-time">{time}</div>
+        <div className="ch-schedule-bar" style={{ background: barColor }} />
+        <div className="ch-schedule-content">
+          <div className="ch-schedule-title">{wo.customers?.name ?? wo.title}</div>
+          <div className="ch-schedule-meta truncate">
+            <span className="inline-flex items-center gap-1">
+              <MapPin className="inline w-3 h-3" />{wo.property_address ?? "—"}
+            </span>
+            {wo.assigned_to_email && (
+              <span className="ml-2 inline-flex items-center gap-1">
+                <User className="inline w-3 h-3" />{wo.assigned_to_email}
               </span>
             )}
           </div>
         </div>
-        <ArrowRight className="w-4 h-4 text-neutral-300 group-hover:text-neutral-700 group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+        <span className={`ch-pill ${STATUS_TO_PILL[wo.status]}`}>{wo.status.replace("_", " ")}</span>
       </div>
     </Link>
   );

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -1,22 +1,28 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Plus, Search, FileText, MoreHorizontal, Copy, Trash2, Eye } from "@/components/ui/icons";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/layout/page-header";
 import { deleteInvoice, duplicateInvoice } from "@/lib/actions/invoices";
-import { formatCurrency, formatDate, getStatusColor } from "@/lib/utils";
+import { formatCurrency, formatDate } from "@/lib/utils";
 import type { Customer, InvoiceWithCustomer } from "@/types/database";
 
-const STATUSES = ["all", "draft", "sent", "paid", "overdue", "partial", "cancelled"];
+const TABS = [
+  { id: "all",       label: "All"       },
+  { id: "draft",     label: "Draft"     },
+  { id: "sent",      label: "Sent"      },
+  { id: "partial",   label: "Partial"   },
+  { id: "paid",      label: "Paid"      },
+  { id: "overdue",   label: "Overdue"   },
+  { id: "cancelled", label: "Cancelled" },
+] as const;
 
 interface InvoicesClientProps {
   invoices: InvoiceWithCustomer[];
@@ -25,16 +31,33 @@ interface InvoicesClientProps {
 }
 
 export function InvoicesClient({ invoices: initial, currency = "GBP" }: InvoicesClientProps) {
+  const router = useRouter();
   const [invoices, setInvoices] = useState(initial);
   const [search, setSearch] = useState("");
-  const [status, setStatus] = useState("all");
+  const [tab, setTab] = useState<typeof TABS[number]["id"]>("all");
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const filtered = invoices.filter((inv) => {
-    const matchSearch = `${inv.number} ${inv.customers?.name} ${inv.customers?.email}`.toLowerCase().includes(search.toLowerCase());
-    const matchStatus = status === "all" || inv.status === status;
+  const filtered = useMemo(() => invoices.filter((inv) => {
+    const matchSearch = `${inv.number} ${inv.customers?.name ?? ""} ${inv.customers?.email ?? ""}`.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = tab === "all" || inv.status === tab;
     return matchSearch && matchStatus;
-  });
+  }), [invoices, search, tab]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: invoices.length };
+    for (const t of TABS) c[t.id] = invoices.filter((i) => t.id === "all" || i.status === t.id).length;
+    return c;
+  }, [invoices]);
+
+  const totalOutstanding = useMemo(
+    () => invoices.filter((i) => ["sent", "partial", "overdue"].includes(i.status))
+                  .reduce((s, i) => s + (i.total - i.amount_paid), 0),
+    [invoices]
+  );
+  const totalPaid = useMemo(
+    () => invoices.filter((i) => i.status === "paid").reduce((s, i) => s + i.total, 0),
+    [invoices]
+  );
 
   const handleDuplicate = async (id: string) => {
     try {
@@ -54,77 +77,121 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
     setDeleteId(null);
   };
 
-  const totals = {
-    all: filtered.reduce((s, i) => s + i.total, 0),
-    outstanding: filtered.filter(i => ["sent", "partial"].includes(i.status)).reduce((s, i) => s + i.total - i.amount_paid, 0),
-  };
-
   return (
-    <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Invoices</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{invoices.length} total · {formatCurrency(totals.outstanding, currency)} outstanding</p>
-        </div>
-        <Link href="/invoices/new" className="w-full sm:w-auto">
-          <Button size="sm" className="gap-1.5 w-full sm:w-auto"><Plus className="w-3.5 h-3.5" />New invoice</Button>
-        </Link>
-      </motion.div>
+    <div>
+      <PageHeader
+        title="Invoices"
+        subtitle={`${invoices.length} total · ${formatCurrency(totalOutstanding, currency)} outstanding`}
+        actions={
+          <Link href="/invoices/new">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+              <Plus className="w-3.5 h-3.5" /> New invoice
+            </button>
+          </Link>
+        }
+      />
 
-      {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-3">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <Input className="pl-9" placeholder="Search invoices..." value={search} onChange={(e) => setSearch(e.target.value)} />
+      {/* KPI strip */}
+      <div className="ch-stat-grid">
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileText className="w-3.5 h-3.5" /><span>Total</span></div>
+          <div className="ch-stat-value">{invoices.length}</div>
+          <div className="ch-stat-meta">all time</div>
         </div>
-        <Select value={status} onValueChange={setStatus}>
-          <SelectTrigger className="w-full sm:w-40">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            {STATUSES.map((s) => (
-              <SelectItem key={s} value={s}>{s === "all" ? "All statuses" : s.charAt(0).toUpperCase() + s.slice(1)}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileText className="w-3.5 h-3.5" /><span>Outstanding</span></div>
+          <div className="ch-stat-value">{formatCurrency(totalOutstanding, currency)}</div>
+          <div className="ch-stat-meta">awaiting payment</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileText className="w-3.5 h-3.5" /><span>Paid</span></div>
+          <div className="ch-stat-value">{formatCurrency(totalPaid, currency)}</div>
+          <div className="ch-stat-meta">all time</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileText className="w-3.5 h-3.5" /><span>Overdue</span></div>
+          <div className="ch-stat-value">{counts.overdue ?? 0}</div>
+          <div className="ch-stat-meta">need follow-up</div>
+        </div>
+      </div>
+
+      {/* Status tabs */}
+      <div className="ch-tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            className={`ch-tab ${tab === t.id ? "active" : ""}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+            <span className="count">{counts[t.id] ?? 0}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Search */}
+      <div className="ch-filter-bar">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input
+            placeholder="Search invoices..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 h-9"
+          />
+        </div>
       </div>
 
       {/* Table */}
       {filtered.length === 0 ? (
-        <div className="text-center py-20">
-          <FileText className="w-12 h-12 text-muted-foreground/30 mx-auto mb-3" />
-          <h3 className="font-medium mb-1">No invoices found</h3>
-          <p className="text-sm text-muted-foreground mb-4">{search || status !== "all" ? "Try different filters" : "Create your first invoice to get started"}</p>
-          {!search && status === "all" && <Link href="/invoices/new"><Button size="sm">Create invoice</Button></Link>}
+        <div className="ch-empty">
+          <FileText className="w-10 h-10 text-muted-foreground/30 mx-auto mb-3" />
+          <h4>No invoices found</h4>
+          <p>{search || tab !== "all" ? "Try different filters." : "Create your first invoice to get started."}</p>
+          {!search && tab === "all" && (
+            <Link href="/invoices/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium">
+                <Plus className="w-3 h-3" /> Create invoice
+              </button>
+            </Link>
+          )}
         </div>
       ) : (
-        <div className="space-y-2">
-          {filtered.map((invoice, i) => (
-            <motion.div key={invoice.id} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03 }}>
-              <Card className="hover:shadow-sm transition-shadow">
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-4">
-                    <div className="min-w-0 flex-1 grid grid-cols-1 sm:grid-cols-4 gap-2 items-center">
-                      <div>
-                        <Link href={`/invoices/${invoice.id}`} className="font-medium text-sm hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                          {invoice.number}
-                        </Link>
-                        <p className="text-xs text-muted-foreground">{invoice.customers?.name ?? "No client"}</p>
-                      </div>
-                      <div className="hidden sm:block text-sm text-muted-foreground">
-                        Issued {formatDate(invoice.issue_date)}
-                      </div>
-                      <div className="hidden sm:block text-sm text-muted-foreground">
-                        Due {formatDate(invoice.due_date)}
-                      </div>
-                      <div className="flex items-center gap-2 sm:justify-end">
-                        <Badge variant="secondary" className={`text-xs ${getStatusColor(invoice.status)}`}>{invoice.status}</Badge>
-                        <span className="font-semibold text-sm">{formatCurrency(invoice.total, currency)}</span>
-                      </div>
-                    </div>
+        <motion.div
+          initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}
+          className="ch-table-wrap"
+        >
+          <table className="ch-table">
+            <thead>
+              <tr>
+                <th>Invoice</th>
+                <th>Customer</th>
+                <th>Issued</th>
+                <th>Due</th>
+                <th>Status</th>
+                <th className="num">Total</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((invoice) => (
+                <tr
+                  key={invoice.id}
+                  onClick={() => router.push(`/invoices/${invoice.id}`)}
+                  onAuxClick={(e) => { if (e.button === 1) window.open(`/invoices/${invoice.id}`, "_blank"); }}
+                >
+                  <td><span className="ref">{invoice.number}</span></td>
+                  <td className="font-medium">{invoice.customers?.name ?? "No client"}</td>
+                  <td className="text-muted-foreground">{formatDate(invoice.issue_date)}</td>
+                  <td className="text-muted-foreground">{formatDate(invoice.due_date)}</td>
+                  <td><span className={`ch-pill ${invoice.status}`}>{invoice.status}</span></td>
+                  <td className="num font-semibold">{formatCurrency(invoice.total, currency)}</td>
+                  <td className="text-right" onClick={(e) => e.stopPropagation()}>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0"><MoreHorizontal className="w-4 h-4" /></Button>
+                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted">
+                          <MoreHorizontal className="w-4 h-4" />
+                        </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuItem asChild>
@@ -139,12 +206,12 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
-        </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
       )}
 
       <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -1,0 +1,23 @@
+/**
+ * Standard page header used across list pages — matches the Connected Hub
+ * design's `.ch-page-header` block. Server-component-safe (no hooks).
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div className="ch-page-header">
+      <div>
+        <h1 className="ch-page-title">{title}</h1>
+        {subtitle && <p className="ch-page-subtitle">{subtitle}</p>}
+      </div>
+      {actions && <div className="ch-page-actions">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -2,12 +2,10 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Plus, Search, Package, Edit, Trash2, Archive, Upload } from "@/components/ui/icons";
+import { Plus, Search, Package, Edit, Trash2, Upload } from "@/components/ui/icons";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/layout/page-header";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { createProduct, updateProduct, deleteProduct, bulkImportProducts } from "@/lib/actions/products";
@@ -76,71 +74,128 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
     setDeleteId(null);
   };
 
-  return (
-    <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Products & Services</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{products.length} item{products.length !== 1 ? "s" : ""}</p>
-        </div>
-        <div className="flex items-center gap-2 w-full sm:w-auto">
-          <Button size="sm" variant="outline" className="gap-1.5 flex-1 sm:flex-initial" onClick={() => setShowImport(true)}>
-            <Upload className="w-3.5 h-3.5" />Import CSV
-          </Button>
-          <Button size="sm" className="gap-1.5 flex-1 sm:flex-initial" onClick={() => setShowNew(true)}>
-            <Plus className="w-3.5 h-3.5" />Add product
-          </Button>
-        </div>
-      </motion.div>
+  const totalCatalogValue = products.reduce((s, p) => s + (p.unit_price ?? 0), 0);
+  const archivedCount = products.filter((p) => p.archived).length;
 
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <Input className="pl-9" placeholder="Search products..." value={search} onChange={(e) => setSearch(e.target.value)} />
+  return (
+    <div>
+      <PageHeader
+        title="Products & Services"
+        subtitle={`${products.length - archivedCount} active · ${archivedCount} archived`}
+        actions={
+          <>
+            <button
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+              onClick={() => setShowImport(true)}
+            >
+              <Upload className="w-3.5 h-3.5" /> Import CSV
+            </button>
+            <button
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+              onClick={() => setShowNew(true)}
+            >
+              <Plus className="w-3.5 h-3.5" /> Add product
+            </button>
+          </>
+        }
+      />
+
+      <div className="ch-stat-grid">
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Package className="w-3.5 h-3.5" /><span>Total items</span></div>
+          <div className="ch-stat-value">{products.length}</div>
+          <div className="ch-stat-meta">in catalog</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Package className="w-3.5 h-3.5" /><span>Catalog value</span></div>
+          <div className="ch-stat-value">{formatCurrency(totalCatalogValue, currency)}</div>
+          <div className="ch-stat-meta">sum of unit prices</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><Package className="w-3.5 h-3.5" /><span>Active</span></div>
+          <div className="ch-stat-value">{products.length - archivedCount}</div>
+          <div className="ch-stat-meta">available to invoice</div>
+        </div>
+      </div>
+
+      <div className="ch-filter-bar">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input className="pl-9 h-9" placeholder="Search products..." value={search} onChange={(e) => setSearch(e.target.value)} />
+        </div>
       </div>
 
       {filtered.length === 0 ? (
-        <div className="text-center py-20">
-          <Package className="w-12 h-12 text-muted-foreground/30 mx-auto mb-3" />
-          <h3 className="font-medium mb-1">No products found</h3>
-          <p className="text-sm text-muted-foreground mb-4">{search ? "Try a different search" : "Add your products and services to quickly fill line items"}</p>
-          {!search && <Button size="sm" onClick={() => setShowNew(true)}>Add product</Button>}
+        <div className="ch-empty">
+          <Package className="w-10 h-10 text-muted-foreground/30 mx-auto mb-3" />
+          <h4>No products found</h4>
+          <p>{search ? "Try a different search." : "Add your products and services to quickly fill line items."}</p>
+          {!search && (
+            <button
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium"
+              onClick={() => setShowNew(true)}
+            >
+              <Plus className="w-3 h-3" /> Add product
+            </button>
+          )}
         </div>
       ) : (
-        <div className="grid gap-3">
-          <AnimatePresence>
-            {filtered.map((product) => (
-              <motion.div key={product.id} layout initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -12 }}>
-                <Card>
-                  <CardContent className="p-4 flex items-center gap-4">
-                    <div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">
-                      <Package className="w-5 h-5 text-muted-foreground" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-medium text-sm">{product.name}</span>
-                        {product.unit && <Badge variant="outline" className="text-xs">{product.unit}</Badge>}
-                        {product.archived && <Badge variant="secondary" className="text-xs">Archived</Badge>}
+        <motion.div
+          initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}
+          className="ch-table-wrap"
+        >
+          <table className="ch-table">
+            <thead>
+              <tr>
+                <th>Product</th>
+                <th>Unit</th>
+                <th>Tax</th>
+                <th>Status</th>
+                <th className="num">Unit price</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <AnimatePresence>
+                {filtered.map((product) => (
+                  <tr key={product.id} onClick={() => setEditProduct(product)}>
+                    <td>
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div className="w-7 h-7 rounded-md bg-muted flex items-center justify-center flex-shrink-0">
+                          <Package className="w-3.5 h-3.5 text-muted-foreground" />
+                        </div>
+                        <div className="min-w-0">
+                          <div className="font-semibold truncate">{product.name}</div>
+                          {product.description && (
+                            <div className="text-[11.5px] text-muted-foreground truncate max-w-md">{product.description}</div>
+                          )}
+                        </div>
                       </div>
-                      {product.description && <p className="text-xs text-muted-foreground mt-0.5 truncate">{product.description}</p>}
-                    </div>
-                    <div className="text-right flex-shrink-0">
-                      <p className="font-semibold text-sm">{formatCurrency(product.unit_price, currency)}</p>
-                      <p className="text-xs text-muted-foreground">{product.tax_rate}% tax</p>
-                    </div>
-                    <div className="flex items-center gap-1 flex-shrink-0">
-                      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => setEditProduct(product)}>
-                        <Edit className="w-3.5 h-3.5" />
-                      </Button>
-                      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={() => setDeleteId(product.id)}>
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
-            ))}
-          </AnimatePresence>
-        </div>
+                    </td>
+                    <td className="text-muted-foreground">{product.unit ?? "—"}</td>
+                    <td className="text-muted-foreground">{product.tax_rate}%</td>
+                    <td>
+                      <span className={`ch-pill ${product.archived ? "archived" : "active"}`}>
+                        {product.archived ? "archived" : "active"}
+                      </span>
+                    </td>
+                    <td className="num font-semibold">{formatCurrency(product.unit_price, currency)}</td>
+                    <td className="text-right" onClick={(e) => e.stopPropagation()}>
+                      <div className="flex items-center justify-end gap-1">
+                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted" onClick={() => setEditProduct(product)}>
+                          <Edit className="w-3.5 h-3.5" />
+                        </button>
+                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-destructive" onClick={() => setDeleteId(product.id)}>
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </AnimatePresence>
+            </tbody>
+          </table>
+        </motion.div>
       )}
 
       {/* New product sheet */}

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -1,37 +1,59 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Plus, Search, FileCheck, MoreHorizontal, Trash2, Eye, ArrowRight } from "@/components/ui/icons";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/layout/page-header";
 import { deleteQuote, convertQuoteToInvoice } from "@/lib/actions/quotes";
-import { formatCurrency, formatDate, getStatusColor } from "@/lib/utils";
-import { useRouter } from "next/navigation";
+import { formatCurrency, formatDate } from "@/lib/utils";
 import type { Customer, QuoteWithCustomer } from "@/types/database";
 
-const STATUSES = ["all", "draft", "sent", "accepted", "rejected", "expired"];
+const TABS = [
+  { id: "all",      label: "All"      },
+  { id: "draft",    label: "Draft"    },
+  { id: "sent",     label: "Sent"     },
+  { id: "accepted", label: "Accepted" },
+  { id: "rejected", label: "Rejected" },
+  { id: "expired",  label: "Expired"  },
+] as const;
 
 export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: QuoteWithCustomer[]; customers: Customer[]; currency?: string }) {
   const router = useRouter();
   const [quotes, setQuotes] = useState(initial);
   const [search, setSearch] = useState("");
-  const [status, setStatus] = useState("all");
+  const [tab, setTab] = useState<typeof TABS[number]["id"]>("all");
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [converting, setConverting] = useState<string | null>(null);
 
-  const filtered = quotes.filter((q) => {
-    const matchSearch = `${q.number} ${q.customers?.name}`.toLowerCase().includes(search.toLowerCase());
-    const matchStatus = status === "all" || q.status === status;
+  const filtered = useMemo(() => quotes.filter((q) => {
+    const matchSearch = `${q.number} ${q.customers?.name ?? ""}`.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = tab === "all" || q.status === tab;
     return matchSearch && matchStatus;
-  });
+  }), [quotes, search, tab]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: quotes.length };
+    for (const t of TABS) c[t.id] = quotes.filter((q) => t.id === "all" || q.status === t.id).length;
+    return c;
+  }, [quotes]);
+
+  const totalPipeline = useMemo(
+    () => quotes.filter((q) => q.status === "sent").reduce((s, q) => s + q.total, 0),
+    [quotes]
+  );
+  const totalAccepted = useMemo(
+    () => quotes.filter((q) => q.status === "accepted").reduce((s, q) => s + q.total, 0),
+    [quotes]
+  );
+  const acceptanceRate = quotes.length === 0
+    ? 0
+    : Math.round((counts.accepted / Math.max(counts.accepted + counts.rejected + counts.expired, 1)) * 100);
 
   const handleDelete = async () => {
     if (!deleteId) return;
@@ -53,63 +75,103 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
   };
 
   return (
-    <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold">Quotes</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{quotes.length} total</p>
-        </div>
-        <Link href="/quotes/new" className="w-full sm:w-auto">
-          <Button size="sm" className="gap-1.5 w-full sm:w-auto"><Plus className="w-3.5 h-3.5" />New quote</Button>
-        </Link>
-      </motion.div>
+    <div>
+      <PageHeader
+        title="Quotes"
+        subtitle={`${quotes.length} total · ${formatCurrency(totalPipeline, currency)} in pipeline`}
+        actions={
+          <Link href="/quotes/new">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+              <Plus className="w-3.5 h-3.5" /> New quote
+            </button>
+          </Link>
+        }
+      />
 
-      <div className="flex flex-col sm:flex-row gap-3">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <Input className="pl-9" placeholder="Search quotes..." value={search} onChange={(e) => setSearch(e.target.value)} />
+      <div className="ch-stat-grid">
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileCheck className="w-3.5 h-3.5" /><span>Total</span></div>
+          <div className="ch-stat-value">{quotes.length}</div>
+          <div className="ch-stat-meta">all time</div>
         </div>
-        <Select value={status} onValueChange={setStatus}>
-          <SelectTrigger className="w-full sm:w-40">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            {STATUSES.map((s) => (
-              <SelectItem key={s} value={s}>{s === "all" ? "All statuses" : s.charAt(0).toUpperCase() + s.slice(1)}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileCheck className="w-3.5 h-3.5" /><span>Open pipeline</span></div>
+          <div className="ch-stat-value">{formatCurrency(totalPipeline, currency)}</div>
+          <div className="ch-stat-meta">awaiting decision</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileCheck className="w-3.5 h-3.5" /><span>Accepted</span></div>
+          <div className="ch-stat-value">{formatCurrency(totalAccepted, currency)}</div>
+          <div className="ch-stat-meta">won deals</div>
+        </div>
+        <div className="ch-stat">
+          <div className="ch-stat-label"><FileCheck className="w-3.5 h-3.5" /><span>Acceptance rate</span></div>
+          <div className="ch-stat-value">{acceptanceRate}%</div>
+          <div className="ch-stat-meta">of decided quotes</div>
+        </div>
+      </div>
+
+      <div className="ch-tabs">
+        {TABS.map((t) => (
+          <button key={t.id} className={`ch-tab ${tab === t.id ? "active" : ""}`} onClick={() => setTab(t.id)}>
+            {t.label}
+            <span className="count">{counts[t.id] ?? 0}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="ch-filter-bar">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input placeholder="Search quotes..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-9" />
+        </div>
       </div>
 
       {filtered.length === 0 ? (
-        <div className="text-center py-20">
-          <FileCheck className="w-12 h-12 text-muted-foreground/30 mx-auto mb-3" />
-          <h3 className="font-medium mb-1">No quotes found</h3>
-          <p className="text-sm text-muted-foreground mb-4">{search || status !== "all" ? "Try different filters" : "Create your first quote"}</p>
-          {!search && status === "all" && <Link href="/quotes/new"><Button size="sm">Create quote</Button></Link>}
+        <div className="ch-empty">
+          <FileCheck className="w-10 h-10 text-muted-foreground/30 mx-auto mb-3" />
+          <h4>No quotes found</h4>
+          <p>{search || tab !== "all" ? "Try different filters." : "Create your first quote."}</p>
+          {!search && tab === "all" && (
+            <Link href="/quotes/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium">
+                <Plus className="w-3 h-3" /> Create quote
+              </button>
+            </Link>
+          )}
         </div>
       ) : (
-        <div className="space-y-2">
-          {filtered.map((quote, i) => (
-            <motion.div key={quote.id} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03 }}>
-              <Card className="hover:shadow-sm transition-shadow">
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-4">
-                    <div className="min-w-0 flex-1 grid grid-cols-1 sm:grid-cols-4 gap-2 items-center">
-                      <div>
-                        <Link href={`/quotes/${quote.id}`} className="font-medium text-sm hover:text-blue-600 dark:hover:text-blue-400 transition-colors">{quote.number}</Link>
-                        <p className="text-xs text-muted-foreground">{quote.customers?.name ?? "No client"}</p>
-                      </div>
-                      <div className="hidden sm:block text-sm text-muted-foreground">Issued {formatDate(quote.issue_date)}</div>
-                      <div className="hidden sm:block text-sm text-muted-foreground">Expires {formatDate(quote.expiry_date)}</div>
-                      <div className="flex items-center gap-2 sm:justify-end">
-                        <Badge variant="secondary" className={`text-xs ${getStatusColor(quote.status)}`}>{quote.status}</Badge>
-                        <span className="font-semibold text-sm">{formatCurrency(quote.total, currency)}</span>
-                      </div>
-                    </div>
+        <motion.div
+          initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}
+          className="ch-table-wrap"
+        >
+          <table className="ch-table">
+            <thead>
+              <tr>
+                <th>Quote</th>
+                <th>Customer</th>
+                <th>Issued</th>
+                <th>Expires</th>
+                <th>Status</th>
+                <th className="num">Total</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((quote) => (
+                <tr key={quote.id} onClick={() => router.push(`/quotes/${quote.id}`)}>
+                  <td><span className="ref">{quote.number}</span></td>
+                  <td className="font-medium">{quote.customers?.name ?? "No client"}</td>
+                  <td className="text-muted-foreground">{formatDate(quote.issue_date)}</td>
+                  <td className="text-muted-foreground">{formatDate(quote.expiry_date)}</td>
+                  <td><span className={`ch-pill ${quote.status}`}>{quote.status}</span></td>
+                  <td className="num font-semibold">{formatCurrency(quote.total, currency)}</td>
+                  <td className="text-right" onClick={(e) => e.stopPropagation()}>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0"><MoreHorizontal className="w-4 h-4" /></Button>
+                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted">
+                          <MoreHorizontal className="w-4 h-4" />
+                        </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuItem asChild>
@@ -126,12 +188,12 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
-        </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
       )}
 
       <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>


### PR DESCRIPTION
Pulls the prototype's actual page patterns into the app: a token-bound .ch-* utility set in globals.css, dashboard rebuilt to the prototype's overview (KPI strip with sparkline, 6-month bar chart, recent-invoices table, quick actions, today's schedule, activity feed), and invoices/quotes/customers/products list pages converted from card-rows to proper tables with status tabs and KPI strips.