### PR TITLE
feat(ui): app-wide loaders + business-switch overlay

### DIFF
--- a/src/app/(dashboard)/agents/loading.tsx
+++ b/src/app/(dashboard)/agents/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/contacts/loading.tsx
+++ b/src/app/(dashboard)/contacts/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/loading.tsx
@@ -1,13 +1,51 @@
+/**
+ * Route-segment fallback while a (dashboard) page's RSCs stream in.
+ * Mirrors the prototype's page header + KPI strip + table skeleton so the
+ * canvas doesn't reflow when the real content arrives.
+ */
 export default function Loading() {
   return (
-    <div className="space-y-6 max-w-5xl animate-pulse">
-      <div className="h-8 w-48 bg-muted rounded-lg" />
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-28 bg-muted rounded-xl" />
+    <div className="animate-pulse">
+      {/* Page header */}
+      <div className="ch-page-header">
+        <div>
+          <div className="h-7 w-48 bg-muted rounded-md" />
+          <div className="h-3 w-64 bg-muted rounded-md mt-2.5" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-28 bg-muted rounded-md" />
+          <div className="h-9 w-32 bg-muted rounded-md" />
+        </div>
+      </div>
+
+      {/* Stat grid */}
+      <div className="ch-stat-grid">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="ch-stat">
+            <div className="h-3 w-24 bg-muted rounded-md" />
+            <div className="h-7 w-32 bg-muted rounded-md" />
+            <div className="h-2.5 w-20 bg-muted rounded-md" />
+          </div>
         ))}
       </div>
-      <div className="h-64 bg-muted rounded-xl" />
+
+      {/* Body */}
+      <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
+        <div className="px-4 py-3 border-b border-border">
+          <div className="h-4 w-32 bg-muted rounded-md" />
+        </div>
+        <div className="divide-y divide-border">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="px-4 py-3 flex items-center gap-4">
+              <div className="h-3 w-20 bg-muted rounded-md" />
+              <div className="h-3 w-32 bg-muted rounded-md" />
+              <div className="h-3 w-24 bg-muted rounded-md ml-auto" />
+              <div className="h-5 w-16 bg-muted rounded-full" />
+              <div className="h-3 w-20 bg-muted rounded-md" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/products/loading.tsx
+++ b/src/app/(dashboard)/products/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/recurring/loading.tsx
+++ b/src/app/(dashboard)/recurring/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/reports/loading.tsx
+++ b/src/app/(dashboard)/reports/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/settings/loading.tsx
+++ b/src/app/(dashboard)/settings/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/tasks/loading.tsx
+++ b/src/app/(dashboard)/tasks/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/team/loading.tsx
+++ b/src/app/(dashboard)/team/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/components/business/business-switcher.tsx
+++ b/src/components/business/business-switcher.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import { setActiveBusiness } from "@/lib/actions/business";
 import { AddBusinessModal } from "./add-business-modal";
+import { useAppLoading } from "@/components/layout/app-loading";
 import type { Business } from "@/types/database";
 
 interface BusinessSwitcherProps {
@@ -26,13 +27,21 @@ export function BusinessSwitcher({ business, businesses, onClose }: BusinessSwit
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [addOpen, setAddOpen] = useState(false);
+  const { setBusy } = useAppLoading();
 
   const handleSwitch = (biz: Business) => {
     if (biz.id === business.id) return;
+    setBusy(`Switching to ${biz.name}…`);
     startTransition(async () => {
-      await setActiveBusiness(biz.id);
-      router.refresh();
-      onClose?.();
+      try {
+        await setActiveBusiness(biz.id);
+        router.refresh();
+        onClose?.();
+      } finally {
+        // Clear the overlay shortly after refresh kicks off so the new
+        // route's RSC payload arrives behind the spinner without flashing.
+        setTimeout(() => setBusy(null), 350);
+      }
     });
   };
 

--- a/src/components/layout/app-loading.tsx
+++ b/src/components/layout/app-loading.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import { Loader2 } from "@/components/ui/icons";
+
+interface AppLoadingValue {
+  /** Show a full-screen scrim with a spinner + label (e.g. while switching business). */
+  setBusy: (label: string | null) => void;
+  busy: string | null;
+}
+
+const AppLoadingCtx = createContext<AppLoadingValue>({ busy: null, setBusy: () => {} });
+
+export function useAppLoading() {
+  return useContext(AppLoadingCtx);
+}
+
+export function AppLoadingProvider({ children }: { children: ReactNode }) {
+  const [busy, setBusyState] = useState<string | null>(null);
+  const setBusy = useCallback((label: string | null) => setBusyState(label), []);
+
+  return (
+    <AppLoadingCtx.Provider value={{ busy, setBusy }}>
+      {children}
+      {busy && (
+        <div
+          className="fixed inset-0 z-[90] flex items-center justify-center bg-background/70 backdrop-blur-[1px]"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex items-center gap-3 px-5 py-3 rounded-xl bg-card border border-border shadow-lg">
+            <Loader2 className="w-4 h-4 animate-spin text-primary" />
+            <span className="text-sm font-medium">{busy}</span>
+          </div>
+        </div>
+      )}
+    </AppLoadingCtx.Provider>
+  );
+}

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { AppSidebar } from "./app-sidebar";
 import { AppHeader } from "./app-header";
 import { AppearanceProvider } from "./appearance-provider";
+import { AppLoadingProvider } from "./app-loading";
+import { RouteProgress } from "./route-progress";
 import { AgentPanel } from "@/components/agent/agent-panel";
 import type { Business } from "@/types/database";
 import type { Role } from "@/lib/permissions";
@@ -22,6 +24,8 @@ export function DashboardShell({ business, businesses, user, userRole, children 
 
   return (
     <AppearanceProvider accentColor={business.accent_color} bgPattern={business.bg_pattern} sidebarTheme={business.sidebar_theme}>
+      <AppLoadingProvider>
+      <Suspense fallback={null}><RouteProgress /></Suspense>
       <div className="flex h-screen overflow-hidden bg-background">
         {/* Sidebar */}
         <AppSidebar
@@ -58,6 +62,7 @@ export function DashboardShell({ business, businesses, user, userRole, children 
       </div>
 
       <AgentPanel />
+      </AppLoadingProvider>
     </AppearanceProvider>
   );
 }

--- a/src/components/layout/route-progress.tsx
+++ b/src/components/layout/route-progress.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+/**
+ * Top-of-page route progress bar — appears whenever the URL changes (push,
+ * replace, refresh) and during any pending transition. No external deps;
+ * the bar grows toward 90% over ~600ms then snaps to 100% when the new
+ * route's RSCs settle in.
+ *
+ * Drop-in: render once inside the dashboard shell.
+ */
+export function RouteProgress() {
+  const pathname = usePathname();
+  const params   = useSearchParams();
+  const [progress, setProgress] = useState(0);
+  const [visible,  setVisible]  = useState(false);
+
+  useEffect(() => {
+    let raf = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    setVisible(true);
+    setProgress(8);
+
+    // Climb toward 90% over ~600ms with an easing curve.
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / 600);
+      const eased = 1 - Math.pow(1 - t, 2);
+      setProgress(8 + 82 * eased);
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    // Snap to 100% on the next frame; the new route is already painting.
+    timer = setTimeout(() => {
+      setProgress(100);
+      setTimeout(() => setVisible(false), 180);
+    }, 350);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      if (timer) clearTimeout(timer);
+    };
+  }, [pathname, params]);
+
+  return (
+    <div
+      aria-hidden
+      className="fixed top-0 left-0 right-0 z-[100] pointer-events-none"
+      style={{ height: 2 }}
+    >
+      <div
+        className="h-full bg-primary transition-[width,opacity] ease-out"
+        style={{
+          width: `${progress}%`,
+          opacity: visible ? 1 : 0,
+          transitionDuration: visible ? "180ms" : "300ms",
+          boxShadow: visible ? "0 0 6px hsl(var(--primary) / 0.5)" : undefined,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,48 @@
+import { Loader2 } from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * One spinner to rule them all. Three sizes; defaults to inheriting `currentColor`
+ * so it matches whatever button / pill / row you drop it into.
+ */
+export function Spinner({
+  size = "sm",
+  className,
+}: {
+  size?: "xs" | "sm" | "md" | "lg";
+  className?: string;
+}) {
+  const px =
+    size === "xs" ? "w-3 h-3" :
+    size === "sm" ? "w-3.5 h-3.5" :
+    size === "md" ? "w-4 h-4" :
+                    "w-5 h-5";
+  return <Loader2 className={cn(px, "animate-spin", className)} aria-hidden />;
+}
+
+/**
+ * Centered "loading…" row used inside cards while a fetch resolves —
+ * matches the .ch-empty padding so the panel doesn't reflow when real
+ * data arrives.
+ */
+export function LoadingRow({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 text-muted-foreground py-12">
+      <Spinner size="sm" className="text-primary" />
+      <span className="text-sm">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * Pill-style "fetching" indicator for tight spaces (next to a label, inside
+ * a row, etc.). Same look as the inline hint we use on AddressSelect.
+ */
+export function FetchingPill({ label = "Loading…" }: { label?: string }) {
+  return (
+    <span className="ml-1 inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+      <Spinner size="xs" />
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
Top-of-page route progress bar, scrim+pill overlay during business switch with router.refresh(), and route-segment skeletons that mirror the new Connected Hub page shape.