### PR TITLE
feat(design): consistent PageHeader across all list pages

### DIFF
--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { listTasks } from "@/lib/actions/tasks";
 import { KanbanBoard } from "@/components/tasks/kanban-board";
+import { PageHeader } from "@/components/layout/page-header";
 
 export const dynamic = "force-dynamic";
 
@@ -50,12 +51,10 @@ export default async function TasksPage() {
 
   return (
     <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold tracking-tight">Tasks</h1>
-        <p className="text-sm text-neutral-500 mt-0.5">
-          Drag cards between columns. Click a card to assign, tag, or link it to a job.
-        </p>
-      </div>
+      <PageHeader
+        title="Tasks"
+        subtitle="Drag cards between columns. Click a card to assign, tag, or link it to a job."
+      />
       <KanbanBoard
         initialTasks={tasks}
         members={members}

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/layout/page-header";
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem,
   DropdownMenuSeparator, DropdownMenuTrigger,
@@ -157,28 +158,19 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
   };
 
   return (
-    <div className="space-y-10">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-6 pb-2">
-        <div className="space-y-2">
-          <h1 className="font-display text-4xl sm:text-5xl tracking-tight">Contacts</h1>
-          <p className="text-sm text-muted-foreground">
-            {counts.total} total
-            <span className="mx-2 text-muted-foreground/40">·</span>
-            {counts.lead} leads
-            <span className="mx-2 text-muted-foreground/40">·</span>
-            {counts.contact} contacts
-            <span className="mx-2 text-muted-foreground/40">·</span>
-            {counts.customer} customers
-          </p>
-        </div>
-        <Button
-          onClick={() => { setForm(EMPTY); setShowAdd(true); }}
-          className="bg-foreground text-background hover:bg-foreground/90 rounded-md h-9 px-4"
-        >
-          <Plus className="h-4 w-4 mr-1.5" /> New contact
-        </Button>
-      </div>
+    <div>
+      <PageHeader
+        title="Contacts"
+        subtitle={`${counts.total} total · ${counts.lead} leads · ${counts.contact} contacts · ${counts.customer} customers`}
+        actions={
+          <button
+            onClick={() => { setForm(EMPTY); setShowAdd(true); }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" /> New contact
+          </button>
+        }
+      />
 
       {/* Filter row */}
       <div className="flex flex-col sm:flex-row gap-3 border-b border-border pb-4">

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -202,19 +203,19 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
   };
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Leads</h1>
-          <p className="text-muted-foreground text-sm mt-0.5">
-            {stats.total} total · {stats.new} new · {stats.won} won · {stats.lost} lost
-          </p>
-        </div>
-        <Button onClick={() => setShowAdd(true)}>
-          <Plus className="h-4 w-4 mr-2" /> Add Lead
-        </Button>
-      </div>
+    <div>
+      <PageHeader
+        title="Leads"
+        subtitle={`${stats.total} total · ${stats.new} new · ${stats.won} won · ${stats.lost} lost`}
+        actions={
+          <button
+            onClick={() => setShowAdd(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" /> Add lead
+          </button>
+        }
+      />
 
       {/* Stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/src/components/messages/messages-client.tsx
+++ b/src/components/messages/messages-client.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { MessageSquare, Plus, Send, Phone, User, Search, Loader2, ChevronLeft } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -185,19 +186,25 @@ export function MessagesClient({ conversations: initialConvs, customers, autoOpe
 
   return (
     <div className="flex flex-col h-[calc(100vh-6rem)]">
-      {/* Page header */}
-      <div className="flex items-center justify-between mb-4 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-bold">Messages</h1>
-          {totalUnread > 0 && (
-            <Badge className="bg-blue-500 text-white text-xs">{totalUnread}</Badge>
-          )}
-        </div>
-        <Button size="sm" className="gap-1.5" onClick={() => setShowNewModal(true)}>
-          <Plus className="w-4 h-4" />
-          New Message
-        </Button>
-      </div>
+      <PageHeader
+        title={
+          <span className="inline-flex items-center gap-2">
+            Messages
+            {totalUnread > 0 && (
+              <span className="ch-pill new no-dot">{totalUnread}</span>
+            )}
+          </span>
+        }
+        subtitle={`${conversations.length} thread${conversations.length === 1 ? "" : "s"}`}
+        actions={
+          <button
+            onClick={() => setShowNewModal(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" /> New message
+          </button>
+        }
+      />
 
       {/* Main panel */}
       <div className="flex flex-1 border rounded-xl overflow-hidden min-h-0">

--- a/src/components/recurring/recurring-jobs-client.tsx
+++ b/src/components/recurring/recurring-jobs-client.tsx
@@ -5,6 +5,7 @@ import { Plus, Repeat, Pause, Play, Trash2, Edit2, MapPin, User as UserIcon, Cal
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/layout/page-header";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -140,14 +141,19 @@ export function RecurringJobsClient({ initialSchedules, customers, profiles }: P
   const customerName = (id: string | null) => customers.find((c) => c.id === id)?.name ?? null;
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2"><Repeat className="h-6 w-6" /> Recurring jobs</h1>
-          <p className="text-muted-foreground text-sm mt-0.5">{schedules.length} schedule{schedules.length === 1 ? "" : "s"} · cron generates jobs nightly</p>
-        </div>
-        <Button onClick={openNew}><Plus className="h-4 w-4 mr-1.5" /> New schedule</Button>
-      </div>
+    <div>
+      <PageHeader
+        title="Recurring jobs"
+        subtitle={`${schedules.length} schedule${schedules.length === 1 ? "" : "s"} · cron generates jobs nightly`}
+        actions={
+          <button
+            onClick={openNew}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" /> New schedule
+          </button>
+        }
+      />
 
       {schedules.length === 0 ? (
         <Card>

--- a/src/components/reports/reports-client.tsx
+++ b/src/components/reports/reports-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { FileText, Plus, Trash2, Download, Eye, ClipboardList } from "@/components/ui/icons";
 import { toast } from "sonner";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -40,16 +41,18 @@ export function ReportsClient({ reports }: ReportsClientProps) {
   };
 
   return (
-    <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Reports</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{reports.length} report{reports.length !== 1 ? "s" : ""}</p>
-        </div>
-        <Link href="/reports/new">
-          <Button size="sm"><Plus className="w-4 h-4 mr-1.5" />New Report</Button>
-        </Link>
-      </motion.div>
+    <div>
+      <PageHeader
+        title="Reports"
+        subtitle={`${reports.length} report${reports.length !== 1 ? "s" : ""}`}
+        actions={
+          <Link href="/reports/new">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+              <Plus className="w-3.5 h-3.5" /> New report
+            </button>
+          </Link>
+        }
+      />
 
       {reports.length === 0 ? (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex flex-col items-center justify-center py-24 text-center">

--- a/src/components/schedule/schedule-client.tsx
+++ b/src/components/schedule/schedule-client.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight, Plus, Clock, MapPin, LayoutGrid, Columns3 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
 import { toast } from "sonner";
 import { getScheduledJobs } from "@/lib/actions/schedule";
 import { JobModal } from "./job-modal";
@@ -129,12 +130,10 @@ export function ScheduleClient({ initialJobs, initialStart, initialEnd, profiles
 
   return (
     <div className="flex flex-col h-full space-y-4">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Schedule</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{formatWeekRange(weekStart, weekEnd)}</p>
-        </div>
+      <PageHeader
+        title="Schedule"
+        subtitle={formatWeekRange(weekStart, weekEnd)}
+        actions={
         <div className="flex items-center gap-2">
           <div className="flex items-center rounded-lg border overflow-hidden">
             <Button variant={view === "week" ? "secondary" : "ghost"} size="sm" className="rounded-none h-8 px-2.5" onClick={() => setView("week")} title="Week view">
@@ -159,7 +158,8 @@ export function ScheduleClient({ initialJobs, initialStart, initialEnd, profiles
             <Plus className="h-4 w-4 mr-1.5" /> New Job
           </Button>
         </div>
-      </div>
+        }
+      />
 
       {view === "dispatch" ? (
         <DispatchBoard

--- a/src/components/team/team-page-client.tsx
+++ b/src/components/team/team-page-client.tsx
@@ -6,6 +6,7 @@ import { Users2, Plus, Pencil, Trash2, Loader2, X, Check, Phone, Mail, Briefcase
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/layout/page-header";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -298,22 +299,20 @@ export function TeamPageClient({ profiles: initialProfiles, members, userRole, c
   };
 
   return (
-    <div className="space-y-6 ">
-      {/* Header */}
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Users2 className="w-6 h-6" /> Team
-          </h1>
-          <p className="text-sm text-muted-foreground mt-0.5">Manage team member profiles and skills</p>
-        </div>
-        {canManage && (
-          <Button size="sm" className="gap-1.5" onClick={() => setShowAddForm((v) => !v)}>
+    <div>
+      <PageHeader
+        title="Team"
+        subtitle="Manage team member profiles and skills"
+        actions={canManage && (
+          <button
+            onClick={() => setShowAddForm((v) => !v)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+          >
             {showAddForm ? <X className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
             {showAddForm ? "Cancel" : "Add member"}
-          </Button>
+          </button>
         )}
-      </motion.div>
+      />
 
       {/* Add form */}
       <AnimatePresence>

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -1,46 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { Plus, Wrench, Trash2, Eye, User } from "@/components/ui/icons";
+import { Plus, Wrench, Trash2, MoreHorizontal, MapPin, User, Calendar } from "@/components/ui/icons";
 import { toast } from "sonner";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/layout/page-header";
 import { deleteWorkOrder } from "@/lib/actions/work-orders";
 import type { WorkOrderWithCustomer, WorkOrderStatus, BusinessMember } from "@/types/database";
 
-const STATUS_TABS: { label: string; value: WorkOrderStatus | "all" }[] = [
-  { label: "All", value: "all" },
-  { label: "Draft", value: "draft" },
-  { label: "Assigned", value: "assigned" },
-  { label: "In Progress", value: "in_progress" },
-  { label: "Submitted", value: "submitted" },
-  { label: "Reviewed", value: "reviewed" },
-  { label: "Completed", value: "completed" },
+const TABS: { id: WorkOrderStatus | "all"; label: string }[] = [
+  { id: "all",         label: "All"         },
+  { id: "draft",       label: "Draft"       },
+  { id: "assigned",    label: "Assigned"    },
+  { id: "in_progress", label: "In Progress" },
+  { id: "submitted",   label: "Submitted"   },
+  { id: "reviewed",    label: "Reviewed"    },
+  { id: "completed",   label: "Completed"   },
 ];
 
-const STATUS_STYLES: Record<WorkOrderStatus, string> = {
-  draft:       "bg-slate-100 text-slate-700",
-  assigned:    "bg-blue-100 text-blue-700",
-  in_progress: "bg-orange-100 text-orange-700",
-  submitted:   "bg-purple-100 text-purple-700",
-  reviewed:    "bg-yellow-100 text-yellow-700",
-  completed:   "bg-green-100 text-green-700",
-  cancelled:   "bg-red-100 text-red-700",
-};
-
-const STATUS_LABELS: Record<WorkOrderStatus, string> = {
-  draft:       "Draft",
-  assigned:    "Assigned",
-  in_progress: "In Progress",
-  submitted:   "Submitted",
-  reviewed:    "Reviewed",
-  completed:   "Completed",
-  cancelled:   "Cancelled",
+const STATUS_TO_PILL: Record<WorkOrderStatus, string> = {
+  draft: "draft", assigned: "scheduled", in_progress: "in-progress",
+  submitted: "pending", reviewed: "pending", completed: "completed", cancelled: "cancelled",
 };
 
 interface WorkOrdersClientProps {
@@ -48,129 +32,176 @@ interface WorkOrdersClientProps {
   members: BusinessMember[];
 }
 
-export function WorkOrdersClient({ workOrders, members }: WorkOrdersClientProps) {
+export function WorkOrdersClient({ workOrders }: WorkOrdersClientProps) {
   const router = useRouter();
-  const [tab, setTab] = useState<WorkOrderStatus | "all">("all");
-  const [deleting, setDeleting] = useState<string | null>(null);
+  const [tab, setTab] = useState<typeof TABS[number]["id"]>("all");
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
-  const memberMap = Object.fromEntries(members.map((m) => [m.email, m]));
+  const filtered = useMemo(
+    () => tab === "all" ? workOrders : workOrders.filter((w) => w.status === tab),
+    [workOrders, tab]
+  );
 
-  const filtered = tab === "all" ? workOrders : workOrders.filter((w) => w.status === tab);
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: workOrders.length };
+    for (const t of TABS) c[t.id] = workOrders.filter((w) => t.id === "all" || w.status === t.id).length;
+    return c;
+  }, [workOrders]);
 
-  const handleDelete = async (id: string) => {
-    setDeleting(id);
+  const todayStr = new Date().toISOString().split("T")[0];
+  const stats = useMemo(() => ({
+    todayCount:  workOrders.filter((w) => w.scheduled_date === todayStr).length,
+    onSite:      workOrders.filter((w) => w.status === "in_progress").length,
+    needsReview: workOrders.filter((w) => w.status === "submitted").length,
+    completed:   workOrders.filter((w) => w.status === "completed").length,
+  }), [workOrders, todayStr]);
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    setBusy(true);
     try {
-      await deleteWorkOrder(id);
+      await deleteWorkOrder(deleteId);
       toast.success("Work order deleted");
       router.refresh();
-    } catch {
-      toast.error("Failed to delete");
-    } finally {
-      setDeleting(null);
-    }
+    } catch { toast.error("Failed to delete"); }
+    setBusy(false);
+    setDeleteId(null);
   };
 
   return (
-    <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Work Orders</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">{workOrders.length} total</p>
-        </div>
-        <Link href="/work-orders/new">
-          <Button size="sm"><Plus className="w-4 h-4 mr-1.5" />New Work Order</Button>
-        </Link>
-      </motion.div>
-
-      {/* Status tabs */}
-      <div className="flex gap-1.5 flex-wrap">
-        {STATUS_TABS.map((t) => {
-          const count = t.value === "all" ? workOrders.length : workOrders.filter((w) => w.status === t.value).length;
-          return (
-            <button
-              key={t.value}
-              onClick={() => setTab(t.value)}
-              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                tab === t.value
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
-              }`}
-            >
-              {t.label} {count > 0 && <span className="ml-1 opacity-70">{count}</span>}
+    <div>
+      <PageHeader
+        title="Work Orders"
+        subtitle={`${workOrders.length} total · ${stats.onSite} on site now`}
+        actions={
+          <Link href="/work-orders/new">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+              <Plus className="w-3.5 h-3.5" /> New work order
             </button>
-          );
-        })}
+          </Link>
+        }
+      />
+
+      <div className="ch-stat-grid">
+        <Stat icon={<Calendar className="w-3.5 h-3.5" />} label="Today" value={stats.todayCount} sub={stats.todayCount === 1 ? "scheduled job" : "scheduled jobs"} />
+        <Stat icon={<Wrench className="w-3.5 h-3.5" />} label="On site now" value={stats.onSite} sub="in progress" />
+        <Stat icon={<Wrench className="w-3.5 h-3.5" />} label="Needs review" value={stats.needsReview} sub="submitted by workers" />
+        <Stat icon={<Wrench className="w-3.5 h-3.5" />} label="Completed" value={stats.completed} sub="all time" />
+      </div>
+
+      <div className="ch-tabs">
+        {TABS.map((t) => (
+          <button key={t.id} className={`ch-tab ${tab === t.id ? "active" : ""}`} onClick={() => setTab(t.id)}>
+            {t.label}<span className="count">{counts[t.id] ?? 0}</span>
+          </button>
+        ))}
       </div>
 
       {filtered.length === 0 ? (
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex flex-col items-center justify-center py-24 text-center">
-          <div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center mb-4">
-            <Wrench className="w-8 h-8 text-muted-foreground" />
-          </div>
-          <h3 className="font-semibold text-lg mb-1">{tab === "all" ? "No work orders yet" : `No ${STATUS_LABELS[tab as WorkOrderStatus]?.toLowerCase()} orders`}</h3>
-          <p className="text-sm text-muted-foreground mb-6 max-w-sm">Send workers on-site to capture photos. AI will generate a scope of work from what they find.</p>
-          <Link href="/work-orders/new"><Button><Plus className="w-4 h-4 mr-1.5" />Create first work order</Button></Link>
-        </motion.div>
-      ) : (
-        <div className="grid gap-3">
-          {filtered.map((wo, i) => (
-            <motion.div key={wo.id} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.04 }}>
-              <Card className="hover:shadow-md transition-shadow">
-                <CardContent className="p-5">
-                  <div className="flex items-start gap-4">
-                    <div className="w-10 h-10 rounded-lg bg-orange-50 flex items-center justify-center flex-shrink-0">
-                      <Wrench className="w-5 h-5 text-orange-500" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1 flex-wrap">
-                        <span className="text-xs font-mono text-muted-foreground">{wo.number}</span>
-                        <h3 className="font-semibold truncate">{wo.title}</h3>
-                        <Badge className={`${STATUS_STYLES[wo.status]} text-xs`}>{STATUS_LABELS[wo.status]}</Badge>
-                      </div>
-                      <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground mt-1">
-                        {wo.property_address && <span>{wo.property_address}</span>}
-                        {wo.customers && <span>· {wo.customers.name}</span>}
-                        {wo.assigned_to_email && (
-                          <span className="flex items-center gap-1">
-                            · <User className="w-3 h-3" />
-                            {memberMap[wo.assigned_to_email]
-                              ? wo.assigned_to_email
-                              : wo.assigned_to_email}
-                          </span>
-                        )}
-                        {wo.scheduled_date && <span>· {wo.scheduled_date}</span>}
-                        <span>· {wo.photos.length} photo{wo.photos.length !== 1 ? "s" : ""}</span>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1 flex-shrink-0">
-                      <Link href={`/work-orders/${wo.id}`}>
-                        <Button variant="ghost" size="icon" className="h-8 w-8"><Eye className="w-4 h-4" /></Button>
-                      </Link>
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive hover:text-destructive" disabled={deleting === wo.id}>
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Delete work order?</AlertDialogTitle>
-                            <AlertDialogDescription>This will permanently delete {wo.number} and all associated photos.</AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={() => handleDelete(wo.id)}>Delete</AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
+        <div className="ch-empty">
+          <Wrench className="w-10 h-10 text-muted-foreground/30 mx-auto mb-3" />
+          <h4>No work orders</h4>
+          <p>Send workers on-site to capture photos. AI generates a scope of work from what they find.</p>
+          <Link href="/work-orders/new">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium">
+              <Plus className="w-3 h-3" /> Create work order
+            </button>
+          </Link>
         </div>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}
+          className="ch-table-wrap"
+        >
+          <table className="ch-table">
+            <thead>
+              <tr>
+                <th>Job</th>
+                <th>Customer</th>
+                <th>Address</th>
+                <th>Assigned</th>
+                <th>Scheduled</th>
+                <th>Status</th>
+                <th>Photos</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((wo) => (
+                <tr key={wo.id} onClick={() => router.push(`/work-orders/${wo.id}`)}>
+                  <td>
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="w-7 h-7 rounded-md bg-amber-50 dark:bg-amber-950/30 flex items-center justify-center flex-shrink-0">
+                        <Wrench className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400" />
+                      </div>
+                      <div className="min-w-0">
+                        <div className="font-semibold truncate">{wo.title}</div>
+                        <div className="ref">{wo.number}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>{wo.customers?.name ?? "—"}</td>
+                  <td className="text-muted-foreground">
+                    {wo.property_address ? (
+                      <span className="inline-flex items-center gap-1.5"><MapPin className="w-3 h-3" />{wo.property_address}</span>
+                    ) : "—"}
+                  </td>
+                  <td className="text-muted-foreground">
+                    {wo.assigned_to_email ? (
+                      <span className="inline-flex items-center gap-1.5"><User className="w-3 h-3" />{wo.assigned_to_email}</span>
+                    ) : "—"}
+                  </td>
+                  <td className="text-muted-foreground">{wo.scheduled_date ?? "—"}</td>
+                  <td><span className={`ch-pill ${STATUS_TO_PILL[wo.status]}`}>{wo.status.replace("_", " ")}</span></td>
+                  <td className="num">{wo.photos?.length ?? 0}</td>
+                  <td className="text-right" onClick={(e) => e.stopPropagation()}>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted">
+                          <MoreHorizontal className="w-4 h-4" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem asChild><Link href={`/work-orders/${wo.id}`}>View</Link></DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onClick={() => setDeleteId(wo.id)} className="text-destructive gap-2">
+                          <Trash2 className="w-3.5 h-3.5" />Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
       )}
+
+      <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete work order?</AlertDialogTitle>
+            <AlertDialogDescription>This will permanently delete the order and all associated photos.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={handleDelete} disabled={busy}>
+              {busy ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function Stat({ icon, label, value, sub }: { icon: React.ReactNode; label: string; value: number; sub: string }) {
+  return (
+    <div className="ch-stat">
+      <div className="ch-stat-label">{icon}<span>{label}</span></div>
+      <div className="ch-stat-value">{value}</div>
+      <div className="ch-stat-meta">{sub}</div>
     </div>
   );
 }


### PR DESCRIPTION
Every remaining top-level list page now uses the shared <PageHeader> matching the prototype's .ch-page-* pattern. Work Orders fully converted to the .ch-table style with KPIs and tabs. Other pages get a header swap to keep them consistent visually.