### PR TITLE
fix: stale state on biz switch + rename Reports → Site Reports under Sales

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -24,10 +24,11 @@ const navSections: NavSection[] = [
     { label: "Tasks",      href: "/tasks",      icon: Columns3                      },
   ]},
   { section: "Sales", items: [
-    { label: "Leads",      href: "/leads",      icon: UserPlus                      },
-    { label: "Quotes",     href: "/quotes",     icon: FileCheck                     },
-    { label: "Invoices",   href: "/invoices",   icon: FileText                      },
-    { label: "Recurring",  href: "/recurring",  icon: Repeat                        },
+    { label: "Leads",         href: "/leads",      icon: UserPlus                      },
+    { label: "Quotes",        href: "/quotes",     icon: FileCheck                     },
+    { label: "Invoices",      href: "/invoices",   icon: FileText                      },
+    { label: "Site Reports",  href: "/reports",    icon: ClipboardList                 },
+    { label: "Recurring",     href: "/recurring",  icon: Repeat                        },
   ]},
   { section: "Service", items: [
     { label: "Work Orders", href: "/work-orders", icon: Wrench,        worker: true },
@@ -43,9 +44,6 @@ const navSections: NavSection[] = [
   { section: "Workforce", items: [
     { label: "Team",       href: "/team",       icon: Users2                        },
     { label: "Agents",     href: "/agents",     icon: Bot                           },
-  ]},
-  { section: "Insights", items: [
-    { label: "Reports",    href: "/reports",    icon: ClipboardList                 },
   ]},
   { section: "Account", items: [
     { label: "Help",       href: "/help",       icon: HelpCircle,    worker: true   },

--- a/src/components/layout/appearance-provider.tsx
+++ b/src/components/layout/appearance-provider.tsx
@@ -140,20 +140,21 @@ export function AppearanceProvider({
   bgPattern?: string;
   sidebarTheme?: string;
 }) {
-  const [accentColor, setAccentColor] = useState(initialAccent);
-  const [bgPattern, setBgPattern] = useState(initialPattern);
-  const [sidebarTheme, setSidebarTheme] = useState(initialTheme);
+  const [accentColor, setAccentColor]     = useState(initialAccent);
+  const [bgPattern,   setBgPattern]       = useState(initialPattern);
+  const [sidebarTheme, setSidebarTheme]   = useState(initialTheme);
+
+  // Sync state when the active business changes (router.refresh re-renders
+  // this provider with the new business's saved appearance, but useState
+  // ignores prop changes after mount — without this sync, switching
+  // businesses left the previous biz's theme in place until a hard reload.
+  useEffect(() => { setAccentColor(initialAccent);  }, [initialAccent]);
+  useEffect(() => { setBgPattern(initialPattern);   }, [initialPattern]);
+  useEffect(() => { setSidebarTheme(initialTheme);  }, [initialTheme]);
 
   useEffect(() => { document.documentElement.dataset.accent = accentColor; }, [accentColor]);
   useEffect(() => { document.documentElement.dataset.pattern = bgPattern; }, [bgPattern]);
   useEffect(() => { document.documentElement.dataset.sidebarTheme = sidebarTheme; }, [sidebarTheme]);
-
-  // Hydration catch — apply all on first mount
-  useEffect(() => {
-    document.documentElement.dataset.accent = initialAccent;
-    document.documentElement.dataset.pattern = initialPattern;
-    document.documentElement.dataset.sidebarTheme = initialTheme;
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <AppearanceContext.Provider value={{ accentColor, bgPattern, sidebarTheme, setAccentColor, setBgPattern, setSidebarTheme }}>

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -53,8 +53,12 @@ export function DashboardShell({ business, businesses, user, userRole, children 
           />
           <main className="app-content flex-1 overflow-auto">
             {/* Connected Hub layout: content fills the main pane (no max-width
-                cap), with the prototype's uniform 24px padding. */}
-            <div className="w-full p-6">
+                cap), with the prototype's uniform 24px padding.
+                Keyed by business.id so switching businesses fully remounts
+                the page tree — list components hold their data in local
+                useState(initial) and otherwise show the previous biz's
+                rows until a hard refresh. */}
+            <div key={business.id} className="w-full p-6">
               {children}
             </div>
           </main>

--- a/src/components/reports/report-generator.tsx
+++ b/src/components/reports/report-generator.tsx
@@ -276,7 +276,7 @@ export function ReportGenerator({ customers: initialCustomers, business, default
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-center gap-4">
         <Link href="/reports"><Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button></Link>
         <div>
-          <h1 className="text-2xl font-bold">New Report</h1>
+          <h1 className="text-2xl font-bold tracking-tight">New site report</h1>
           <p className="text-sm text-muted-foreground">Step {step} of 2</p>
         </div>
       </motion.div>

--- a/src/components/reports/reports-client.tsx
+++ b/src/components/reports/reports-client.tsx
@@ -43,12 +43,12 @@ export function ReportsClient({ reports }: ReportsClientProps) {
   return (
     <div>
       <PageHeader
-        title="Reports"
-        subtitle={`${reports.length} report${reports.length !== 1 ? "s" : ""}`}
+        title="Site Reports"
+        subtitle={`${reports.length} report${reports.length !== 1 ? "s" : ""} for clients · inspection / scope-of-works`}
         actions={
           <Link href="/reports/new">
             <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
-              <Plus className="w-3.5 h-3.5" /> New report
+              <Plus className="w-3.5 h-3.5" /> New site report
             </button>
           </Link>
         }


### PR DESCRIPTION
Keyed dashboard content by business.id so everything remounts cleanly on switch (no more previous-biz data lingering). Plus moved Reports out of the empty Insights section into Sales and renamed to Site Reports to disambiguate from analytics.