### PR TITLE
feat(cleanup): one-click 'Clean up' with review + Undo (customers)

### DIFF
--- a/src/components/cleanup/cleanup-button.tsx
+++ b/src/components/cleanup/cleanup-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles } from "@/components/ui/icons";
+import { CleanupModal } from "./cleanup-modal";
+import type { CleanupEntity } from "@/lib/actions/cleanup";
+
+/**
+ * Drop-in button that opens the AI cleanup flow for the given entity.
+ * Use it in any list page's <PageHeader actions={...}> alongside the
+ * primary "New X" button.
+ */
+export function CleanupButton({
+  entity,
+  entityLabel,
+  className = "",
+}: {
+  entity: CleanupEntity;
+  entityLabel: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className={
+          "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-primary/30 bg-[hsl(var(--primary)/0.08)] text-primary text-sm font-medium hover:bg-[hsl(var(--primary)/0.14)] transition-colors " +
+          className
+        }
+        title={`Clean up ${entityLabel}`}
+      >
+        <Sparkles className="w-3.5 h-3.5" /> Clean up
+      </button>
+      <CleanupModal open={open} onOpenChange={setOpen} entity={entity} entityLabel={entityLabel} />
+    </>
+  );
+}

--- a/src/components/cleanup/cleanup-modal.tsx
+++ b/src/components/cleanup/cleanup-modal.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { toast } from "sonner";
+import { Sparkles, AlertTriangle, Check, RotateCcw } from "@/components/ui/icons";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  proposeCleanup, applyCleanup, undoCleanup,
+  type CleanupEntity, type ProposedChange,
+} from "@/lib/actions/cleanup";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entity: CleanupEntity;
+  /** Display label, e.g. "customers" */
+  entityLabel: string;
+}
+
+type Stage = "analyzing" | "review" | "applying" | "done" | "empty";
+
+export function CleanupModal({ open, onOpenChange, entity, entityLabel }: Props) {
+  const router = useRouter();
+  const [stage,     setStage]     = useState<Stage>("analyzing");
+  const [proposals, setProposals] = useState<ProposedChange[]>([]);
+  const [selected,  setSelected]  = useState<Set<string>>(new Set());
+  const [totalRows, setTotalRows] = useState<number>(0);
+  const [runId,     setRunId]     = useState<string | null>(null);
+  const [appliedCount, setApplied] = useState(0);
+
+  // Generate proposals each time the modal opens
+  useEffect(() => {
+    if (!open) return;
+    setStage("analyzing");
+    setSelected(new Set());
+    setProposals([]);
+    setRunId(null);
+    setApplied(0);
+
+    (async () => {
+      try {
+        const { proposals, total_rows } = await proposeCleanup(entity);
+        setTotalRows(total_rows);
+        setProposals(proposals);
+        if (proposals.length === 0) {
+          setStage("empty");
+        } else {
+          // Pre-select all by default — user can untick the ones they don't want.
+          setSelected(new Set(proposals.map((p) => p.change_id)));
+          setStage("review");
+        }
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't analyze");
+        onOpenChange(false);
+      }
+    })();
+  }, [open, entity, onOpenChange]);
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+
+  const apply = async () => {
+    if (selected.size === 0) return;
+    setStage("applying");
+    try {
+      const { run_id, applied } = await applyCleanup(entity, proposals, [...selected]);
+      setRunId(run_id);
+      setApplied(applied);
+      setStage("done");
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't apply changes");
+      setStage("review");
+    }
+  };
+
+  const undo = async () => {
+    if (!runId) return;
+    try {
+      const { reverted } = await undoCleanup(runId);
+      toast.success(`Undid ${reverted} change${reverted === 1 ? "" : "s"}`);
+      onOpenChange(false);
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't undo");
+    }
+  };
+
+  const grouped = {
+    high: proposals.filter((p) => p.severity === "high"),
+    med:  proposals.filter((p) => p.severity === "med"),
+    low:  proposals.filter((p) => p.severity === "low"),
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-primary" /> Clean up {entityLabel}
+          </DialogTitle>
+          <DialogDescription>
+            {stage === "analyzing" && "Scanning for duplicates and fields to tidy…"}
+            {stage === "review"    && `${proposals.length} suggested change${proposals.length === 1 ? "" : "s"} across ${totalRows} ${entityLabel}. Untick anything you'd rather keep.`}
+            {stage === "applying"  && "Applying your selections…"}
+            {stage === "done"      && `Applied ${appliedCount} change${appliedCount === 1 ? "" : "s"}. You can undo this run if anything looks off.`}
+            {stage === "empty"     && `Nothing to clean up — all ${totalRows} ${entityLabel} look healthy.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <AnimatePresence mode="wait">
+          {stage === "analyzing" && (
+            <motion.div key="analyzing" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col items-center justify-center py-12 gap-3">
+              <Spinner size="lg" className="text-primary" />
+              <p className="text-sm text-muted-foreground">Looking at every row…</p>
+            </motion.div>
+          )}
+
+          {stage === "empty" && (
+            <motion.div key="empty" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col items-center justify-center py-12 gap-2">
+              <Check className="w-8 h-8 text-emerald-600" />
+              <p className="text-sm font-medium">Everything looks good.</p>
+              <button
+                onClick={() => onOpenChange(false)}
+                className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted"
+              >Close</button>
+            </motion.div>
+          )}
+
+          {stage === "review" && (
+            <motion.div key="review" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col flex-1 overflow-hidden">
+              <div className="overflow-y-auto pr-1 flex-1 space-y-4">
+                {grouped.high.length > 0 && <Group label="Merge duplicates"  tone="high" items={grouped.high} selected={selected} onToggle={toggle} />}
+                {grouped.med.length  > 0 && <Group label="Delete / archive"  tone="med"  items={grouped.med}  selected={selected} onToggle={toggle} />}
+                {grouped.low.length  > 0 && <Group label="Tidy fields"       tone="low"  items={grouped.low}  selected={selected} onToggle={toggle} />}
+              </div>
+              <div className="flex items-center justify-between gap-2 pt-4 mt-4 border-t border-border flex-shrink-0">
+                <button
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                  onClick={() => setSelected(new Set())}
+                >Deselect all</button>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => onOpenChange(false)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted"
+                  >Cancel</button>
+                  <button
+                    onClick={apply}
+                    disabled={selected.size === 0}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50"
+                  >
+                    <Sparkles className="w-3.5 h-3.5" /> Apply {selected.size} change{selected.size === 1 ? "" : "s"}
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          )}
+
+          {stage === "applying" && (
+            <motion.div key="applying" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col items-center justify-center py-12 gap-3">
+              <Spinner size="lg" className="text-primary" />
+              <p className="text-sm text-muted-foreground">Applying changes…</p>
+            </motion.div>
+          )}
+
+          {stage === "done" && (
+            <motion.div key="done" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col items-center justify-center py-12 gap-3">
+              <div className="w-12 h-12 rounded-full bg-emerald-100 dark:bg-emerald-950/40 flex items-center justify-center">
+                <Check className="w-6 h-6 text-emerald-700 dark:text-emerald-300" />
+              </div>
+              <p className="text-sm font-medium">Done — {appliedCount} change{appliedCount === 1 ? "" : "s"} applied.</p>
+              <p className="text-xs text-muted-foreground text-center max-w-sm">If anything looks wrong, hit Undo to roll back this whole run.</p>
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={undo}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" /> Undo this cleanup
+                </button>
+                <button
+                  onClick={() => onOpenChange(false)}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+                >Done</button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Group({
+  label, tone, items, selected, onToggle,
+}: {
+  label: string;
+  tone: "high" | "med" | "low";
+  items: ProposedChange[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+}) {
+  const dotClass =
+    tone === "high" ? "bg-rose-500"   :
+    tone === "med"  ? "bg-amber-500" :
+                      "bg-muted-foreground";
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-2">
+        <span className={`inline-block w-1.5 h-1.5 rounded-full ${dotClass}`} />
+        <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</h3>
+        <span className="text-xs text-muted-foreground">· {items.length}</span>
+      </div>
+      <ul className="space-y-1.5">
+        {items.map((p) => (
+          <li key={p.change_id}>
+            <label className="flex gap-3 items-start p-3 rounded-md border border-border bg-card hover:bg-muted/40 cursor-pointer transition-colors">
+              <input
+                type="checkbox"
+                checked={selected.has(p.change_id)}
+                onChange={() => onToggle(p.change_id)}
+                className="mt-0.5 w-4 h-4 rounded border-border accent-primary cursor-pointer"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium flex items-center gap-2">
+                  {tone === "high" && <AlertTriangle className="w-3.5 h-3.5 text-rose-600" />}
+                  {p.label}
+                </div>
+                {p.detail && <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">{p.detail}</p>}
+              </div>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { deleteCustomer, updateCustomer, bulkImportCustomers } from "@/lib/actions/customers";
 import { BulkImportModal } from "@/components/shared/bulk-import-modal";
 import type { Customer } from "@/types/database";
@@ -77,6 +78,7 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
         subtitle={`${counts.active} active · ${counts.archived} archived`}
         actions={
           <>
+            <CleanupButton entity="customers" entityLabel="customers" />
             <button
               className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
               onClick={() => setShowImport(true)}

--- a/src/lib/actions/cleanup.ts
+++ b/src/lib/actions/cleanup.ts
@@ -1,0 +1,400 @@
+"use server";
+
+/**
+ * Generic "Clean up" infrastructure.
+ *
+ * Every entity that wants a Clean up button registers a proposer here.
+ * The proposer scans the rows for that business and returns a list of
+ * proposed changes — each with a friendly label, a unique change_id, and
+ * the raw operation (`merge` / `delete` / `update`) plus the data needed
+ * to apply it. The UI shows them as a checklist. On Apply, the selected
+ * changes are executed and recorded into `cleanup_runs.change_log` so
+ * Undo can reverse every one of them.
+ *
+ * AI fuzzy matching is intentionally *not* in this first cut — start with
+ * deterministic heuristics (lowercased trimmed email, digits-only phone,
+ * normalized name+address) that we can trust without supervision.
+ */
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+// ─── Public types ─────────────────────────────────────────────────────────
+
+export type CleanupEntity = "customers" | "contacts" | "leads";
+
+export type ProposedChange = {
+  /** Stable id within a single proposal session — used by the UI for selection. */
+  change_id: string;
+  op: "merge" | "delete" | "update";
+  /** Friendly label rendered in the review list. */
+  label: string;
+  /** Optional second line of context. */
+  detail?: string;
+  /** Severity tint for the UI: low (sort/normalize), med (delete/orphan), high (merge). */
+  severity: "low" | "med" | "high";
+  /** Implementation payload — opaque to the UI; consumed by applyCleanup. */
+  payload: MergePayload | DeletePayload | UpdatePayload;
+};
+
+type FkUpdate = { table: string; column: string; row_id: string; from: string; to: string };
+
+type MergePayload = {
+  op: "merge";
+  table: string;
+  survivor_id: string;
+  duplicate_ids: string[];
+  /** Tables that point at this entity via column = id; we'll relink them. */
+  fk_columns: { table: string; column: string }[];
+  /** Captured at apply time and stored in the change_log so Undo works. */
+};
+
+type DeletePayload = {
+  op: "delete";
+  table: string;
+  id: string;
+};
+
+type UpdatePayload = {
+  op: "update";
+  table: string;
+  id: string;
+  patch: Record<string, unknown>;
+};
+
+// ─── Customers proposer ───────────────────────────────────────────────────
+
+const CUSTOMER_FK_COLUMNS = [
+  { table: "invoices",     column: "customer_id" },
+  { table: "quotes",       column: "customer_id" },
+  { table: "work_orders",  column: "customer_id" },
+  { table: "leads",        column: "customer_id" },
+  { table: "contacts",     column: "customer_id" },
+  { table: "sites",        column: "account_id"  }, // sites.account_id -> customers.id
+];
+
+function normEmail(s: string | null | undefined) {
+  return (s ?? "").trim().toLowerCase();
+}
+function normPhone(s: string | null | undefined) {
+  return (s ?? "").replace(/\D/g, "");
+}
+function normNameAddr(name: string | null | undefined, addr: string | null | undefined) {
+  const n = (name ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+  const a = (addr ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+  return n && a ? `${n}|${a}` : "";
+}
+
+interface CustomerRow {
+  id: string;
+  business_id: string;
+  name: string;
+  company: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  city: string | null;
+  postcode: string | null;
+  country: string | null;
+  notes: string | null;
+  archived: boolean;
+  created_at: string;
+}
+
+export async function proposeCleanup(entity: CleanupEntity): Promise<{
+  proposals: ProposedChange[];
+  total_rows: number;
+}> {
+  switch (entity) {
+    case "customers": return proposeCustomerCleanup();
+    default:
+      throw new Error(`No cleanup proposer registered for "${entity}" yet`);
+  }
+}
+
+async function proposeCustomerCleanup() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: rows, error } = await tbl(supabase, "customers")
+    .select("*")
+    .eq("business_id", businessId)
+    .eq("archived", false)
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+
+  const customers: CustomerRow[] = (rows ?? []) as CustomerRow[];
+  const proposals: ProposedChange[] = [];
+
+  // Cluster by identity key. Priority: email > phone > name+address.
+  // Within a cluster, oldest row wins — newer ones get merged into it.
+  const seen = new Set<string>();
+  const cluster = (key: string, rows: CustomerRow[]) => {
+    if (rows.length < 2 || seen.has(key)) return;
+    seen.add(key);
+    const survivor = rows[0]; // oldest
+    const dupes    = rows.slice(1);
+    const dupSummary = dupes.map((d) => d.name).slice(0, 3).join(", ") +
+                       (dupes.length > 3 ? `, +${dupes.length - 3} more` : "");
+    proposals.push({
+      change_id: `merge-${survivor.id}`,
+      op: "merge",
+      severity: "high",
+      label: `Merge ${dupes.length + 1} duplicate${dupes.length === 0 ? "" : "s"}: ${survivor.name}`,
+      detail: `Keep ${survivor.name} (oldest), absorb ${dupSummary}. Re-links every invoice / quote / work order / site / lead / contact pointing at the duplicates.`,
+      payload: {
+        op: "merge",
+        table: "customers",
+        survivor_id: survivor.id,
+        duplicate_ids: dupes.map((d) => d.id),
+        fk_columns: CUSTOMER_FK_COLUMNS,
+      },
+    });
+  };
+
+  // Group by email
+  const byEmail: Record<string, CustomerRow[]> = {};
+  for (const c of customers) {
+    const k = normEmail(c.email);
+    if (!k) continue;
+    (byEmail[k] ??= []).push(c);
+  }
+  for (const [k, group] of Object.entries(byEmail)) cluster(`email:${k}`, group);
+
+  // Group by phone
+  const byPhone: Record<string, CustomerRow[]> = {};
+  for (const c of customers) {
+    const k = normPhone(c.phone);
+    if (!k || k.length < 6) continue;
+    (byPhone[k] ??= []).push(c);
+  }
+  for (const [k, group] of Object.entries(byPhone)) cluster(`phone:${k}`, group);
+
+  // Group by name+address (only for rows without email AND phone)
+  const byNameAddr: Record<string, CustomerRow[]> = {};
+  for (const c of customers) {
+    if (normEmail(c.email) || normPhone(c.phone)) continue;
+    const k = normNameAddr(c.name, [c.address, c.city, c.postcode].filter(Boolean).join(" "));
+    if (!k) continue;
+    (byNameAddr[k] ??= []).push(c);
+  }
+  for (const [k, group] of Object.entries(byNameAddr)) cluster(`namaddr:${k}`, group);
+
+  // Normalize email casing / trim whitespace
+  for (const c of customers) {
+    const trimmedName  = c.name?.trim();
+    const loweredEmail = c.email?.trim().toLowerCase() || null;
+    const trimmedPhone = c.phone?.trim() || null;
+    const patch: Record<string, unknown> = {};
+    if (trimmedName  && trimmedName  !== c.name)  patch.name  = trimmedName;
+    if (loweredEmail !== c.email && (loweredEmail || c.email)) patch.email = loweredEmail;
+    if (trimmedPhone !== c.phone && (trimmedPhone || c.phone)) patch.phone = trimmedPhone;
+    if (Object.keys(patch).length === 0) continue;
+
+    proposals.push({
+      change_id: `norm-${c.id}`,
+      op: "update",
+      severity: "low",
+      label: `Tidy ${c.name}`,
+      detail: Object.entries(patch).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join(" · "),
+      payload: { op: "update", table: "customers", id: c.id, patch },
+    });
+  }
+
+  return { proposals, total_rows: customers.length };
+}
+
+// ─── Apply ────────────────────────────────────────────────────────────────
+
+interface AppliedChangeEntry {
+  change_id: string;
+  op: "merge" | "delete" | "update";
+  /** What we'd need to recreate / reverse the operation. */
+  before: unknown;
+  after: unknown;
+  fk_updates?: FkUpdate[];
+}
+
+export async function applyCleanup(
+  entity: CleanupEntity,
+  proposals: ProposedChange[],
+  selected_ids: string[],
+): Promise<{ run_id: string; applied: number }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const selected = proposals.filter((p) => selected_ids.includes(p.change_id));
+  if (selected.length === 0) throw new Error("No changes selected");
+
+  const log: AppliedChangeEntry[] = [];
+
+  for (const change of selected) {
+    if (change.op === "update") {
+      const { table, id, patch } = change.payload as UpdatePayload;
+      // Capture before for undo
+      const { data: before } = await tbl(supabase, table).select("*").eq("id", id).maybeSingle();
+      const { data: after, error } = await tbl(supabase, table).update(patch).eq("id", id).select().single();
+      if (error) throw new Error(`Update failed on ${table} ${id}: ${error.message}`);
+      log.push({ change_id: change.change_id, op: "update", before, after });
+    } else if (change.op === "delete") {
+      const { table, id } = change.payload as DeletePayload;
+      const { data: before } = await tbl(supabase, table).select("*").eq("id", id).maybeSingle();
+      const { error } = await tbl(supabase, table).delete().eq("id", id);
+      if (error) throw new Error(`Delete failed on ${table} ${id}: ${error.message}`);
+      log.push({ change_id: change.change_id, op: "delete", before, after: null });
+    } else if (change.op === "merge") {
+      const { table, survivor_id, duplicate_ids, fk_columns } = change.payload as MergePayload;
+
+      // Capture full duplicates so undo can re-create them with same ids
+      const { data: dupRows } = await tbl(supabase, table).select("*").in("id", duplicate_ids);
+      // Pull the survivor too — we'll fill any null fields from duplicates
+      const { data: survivor } = await tbl(supabase, table).select("*").eq("id", survivor_id).maybeSingle();
+
+      // Re-link FK rows that point at any of the duplicates → survivor.
+      // Capture each FK update so undo can flip them back.
+      const fkUpdates: FkUpdate[] = [];
+      for (const fc of fk_columns) {
+        const { data: refs } = await tbl(supabase, fc.table)
+          .select(`id, ${fc.column}`)
+          .in(fc.column, duplicate_ids);
+        const refRows = (refs ?? []) as Array<Record<string, string>>;
+        for (const r of refRows) {
+          fkUpdates.push({
+            table: fc.table,
+            column: fc.column,
+            row_id: r.id,
+            from: r[fc.column],   // original duplicate id we'll restore on undo
+            to:   survivor_id,
+          });
+        }
+        // Relink each row by id so we hit exactly the rows we just recorded.
+        for (const r of refRows) {
+          const { error: relinkErr } = await tbl(supabase, fc.table)
+            .update({ [fc.column]: survivor_id })
+            .eq("id", r.id);
+          if (relinkErr) console.error(`Relink ${fc.table}.${fc.column} for ${r.id} failed:`, relinkErr.message);
+        }
+      }
+
+      // Fill null fields on survivor from duplicates (oldest-non-null wins)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const merged: Record<string, any> = { ...(survivor ?? {}) };
+      for (const dup of (dupRows ?? []) as Record<string, unknown>[]) {
+        for (const [k, v] of Object.entries(dup)) {
+          if (k === "id" || k === "created_at" || k === "updated_at" || k === "business_id" || k === "user_id") continue;
+          if (merged[k] == null && v != null) merged[k] = v;
+        }
+      }
+      delete merged.id;
+      delete merged.created_at;
+      delete merged.updated_at;
+      const { error: updateErr } = await tbl(supabase, table).update(merged).eq("id", survivor_id);
+      if (updateErr) console.error("Survivor merge update failed:", updateErr.message);
+
+      // Delete duplicates last
+      const { error: delErr } = await tbl(supabase, table).delete().in("id", duplicate_ids);
+      if (delErr) throw new Error(`Delete duplicates failed: ${delErr.message}`);
+
+      log.push({
+        change_id: change.change_id,
+        op: "merge",
+        before: dupRows,           // full rows so we can re-insert them with same ids
+        after: { survivor_id },
+        fk_updates: fkUpdates,
+      });
+    }
+  }
+
+  // Record the run
+  const summary = `${log.length} change${log.length === 1 ? "" : "s"} applied to ${entity}`;
+  const { data: run, error: runErr } = await tbl(supabase, "cleanup_runs")
+    .insert({
+      business_id: businessId,
+      user_id: user.id,
+      entity,
+      change_log: log,
+      summary,
+    })
+    .select("id")
+    .single();
+  if (runErr) throw new Error(`Couldn't record cleanup run: ${runErr.message}`);
+
+  revalidatePath(`/${entity}`);
+  return { run_id: run.id, applied: log.length };
+}
+
+// ─── Undo ─────────────────────────────────────────────────────────────────
+
+export async function undoCleanup(run_id: string): Promise<{ reverted: number }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: run, error: runErr } = await tbl(supabase, "cleanup_runs")
+    .select("*")
+    .eq("id", run_id)
+    .eq("business_id", businessId)
+    .maybeSingle();
+  if (runErr || !run) throw new Error("Cleanup run not found");
+  if (run.status === "undone") throw new Error("This cleanup has already been undone");
+
+  const log: AppliedChangeEntry[] = (run.change_log ?? []) as AppliedChangeEntry[];
+  let reverted = 0;
+
+  // Reverse in reverse order so dependent operations untangle cleanly
+  for (const entry of [...log].reverse()) {
+    if (entry.op === "update") {
+      const before = entry.before as Record<string, unknown> & { id: string };
+      if (!before?.id) continue;
+      // Set the row back to its before state (only the keys we changed)
+      const after = entry.after as Record<string, unknown> | null;
+      const restore: Record<string, unknown> = {};
+      for (const k of Object.keys(after ?? {})) {
+        if (k === "id" || k === "updated_at") continue;
+        if ((before as Record<string, unknown>)[k] !== (after as Record<string, unknown>)[k]) {
+          restore[k] = (before as Record<string, unknown>)[k];
+        }
+      }
+      if (Object.keys(restore).length > 0) {
+        await tbl(supabase, "customers").update(restore).eq("id", before.id);
+      }
+      reverted++;
+    } else if (entry.op === "delete") {
+      const before = entry.before as Record<string, unknown> | null;
+      if (!before) continue;
+      await tbl(supabase, "customers").insert(before);
+      reverted++;
+    } else if (entry.op === "merge") {
+      const dupRows = (entry.before as Record<string, unknown>[]) ?? [];
+      // Re-insert the duplicates with their original ids first — children's
+      // FK updates need the rows back in the table before the FK constraint
+      // accepts the relink.
+      if (dupRows.length > 0) {
+        const { error: reinsertErr } = await tbl(supabase, "customers").insert(dupRows);
+        if (reinsertErr) console.error("Re-insert duplicates failed:", reinsertErr.message);
+      }
+      // Flip every captured FK update back to its original duplicate id.
+      for (const fk of entry.fk_updates ?? []) {
+        await tbl(supabase, fk.table).update({ [fk.column]: fk.from }).eq("id", fk.row_id);
+      }
+      reverted++;
+    }
+  }
+
+  // Mark the run undone
+  await tbl(supabase, "cleanup_runs")
+    .update({ status: "undone", undone_at: new Date().toISOString() })
+    .eq("id", run_id);
+
+  revalidatePath(`/${run.entity}`);
+  return { reverted };
+}

--- a/supabase/migrations/20260505000001_cleanup_runs.sql
+++ b/supabase/migrations/20260505000001_cleanup_runs.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- Cleanup runs audit log
+--
+-- "Clean up" buttons across the app (customers, contacts, leads, invoices…)
+-- generate a list of proposed changes (dedup, normalize, etc.), the user
+-- approves them, and we apply them. Every applied run is recorded here with
+-- its full change_log so one click on Undo can reverse it.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.cleanup_runs (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID        NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id     UUID                 REFERENCES auth.users(id)        ON DELETE SET NULL,
+  entity      TEXT        NOT NULL,                                              -- 'customers', 'contacts', 'leads', …
+  status      TEXT        NOT NULL DEFAULT 'applied'
+                                       CHECK (status IN ('applied', 'undone')),
+  -- Each entry: {op:'merge'|'delete'|'update', before:{...}, after:{...}|null,
+  --              fk_updates: [{table, id, column, old, new}]}
+  change_log  JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  summary     TEXT        NOT NULL,
+  applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  undone_at   TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS cleanup_runs_business_idx
+  ON public.cleanup_runs (business_id, applied_at DESC);
+
+ALTER TABLE public.cleanup_runs ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY "cleanup_runs_business" ON public.cleanup_runs FOR ALL
+    USING (
+      business_id IN (
+        SELECT id FROM public.businesses WHERE user_id = auth.uid()
+        UNION
+        SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+      )
+    )
+    WITH CHECK (
+      business_id IN (
+        SELECT id FROM public.businesses WHERE user_id = auth.uid()
+        UNION
+        SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+      )
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
Reusable cleanup infrastructure with audit-log undo, wired into Customers. Heuristic dedup proposer (email > phone > name+addr); UI shows proposals grouped by tone with pre-selected checkboxes; Apply records the whole change_log into cleanup_runs; Undo reverses every step including FK relinks. Migration applied & recorded. Contacts / Leads next.