### PR TITLE
feat(customers): empty-row cleanup + multi-select + invoice/billed/outstanding columns

### DIFF
--- a/src/app/(dashboard)/customers/page.tsx
+++ b/src/app/(dashboard)/customers/page.tsx
@@ -1,7 +1,18 @@
-import { getCustomers } from "@/lib/actions/customers";
+import { getCustomers, getCustomerStats } from "@/lib/actions/customers";
+import { getBusiness } from "@/lib/actions/business";
 import { CustomersClient } from "@/components/customers/customers-client";
 
 export default async function CustomersPage() {
-  const customers = await getCustomers();
-  return <CustomersClient customers={customers} />;
+  const [customers, stats, business] = await Promise.all([
+    getCustomers(true), // include archived; the client-side tabs filter by status
+    getCustomerStats().catch(() => ({})),
+    getBusiness().catch(() => null),
+  ]);
+  return (
+    <CustomersClient
+      customers={customers}
+      stats={stats}
+      currency={business?.currency ?? "GBP"}
+    />
+  );
 }

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -11,7 +11,8 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
-import { deleteCustomer, updateCustomer, bulkImportCustomers } from "@/lib/actions/customers";
+import { deleteCustomer, updateCustomer, bulkImportCustomers, bulkArchiveCustomers } from "@/lib/actions/customers";
+import { formatCurrency } from "@/lib/utils";
 import { BulkImportModal } from "@/components/shared/bulk-import-modal";
 import type { Customer } from "@/types/database";
 
@@ -31,13 +32,31 @@ function initials(name: string) {
   return name.split(/\s+/).map((p) => p[0]).filter(Boolean).join("").toUpperCase().slice(0, 2);
 }
 
-export function CustomersClient({ customers: initial }: { customers: Customer[] }) {
+type CustomerStats = Record<string, {
+  invoice_count: number;
+  total_billed: number;
+  total_paid: number;
+  outstanding: number;
+}>;
+
+export function CustomersClient({
+  customers: initial,
+  stats = {},
+  currency = "GBP",
+}: {
+  customers: Customer[];
+  stats?: CustomerStats;
+  currency?: string;
+}) {
   const router = useRouter();
   const [customers, setCustomers] = useState(initial);
   const [search, setSearch] = useState("");
   const [tab, setTab] = useState<"active" | "archived" | "all">("active");
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkAction, setBulkAction] = useState<"archive" | "delete" | null>(null);
+  const [busy, setBusy] = useState(false);
 
   const filtered = useMemo(() => customers.filter((c) => {
     const matchSearch = `${c.name} ${c.email ?? ""} ${c.company ?? ""}`.toLowerCase().includes(search.toLowerCase());
@@ -136,6 +155,36 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
         </div>
       </div>
 
+      {/* Bulk-action bar — appears when ≥1 row is selected */}
+      {selected.size > 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }}
+          className="flex items-center justify-between gap-2 px-3 py-2 mb-2 rounded-md border border-primary/30 bg-[hsl(var(--primary)/0.08)]"
+        >
+          <span className="text-sm font-medium text-primary">
+            {selected.size} selected
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setSelected(new Set())}
+            >Clear</button>
+            <button
+              onClick={() => setBulkAction("archive")}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+            >
+              <Archive className="w-3.5 h-3.5" /> Archive
+            </button>
+            <button
+              onClick={() => setBulkAction("delete")}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-destructive text-destructive-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+            >
+              <Trash2 className="w-3.5 h-3.5" /> Delete
+            </button>
+          </div>
+        </motion.div>
+      )}
+
       {filtered.length === 0 ? (
         <div className="ch-empty">
           <Users className="w-10 h-10 text-muted-foreground/30 mx-auto mb-3" />
@@ -157,16 +206,50 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
           <table className="ch-table">
             <thead>
               <tr>
+                <th style={{ width: 32 }} onClick={(e) => e.stopPropagation()}>
+                  <input
+                    type="checkbox"
+                    aria-label="Select all"
+                    checked={filtered.length > 0 && filtered.every((c) => selected.has(c.id))}
+                    onChange={(e) => {
+                      const next = new Set(selected);
+                      if (e.target.checked) filtered.forEach((c) => next.add(c.id));
+                      else filtered.forEach((c) => next.delete(c.id));
+                      setSelected(next);
+                    }}
+                    className="w-4 h-4 rounded border-border accent-primary cursor-pointer"
+                  />
+                </th>
                 <th>Customer</th>
                 <th>Email</th>
                 <th>Phone</th>
+                <th className="num">Invoices</th>
+                <th className="num">Billed</th>
+                <th className="num">Outstanding</th>
                 <th>Status</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
-              {filtered.map((customer) => (
+              {filtered.map((customer) => {
+                const s = stats[customer.id];
+                const checked = selected.has(customer.id);
+                return (
                 <tr key={customer.id} onClick={() => router.push(`/customers/${customer.id}`)}>
+                  <td onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      aria-label={`Select ${customer.name}`}
+                      checked={checked}
+                      onChange={() => {
+                        const next = new Set(selected);
+                        if (checked) next.delete(customer.id);
+                        else next.add(customer.id);
+                        setSelected(next);
+                      }}
+                      className="w-4 h-4 rounded border-border accent-primary cursor-pointer"
+                    />
+                  </td>
                   <td>
                     <div className="flex items-center gap-3 min-w-0">
                       <div className="w-7 h-7 rounded-full bg-[hsl(var(--primary)/0.12)] text-[hsl(var(--primary))] flex items-center justify-center font-semibold text-[11px] flex-shrink-0">
@@ -191,6 +274,15 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
                     {customer.phone ? (
                       <span className="inline-flex items-center gap-1.5"><Phone className="w-3 h-3" /> {customer.phone}</span>
                     ) : "—"}
+                  </td>
+                  <td className="num">
+                    {s?.invoice_count ? <span className="font-medium">{s.invoice_count}</span> : <span className="text-muted-foreground">—</span>}
+                  </td>
+                  <td className="num">
+                    {s?.total_billed ? formatCurrency(s.total_billed, currency) : <span className="text-muted-foreground">—</span>}
+                  </td>
+                  <td className="num">
+                    {s?.outstanding ? <span className="font-semibold text-amber-700 dark:text-amber-400">{formatCurrency(s.outstanding, currency)}</span> : <span className="text-muted-foreground">—</span>}
                   </td>
                   <td>
                     <span className={`ch-pill ${customer.archived ? "archived" : "active"}`}>
@@ -221,7 +313,8 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
                     </DropdownMenu>
                   </td>
                 </tr>
-              ))}
+              );
+              })}
             </tbody>
           </table>
         </motion.div>
@@ -248,6 +341,50 @@ export function CustomersClient({ customers: initial }: { customers: Customer[] 
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Bulk action confirmation */}
+      <AlertDialog open={!!bulkAction} onOpenChange={() => !busy && setBulkAction(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {bulkAction === "delete" ? "Delete" : "Archive"} {selected.size} customer{selected.size === 1 ? "" : "s"}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {bulkAction === "delete"
+                ? "This permanently removes the rows. Their invoices and quotes will lose their customer link but otherwise stay put. This cannot be undone."
+                : "Archived customers are hidden by default. You can find them under the Archived tab and unarchive any of them later."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy}
+              onClick={async () => {
+                if (!bulkAction) return;
+                setBusy(true);
+                try {
+                  const ids = [...selected];
+                  await bulkArchiveCustomers(ids, bulkAction === "delete" ? "hard" : "archive");
+                  if (bulkAction === "delete") {
+                    setCustomers((prev) => prev.filter((c) => !selected.has(c.id)));
+                  } else {
+                    setCustomers((prev) => prev.map((c) => selected.has(c.id) ? { ...c, archived: true } : c));
+                  }
+                  toast.success(`${ids.length} ${bulkAction === "delete" ? "deleted" : "archived"}`);
+                  setSelected(new Set());
+                } catch { toast.error("Couldn't complete the bulk action"); }
+                setBusy(false);
+                setBulkAction(null);
+              }}
+              className={bulkAction === "delete"
+                ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                : ""}
+            >
+              {busy ? "Working…" : bulkAction === "delete" ? "Delete" : "Archive"}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/lib/actions/cleanup.ts
+++ b/src/lib/actions/cleanup.ts
@@ -186,16 +186,71 @@ async function proposeCustomerCleanup() {
   }
   for (const [k, group] of Object.entries(byNameAddr)) cluster(`namaddr:${k}`, group);
 
-  // Track every id that's going to be merged-as-duplicate so we don't
-  // also propose a tidy on a row that'll be deleted seconds later.
-  const willBeMerged = new Set<string>();
+  // Pull all FK references so we can propose safe deletes for empty rows
+  // (only when no children point at them).
+  const idsRefByFk = new Set<string>();
+  for (const fc of CUSTOMER_FK_COLUMNS) {
+    const { data: refs } = await tbl(supabase, fc.table)
+      .select(fc.column)
+      .eq("business_id", businessId)
+      .not(fc.column, "is", null);
+    for (const r of (refs ?? []) as Array<Record<string, string | null>>) {
+      const id = r[fc.column];
+      if (id) idsRefByFk.add(id);
+    }
+  }
+
+  // Empty rows — name is the only NOT NULL column on customers. Propose a
+  // delete when nothing real is on the row AND nothing FK-references it.
+  // Otherwise (rare: an invoice points at a name-only customer), propose
+  // archiving instead so the historical link stays intact.
+  for (const c of customers) {
+    const isEmpty =
+      !c.email?.trim() && !c.phone?.trim() &&
+      !c.address?.trim() && !c.city?.trim() &&
+      !c.postcode?.trim() && !c.country?.trim() &&
+      !c.company?.trim() && !c.notes?.trim() &&
+      // Either name is missing/placeholder OR all the rest is missing.
+      (!c.name?.trim() || /^(unknown|n\/a|new customer|no name|customer)$/i.test(c.name.trim()) || true);
+
+    if (!isEmpty) continue;
+
+    const referenced = idsRefByFk.has(c.id);
+    if (referenced) {
+      proposals.push({
+        change_id: `arch-${c.id}`,
+        op: "update",
+        severity: "med",
+        label: `Archive empty customer · ${c.name || "(no name)"}`,
+        detail: "All fields are blank, but invoices / quotes / sites still reference this row — archiving instead of deleting keeps history intact.",
+        payload: { op: "update", table: "customers", id: c.id, patch: { archived: true } },
+      });
+    } else {
+      proposals.push({
+        change_id: `del-${c.id}`,
+        op: "delete",
+        severity: "med",
+        label: `Delete empty customer · ${c.name || "(no name)"}`,
+        detail: "No email, phone, address, company, or notes — and nothing else points at this row.",
+        payload: { op: "delete", table: "customers", id: c.id },
+      });
+    }
+  }
+
+  // Track every id that'll be removed (merged / deleted / archived) so we
+  // don't also propose a tidy on a row that'll be gone seconds later.
+  const willBeRemoved = new Set<string>();
   for (const p of proposals) {
-    if (p.op === "merge") for (const id of (p.payload as MergePayload).duplicate_ids) willBeMerged.add(id);
+    if (p.op === "merge")  for (const id of (p.payload as MergePayload).duplicate_ids) willBeRemoved.add(id);
+    if (p.op === "delete") willBeRemoved.add((p.payload as DeletePayload).id);
+    if (p.op === "update" && p.change_id.startsWith("arch-")) {
+      willBeRemoved.add((p.payload as UpdatePayload).id);
+    }
   }
 
   // Normalize email casing / trim whitespace
   for (const c of customers) {
-    if (willBeMerged.has(c.id)) continue;
+    if (willBeRemoved.has(c.id)) continue;
     const trimmedName  = c.name?.trim();
     const loweredEmail = c.email?.trim().toLowerCase() || null;
     const trimmedPhone = c.phone?.trim() || null;

--- a/src/lib/actions/customers.ts
+++ b/src/lib/actions/customers.ts
@@ -104,6 +104,76 @@ export async function deleteCustomer(id: string): Promise<void> {
   revalidatePath("/customers");
 }
 
+/**
+ * Bulk action for the multi-select toolbar. Defaults to soft-delete
+ * (archive) so historical invoice / quote / work-order links keep their
+ * customer name; pass mode="hard" to actually drop the rows.
+ */
+export async function bulkArchiveCustomers(
+  ids: string[],
+  mode: "archive" | "hard" = "archive",
+): Promise<{ ok: number }> {
+  if (!ids.length) return { ok: 0 };
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (mode === "hard") {
+    const { error } = await tbl(supabase, "customers")
+      .delete()
+      .in("id", ids)
+      .eq("business_id", businessId);
+    if (error) throw error;
+  } else {
+    const { error } = await tbl(supabase, "customers")
+      .update({ archived: true })
+      .in("id", ids)
+      .eq("business_id", businessId);
+    if (error) throw error;
+  }
+  revalidateTag(`customers-${businessId}`, {});
+  revalidatePath("/customers");
+  return { ok: ids.length };
+}
+
+/**
+ * Returns aggregate stats per customer: invoice count, total billed,
+ * total paid, outstanding. Cheap enough to fetch all rows for the
+ * business and group client-side; we already do that elsewhere.
+ */
+export async function getCustomerStats(): Promise<Record<string, {
+  invoice_count: number;
+  total_billed: number;
+  total_paid: number;
+  outstanding: number;
+}>> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: invoices, error } = await tbl(supabase, "invoices")
+    .select("customer_id, total, amount_paid, status")
+    .eq("business_id", businessId);
+  if (error) throw error;
+
+  const stats: Record<string, { invoice_count: number; total_billed: number; total_paid: number; outstanding: number }> = {};
+  for (const inv of (invoices ?? []) as Array<{
+    customer_id: string | null; total: number; amount_paid: number; status: string;
+  }>) {
+    if (!inv.customer_id) continue;
+    const s = stats[inv.customer_id] ??= { invoice_count: 0, total_billed: 0, total_paid: 0, outstanding: 0 };
+    s.invoice_count += 1;
+    s.total_billed  += Number(inv.total ?? 0);
+    s.total_paid    += Number(inv.amount_paid ?? 0);
+    if (inv.status !== "cancelled" && inv.status !== "draft") {
+      s.outstanding += Math.max(0, Number(inv.total ?? 0) - Number(inv.amount_paid ?? 0));
+    }
+  }
+  return stats;
+}
+
 export async function bulkImportCustomers(
   rows: Array<Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "archived">>
 ): Promise<{ imported: number; errors: string[] }> {


### PR DESCRIPTION
Cleanup proposer now detects empty rows (with safe archive fallback when children FK them). Customer table grows three numbers columns (Invoices · Billed · Outstanding). Multi-select checkboxes + bulk Archive/Delete toolbar. Pattern drops into contacts/leads/invoices next.