### PR TITLE
feat: Smart Organise on every list + progress bar; fix invoice email NaN + 401

### DIFF
--- a/src/app/api/pdf/invoice/[id]/route.ts
+++ b/src/app/api/pdf/invoice/[id]/route.ts
@@ -1,18 +1,66 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getInvoice } from "@/lib/actions/invoices";
 import { getBusiness } from "@/lib/actions/business";
 
-export async function GET(_: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const token = req.nextUrl.searchParams.get("token");
 
-    const [invoiceData, business] = await Promise.all([getInvoice(id), getBusiness()]);
+  try {
+    // Two paths: tokenised (customer email Download button — no auth, validate
+    // the portal token then fetch via the admin client) or signed-in user.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const inv = invoiceData as any;
+    let inv: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let business: any;
+
+    if (token) {
+      const sb = createAdminClient();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tbl = (s: any, n: string) => s.from(n);
+
+      const { data: link } = await tbl(sb, "customer_portal_tokens")
+        .select("business_id, customer_id, expires_at, revoked_at")
+        .eq("token", token)
+        .maybeSingle();
+
+      if (!link || link.revoked_at) {
+        return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      }
+      if (link.expires_at && new Date(link.expires_at) < new Date()) {
+        return NextResponse.json({ error: "Token expired" }, { status: 401 });
+      }
+
+      const [{ data: invData }, { data: bizData }, { data: cust }] = await Promise.all([
+        tbl(sb, "invoices")
+          .select("*")
+          .eq("id", id)
+          .eq("business_id", link.business_id)
+          .eq("customer_id", link.customer_id)
+          .maybeSingle(),
+        tbl(sb, "businesses").select("*").eq("id", link.business_id).maybeSingle(),
+        tbl(sb, "customers").select("*").eq("id", link.customer_id).maybeSingle(),
+      ]);
+
+      if (!invData) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      inv = { ...(invData as any), customers: cust ?? null };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      business = bizData as any;
+    } else {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+      const [invoiceData, biz] = await Promise.all([getInvoice(id), getBusiness()]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      inv = invoiceData as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      business = biz as any;
+    }
+
     const customer = inv.customers ?? null;
     const lineItems = inv.line_items ?? [];
 

--- a/src/components/cleanup/cleanup-button.tsx
+++ b/src/components/cleanup/cleanup-button.tsx
@@ -28,9 +28,9 @@ export function CleanupButton({
           "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-primary/30 bg-[hsl(var(--primary)/0.08)] text-primary text-sm font-medium hover:bg-[hsl(var(--primary)/0.14)] transition-colors " +
           className
         }
-        title={`Clean up ${entityLabel}`}
+        title={`Smart Organise ${entityLabel}`}
       >
-        <Sparkles className="w-3.5 h-3.5" /> Clean up
+        <Sparkles className="w-3.5 h-3.5" /> Smart Organise
       </button>
       <CleanupModal open={open} onOpenChange={setOpen} entity={entity} entityLabel={entityLabel} />
     </>

--- a/src/components/cleanup/cleanup-modal.tsx
+++ b/src/components/cleanup/cleanup-modal.tsx
@@ -30,6 +30,25 @@ export function CleanupModal({ open, onOpenChange, entity, entityLabel }: Props)
   const [totalRows, setTotalRows] = useState<number>(0);
   const [runId,     setRunId]     = useState<string | null>(null);
   const [appliedCount, setApplied] = useState(0);
+  /** 0–100. Animated separately from the actual server work — we drive it
+   *  with rAF so the user sees movement even when the server takes a beat. */
+  const [progress, setProgress] = useState(0);
+
+  // Animated progress: climbs from 0 to ~92% over the analyze/apply window
+  // then snaps to 100% when the work returns. Pure rAF, no deps.
+  useEffect(() => {
+    if (stage !== "analyzing" && stage !== "applying") return;
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / 1400);
+      const eased = 1 - Math.pow(1 - t, 2);
+      setProgress(8 + 84 * eased);
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [stage]);
 
   // Generate proposals each time the modal opens
   useEffect(() => {
@@ -39,12 +58,14 @@ export function CleanupModal({ open, onOpenChange, entity, entityLabel }: Props)
     setProposals([]);
     setRunId(null);
     setApplied(0);
+    setProgress(0);
 
     (async () => {
       try {
         const { proposals, total_rows } = await proposeCleanup(entity);
         setTotalRows(total_rows);
         setProposals(proposals);
+        setProgress(100);
         if (proposals.length === 0) {
           setStage("empty");
         } else {
@@ -69,11 +90,14 @@ export function CleanupModal({ open, onOpenChange, entity, entityLabel }: Props)
   const apply = async () => {
     if (selected.size === 0) return;
     setStage("applying");
+    setProgress(0);
     try {
       const { run_id, applied } = await applyCleanup(entity, proposals, [...selected]);
       setRunId(run_id);
       setApplied(applied);
+      setProgress(100);
       setStage("done");
+      // Refetch so the page picks up the changes immediately.
       router.refresh();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Couldn't apply changes");
@@ -93,6 +117,15 @@ export function CleanupModal({ open, onOpenChange, entity, entityLabel }: Props)
     }
   };
 
+  // Always refetch when the modal closes after a successful run, so list
+  // components that hold their own useState(initial) pick up the new data.
+  const handleOpenChange = (next: boolean) => {
+    if (!next && stage === "done") {
+      router.refresh();
+    }
+    onOpenChange(next);
+  };
+
   const grouped = {
     high: proposals.filter((p) => p.severity === "high"),
     med:  proposals.filter((p) => p.severity === "med"),
@@ -100,20 +133,30 @@ export function CleanupModal({ open, onOpenChange, entity, entityLabel }: Props)
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Sparkles className="w-4 h-4 text-primary" /> Clean up {entityLabel}
+            <Sparkles className="w-4 h-4 text-primary" /> Smart Organise · {entityLabel}
           </DialogTitle>
           <DialogDescription>
-            {stage === "analyzing" && "Scanning for duplicates and fields to tidy…"}
+            {stage === "analyzing" && "Scanning for duplicates, empty rows, and fields to tidy…"}
             {stage === "review"    && `${proposals.length} suggested change${proposals.length === 1 ? "" : "s"} across ${totalRows} ${entityLabel}. Untick anything you'd rather keep.`}
             {stage === "applying"  && "Applying your selections…"}
             {stage === "done"      && `Applied ${appliedCount} change${appliedCount === 1 ? "" : "s"}. You can undo this run if anything looks off.`}
-            {stage === "empty"     && `Nothing to clean up — all ${totalRows} ${entityLabel} look healthy.`}
+            {stage === "empty"     && `Nothing to organise — all ${totalRows} ${entityLabel} look healthy.`}
           </DialogDescription>
         </DialogHeader>
+
+        {/* Progress bar — visible during analyzing + applying */}
+        {(stage === "analyzing" || stage === "applying") && (
+          <div className="h-1 -mt-2 mb-1 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full bg-primary transition-[width] duration-200 ease-out"
+              style={{ width: `${progress}%`, boxShadow: "0 0 8px hsl(var(--primary) / 0.5)" }}
+            />
+          </div>
+        )}
 
         <AnimatePresence mode="wait">
           {stage === "analyzing" && (

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem,
   DropdownMenuSeparator, DropdownMenuTrigger,
@@ -163,12 +164,15 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
         title="Contacts"
         subtitle={`${counts.total} total · ${counts.lead} leads · ${counts.contact} contacts · ${counts.customer} customers`}
         actions={
-          <button
-            onClick={() => { setForm(EMPTY); setShowAdd(true); }}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
-          >
-            <Plus className="w-3.5 h-3.5" /> New contact
-          </button>
+          <>
+            <CleanupButton entity="contacts" entityLabel="contacts" />
+            <button
+              onClick={() => { setForm(EMPTY); setShowAdd(true); }}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+            >
+              <Plus className="w-3.5 h-3.5" /> New contact
+            </button>
+          </>
         }
       />
 

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { deleteInvoice, duplicateInvoice, updateInvoice } from "@/lib/actions/invoices";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import type { Customer, Invoice, InvoiceWithCustomer } from "@/types/database";
@@ -101,11 +102,14 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
         title="Invoices"
         subtitle={`${invoices.length} total · ${formatCurrency(totalOutstanding, currency)} outstanding`}
         actions={
-          <Link href="/invoices/new">
-            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
-              <Plus className="w-3.5 h-3.5" /> New invoice
-            </button>
-          </Link>
+          <>
+            <CleanupButton entity="invoices" entityLabel="invoices" />
+            <Link href="/invoices/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+                <Plus className="w-3.5 h-3.5" /> New invoice
+              </button>
+            </Link>
+          </>
         }
       />
 

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -208,12 +209,15 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
         title="Leads"
         subtitle={`${stats.total} total · ${stats.new} new · ${stats.won} won · ${stats.lost} lost`}
         actions={
-          <button
-            onClick={() => setShowAdd(true)}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
-          >
-            <Plus className="w-3.5 h-3.5" /> Add lead
-          </button>
+          <>
+            <CleanupButton entity="leads" entityLabel="leads" />
+            <button
+              onClick={() => setShowAdd(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+            >
+              <Plus className="w-3.5 h-3.5" /> Add lead
+            </button>
+          </>
         }
       />
 

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -6,6 +6,7 @@ import { Plus, Search, Package, Edit, Trash2, Upload } from "@/components/ui/ico
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { createProduct, updateProduct, deleteProduct, bulkImportProducts } from "@/lib/actions/products";
@@ -84,6 +85,7 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
         subtitle={`${products.length - archivedCount} active · ${archivedCount} archived`}
         actions={
           <>
+            <CleanupButton entity="products" entityLabel="products" />
             <button
               className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
               onClick={() => setShowImport(true)}

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { deleteQuote, convertQuoteToInvoice, updateQuote } from "@/lib/actions/quotes";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import type { Customer, QuoteWithCustomer } from "@/types/database";
@@ -96,11 +97,14 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
         title="Quotes"
         subtitle={`${quotes.length} total · ${formatCurrency(totalPipeline, currency)} in pipeline`}
         actions={
-          <Link href="/quotes/new">
-            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
-              <Plus className="w-3.5 h-3.5" /> New quote
-            </button>
-          </Link>
+          <>
+            <CleanupButton entity="quotes" entityLabel="quotes" />
+            <Link href="/quotes/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+                <Plus className="w-3.5 h-3.5" /> New quote
+              </button>
+            </Link>
+          </>
         }
       />
 

--- a/src/components/team/team-page-client.tsx
+++ b/src/components/team/team-page-client.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -304,13 +305,16 @@ export function TeamPageClient({ profiles: initialProfiles, members, userRole, c
         title="Team"
         subtitle="Manage team member profiles and skills"
         actions={canManage && (
-          <button
-            onClick={() => setShowAddForm((v) => !v)}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
-          >
-            {showAddForm ? <X className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
-            {showAddForm ? "Cancel" : "Add member"}
-          </button>
+          <>
+            <CleanupButton entity="team_profiles" entityLabel="team profiles" />
+            <button
+              onClick={() => setShowAddForm((v) => !v)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
+            >
+              {showAddForm ? <X className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
+              {showAddForm ? "Cancel" : "Add member"}
+            </button>
+          </>
         )}
       />
 

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/layout/page-header";
+import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { deleteWorkOrder } from "@/lib/actions/work-orders";
 import type { WorkOrderWithCustomer, WorkOrderStatus, BusinessMember } from "@/types/database";
 
@@ -75,11 +76,14 @@ export function WorkOrdersClient({ workOrders }: WorkOrdersClientProps) {
         title="Work Orders"
         subtitle={`${workOrders.length} total · ${stats.onSite} on site now`}
         actions={
-          <Link href="/work-orders/new">
-            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
-              <Plus className="w-3.5 h-3.5" /> New work order
-            </button>
-          </Link>
+          <>
+            <CleanupButton entity="work_orders" entityLabel="work orders" />
+            <Link href="/work-orders/new">
+              <button className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity">
+                <Plus className="w-3.5 h-3.5" /> New work order
+              </button>
+            </Link>
+          </>
         }
       />
 

--- a/src/lib/actions/cleanup.ts
+++ b/src/lib/actions/cleanup.ts
@@ -25,7 +25,15 @@ const tbl = (sb: any, name: string) => sb.from(name);
 
 // ─── Public types ─────────────────────────────────────────────────────────
 
-export type CleanupEntity = "customers" | "contacts" | "leads";
+export type CleanupEntity =
+  | "customers"
+  | "contacts"
+  | "leads"
+  | "invoices"
+  | "quotes"
+  | "products"
+  | "work_orders"
+  | "team_profiles";
 
 export type ProposedChange = {
   /** Stable id within a single proposal session — used by the UI for selection. */
@@ -110,9 +118,18 @@ export async function proposeCleanup(entity: CleanupEntity): Promise<{
   total_rows: number;
 }> {
   switch (entity) {
-    case "customers": return proposeCustomerCleanup();
-    default:
-      throw new Error(`No cleanup proposer registered for "${entity}" yet`);
+    case "customers":     return proposeCustomerCleanup();
+    case "contacts":      return proposeContactsCleanup();
+    case "leads":         return proposeLeadsCleanup();
+    case "invoices":      return proposeInvoicesCleanup();
+    case "quotes":        return proposeQuotesCleanup();
+    case "products":      return proposeProductsCleanup();
+    case "work_orders":   return proposeWorkOrdersCleanup();
+    case "team_profiles": return proposeTeamProfilesCleanup();
+    default: {
+      const _: never = entity;
+      throw new Error(`No cleanup proposer registered for "${_}"`);
+    }
   }
 }
 
@@ -278,6 +295,8 @@ async function proposeCustomerCleanup() {
 interface AppliedChangeEntry {
   change_id: string;
   op: "merge" | "delete" | "update";
+  /** Table this change targeted — needed for undo to talk to the right row. */
+  table: string;
   /** What we'd need to recreate / reverse the operation. */
   before: unknown;
   after: unknown;
@@ -325,13 +344,13 @@ export async function applyCleanup(
         .update(patch).eq("id", id).select().maybeSingle();
       if (error) throw new Error(`Update failed on ${table} ${id}: ${error.message}`);
       if (!after) continue;
-      log.push({ change_id: change.change_id, op: "update", before, after });
+      log.push({ change_id: change.change_id, op: "update", table, before, after });
     } else if (change.op === "delete") {
       const { table, id } = change.payload as DeletePayload;
       const { data: before } = await tbl(supabase, table).select("*").eq("id", id).maybeSingle();
       const { error } = await tbl(supabase, table).delete().eq("id", id);
       if (error) throw new Error(`Delete failed on ${table} ${id}: ${error.message}`);
-      log.push({ change_id: change.change_id, op: "delete", before, after: null });
+      log.push({ change_id: change.change_id, op: "delete", table, before, after: null });
     } else if (change.op === "merge") {
       const { table, survivor_id, duplicate_ids, fk_columns } = change.payload as MergePayload;
 
@@ -388,6 +407,7 @@ export async function applyCleanup(
       log.push({
         change_id: change.change_id,
         op: "merge",
+        table,
         before: dupRows,           // full rows so we can re-insert them with same ids
         after: { survivor_id },
         fk_updates: fkUpdates,
@@ -434,6 +454,7 @@ export async function undoCleanup(run_id: string): Promise<{ reverted: number }>
 
   // Reverse in reverse order so dependent operations untangle cleanly
   for (const entry of [...log].reverse()) {
+    const targetTable = entry.table || "customers"; // legacy entries default to customers
     if (entry.op === "update") {
       const before = entry.before as Record<string, unknown> & { id: string };
       if (!before?.id) continue;
@@ -447,13 +468,13 @@ export async function undoCleanup(run_id: string): Promise<{ reverted: number }>
         }
       }
       if (Object.keys(restore).length > 0) {
-        await tbl(supabase, "customers").update(restore).eq("id", before.id);
+        await tbl(supabase, targetTable).update(restore).eq("id", before.id);
       }
       reverted++;
     } else if (entry.op === "delete") {
       const before = entry.before as Record<string, unknown> | null;
       if (!before) continue;
-      await tbl(supabase, "customers").insert(before);
+      await tbl(supabase, targetTable).insert(before);
       reverted++;
     } else if (entry.op === "merge") {
       const dupRows = (entry.before as Record<string, unknown>[]) ?? [];
@@ -461,7 +482,7 @@ export async function undoCleanup(run_id: string): Promise<{ reverted: number }>
       // FK updates need the rows back in the table before the FK constraint
       // accepts the relink.
       if (dupRows.length > 0) {
-        const { error: reinsertErr } = await tbl(supabase, "customers").insert(dupRows);
+        const { error: reinsertErr } = await tbl(supabase, targetTable).insert(dupRows);
         if (reinsertErr) console.error("Re-insert duplicates failed:", reinsertErr.message);
       }
       // Flip every captured FK update back to its original duplicate id.
@@ -479,4 +500,445 @@ export async function undoCleanup(run_id: string): Promise<{ reverted: number }>
 
   revalidatePath(`/${run.entity}`);
   return { reverted };
+}
+
+// ─── Generic helpers ──────────────────────────────────────────────────────
+
+async function pullRows(table: string, select: string = "*", filterArchived = true) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  let q = tbl(supabase, table).select(select).eq("business_id", businessId);
+  if (filterArchived) {
+    // Some tables don't have an archived column; ignore the error if so.
+    q = q.or(`archived.is.null,archived.eq.false`);
+  }
+  q = q.order("created_at", { ascending: true });
+  const { data } = await q;
+  return { rows: (data ?? []) as Record<string, unknown>[], businessId, supabase };
+}
+
+// ─── Contacts (CRM) ───────────────────────────────────────────────────────
+
+interface ContactRow {
+  id: string; name: string; email: string | null; phone: string | null;
+  company: string | null; lifecycle_stage?: string | null; notes: string | null;
+  customer_id: string | null;
+}
+
+async function proposeContactsCleanup() {
+  const { rows } = await pullRows("contacts");
+  const contacts = rows as unknown as ContactRow[];
+  const proposals: ProposedChange[] = [];
+
+  // Dedup by email > phone (no FK relinks needed — contacts has no inbound FKs)
+  const seen = new Set<string>();
+  const cluster = (key: string, group: ContactRow[]) => {
+    if (group.length < 2 || seen.has(key)) return;
+    seen.add(key);
+    const survivor = group[0];
+    const dupes = group.slice(1);
+    proposals.push({
+      change_id: `merge-c-${survivor.id}`,
+      op: "merge",
+      severity: "high",
+      label: `Merge ${dupes.length + 1} duplicate contacts: ${survivor.name}`,
+      detail: `Keep the oldest, absorb ${dupes.length} other entr${dupes.length === 1 ? "y" : "ies"}.`,
+      payload: {
+        op: "merge",
+        table: "contacts",
+        survivor_id: survivor.id,
+        duplicate_ids: dupes.map((d) => d.id),
+        fk_columns: [],
+      },
+    });
+  };
+
+  const byEmail: Record<string, ContactRow[]> = {};
+  for (const c of contacts) {
+    const k = normEmail(c.email);
+    if (k) (byEmail[k] ??= []).push(c);
+  }
+  for (const [k, g] of Object.entries(byEmail)) cluster(`email:${k}`, g);
+
+  const byPhone: Record<string, ContactRow[]> = {};
+  for (const c of contacts) {
+    if (normEmail(c.email)) continue; // already handled
+    const k = normPhone(c.phone);
+    if (k && k.length >= 6) (byPhone[k] ??= []).push(c);
+  }
+  for (const [k, g] of Object.entries(byPhone)) cluster(`phone:${k}`, g);
+
+  // Empty rows — only delete if not linked to a customer
+  const removed = new Set<string>();
+  for (const p of proposals) {
+    if (p.op === "merge") for (const id of (p.payload as MergePayload).duplicate_ids) removed.add(id);
+  }
+  for (const c of contacts) {
+    if (removed.has(c.id)) continue;
+    if (c.email?.trim() || c.phone?.trim() || c.company?.trim() || c.notes?.trim()) continue;
+    if (c.customer_id) {
+      proposals.push({
+        change_id: `arch-c-${c.id}`, op: "update", severity: "med",
+        label: `Archive empty contact · ${c.name || "(no name)"}`,
+        detail: "Linked to a customer but otherwise empty.",
+        payload: { op: "update", table: "contacts", id: c.id, patch: { archived: true } },
+      });
+      removed.add(c.id);
+    } else {
+      proposals.push({
+        change_id: `del-c-${c.id}`, op: "delete", severity: "med",
+        label: `Delete empty contact · ${c.name || "(no name)"}`,
+        detail: "No email, phone, company, notes, or customer link.",
+        payload: { op: "delete", table: "contacts", id: c.id },
+      });
+      removed.add(c.id);
+    }
+  }
+
+  // Tidy
+  for (const c of contacts) {
+    if (removed.has(c.id)) continue;
+    const trimmed = c.name?.trim();
+    const lowered = c.email?.trim().toLowerCase() || null;
+    const patch: Record<string, unknown> = {};
+    if (trimmed && trimmed !== c.name) patch.name = trimmed;
+    if (lowered !== c.email && (lowered || c.email)) patch.email = lowered;
+    if (Object.keys(patch).length === 0) continue;
+    proposals.push({
+      change_id: `norm-c-${c.id}`, op: "update", severity: "low",
+      label: `Tidy ${c.name}`,
+      detail: Object.entries(patch).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join(" · "),
+      payload: { op: "update", table: "contacts", id: c.id, patch },
+    });
+  }
+
+  return { proposals, total_rows: contacts.length };
+}
+
+// ─── Leads ────────────────────────────────────────────────────────────────
+
+interface LeadRow {
+  id: string; name: string; email: string | null; phone: string | null;
+  status: string; created_at: string; customer_id: string | null;
+  source: string | null; notes: string | null;
+}
+
+async function proposeLeadsCleanup() {
+  const { rows } = await pullRows("leads", "*", false);
+  const leads = rows as unknown as LeadRow[];
+  const proposals: ProposedChange[] = [];
+  const removed = new Set<string>();
+
+  // Empty rows — no email, phone, or notes; no conversion to customer.
+  for (const l of leads) {
+    if (l.email?.trim() || l.phone?.trim() || l.notes?.trim() || l.customer_id) continue;
+    proposals.push({
+      change_id: `del-l-${l.id}`, op: "delete", severity: "med",
+      label: `Delete empty lead · ${l.name || "(no name)"}`,
+      detail: "No email, phone, notes, or conversion.",
+      payload: { op: "delete", table: "leads", id: l.id },
+    });
+    removed.add(l.id);
+  }
+
+  // Stale "new" leads older than 90 days → mark as lost so the inbox stays clean.
+  const ninetyDaysAgo = Date.now() - 90 * 24 * 60 * 60 * 1000;
+  for (const l of leads) {
+    if (removed.has(l.id)) continue;
+    if (l.status !== "new") continue;
+    if (new Date(l.created_at).getTime() > ninetyDaysAgo) continue;
+    proposals.push({
+      change_id: `lost-l-${l.id}`, op: "update", severity: "med",
+      label: `Mark stale lead as lost · ${l.name || "(no name)"}`,
+      detail: "Status='new' and untouched for 90+ days.",
+      payload: { op: "update", table: "leads", id: l.id, patch: { status: "lost" } },
+    });
+  }
+
+  // Tidy
+  for (const l of leads) {
+    if (removed.has(l.id)) continue;
+    const trimmed = l.name?.trim();
+    const lowered = l.email?.trim().toLowerCase() || null;
+    const patch: Record<string, unknown> = {};
+    if (trimmed && trimmed !== l.name) patch.name = trimmed;
+    if (lowered !== l.email && (lowered || l.email)) patch.email = lowered;
+    if (Object.keys(patch).length === 0) continue;
+    proposals.push({
+      change_id: `norm-l-${l.id}`, op: "update", severity: "low",
+      label: `Tidy ${l.name}`,
+      detail: Object.entries(patch).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join(" · "),
+      payload: { op: "update", table: "leads", id: l.id, patch },
+    });
+  }
+
+  return { proposals, total_rows: leads.length };
+}
+
+// ─── Invoices ─────────────────────────────────────────────────────────────
+
+interface InvoiceRow {
+  id: string; number: string; status: string;
+  due_date: string | null; total: number; amount_paid: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  line_items: any; created_at: string;
+}
+
+async function proposeInvoicesCleanup() {
+  const { rows } = await pullRows("invoices", "*", false);
+  const invoices = rows as unknown as InvoiceRow[];
+  const proposals: ProposedChange[] = [];
+  const today = new Date().toISOString().split("T")[0];
+  const sixtyDaysAgo = Date.now() - 60 * 24 * 60 * 60 * 1000;
+
+  // Mark sent invoices past their due_date as overdue.
+  for (const inv of invoices) {
+    if (inv.status !== "sent" && inv.status !== "partial") continue;
+    if (!inv.due_date || inv.due_date >= today) continue;
+    proposals.push({
+      change_id: `overdue-${inv.id}`, op: "update", severity: "med",
+      label: `Mark ${inv.number} as overdue`,
+      detail: `Due ${inv.due_date}, status still ${inv.status}.`,
+      payload: { op: "update", table: "invoices", id: inv.id, patch: { status: "overdue" } },
+    });
+  }
+
+  // Cancel stale empty drafts (no items, older than 60 days).
+  for (const inv of invoices) {
+    if (inv.status !== "draft") continue;
+    const items = Array.isArray(inv.line_items) ? inv.line_items : [];
+    if (items.length > 0) continue;
+    if (new Date(inv.created_at).getTime() > sixtyDaysAgo) continue;
+    proposals.push({
+      change_id: `del-i-${inv.id}`, op: "delete", severity: "med",
+      label: `Delete empty draft ${inv.number}`,
+      detail: "No line items, untouched for 60+ days.",
+      payload: { op: "delete", table: "invoices", id: inv.id },
+    });
+  }
+
+  return { proposals, total_rows: invoices.length };
+}
+
+// ─── Quotes ───────────────────────────────────────────────────────────────
+
+interface QuoteRow {
+  id: string; number: string; status: string;
+  expiry_date: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  line_items: any; created_at: string;
+}
+
+async function proposeQuotesCleanup() {
+  const { rows } = await pullRows("quotes", "*", false);
+  const quotes = rows as unknown as QuoteRow[];
+  const proposals: ProposedChange[] = [];
+  const today = new Date().toISOString().split("T")[0];
+  const sixtyDaysAgo = Date.now() - 60 * 24 * 60 * 60 * 1000;
+
+  // Mark sent quotes past their expiry_date as expired.
+  for (const q of quotes) {
+    if (q.status !== "sent") continue;
+    if (!q.expiry_date || q.expiry_date >= today) continue;
+    proposals.push({
+      change_id: `expired-${q.id}`, op: "update", severity: "med",
+      label: `Mark ${q.number} as expired`,
+      detail: `Expired ${q.expiry_date}, status still sent.`,
+      payload: { op: "update", table: "quotes", id: q.id, patch: { status: "expired" } },
+    });
+  }
+
+  // Drop stale empty drafts.
+  for (const q of quotes) {
+    if (q.status !== "draft") continue;
+    const items = Array.isArray(q.line_items) ? q.line_items : [];
+    if (items.length > 0) continue;
+    if (new Date(q.created_at).getTime() > sixtyDaysAgo) continue;
+    proposals.push({
+      change_id: `del-q-${q.id}`, op: "delete", severity: "med",
+      label: `Delete empty draft ${q.number}`,
+      detail: "No line items, untouched for 60+ days.",
+      payload: { op: "delete", table: "quotes", id: q.id },
+    });
+  }
+
+  return { proposals, total_rows: quotes.length };
+}
+
+// ─── Products ─────────────────────────────────────────────────────────────
+
+interface ProductRow {
+  id: string; name: string; description: string | null; unit_price: number;
+  unit: string | null; archived: boolean;
+}
+
+async function proposeProductsCleanup() {
+  const { rows } = await pullRows("products");
+  const products = rows as unknown as ProductRow[];
+  const proposals: ProposedChange[] = [];
+
+  // Dedup by case-insensitive name.
+  const seen = new Set<string>();
+  const byName: Record<string, ProductRow[]> = {};
+  for (const p of products) {
+    const k = (p.name ?? "").trim().toLowerCase();
+    if (k) (byName[k] ??= []).push(p);
+  }
+  const removed = new Set<string>();
+  for (const [, group] of Object.entries(byName)) {
+    if (group.length < 2) continue;
+    const key = `name:${group[0].id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const survivor = group[0];
+    const dupes = group.slice(1);
+    for (const d of dupes) removed.add(d.id);
+    proposals.push({
+      change_id: `merge-p-${survivor.id}`,
+      op: "merge", severity: "high",
+      label: `Merge ${dupes.length + 1} duplicates of "${survivor.name}"`,
+      detail: "Keeps the oldest entry, deletes the rest. Existing invoices keep their inline copies.",
+      payload: { op: "merge", table: "products", survivor_id: survivor.id,
+                 duplicate_ids: dupes.map((d) => d.id), fk_columns: [] },
+    });
+  }
+
+  // Archive zero-priced empty rows
+  for (const p of products) {
+    if (removed.has(p.id)) continue;
+    if (Number(p.unit_price ?? 0) > 0) continue;
+    if (p.description?.trim()) continue;
+    proposals.push({
+      change_id: `arch-p-${p.id}`, op: "update", severity: "med",
+      label: `Archive empty product · ${p.name}`,
+      detail: "Zero unit price and no description.",
+      payload: { op: "update", table: "products", id: p.id, patch: { archived: true } },
+    });
+  }
+
+  // Tidy name whitespace
+  for (const p of products) {
+    if (removed.has(p.id)) continue;
+    const trimmed = p.name?.trim();
+    if (!trimmed || trimmed === p.name) continue;
+    proposals.push({
+      change_id: `norm-p-${p.id}`, op: "update", severity: "low",
+      label: `Tidy ${p.name}`,
+      detail: `Trim whitespace.`,
+      payload: { op: "update", table: "products", id: p.id, patch: { name: trimmed } },
+    });
+  }
+
+  return { proposals, total_rows: products.length };
+}
+
+// ─── Work orders ──────────────────────────────────────────────────────────
+
+interface WorkOrderRow {
+  id: string; number: string; status: string;
+  property_address: string | null;
+  scheduled_date: string | null; created_at: string;
+}
+
+async function proposeWorkOrdersCleanup() {
+  const { rows } = await pullRows("work_orders", "*", false);
+  const wos = rows as unknown as WorkOrderRow[];
+  const proposals: ProposedChange[] = [];
+  const ninetyDaysAgo = Date.now() - 90 * 24 * 60 * 60 * 1000;
+
+  // Old in-progress jobs (likely abandoned) → flag as needing review.
+  for (const wo of wos) {
+    if (wo.status !== "in_progress") continue;
+    if (new Date(wo.created_at).getTime() > ninetyDaysAgo) continue;
+    proposals.push({
+      change_id: `cancel-wo-${wo.id}`, op: "update", severity: "med",
+      label: `Cancel stale ${wo.number}`,
+      detail: "In progress for 90+ days — likely abandoned. Review manually if needed.",
+      payload: { op: "update", table: "work_orders", id: wo.id, patch: { status: "cancelled" } },
+    });
+  }
+
+  // Tidy address whitespace
+  for (const wo of wos) {
+    const a = wo.property_address?.trim().replace(/\s{2,}/g, " ");
+    if (!a || a === wo.property_address) continue;
+    proposals.push({
+      change_id: `norm-wo-${wo.id}`, op: "update", severity: "low",
+      label: `Tidy ${wo.number}`,
+      detail: "Collapse extra whitespace in address.",
+      payload: { op: "update", table: "work_orders", id: wo.id, patch: { property_address: a } },
+    });
+  }
+
+  return { proposals, total_rows: wos.length };
+}
+
+// ─── Team profiles ────────────────────────────────────────────────────────
+
+interface MemberProfileRow {
+  id: string; name: string; email: string;
+  is_active: boolean; user_id: string | null;
+}
+
+async function proposeTeamProfilesCleanup() {
+  const { rows } = await pullRows("member_profiles", "*", false);
+  const profiles = rows as unknown as MemberProfileRow[];
+  const proposals: ProposedChange[] = [];
+
+  // Dedup by lowercased email
+  const byEmail: Record<string, MemberProfileRow[]> = {};
+  for (const p of profiles) {
+    const k = normEmail(p.email);
+    if (k) (byEmail[k] ??= []).push(p);
+  }
+  const removed = new Set<string>();
+  for (const [, group] of Object.entries(byEmail)) {
+    if (group.length < 2) continue;
+    // Prefer survivor that has user_id set (linked to auth user) over plain profiles.
+    group.sort((a, b) => {
+      if (!!a.user_id !== !!b.user_id) return a.user_id ? -1 : 1;
+      return new Date((a as unknown as { created_at: string }).created_at)
+              .getTime() - new Date((b as unknown as { created_at: string }).created_at).getTime();
+    });
+    const survivor = group[0];
+    const dupes = group.slice(1);
+    for (const d of dupes) removed.add(d.id);
+    proposals.push({
+      change_id: `merge-mp-${survivor.id}`,
+      op: "merge", severity: "high",
+      label: `Merge ${dupes.length + 1} duplicate team profiles: ${survivor.name}`,
+      detail: "Keeps the linked-to-auth profile if present; relinks work_orders + assignments.",
+      payload: {
+        op: "merge", table: "member_profiles",
+        survivor_id: survivor.id,
+        duplicate_ids: dupes.map((d) => d.id),
+        fk_columns: [
+          { table: "work_orders",            column: "assigned_to_profile_id" },
+          { table: "work_order_assignments", column: "member_profile_id"      },
+        ],
+      },
+    });
+  }
+
+  // Tidy name casing/whitespace
+  for (const p of profiles) {
+    if (removed.has(p.id)) continue;
+    const trimmed = p.name?.trim();
+    const lowered = p.email?.trim().toLowerCase();
+    const patch: Record<string, unknown> = {};
+    if (trimmed && trimmed !== p.name) patch.name = trimmed;
+    if (lowered && lowered !== p.email) patch.email = lowered;
+    if (Object.keys(patch).length === 0) continue;
+    proposals.push({
+      change_id: `norm-mp-${p.id}`, op: "update", severity: "low",
+      label: `Tidy ${p.name}`,
+      detail: Object.entries(patch).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join(" · "),
+      payload: { op: "update", table: "member_profiles", id: p.id, patch },
+    });
+  }
+
+  return { proposals, total_rows: profiles.length };
 }

--- a/src/lib/emails/invoice.ts
+++ b/src/lib/emails/invoice.ts
@@ -14,8 +14,21 @@ export function invoiceEmailHtml({
   lineItems: LineItem[];
   portalUrl?: string | null;
 }): string {
+  // Coerce numbers — Postgres returns numeric columns as strings via PostgREST,
+  // so plain subtraction was producing NaN in the email Total field.
+  const num = (v: unknown) => {
+    const n = typeof v === "number" ? v : parseFloat(String(v ?? 0));
+    return Number.isFinite(n) ? n : 0;
+  };
+  const total       = num(invoice.total);
+  const amountPaid  = num(invoice.amount_paid);
+  const subtotal    = num(invoice.subtotal);
+  const discountAmt = num(invoice.discount_amount);
+  const taxTotal    = num(invoice.tax_total);
+  const balanceDue  = Math.max(0, total - amountPaid);
+
   const fmt = (n: number) =>
-    new Intl.NumberFormat("en-GB", { style: "currency", currency: business.currency }).format(n);
+    new Intl.NumberFormat("en-GB", { style: "currency", currency: business.currency }).format(num(n));
 
   const issueDate = new Date(invoice.issue_date).toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" });
   const dueDate = new Date(invoice.due_date).toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" });
@@ -45,7 +58,7 @@ export function invoiceEmailHtml({
       </tr>` : ""}
       <tr>
         <td style="font-size:15px;font-weight:700;color:#18181b;padding-top:16px;border-top:1px solid #e4e4e7;">Amount due</td>
-        <td style="font-size:18px;font-weight:700;color:#3b82f6;text-align:right;padding-top:16px;border-top:1px solid #e4e4e7;">${fmt(invoice.total - invoice.amount_paid)}</td>
+        <td style="font-size:18px;font-weight:700;color:#3b82f6;text-align:right;padding-top:16px;border-top:1px solid #e4e4e7;">${fmt(balanceDue)}</td>
       </tr>
     </table>
 
@@ -56,7 +69,7 @@ export function invoiceEmailHtml({
       </td></tr>
     </table>` : ""}
 
-    ${lineItemsTable(lineItems, business.currency, invoice.subtotal, invoice.discount_amount, invoice.tax_total, invoice.total)}
+    ${lineItemsTable(lineItems, business.currency, subtotal, discountAmt, taxTotal, total)}
 
     ${invoice.notes ? `<p style="margin:24px 0 0;font-size:13px;color:#71717a;"><strong>Notes:</strong> ${invoice.notes}</p>` : ""}
     ${invoice.terms ? `<p style="margin:8px 0 0;font-size:13px;color:#71717a;"><strong>Payment terms:</strong> ${invoice.terms}</p>` : ""}


### PR DESCRIPTION
Renames Clean up → Smart Organise, adds a progress bar to the modal, refetches on close-after-success, and rolls the agent out to invoices / quotes / contacts / leads / products / work-orders / team. Plus two prod bug fixes: invoice email Total: NaN (number coercion) and tokenised PDF download 401 (route now honors ?token=).