### PR TITLE
feat(mobile): invite-code signup + login redirect fix

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -4,10 +4,12 @@ import {
   ScrollView, Text, TextInput, View, ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { Link, useRouter } from "expo-router";
 import { supabase } from "@/lib/supabase";
 import { colors, radius, space } from "@/lib/theme";
 
 export default function Login() {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
@@ -18,12 +20,19 @@ export default function Login() {
       return;
     }
     setBusy(true);
-    const { error } = await supabase.auth.signInWithPassword({
+    const { data, error } = await supabase.auth.signInWithPassword({
       email: email.trim().toLowerCase(),
       password,
     });
     setBusy(false);
-    if (error) Alert.alert("Couldn't sign in", error.message);
+    if (error) {
+      Alert.alert("Couldn't sign in", error.message);
+      return;
+    }
+    // Belt-and-braces redirect — the root layout's onAuthStateChange handler
+    // also fires, but we route directly so success isn't dependent on that
+    // listener winning the race.
+    if (data.session) router.replace("/(tabs)");
   };
 
   return (
@@ -99,9 +108,18 @@ export default function Login() {
             </Pressable>
           </View>
 
-          <Text style={{ marginTop: space.xl, textAlign: "center", color: colors.muted, fontSize: 12 }}>
-            Use the same email your team owner invited you with.
-          </Text>
+          <View style={{ marginTop: space.xl, alignItems: "center", gap: 6 }}>
+            <Link href="/(auth)/signup" asChild>
+              <Pressable hitSlop={10}>
+                <Text style={{ color: colors.primary, fontWeight: "600", fontSize: 13 }}>
+                  Got an invite code? Sign up →
+                </Text>
+              </Pressable>
+            </Link>
+            <Text style={{ textAlign: "center", color: colors.muted, fontSize: 12 }}>
+              Use the same email your team owner invited you with.
+            </Text>
+          </View>
         </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import {
+  Alert, KeyboardAvoidingView, Platform, Pressable,
+  ScrollView, Text, TextInput, View, ActivityIndicator,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Link, useRouter } from "expo-router";
+import { ArrowLeft, CheckCircle2, AlertCircle } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+
+type Stage = "form" | "joining" | "done";
+
+interface InvitePreview {
+  business_id: string;
+  business_name: string;
+  role: string;
+  email: string;
+}
+
+export default function SignUp() {
+  const router = useRouter();
+  const [email,    setEmail]    = useState("");
+  const [code,     setCode]     = useState("");
+  const [password, setPassword] = useState("");
+  const [busy,     setBusy]     = useState(false);
+  const [preview,  setPreview]  = useState<InvitePreview | null>(null);
+  const [stage,    setStage]    = useState<Stage>("form");
+
+  // Look up the invite as soon as the user has entered a 6+ char code.
+  // Surfaces the business name so they confirm before submitting.
+  const verifyCode = async (next: string) => {
+    setCode(next.toUpperCase());
+    setPreview(null);
+    if (next.trim().length < 6) return;
+    const { data, error } = await supabase.rpc("preview_invite", { p_token: next.trim().toUpperCase() });
+    if (error) return;
+    const row = (data as InvitePreview[])?.[0];
+    if (row) setPreview(row);
+  };
+
+  const submit = async () => {
+    const cleanEmail = email.trim().toLowerCase();
+    const cleanCode  = code.trim().toUpperCase();
+
+    if (!cleanEmail || !password || !cleanCode) {
+      Alert.alert("Missing details", "Email, password, and invite code are required.");
+      return;
+    }
+    if (password.length < 6) {
+      Alert.alert("Password too short", "At least 6 characters.");
+      return;
+    }
+    if (preview && preview.email.toLowerCase() !== cleanEmail) {
+      Alert.alert(
+        "Email doesn't match the invite",
+        `This code was sent to ${preview.email}. Use that email — or ask your team owner to send a fresh invite to ${cleanEmail}.`
+      );
+      return;
+    }
+
+    setStage("joining");
+    setBusy(true);
+
+    // 1. Create the auth user
+    const signUpRes = await supabase.auth.signUp({
+      email: cleanEmail,
+      password,
+    });
+    if (signUpRes.error) {
+      // If the user already exists, try signing them in and proceeding to redeem.
+      if (/already.*registered|user.*exists/i.test(signUpRes.error.message)) {
+        const signIn = await supabase.auth.signInWithPassword({ email: cleanEmail, password });
+        if (signIn.error) {
+          setBusy(false); setStage("form");
+          return Alert.alert("Account exists",
+            "An Invoicer account with this email already exists. Sign in with your existing password to redeem the code.");
+        }
+      } else {
+        setBusy(false); setStage("form");
+        return Alert.alert("Couldn't sign up", signUpRes.error.message);
+      }
+    }
+
+    // 2. Redeem the invite — links business_members.user_id to the new auth user.
+    const redeemRes = await supabase.rpc("redeem_invite", { p_token: cleanCode });
+    if (redeemRes.error) {
+      setBusy(false); setStage("form");
+      return Alert.alert("Couldn't redeem invite", redeemRes.error.message);
+    }
+
+    // 3. Light up any existing member_profile with this email so old work-order
+    //    assignments resolve to the new auth user. PostgrestFilterBuilder
+    //    is thenable but doesn't expose .catch — use try/catch.
+    try { await supabase.rpc("link_my_member_profile"); } catch { /* non-fatal */ }
+
+    setBusy(false);
+    setStage("done");
+    setTimeout(() => router.replace("/(tabs)"), 900);
+  };
+
+  if (stage === "done") {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: space.xl }}>
+          <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: colors.primarySoft, alignItems: "center", justifyContent: "center", marginBottom: space.lg }}>
+            <CheckCircle2 size={32} color={colors.primary} />
+          </View>
+          <Text style={{ fontSize: 22, fontWeight: "700", color: colors.text, letterSpacing: -0.4 }}>
+            You&apos;re in.
+          </Text>
+          <Text style={{ marginTop: 8, fontSize: 14, color: colors.muted, textAlign: "center" }}>
+            Welcome to {preview?.business_name ?? "the team"}.
+          </Text>
+          <ActivityIndicator color={colors.primary} style={{ marginTop: space.lg }} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={{ flex: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1, padding: space.xl }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Link href="/(auth)/login" asChild>
+            <Pressable hitSlop={10} style={{ alignSelf: "flex-start", padding: 4, marginBottom: space.lg }}>
+              <ArrowLeft size={20} color={colors.text} />
+            </Pressable>
+          </Link>
+
+          <View style={{ marginBottom: space.xxl }}>
+            <Text style={{ fontSize: 28, fontWeight: "700", color: colors.text, letterSpacing: -0.5 }}>
+              Join your team
+            </Text>
+            <Text style={{ fontSize: 14, color: colors.muted, marginTop: 6 }}>
+              Enter the invite code from the email your owner sent.
+            </Text>
+          </View>
+
+          <View
+            style={{
+              backgroundColor: colors.card,
+              borderRadius: radius.xl,
+              padding: space.lg,
+              borderWidth: 1,
+              borderColor: colors.hairline,
+              gap: space.md,
+            }}
+          >
+            <Field label="Invite code">
+              <TextInput
+                value={code}
+                onChangeText={verifyCode}
+                autoCapitalize="characters"
+                autoCorrect={false}
+                placeholder="A1B2C3D4"
+                placeholderTextColor={colors.muted}
+                style={{ ...inputStyle, fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace", letterSpacing: 4, fontSize: 18 }}
+                maxLength={12}
+              />
+              {/* Live preview pill */}
+              {preview && (
+                <View style={{
+                  flexDirection: "row", alignItems: "center", gap: 8, marginTop: 8,
+                  padding: 10, borderRadius: radius.md, backgroundColor: colors.primarySoft,
+                }}>
+                  <CheckCircle2 size={16} color={colors.primary} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ fontSize: 13, fontWeight: "600", color: colors.primaryText }}>
+                      Joining {preview.business_name}
+                    </Text>
+                    <Text style={{ fontSize: 11, color: colors.primaryText, opacity: 0.8 }}>
+                      as {preview.role} · invite for {preview.email}
+                    </Text>
+                  </View>
+                </View>
+              )}
+              {code.trim().length >= 6 && !preview && (
+                <View style={{
+                  flexDirection: "row", alignItems: "center", gap: 8, marginTop: 8,
+                  padding: 10, borderRadius: radius.md, backgroundColor: "#fef2f2",
+                }}>
+                  <AlertCircle size={16} color="#b91c1c" />
+                  <Text style={{ fontSize: 12, color: "#7f1d1d", flex: 1 }}>
+                    Code not recognised. Check the email or ask your owner to resend.
+                  </Text>
+                </View>
+              )}
+            </Field>
+
+            <Field label="Email">
+              <TextInput
+                value={email}
+                onChangeText={setEmail}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="email-address"
+                placeholder={preview?.email ?? "you@example.com"}
+                placeholderTextColor={colors.muted}
+                style={inputStyle}
+              />
+            </Field>
+
+            <Field label="Choose a password">
+              <TextInput
+                value={password}
+                onChangeText={setPassword}
+                secureTextEntry
+                placeholder="At least 6 characters"
+                placeholderTextColor={colors.muted}
+                style={inputStyle}
+                onSubmitEditing={submit}
+              />
+            </Field>
+
+            <Pressable
+              onPress={submit}
+              disabled={busy}
+              style={({ pressed }) => ({
+                backgroundColor: colors.primary,
+                borderRadius: radius.pill,
+                paddingVertical: 14,
+                alignItems: "center",
+                marginTop: space.sm,
+                opacity: pressed || busy ? 0.85 : 1,
+              })}
+            >
+              {busy ? (
+                <ActivityIndicator color={colors.white} />
+              ) : (
+                <Text style={{ color: colors.white, fontWeight: "700", fontSize: 15 }}>
+                  Create account &amp; join
+                </Text>
+              )}
+            </Pressable>
+          </View>
+
+          <Text style={{ marginTop: space.xl, textAlign: "center", color: colors.muted, fontSize: 12 }}>
+            Already have an account? <Link href="/(auth)/login" asChild>
+              <Text style={{ color: colors.primary, fontWeight: "600" }}>Sign in</Text>
+            </Link>
+          </Text>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const inputStyle = {
+  backgroundColor: "#fafaf3",
+  borderRadius: radius.lg,
+  paddingHorizontal: 14,
+  paddingVertical: 12,
+  fontSize: 15,
+  color: colors.text,
+  borderWidth: 1,
+  borderColor: colors.hairline,
+};
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <View style={{ gap: 6 }}>
+      <Text style={{ fontSize: 11, color: colors.muted, fontWeight: "600", textTransform: "uppercase", letterSpacing: 0.5 }}>
+        {label}
+      </Text>
+      {children}
+    </View>
+  );
+}

--- a/src/lib/actions/members.ts
+++ b/src/lib/actions/members.ts
@@ -50,14 +50,16 @@ export async function addMember(email: string, role: MemberRole): Promise<void> 
   // Admins cannot add other admins — only the owner can
   if (role === "admin" && !isOwner(callerRole)) throw new Error("Only the owner can add admins");
 
-  // Check if there's already a Supabase auth user with this email — if so, link immediately
-  // We can't look up auth.users directly from the client, so we store the email and the
-  // activate_pending_memberships() RPC will link them on their next login.
+  // Generate a short, human-readable invite code so the worker can self-
+  // serve via Connected Hub without needing the email link to load.
+  const inviteToken = generateInviteCode();
+
   const { error } = await tbl(supabase, "business_members").insert({
     business_id: businessId,
     email: email.toLowerCase().trim(),
     role,
     status: "pending",
+    invite_token: inviteToken,
     added_by: user.id,
   });
   if (error) {
@@ -81,6 +83,7 @@ export async function addMember(email: string, role: MemberRole): Promise<void> 
         inviterName,
         role,
         inviteUrl,
+        inviteCode: inviteToken,
       }),
     });
   } catch {
@@ -88,6 +91,42 @@ export async function addMember(email: string, role: MemberRole): Promise<void> 
   }
 
   revalidatePath("/settings");
+}
+
+/** 8-char readable code, no ambiguous chars (no 0/O, 1/I/l). */
+function generateInviteCode(): string {
+  const chars = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+  let out = "";
+  for (let i = 0; i < 8; i++) out += chars[Math.floor(Math.random() * chars.length)];
+  return out;
+}
+
+/** Read the existing invite code (or generate one if missing) so the
+ *  Settings UI can show "Copy code" next to a pending member. */
+export async function getMemberInviteCode(memberId: string): Promise<string | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+  const callerRole = await getCallerRole(supabase, user.id, businessId);
+  if (!canManageTeam(callerRole)) throw new Error("Only owners and admins can view invite codes");
+
+  const { data: row } = await tbl(supabase, "business_members")
+    .select("invite_token, status")
+    .eq("id", memberId)
+    .eq("business_id", businessId)
+    .maybeSingle();
+
+  if (!row || row.status !== "pending") return null;
+  if (row.invite_token) return row.invite_token;
+
+  // Backfill on read for older rows that pre-date the column.
+  const fresh = generateInviteCode();
+  await tbl(supabase, "business_members")
+    .update({ invite_token: fresh })
+    .eq("id", memberId)
+    .eq("business_id", businessId);
+  return fresh;
 }
 
 export async function updateMemberRole(memberId: string, newRole: MemberRole): Promise<void> {

--- a/src/lib/emails/team-invite.ts
+++ b/src/lib/emails/team-invite.ts
@@ -5,23 +5,41 @@ export function teamInviteEmailHtml({
   inviterName,
   role,
   inviteUrl,
+  inviteCode,
 }: {
   businessName: string;
   inviterName: string;
   role: string;
   inviteUrl: string;
+  /** Short human-typeable invite code for the Connected Hub mobile signup. */
+  inviteCode?: string;
 }): string {
   const roleLabel = role.charAt(0).toUpperCase() + role.slice(1);
+  const isWorker  = role === "worker";
 
   const body = `
     <p style="margin:0 0 16px;font-size:14px;color:#71717a;">
       <strong style="color:#18181b;">${inviterName}</strong> has invited you to join
       <strong style="color:#18181b;">${businessName}</strong> on Invoicer as an <strong style="color:#18181b;">${roleLabel}</strong>.
     </p>
-    <p style="margin:0 0 24px;font-size:14px;color:#71717a;">
-      Click the button below to create your account and get started.
-    </p>
-    <p style="margin:0 0 32px;">${btn("Accept invitation", inviteUrl)}</p>
+    ${isWorker && inviteCode ? `
+    <!-- Worker code (Connected Hub mobile) -->
+    <table width="100%" cellpadding="0" cellspacing="0" style="background:#e7f1f0;border:1px solid #b6d6d3;border-radius:10px;padding:18px;margin:0 0 24px;">
+      <tr><td>
+        <p style="margin:0 0 6px;font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:#1f4f4a;font-weight:700;">
+          Mobile invite code
+        </p>
+        <p style="margin:0 0 8px;font-family:'SF Mono','Menlo',monospace;font-size:24px;font-weight:700;color:#1f4f4a;letter-spacing:0.18em;">
+          ${inviteCode}
+        </p>
+        <p style="margin:0;font-size:12px;color:#1f4f4a;">
+          Open <strong>Connected Hub</strong> on your phone, tap <em>"Got an invite code?"</em>, enter your email, this code, and a password.
+        </p>
+      </td></tr>
+    </table>
+    <p style="margin:0 0 12px;font-size:13px;color:#71717a;">Or use the web app:</p>
+    ` : ""}
+    <p style="margin:0 0 32px;">${btn(isWorker ? "Sign up on the web" : "Accept invitation", inviteUrl)}</p>
     <p style="margin:0;font-size:12px;color:#a1a1aa;">
       Or copy this link into your browser:<br/>
       <span style="color:#3b82f6;word-break:break-all;">${inviteUrl}</span>

--- a/supabase/migrations/20260505000002_business_member_invite_codes.sql
+++ b/supabase/migrations/20260505000002_business_member_invite_codes.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- Per-invite codes for self-service worker signup
+--
+-- A worker invited via Settings → Team gets a short code in their email.
+-- They open Connected Hub, tap "Got an invite code?", enter their email +
+-- the code + a password, and the RPC below validates the pair, creates the
+-- linkage, and returns the business name so the app can confirm.
+--
+-- Auth user creation still happens via supabase.auth.signUp — the RPC just
+-- checks the code and unlocks the right business_members row.
+-- ============================================================================
+
+ALTER TABLE public.business_members
+  ADD COLUMN IF NOT EXISTS invite_token TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS business_members_invite_token_idx
+  ON public.business_members (invite_token)
+  WHERE invite_token IS NOT NULL;
+
+-- ─── 1. Validate (no auth needed — used pre-signup to preview the biz) ────
+CREATE OR REPLACE FUNCTION public.preview_invite(p_token TEXT)
+RETURNS TABLE (business_id UUID, business_name TEXT, role TEXT, email TEXT)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT m.business_id, b.name AS business_name, m.role, m.email
+  FROM   public.business_members m
+  JOIN   public.businesses b ON b.id = m.business_id
+  WHERE  m.invite_token = p_token
+    AND  m.status        = 'pending'
+    AND  m.user_id        IS NULL
+  LIMIT  1;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.preview_invite(TEXT) TO anon, authenticated;
+
+-- ─── 2. Redeem (called right after auth.signUp, while logged in) ──────────
+-- Activates the pending row matching the caller's email + the supplied
+-- token, links it to auth.uid(), clears the token so it can't be reused.
+-- Mirrors activate_pending_memberships() but additionally verifies the
+-- invite_token to stop anyone with a known invited email from joining
+-- before the real worker does.
+CREATE OR REPLACE FUNCTION public.redeem_invite(p_token TEXT)
+RETURNS TABLE (business_id UUID, role TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email TEXT;
+  v_uid   UUID;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not signed in';
+  END IF;
+
+  SELECT email INTO v_email FROM auth.users WHERE id = v_uid;
+  IF v_email IS NULL THEN
+    RAISE EXCEPTION 'No email on auth user';
+  END IF;
+
+  RETURN QUERY
+  UPDATE public.business_members
+  SET    user_id      = v_uid,
+         status       = 'active',
+         invite_token = NULL
+  WHERE  invite_token = p_token
+    AND  lower(email) = lower(v_email)
+    AND  status       = 'pending'
+    AND  user_id      IS NULL
+  RETURNING business_id, role;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Invalid invite — code does not match this email or it has already been used';
+  END IF;
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.redeem_invite(TEXT) TO authenticated;


### PR DESCRIPTION
Workers can now join their team straight from Connected Hub: paste an 8-char code emailed by the owner, enter email + password, redirected into the dashboard. Plus an explicit redirect after sign-in fixes the silent-no-op login bug.