### PR TITLE
Email delivery tracking + scheduled sends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "recharts": "^3.8.1",
         "resend": "^4.5.1",
         "sonner": "^2.0.7",
+        "svix": "^1.92.2",
         "tailwind-merge": "^3.2.0",
         "twilio": "^5.13.1",
         "uuid": "^13.0.0",
@@ -2872,6 +2873,12 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5838,6 +5845,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -9201,6 +9214,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -9420,6 +9443,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "recharts": "^3.8.1",
     "resend": "^4.5.1",
     "sonner": "^2.0.7",
+    "svix": "^1.92.2",
     "tailwind-merge": "^3.2.0",
     "twilio": "^5.13.1",
     "uuid": "^13.0.0",

--- a/src/app/api/cron/process-scheduled-sends/route.ts
+++ b/src/app/api/cron/process-scheduled-sends/route.ts
@@ -1,0 +1,242 @@
+/**
+ * GET /api/cron/process-scheduled-sends
+ *
+ * Runs every minute via Vercel Cron. Pulls pending scheduled_sends rows whose
+ * send_at has passed, locks each by flipping status to 'sending', then
+ * dispatches the email/SMS using the admin Supabase client (cron has no user
+ * session). Re-renders the PDF and rolls a portal token the same way the
+ * authenticated send paths do.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "node:crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendEmail } from "@/lib/email";
+import { sendSms } from "@/lib/actions/sms";
+import { invoiceEmailHtml } from "@/lib/emails/invoice";
+import { quoteEmailHtml } from "@/lib/emails/quote";
+import { appUrl } from "@/lib/app-url";
+import type { LineItem } from "@/types/database";
+
+export const maxDuration = 60;
+
+interface Row {
+  id: string;
+  business_id: string;
+  doc_type: "invoice" | "quote";
+  doc_id: string;
+  channel: "email" | "sms";
+  recipients: string[] | null;
+  to_phone: string | null;
+  subject: string | null;
+  body: string | null;
+  attempt_count: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function getOrMintPortalToken(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  businessId: string,
+  customerId: string,
+): Promise<string | null> {
+  const { data: existing } = await tbl(sb, "customer_portal_tokens")
+    .select("token")
+    .eq("business_id", businessId)
+    .eq("customer_id", customerId)
+    .is("revoked_at", null)
+    .or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .limit(1)
+    .maybeSingle();
+  if (existing?.token) return existing.token as string;
+
+  const token = "cust_" + randomBytes(24).toString("hex");
+  await tbl(sb, "customer_portal_tokens").insert({
+    token, business_id: businessId, customer_id: customerId,
+    expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+  });
+  return token;
+}
+
+async function dispatchInvoice(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  row: Row,
+): Promise<void> {
+  const { data: invoice } = await tbl(sb, "invoices")
+    .select("*, customers(*)")
+    .eq("id", row.doc_id)
+    .eq("business_id", row.business_id)
+    .single();
+  if (!invoice) throw new Error("Invoice not found");
+  const { data: business } = await tbl(sb, "businesses").select("*").eq("id", row.business_id).single();
+
+  if (row.channel === "email") {
+    const recipients = (row.recipients ?? (invoice.customers?.email ? [invoice.customers.email] : []))
+      .map((e: string) => e.trim()).filter(Boolean);
+    if (recipients.length === 0) throw new Error("No email recipients");
+
+    const lineItems = (invoice.line_items ?? []) as LineItem[];
+
+    // Render PDF
+    const { renderToStream } = await import("@react-pdf/renderer");
+    const { InvoicePDFDocument } = await import("@/components/invoices/invoice-pdf-document");
+    const React = await import("react");
+    const element = React.createElement(InvoicePDFDocument, { invoice, customer: invoice.customers, business, lineItems });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = await renderToStream(element as any);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const pdfBuffer = Buffer.concat(chunks);
+
+    let portalUrl: string | null = null;
+    if (invoice.customers?.id) {
+      const token = await getOrMintPortalToken(sb, row.business_id, invoice.customers.id);
+      const base = appUrl();
+      if (base && token) portalUrl = `${base}/portal/${token}/invoice/${invoice.id}`;
+    }
+
+    await sendEmail({
+      to: recipients,
+      subject: row.subject ?? `Invoice ${invoice.number} from ${business?.name ?? ""}`,
+      html: invoiceEmailHtml({ invoice, customer: invoice.customers, business, lineItems, portalUrl }),
+      attachments: [{ filename: `${invoice.number}.pdf`, content: pdfBuffer }],
+      tags: { business_id: row.business_id, doc_type: "invoice", doc_id: invoice.id },
+    });
+
+    if (invoice.status === "draft") {
+      await tbl(sb, "invoices").update({ status: "sent" }).eq("id", invoice.id);
+    }
+  } else {
+    if (!row.to_phone) throw new Error("No phone for SMS");
+    await sendSms({
+      to: row.to_phone,
+      body: row.body ?? `Invoice ${invoice.number} is ready.`,
+      customerName: invoice.customers?.name ?? "Customer",
+      customerId: invoice.customers?.id ?? null,
+    });
+  }
+}
+
+async function dispatchQuote(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  row: Row,
+): Promise<void> {
+  const { data: quote } = await tbl(sb, "quotes")
+    .select("*, customers(*)")
+    .eq("id", row.doc_id)
+    .eq("business_id", row.business_id)
+    .single();
+  if (!quote) throw new Error("Quote not found");
+  const { data: business } = await tbl(sb, "businesses").select("*").eq("id", row.business_id).single();
+
+  if (row.channel === "email") {
+    const recipients = (row.recipients ?? (quote.customers?.email ? [quote.customers.email] : []))
+      .map((e: string) => e.trim()).filter(Boolean);
+    if (recipients.length === 0) throw new Error("No email recipients");
+
+    const lineItems = (quote.line_items ?? []) as LineItem[];
+
+    const { renderToStream } = await import("@react-pdf/renderer");
+    const { QuotePDFDocument } = await import("@/components/quotes/quote-pdf-document");
+    const React = await import("react");
+    const element = React.createElement(QuotePDFDocument, { quote, customer: quote.customers, business, lineItems });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = await renderToStream(element as any);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const pdfBuffer = Buffer.concat(chunks);
+
+    let acceptUrl: string | null = null;
+    if (quote.customers?.id) {
+      const token = await getOrMintPortalToken(sb, row.business_id, quote.customers.id);
+      const base = appUrl();
+      if (base && token) acceptUrl = `${base}/portal/${token}/quote/${quote.id}`;
+    }
+
+    await sendEmail({
+      to: recipients,
+      subject: row.subject ?? `Quote ${quote.number} from ${business?.name ?? ""}`,
+      html: quoteEmailHtml({ quote, customer: quote.customers, business, lineItems, acceptUrl }),
+      attachments: [{ filename: `${quote.number}.pdf`, content: pdfBuffer }],
+      tags: { business_id: row.business_id, doc_type: "quote", doc_id: quote.id },
+    });
+
+    if (quote.status === "draft") {
+      await tbl(sb, "quotes").update({ status: "sent" }).eq("id", quote.id);
+    }
+  } else {
+    if (!row.to_phone) throw new Error("No phone for SMS");
+    await sendSms({
+      to: row.to_phone,
+      body: row.body ?? `Quote ${quote.number} is ready.`,
+      customerName: quote.customers?.name ?? "Customer",
+      customerId: quote.customers?.id ?? null,
+    });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const sb = createAdminClient();
+  const nowIso = new Date().toISOString();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: due } = await (sb as any)
+    .from("scheduled_sends")
+    .select("*")
+    .eq("status", "pending")
+    .lte("send_at", nowIso)
+    .order("send_at", { ascending: true })
+    .limit(50);
+
+  const rows = (due ?? []) as Row[];
+  const results: { id: string; status: "sent" | "failed"; error?: string }[] = [];
+
+  for (const row of rows) {
+    // Optimistic claim — only flip pending → sending. If something else
+    // already grabbed it (concurrent worker, manual cancel), skip silently.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: claim } = await (sb as any)
+      .from("scheduled_sends")
+      .update({ status: "sending", attempt_count: row.attempt_count + 1, updated_at: nowIso })
+      .eq("id", row.id)
+      .eq("status", "pending")
+      .select("id")
+      .maybeSingle();
+    if (!claim) continue;
+
+    try {
+      if (row.doc_type === "invoice") await dispatchInvoice(sb, row);
+      else                            await dispatchQuote(sb, row);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any)
+        .from("scheduled_sends")
+        .update({ status: "sent", sent_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+        .eq("id", row.id);
+      results.push({ id: row.id, status: "sent" });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any)
+        .from("scheduled_sends")
+        .update({ status: "failed", last_error: msg, updated_at: new Date().toISOString() })
+        .eq("id", row.id);
+      results.push({ id: row.id, status: "failed", error: msg });
+    }
+  }
+
+  return NextResponse.json({ processed: results.length, results });
+}

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { Webhook } from "svix";
+
+// Resend signs webhook payloads via Svix. Verifying the signature is required —
+// otherwise anyone could POST fake "delivered" events. Set RESEND_WEBHOOK_SECRET
+// to the secret shown when you create the endpoint in Resend's dashboard.
+export async function POST(req: NextRequest) {
+  const secret = process.env.RESEND_WEBHOOK_SECRET;
+  const body = await req.text();
+
+  if (secret) {
+    const id = req.headers.get("svix-id") ?? "";
+    const ts = req.headers.get("svix-timestamp") ?? "";
+    const sig = req.headers.get("svix-signature") ?? "";
+    try {
+      new Webhook(secret).verify(body, { "svix-id": id, "svix-timestamp": ts, "svix-signature": sig });
+    } catch {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+  }
+
+  let payload: unknown;
+  try { payload = JSON.parse(body); } catch { return NextResponse.json({ error: "Bad JSON" }, { status: 400 }); }
+
+  const evt = payload as {
+    type?: string;
+    data?: {
+      email_id?: string;
+      to?: string | string[];
+      created_at?: string;
+      bounce?: { message?: string };
+    };
+  };
+
+  const type = evt.type ?? "";
+  const resendId = evt.data?.email_id;
+  if (!resendId) return NextResponse.json({ ok: true });
+
+  // Map Resend event names to our internal status enum.
+  const STATUS_MAP: Record<string, string> = {
+    "email.sent":              "sent",
+    "email.delivered":         "delivered",
+    "email.delivery_delayed":  "delivery_delayed",
+    "email.bounced":           "bounced",
+    "email.complained":        "complained",
+    "email.opened":            "opened",
+    "email.clicked":           "clicked",
+    "email.failed":            "failed",
+  };
+  const status = STATUS_MAP[type];
+  if (!status) return NextResponse.json({ ok: true });
+
+  const sb = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const update: any = { status, raw: evt };
+  const now = evt.data?.created_at ?? new Date().toISOString();
+  if (status === "delivered") update.delivered_at = now;
+  if (status === "opened")    update.opened_at    = now;
+  if (status === "clicked")   update.clicked_at   = now;
+  if (status === "bounced") {
+    update.bounced_at = now;
+    update.error = evt.data?.bounce?.message ?? null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (sb as any).from("email_events").update(update).eq("resend_id", resendId);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/delivery/delivery-status-card.tsx
+++ b/src/components/delivery/delivery-status-card.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { CheckCircle, AlertCircle, Mail, Clock, Eye, MousePointer2, RotateCcw } from "@/components/ui/icons";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getDeliveryStatus, type EmailEvent } from "@/lib/actions/email-events";
+import type { EmailDocType } from "@/lib/email";
+import { formatDate } from "@/lib/utils";
+
+interface Props {
+  docType: EmailDocType;
+  docId:   string;
+}
+
+const META: Record<EmailEvent["status"], { label: string; tone: string; Icon: typeof Mail }> = {
+  queued:           { label: "Queued",            tone: "text-muted-foreground bg-muted",        Icon: Clock        },
+  sent:             { label: "Sent (in transit)", tone: "text-blue-700 bg-blue-100",             Icon: Mail         },
+  delivered:        { label: "Delivered",         tone: "text-emerald-700 bg-emerald-100",       Icon: CheckCircle  },
+  opened:           { label: "Opened",            tone: "text-emerald-700 bg-emerald-100",       Icon: Eye          },
+  clicked:          { label: "Link clicked",      tone: "text-emerald-700 bg-emerald-100",       Icon: MousePointer2 },
+  delivery_delayed: { label: "Delayed",           tone: "text-amber-700 bg-amber-100",           Icon: Clock        },
+  bounced:          { label: "Bounced",           tone: "text-rose-700 bg-rose-100",             Icon: AlertCircle  },
+  complained:       { label: "Marked as spam",    tone: "text-rose-700 bg-rose-100",             Icon: AlertCircle  },
+  failed:           { label: "Failed to send",    tone: "text-rose-700 bg-rose-100",             Icon: AlertCircle  },
+};
+
+export function DeliveryStatusCard({ docType, docId }: Props) {
+  const [events, setEvents] = useState<EmailEvent[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const rows = await getDeliveryStatus(docType, docId);
+      setEvents(rows);
+    } finally {
+      setLoading(false);
+    }
+  }, [docType, docId]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  if (events === null) return null;
+  if (events.length === 0) return null; // Hide entirely if never sent.
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-2.5">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Email delivery</p>
+          <Button variant="ghost" size="sm" className="h-7 px-2 text-xs gap-1" onClick={refresh} disabled={loading}>
+            <RotateCcw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+        <ul className="space-y-1.5">
+          {events.map((e) => {
+            const m = META[e.status] ?? META.sent;
+            const Icon = m.Icon;
+            const time = e.delivered_at ?? e.opened_at ?? e.bounced_at ?? e.sent_at ?? e.created_at;
+            return (
+              <li key={e.id} className="flex items-center justify-between gap-3 text-sm">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${m.tone}`}>
+                    <Icon className="w-3 h-3" />
+                    {m.label}
+                  </span>
+                  <span className="truncate text-muted-foreground">{e.recipient}</span>
+                </div>
+                <span className="text-xs text-muted-foreground flex-shrink-0">{time ? formatDate(time) : ""}</span>
+              </li>
+            );
+          })}
+        </ul>
+        {events.some((e) => e.status === "bounced" || e.status === "failed") && (
+          <p className="text-xs text-rose-700 pt-1">
+            Some recipients didn't receive this. If your sender domain isn't verified in Resend yet, only the API key owner's mailbox will receive emails — verify the domain to fix this.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/delivery/scheduled-sends-card.tsx
+++ b/src/components/delivery/scheduled-sends-card.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Clock, X } from "@/components/ui/icons";
+import { toast } from "sonner";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getScheduledSends, cancelScheduledSend, type ScheduledSend } from "@/lib/actions/scheduled-sends";
+
+interface Props {
+  docType: "invoice" | "quote";
+  docId: string;
+}
+
+const STATUS_LABEL: Record<ScheduledSend["status"], string> = {
+  pending:   "Pending",
+  sending:   "Dispatching…",
+  sent:      "Sent",
+  cancelled: "Cancelled",
+  failed:    "Failed",
+};
+
+export function ScheduledSendsCard({ docType, docId }: Props) {
+  const router = useRouter();
+  const [rows, setRows] = useState<ScheduledSend[] | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await getScheduledSends(docType, docId);
+      setRows(r);
+    } catch { /* non-fatal */ }
+  }, [docType, docId]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  if (rows === null || rows.length === 0) return null;
+
+  const handleCancel = async (id: string) => {
+    try {
+      await cancelScheduledSend(id);
+      toast.success("Scheduled send cancelled");
+      await refresh();
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't cancel");
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-2.5">
+        <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+          <Clock className="w-3.5 h-3.5" /> Scheduled sends
+        </p>
+        <ul className="space-y-1.5">
+          {rows.map((r) => {
+            const when = new Date(r.send_at).toLocaleString();
+            const recip = r.channel === "email"
+              ? (r.recipients ?? []).join(", ")
+              : (r.to_phone ?? "");
+            const tone =
+              r.status === "pending"   ? "bg-amber-100 text-amber-800" :
+              r.status === "sending"   ? "bg-blue-100  text-blue-800"  :
+              r.status === "sent"      ? "bg-emerald-100 text-emerald-800" :
+              r.status === "cancelled" ? "bg-muted text-muted-foreground" :
+                                         "bg-rose-100 text-rose-800";
+            return (
+              <li key={r.id} className="flex items-center justify-between gap-3 text-sm">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${tone}`}>
+                    {STATUS_LABEL[r.status]}
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-xs">{when}</p>
+                    <p className="text-[11px] text-muted-foreground truncate">
+                      {r.channel === "email" ? "Email" : "SMS"} · {recip}
+                    </p>
+                  </div>
+                </div>
+                {r.status === "pending" && (
+                  <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => handleCancel(r.id)}>
+                    <X className="w-3.5 h-3.5" />
+                  </Button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+        {rows.some((r) => r.status === "failed" && r.last_error) && (
+          <p className="text-[11px] text-rose-700 pt-1">
+            {rows.find((r) => r.status === "failed")?.last_error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -21,6 +21,9 @@ import { SendDocumentModal } from "@/components/send/send-document-modal";
 import { InvoiceEditor } from "./invoice-editor";
 import { InvoicePDFDownload } from "./invoice-pdf";
 import { ProgressInvoiceModal } from "./progress-invoice-modal";
+import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
+import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
+import { scheduleSend } from "@/lib/actions/scheduled-sends";
 
 import { formatCurrency, formatDate, getStatusColor } from "@/lib/utils";
 import type { Business, Customer, Invoice, LineItem, Payment, Product } from "@/types/database";
@@ -414,6 +417,8 @@ export function InvoiceDetailClient({
 
         {/* Sidebar */}
         <div className="space-y-4">
+          <ScheduledSendsCard docType="invoice" docId={invoice.id} />
+          <DeliveryStatusCard docType="invoice" docId={invoice.id} />
           <Card>
             <CardHeader className="pb-2"><CardTitle className="text-sm font-semibold">Payment history</CardTitle></CardHeader>
             <CardContent className="space-y-3">
@@ -498,6 +503,20 @@ export function InvoiceDetailClient({
             toast.success(`Invoice SMS sent to ${r.to}`);
           }
           setInvoice((prev) => ({ ...prev, status: prev.status === "draft" ? "sent" : prev.status }));
+        }}
+        onSchedule={async (sendAtIso, r) => {
+          await scheduleSend({
+            doc_type: "invoice",
+            doc_id: invoice.id,
+            send_at: sendAtIso,
+            channel: r.channel,
+            recipients: r.recipients,
+            to_phone: r.to,
+            subject: r.subject,
+            body: r.body,
+          });
+          toast.success(`Scheduled for ${new Date(sendAtIso).toLocaleString()}`);
+          router.refresh();
         }}
       />
 

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -13,6 +13,9 @@ import { Separator } from "@/components/ui/separator";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { deleteQuote, updateQuote, convertQuoteToInvoice, sendQuoteEmail, sendQuoteSms } from "@/lib/actions/quotes";
+import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
+import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
+import { scheduleSend } from "@/lib/actions/scheduled-sends";
 import { SendDocumentModal } from "@/components/send/send-document-modal";
 import { QuoteEditor } from "./quote-editor";
 import { QuotePDFDownload } from "./quote-pdf";
@@ -197,7 +200,9 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
           </Card>
         </div>
 
-        <div>
+        <div className="space-y-4">
+          <ScheduledSendsCard docType="quote" docId={quote.id} />
+          <DeliveryStatusCard docType="quote" docId={quote.id} />
           <Card>
             <CardContent className="p-5 space-y-3">
               <h3 className="font-semibold text-sm uppercase tracking-wide text-muted-foreground">Quote info</h3>
@@ -238,6 +243,20 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
             toast.success(`Quote SMS sent to ${r.to}`);
           }
           setQuote((prev) => ({ ...prev, status: prev.status === "draft" ? "sent" : prev.status }));
+        }}
+        onSchedule={async (sendAtIso, r) => {
+          await scheduleSend({
+            doc_type: "quote",
+            doc_id: quote.id,
+            send_at: sendAtIso,
+            channel: r.channel,
+            recipients: r.recipients,
+            to_phone: r.to,
+            subject: r.subject,
+            body: r.body,
+          });
+          toast.success(`Scheduled for ${new Date(sendAtIso).toLocaleString()}`);
+          router.refresh();
         }}
       />
 

--- a/src/components/send/send-document-modal.tsx
+++ b/src/components/send/send-document-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2, Mail, MessageSquare, Plus, Send, X } from "@/components/ui/icons";
+import { Loader2, Mail, MessageSquare, Plus, Send, X, Clock } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -36,6 +36,9 @@ interface SendDocumentModalProps {
   defaultSmsBody?: string;
   /** Called when the user clicks send */
   onSend: (result: SendDocumentResult) => Promise<void>;
+  /** Optional — when provided, the modal exposes a "Schedule for later"
+   *  toggle. Receives the same payload as onSend plus the chosen ISO time. */
+  onSchedule?: (sendAtIso: string, result: SendDocumentResult) => Promise<void>;
 }
 
 function isValidEmail(s: string) {
@@ -52,6 +55,7 @@ export function SendDocumentModal({
   defaultSubject,
   defaultSmsBody,
   onSend,
+  onSchedule,
 }: SendDocumentModalProps) {
   const [channel, setChannel] = useState<Channel>("email");
   const [emails, setEmails] = useState<string[]>(defaultEmails);
@@ -60,6 +64,8 @@ export function SendDocumentModal({
   const [phone, setPhone] = useState(defaultPhone ?? "");
   const [smsBody, setSmsBody] = useState(defaultSmsBody ?? "");
   const [sending, setSending] = useState(false);
+  const [schedule, setSchedule] = useState(false);
+  const [sendAtLocal, setSendAtLocal] = useState<string>("");
 
   // Re-sync defaults whenever the modal opens
   useEffect(() => {
@@ -70,6 +76,13 @@ export function SendDocumentModal({
       setSubject(defaultSubject);
       setPhone(defaultPhone ?? "");
       setSmsBody(defaultSmsBody ?? "");
+      setSchedule(false);
+      // Default the picker to "in 1 hour" so the form is never blank.
+      const inOneHour = new Date(Date.now() + 60 * 60 * 1000);
+      const pad = (n: number) => String(n).padStart(2, "0");
+      setSendAtLocal(
+        `${inOneHour.getFullYear()}-${pad(inOneHour.getMonth() + 1)}-${pad(inOneHour.getDate())}T${pad(inOneHour.getHours())}:${pad(inOneHour.getMinutes())}`
+      );
     }
   }, [open, defaultEmails, defaultSubject, defaultPhone, defaultSmsBody]);
 
@@ -92,11 +105,24 @@ export function SendDocumentModal({
       if (!phone.trim()) { toast.error("Phone number is required"); return; }
       if (!smsBody.trim()) { toast.error("Message body is required"); return; }
     }
+
+    const result: SendDocumentResult = channel === "email"
+      ? { channel: "email", recipients: emails, subject: subject.trim() }
+      : { channel: "sms", to: phone.trim(), body: smsBody.trim() };
+
+    let sendAtIso: string | null = null;
+    if (schedule) {
+      if (!sendAtLocal) { toast.error("Pick a date and time"); return; }
+      const d = new Date(sendAtLocal);
+      if (Number.isNaN(d.getTime())) { toast.error("Invalid date/time"); return; }
+      if (d.getTime() <= Date.now() + 30_000) { toast.error("Pick a time at least a minute in the future"); return; }
+      sendAtIso = d.toISOString();
+    }
+
     setSending(true);
     try {
-      await onSend(channel === "email"
-        ? { channel: "email", recipients: emails, subject: subject.trim() }
-        : { channel: "sms", to: phone.trim(), body: smsBody.trim() });
+      if (sendAtIso && onSchedule) await onSchedule(sendAtIso, result);
+      else                          await onSend(result);
       onOpenChange(false);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Failed to send");
@@ -206,13 +232,45 @@ export function SendDocumentModal({
           </div>
         )}
 
+        {onSchedule && (
+          <div className="space-y-3 pt-2 border-t">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={schedule}
+                onChange={(e) => setSchedule(e.target.checked)}
+                className="h-4 w-4 rounded border-border"
+              />
+              <Clock className="w-4 h-4 text-muted-foreground" />
+              <span className="font-medium">Schedule for later</span>
+            </label>
+            {schedule && (
+              <div className="space-y-1.5 pl-6">
+                <Label>Send at</Label>
+                <Input
+                  type="datetime-local"
+                  value={sendAtLocal}
+                  onChange={(e) => setSendAtLocal(e.target.value)}
+                />
+                <p className="text-[11px] text-muted-foreground">
+                  Times are in your local timezone. We&apos;ll dispatch within ~1 minute of the scheduled moment.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
         <div className="flex gap-2 pt-2">
           <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)} disabled={sending}>
             Cancel
           </Button>
           <Button className="flex-1" onClick={handleSend} disabled={sending}>
-            {sending ? <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" /> : <Send className="w-3.5 h-3.5 mr-1.5" />}
-            Send {channel === "email" ? "email" : "SMS"}
+            {sending ? <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+              : schedule ? <Clock className="w-3.5 h-3.5 mr-1.5" />
+              : <Send className="w-3.5 h-3.5 mr-1.5" />}
+            {schedule
+              ? `Schedule ${channel === "email" ? "email" : "SMS"}`
+              : `Send ${channel === "email" ? "email" : "SMS"}`}
           </Button>
         </div>
       </DialogContent>

--- a/src/lib/actions/email-events.ts
+++ b/src/lib/actions/email-events.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import type { EmailDocType } from "@/lib/email";
+
+export interface EmailEvent {
+  id: string;
+  business_id: string;
+  resend_id: string | null;
+  doc_type: EmailDocType;
+  doc_id: string | null;
+  recipient: string;
+  subject: string | null;
+  status: "queued" | "sent" | "delivered" | "bounced" | "complained" | "opened" | "clicked" | "failed" | "delivery_delayed";
+  error: string | null;
+  sent_at: string | null;
+  delivered_at: string | null;
+  opened_at: string | null;
+  clicked_at: string | null;
+  bounced_at: string | null;
+  created_at: string;
+}
+
+/** Returns the latest event per recipient for a given document. The UI shows
+ *  one row per address with the most-progressed lifecycle status — answering
+ *  the customer's "did they get it?" question at a glance. */
+export async function getDeliveryStatus(
+  doc_type: EmailDocType,
+  doc_id: string,
+): Promise<EmailEvent[]> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from("email_events")
+    .select("*")
+    .eq("business_id", businessId)
+    .eq("doc_type", doc_type)
+    .eq("doc_id", doc_id)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  // Collapse to one row per recipient (the most recent — i.e. the latest
+  // lifecycle event for that address).
+  const seen = new Set<string>();
+  const latest: EmailEvent[] = [];
+  for (const row of (data ?? []) as EmailEvent[]) {
+    if (seen.has(row.recipient)) continue;
+    seen.add(row.recipient);
+    latest.push(row);
+  }
+  return latest;
+}

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -490,6 +490,7 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
     subject: opts?.subject ?? `Invoice ${invoiceData.number} from ${businessData.name}`,
     html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl }),
     attachments: [{ filename: `${invoiceData.number}.pdf`, content: pdfBuffer }],
+    tags: { business_id: businessId, doc_type: "invoice", doc_id: invoiceData.id },
   });
 
   // Mark as sent if still draft

--- a/src/lib/actions/quotes.ts
+++ b/src/lib/actions/quotes.ts
@@ -242,6 +242,7 @@ export async function sendQuoteEmail(id: string, opts?: { recipients?: string[];
     subject: opts?.subject ?? `Quote ${quoteData.number} from ${businessData.name}`,
     html: quoteEmailHtml({ quote: quoteData, customer, business: businessData, lineItems, acceptUrl }),
     attachments: [{ filename: `${quoteData.number}.pdf`, content: pdfBuffer }],
+    tags: { business_id: businessId, doc_type: "quote", doc_id: quoteData.id },
   });
 
   // Mark as sent if still draft

--- a/src/lib/actions/scheduled-sends.ts
+++ b/src/lib/actions/scheduled-sends.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+
+export interface ScheduledSend {
+  id: string;
+  business_id: string;
+  user_id: string;
+  doc_type: "invoice" | "quote";
+  doc_id: string;
+  channel: "email" | "sms";
+  send_at: string;
+  recipients: string[] | null;
+  to_phone: string | null;
+  subject: string | null;
+  body: string | null;
+  status: "pending" | "sending" | "sent" | "cancelled" | "failed";
+  attempt_count: number;
+  last_error: string | null;
+  sent_at: string | null;
+  created_at: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Schedule an invoice/quote send for a specific moment in the future.
+ *  Inputs are flat scalars so this is callable from the AI agent layer. */
+export async function scheduleSend(input: {
+  doc_type: "invoice" | "quote";
+  doc_id: string;
+  send_at: string;            // ISO timestamp
+  channel?: "email" | "sms";
+  recipients?: string[];      // for email
+  to_phone?: string;          // for SMS
+  subject?: string;
+  body?: string;
+}): Promise<ScheduledSend> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const sendAtDate = new Date(input.send_at);
+  if (Number.isNaN(sendAtDate.getTime())) throw new Error("Invalid send_at");
+  if (sendAtDate.getTime() <= Date.now() + 30_000) {
+    throw new Error("Pick a time at least a minute in the future");
+  }
+
+  const channel = input.channel ?? "email";
+  if (channel === "email" && (!input.recipients || input.recipients.length === 0)) {
+    throw new Error("At least one recipient is required for email");
+  }
+  if (channel === "sms" && !input.to_phone) {
+    throw new Error("Phone number is required for SMS");
+  }
+
+  const { data, error } = await tbl(supabase, "scheduled_sends")
+    .insert({
+      business_id: businessId,
+      user_id: user.id,
+      doc_type: input.doc_type,
+      doc_id: input.doc_id,
+      channel,
+      send_at: sendAtDate.toISOString(),
+      recipients: input.recipients ?? null,
+      to_phone: input.to_phone ?? null,
+      subject: input.subject ?? null,
+      body: input.body ?? null,
+      status: "pending",
+    })
+    .select("*")
+    .single();
+  if (error) throw error;
+
+  revalidatePath(`/${input.doc_type === "invoice" ? "invoices" : "quotes"}/${input.doc_id}`);
+  return data as ScheduledSend;
+}
+
+export async function getScheduledSends(doc_type: "invoice" | "quote", doc_id: string): Promise<ScheduledSend[]> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "scheduled_sends")
+    .select("*")
+    .eq("business_id", businessId)
+    .eq("doc_type", doc_type)
+    .eq("doc_id", doc_id)
+    .order("send_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as ScheduledSend[];
+}
+
+export async function cancelScheduledSend(id: string): Promise<void> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: row } = await tbl(supabase, "scheduled_sends")
+    .select("doc_type, doc_id, status")
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .maybeSingle();
+  if (!row) throw new Error("Scheduled send not found");
+  if (row.status !== "pending") throw new Error("Already processed — can't cancel");
+
+  const { error } = await tbl(supabase, "scheduled_sends")
+    .update({ status: "cancelled", updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("business_id", businessId);
+  if (error) throw error;
+
+  revalidatePath(`/${row.doc_type === "invoice" ? "invoices" : "quotes"}/${row.doc_id}`);
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,5 @@
 import { Resend } from "resend";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 let _resend: Resend | null = null;
 function getResend(): Resend {
@@ -14,24 +15,75 @@ function getResend(): Resend {
 // During development, Resend allows sending from onboarding@resend.dev to your own email only.
 const FROM = process.env.RESEND_FROM_EMAIL ?? "Invoicer <onboarding@resend.dev>";
 
+export type EmailDocType = "invoice" | "quote" | "team_invite" | "lead" | "custom";
+
+export interface EmailTags {
+  business_id?: string | null;
+  doc_type?: EmailDocType;
+  doc_id?: string | null;
+}
+
 export async function sendEmail({
   to,
   subject,
   html,
   attachments,
+  tags,
 }: {
   to: string | string[];
   subject: string;
   html: string;
   attachments?: Array<{ filename: string; content: Buffer }>;
+  /** Optional metadata so we can log this send to email_events and tie webhook
+   *  events back to the right invoice/quote. Falls back to a 'custom' row when
+   *  business_id is provided without a doc. */
+  tags?: EmailTags;
 }) {
-  const { data, error } = await getResend().emails.send({
-    from: FROM,
-    to,
-    subject,
-    html,
-    attachments,
-  });
-  if (error) throw new Error(error.message);
-  return data;
+  // Resend headers can carry tags for our own webhook handler to read back.
+  const headers: Record<string, string> = {};
+  if (tags?.business_id) headers["X-Invoicer-Business"] = tags.business_id;
+  if (tags?.doc_type)    headers["X-Invoicer-Doc-Type"] = tags.doc_type;
+  if (tags?.doc_id)      headers["X-Invoicer-Doc-Id"]   = tags.doc_id;
+
+  let resendId: string | null = null;
+  let sendError: string | null = null;
+  try {
+    const { data, error } = await getResend().emails.send({
+      from: FROM,
+      to,
+      subject,
+      html,
+      attachments,
+      headers: Object.keys(headers).length ? headers : undefined,
+    });
+    if (error) throw new Error(error.message);
+    resendId = data?.id ?? null;
+  } catch (e) {
+    sendError = e instanceof Error ? e.message : String(e);
+  }
+
+  // Best-effort log — never fail the send because logging failed.
+  if (tags?.business_id) {
+    try {
+      const sb = createAdminClient();
+      const recipients = Array.isArray(to) ? to : [to];
+      const rows = recipients.map((recipient) => ({
+        business_id: tags.business_id!,
+        resend_id:   resendId,
+        doc_type:    tags.doc_type ?? "custom",
+        doc_id:      tags.doc_id ?? null,
+        recipient,
+        subject,
+        status:      sendError ? "failed" : "sent",
+        error:       sendError,
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any).from("email_events").insert(rows);
+    } catch {
+      /* logging is non-fatal */
+    }
+  }
+
+  if (sendError) throw new Error(sendError);
+  return { id: resendId };
 }

--- a/supabase/migrations/20260506000001_email_events.sql
+++ b/supabase/migrations/20260506000001_email_events.sql
@@ -1,0 +1,49 @@
+-- Track every outbound email + delivery events so the user can see whether a
+-- customer actually received an invoice/quote. Resend webhooks update the
+-- status fields as the lifecycle progresses (delivered/bounced/opened).
+
+create table if not exists public.email_events (
+  id           uuid primary key default gen_random_uuid(),
+  business_id  uuid not null references public.businesses(id) on delete cascade,
+  resend_id    text,
+  doc_type     text not null check (doc_type in ('invoice','quote','team_invite','lead','custom')),
+  doc_id       uuid,
+  recipient    text not null,
+  subject      text,
+  status       text not null default 'sent' check (status in ('queued','sent','delivered','bounced','complained','opened','clicked','failed','delivery_delayed')),
+  error        text,
+  sent_at      timestamptz default now(),
+  delivered_at timestamptz,
+  opened_at    timestamptz,
+  clicked_at   timestamptz,
+  bounced_at   timestamptz,
+  raw          jsonb,
+  created_at   timestamptz default now()
+);
+
+create index if not exists email_events_doc_idx        on public.email_events (business_id, doc_type, doc_id, created_at desc);
+create index if not exists email_events_resend_id_idx  on public.email_events (resend_id) where resend_id is not null;
+create index if not exists email_events_recipient_idx  on public.email_events (business_id, recipient, created_at desc);
+
+alter table public.email_events enable row level security;
+
+-- Members of the business can read their email events.
+create policy "members read business email events"
+  on public.email_events
+  for select
+  using (
+    exists (
+      select 1 from public.business_members bm
+      where bm.business_id = email_events.business_id
+        and bm.user_id = auth.uid()
+        and bm.status = 'active'
+    )
+    or exists (
+      select 1 from public.businesses b
+      where b.id = email_events.business_id
+        and b.user_id = auth.uid()
+    )
+  );
+
+-- Inserts/updates only happen via service-role (server actions + webhooks).
+-- No insert/update policy → blocked for end users by default.

--- a/supabase/migrations/20260506000002_scheduled_sends.sql
+++ b/supabase/migrations/20260506000002_scheduled_sends.sql
@@ -1,0 +1,78 @@
+-- Schedule an invoice/quote to be emailed (or SMS'd) at a future moment.
+-- A cron pulls 'pending' rows whose send_at has passed and dispatches them
+-- via the same server actions used for immediate sends.
+
+create table if not exists public.scheduled_sends (
+  id            uuid primary key default gen_random_uuid(),
+  business_id   uuid not null references public.businesses(id) on delete cascade,
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  doc_type      text not null check (doc_type in ('invoice','quote')),
+  doc_id        uuid not null,
+  channel       text not null default 'email' check (channel in ('email','sms')),
+  send_at       timestamptz not null,
+  recipients    text[],
+  to_phone      text,
+  subject       text,
+  body          text,
+  status        text not null default 'pending' check (status in ('pending','sending','sent','cancelled','failed')),
+  attempt_count int not null default 0,
+  last_error    text,
+  sent_at       timestamptz,
+  created_at    timestamptz default now(),
+  updated_at    timestamptz default now()
+);
+
+create index if not exists scheduled_sends_due_idx on public.scheduled_sends (status, send_at)
+  where status in ('pending','sending');
+create index if not exists scheduled_sends_doc_idx on public.scheduled_sends (business_id, doc_type, doc_id, status);
+
+alter table public.scheduled_sends enable row level security;
+
+create policy "members read own business scheduled sends"
+  on public.scheduled_sends
+  for select
+  using (
+    exists (
+      select 1 from public.business_members bm
+      where bm.business_id = scheduled_sends.business_id
+        and bm.user_id = auth.uid()
+        and bm.status = 'active'
+    )
+    or exists (
+      select 1 from public.businesses b
+      where b.id = scheduled_sends.business_id
+        and b.user_id = auth.uid()
+    )
+  );
+
+create policy "members manage own business scheduled sends"
+  on public.scheduled_sends
+  for all
+  using (
+    exists (
+      select 1 from public.business_members bm
+      where bm.business_id = scheduled_sends.business_id
+        and bm.user_id = auth.uid()
+        and bm.status = 'active'
+        and bm.role in ('owner','admin','staff')
+    )
+    or exists (
+      select 1 from public.businesses b
+      where b.id = scheduled_sends.business_id
+        and b.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.business_members bm
+      where bm.business_id = scheduled_sends.business_id
+        and bm.user_id = auth.uid()
+        and bm.status = 'active'
+        and bm.role in ('owner','admin','staff')
+    )
+    or exists (
+      select 1 from public.businesses b
+      where b.id = scheduled_sends.business_id
+        and b.user_id = auth.uid()
+    )
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
     {
       "path": "/api/cron/recurring-jobs",
       "schedule": "30 19 * * *"
+    },
+    {
+      "path": "/api/cron/process-scheduled-sends",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Delivery status** per email on every invoice + quote — sent / delivered / opened / bounced — driven by Resend webhooks. Tells you whether the customer actually received the message.
- **Schedule send** for email or SMS — modal toggle 'Schedule for later' with datetime picker. Cron processes pending sends every minute. Cancellable while still pending.

## Migrations
- 20260506000001_email_events
- 20260506000002_scheduled_sends

## Setup required
- Add Resend webhook → \`/api/webhooks/resend\` and copy the signing secret to \`RESEND_WEBHOOK_SECRET\`
- (Most important) Verify a sender domain in Resend or customers will keep not receiving emails. Set \`RESEND_FROM_EMAIL\` once verified.

## Test plan
- [ ] Send an invoice → DeliveryStatusCard shows 'Sent (in transit)' immediately, flips to 'Delivered' once Resend confirms
- [ ] Schedule an invoice for 2 minutes from now → ScheduledSendsCard shows it as Pending → cron fires → row flips to Sent and a real email lands
- [ ] Cancel a pending scheduled send before its time → status flips to Cancelled, no send happens
- [ ] Bounced address → DeliveryStatusCard turns rose-colored with the 'verify domain' hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)