### PR TITLE
Share-to-customer-hub link + clone for quotes & reports

### DIFF
--- a/src/app/api/pdf/report/[id]/route.ts
+++ b/src/app/api/pdf/report/[id]/route.ts
@@ -1,16 +1,50 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getReport } from "@/lib/actions/reports";
 import { getBusiness } from "@/lib/actions/business";
+import type { Report, Business } from "@/types/database";
 
-export async function GET(_: Request, { params }: { params: Promise<{ id: string }> }) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const url = new URL(req.url);
+  const portalToken = url.searchParams.get("token");
 
-    const [reportData, business] = await Promise.all([getReport(id), getBusiness()]);
+  try {
+    let reportData: Report & { customers: unknown };
+    let business:   Business;
+
+    if (portalToken) {
+      // Customer portal access — validate the token covers this report's
+      // customer + business, then fetch via admin client (no auth session).
+      const sb = createAdminClient();
+      const { data: link } = await tbl(sb, "customer_portal_tokens")
+        .select("business_id, customer_id, expires_at, revoked_at")
+        .eq("token", portalToken)
+        .maybeSingle();
+      if (!link || link.revoked_at) return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      if (link.expires_at && new Date(link.expires_at) < new Date()) {
+        return NextResponse.json({ error: "Token expired" }, { status: 401 });
+      }
+      const [{ data: r }, { data: biz }] = await Promise.all([
+        tbl(sb, "reports").select("*, customers(*)").eq("id", id).eq("business_id", link.business_id).eq("customer_id", link.customer_id).maybeSingle(),
+        tbl(sb, "businesses").select("*").eq("id", link.business_id).single(),
+      ]);
+      if (!r) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      reportData = r;
+      business   = biz;
+    } else {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+      const [reportRes, bizRes] = await Promise.all([getReport(id), getBusiness()]);
+      reportData = reportRes;
+      business   = bizRes;
+    }
 
     // react-pdf can't reliably load remote images during a server-rendered
     // stream — fetch the logo and embed as a data URL so it actually shows.

--- a/src/app/portal/[token]/page.tsx
+++ b/src/app/portal/[token]/page.tsx
@@ -34,7 +34,7 @@ export default async function CustomerPortalPage({ params }: { params: Promise<{
   ]);
   if (!customer) notFound();
 
-  const [{ data: invoices }, { data: quotes }, { data: workOrders }] = await Promise.all([
+  const [{ data: invoices }, { data: quotes }, { data: workOrders }, { data: reports }] = await Promise.all([
     tbl(sb, "invoices")
       .select("id, number, status, issue_date, due_date, total, amount_paid")
       .eq("business_id", link.business_id)
@@ -50,11 +50,17 @@ export default async function CustomerPortalPage({ params }: { params: Promise<{
       .eq("business_id", link.business_id)
       .eq("customer_id", link.customer_id)
       .order("scheduled_date", { ascending: false }),
+    tbl(sb, "reports")
+      .select("id, title, status, report_date, property_address")
+      .eq("business_id", link.business_id)
+      .eq("customer_id", link.customer_id)
+      .order("report_date", { ascending: false }),
   ]);
 
   const invs = invoices ?? [];
   const qts = quotes ?? [];
   const wos = workOrders ?? [];
+  const rps = reports ?? [];
   const totalOwing = invs
     .filter((i: { status: string }) => i.status !== "paid" && i.status !== "cancelled")
     .reduce((s: number, i: { total: number; amount_paid: number }) => s + (i.total - (i.amount_paid || 0)), 0);
@@ -123,23 +129,26 @@ export default async function CustomerPortalPage({ params }: { params: Promise<{
           ) : (
             <div className="space-y-2">
               {invs.map((inv: { id: string; number: string; status: string; issue_date: string; due_date: string; total: number; amount_paid: number }) => (
-                <Card key={inv.id} className="p-4 flex items-center justify-between gap-4">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-medium">#{inv.number}</span>
-                      <StatusBadge status={inv.status} />
+                <Link key={inv.id} href={`/portal/${token}/invoice/${inv.id}`}>
+                  <Card className="p-4 flex items-center justify-between gap-4 hover:shadow-md transition-shadow">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium">#{inv.number}</span>
+                        <StatusBadge status={inv.status} />
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Issued {formatDate(inv.issue_date)} · Due {formatDate(inv.due_date)}
+                      </p>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      Issued {formatDate(inv.issue_date)} · Due {formatDate(inv.due_date)}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold">{formatCurrency(inv.total)}</p>
-                    {inv.amount_paid > 0 && inv.amount_paid < inv.total && (
-                      <p className="text-xs text-emerald-500">{formatCurrency(inv.amount_paid)} paid</p>
-                    )}
-                  </div>
-                </Card>
+                    <div className="text-right">
+                      <p className="font-semibold">{formatCurrency(inv.total)}</p>
+                      {inv.amount_paid > 0 && inv.amount_paid < inv.total && (
+                        <p className="text-xs text-emerald-500">{formatCurrency(inv.amount_paid)} paid</p>
+                      )}
+                      <p className="text-xs text-emerald-600 mt-0.5">View →</p>
+                    </div>
+                  </Card>
+                </Link>
               ))}
             </div>
           )}
@@ -210,6 +219,34 @@ export default async function CustomerPortalPage({ params }: { params: Promise<{
             </div>
           )}
         </section>
+
+        {/* Reports */}
+        {rps.length > 0 && (
+          <section>
+            <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+              <FileText className="w-4 h-4 text-amber-500" /> Reports
+            </h3>
+            <div className="space-y-2">
+              {rps.map((r: { id: string; title: string; status: string; report_date: string | null; property_address: string | null }) => (
+                <Link key={r.id} href={`/portal/${token}/report/${r.id}`}>
+                  <Card className="p-4 flex items-center justify-between gap-4 hover:shadow-md transition-shadow">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium truncate">{r.title}</span>
+                        <StatusBadge status={r.status === "complete" ? "completed" : "draft"} />
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {r.report_date ? formatDate(r.report_date) : ""}
+                        {r.property_address ? ` · ${r.property_address}` : ""}
+                      </p>
+                    </div>
+                    <p className="text-xs text-amber-600 font-medium flex-shrink-0">View →</p>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
 
         <footer className="text-center text-xs text-muted-foreground py-6 border-t">
           Powered by Invoicer · This link is private to {customer.name}

--- a/src/app/portal/[token]/report/[id]/page.tsx
+++ b/src/app/portal/[token]/report/[id]/page.tsx
@@ -1,0 +1,139 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, FileText, Download } from "@/components/ui/icons";
+import { formatDate } from "@/lib/utils";
+import type { Report } from "@/types/database";
+
+export const dynamic = "force-dynamic";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+export default async function PortalReportPage({ params }: { params: Promise<{ token: string; id: string }> }) {
+  const { token, id } = await params;
+  const sb = createAdminClient();
+
+  const { data: link } = await tbl(sb, "customer_portal_tokens")
+    .select("business_id, customer_id, expires_at, revoked_at")
+    .eq("token", token)
+    .maybeSingle();
+  if (!link || link.revoked_at) notFound();
+  if (link.expires_at && new Date(link.expires_at) < new Date()) notFound();
+
+  const [{ data: report }, { data: business }] = await Promise.all([
+    tbl(sb, "reports")
+      .select("*")
+      .eq("id", id)
+      .eq("business_id", link.business_id)
+      .eq("customer_id", link.customer_id)
+      .maybeSingle(),
+    tbl(sb, "businesses").select("name, logo_url, license_number").eq("id", link.business_id).maybeSingle(),
+  ]);
+  if (!report) notFound();
+
+  const r = report as Report;
+  const m = r.meta;
+  const inspectorLine = m.inspector_name + (m.inspector_license ? `  (Lic. ${m.inspector_license})` : "");
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/30">
+      <header className="border-b bg-background/80 backdrop-blur sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between gap-4">
+          <Link href={`/portal/${token}`} className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+            <ArrowLeft className="w-4 h-4" /> Back
+          </Link>
+          {business?.logo_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={business.logo_url} alt={business.name} className="w-8 h-8 rounded object-contain" />
+          ) : (
+            <span className="text-sm font-semibold">{business?.name}</span>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        {/* Title */}
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <div className="flex items-center gap-2">
+              <FileText className="w-6 h-6 text-primary" />
+              <h1 className="text-2xl font-bold">{r.title}</h1>
+            </div>
+            <p className="text-sm text-muted-foreground mt-1">
+              From {business?.name} · {r.report_date ? `Report ${formatDate(r.report_date)}` : ""}
+              {r.inspection_date ? ` · Inspected ${formatDate(r.inspection_date)}` : ""}
+            </p>
+          </div>
+          <Badge variant="secondary" className={r.status === "complete"
+            ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+            : "bg-amber-500/15 text-amber-600 dark:text-amber-400"}>
+            {r.status === "complete" ? "Final" : "Draft"}
+          </Badge>
+        </div>
+
+        {/* Property summary */}
+        <Card className="p-5 space-y-3">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">Property &amp; inspection</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+            {[
+              ["Property", r.property_address],
+              ["Roof type", m.roof_type],
+              ["Roof features", m.roof_features],
+              ["Inspection method", m.inspection_method],
+              ["Inspector", inspectorLine],
+              ["Inspection date", r.inspection_date ? formatDate(r.inspection_date) : null],
+            ].map(([k, v]) => (
+              <div key={k}>
+                <span className="text-muted-foreground text-xs">{k}</span>
+                <p className="font-medium">{v || "—"}</p>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        {/* Sections */}
+        {r.sections.map((sec) => sec.content?.trim() ? (
+          <Card key={sec.id} className="p-5 space-y-2">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">{sec.title}</p>
+            <p className="text-sm whitespace-pre-line">{sec.content}</p>
+          </Card>
+        ) : null)}
+
+        {/* Photos */}
+        {r.photos.length > 0 && (
+          <Card className="p-5 space-y-3">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">Photos ({r.photos.length})</p>
+            <div className="grid grid-cols-2 gap-3">
+              {r.photos.map((p) => (
+                <div key={p.id} className="space-y-1">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={p.url} alt={p.caption || "Site photo"} className="w-full aspect-video object-cover rounded" />
+                  {p.caption && <p className="text-xs text-muted-foreground">{p.caption}</p>}
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        {/* PDF download */}
+        <Card className="p-6 text-center">
+          <a
+            href={`/api/pdf/report/${r.id}?token=${token}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium text-foreground hover:bg-muted transition-colors"
+          >
+            <Download className="w-3.5 h-3.5" /> Download full PDF report
+          </a>
+        </Card>
+
+        <footer className="text-center text-xs text-muted-foreground py-6 border-t">
+          Powered by Invoicer
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, Edit, Send, Copy, Trash2, CheckCircle, DollarSign, MoreHorizontal, FileStack, ArrowRight } from "@/components/ui/icons";
+import { ArrowLeft, Edit, Send, Copy, Trash2, CheckCircle, DollarSign, MoreHorizontal, FileStack, ArrowRight, Link2 } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -24,6 +24,7 @@ import { ProgressInvoiceModal } from "./progress-invoice-modal";
 import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
 import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
 import { scheduleSend } from "@/lib/actions/scheduled-sends";
+import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
 
 import { formatCurrency, formatDate, getStatusColor } from "@/lib/utils";
 import type { Business, Customer, Invoice, LineItem, Payment, Product } from "@/types/database";
@@ -54,6 +55,7 @@ export function InvoiceDetailClient({
   const [paymentRef, setPaymentRef] = useState("");
   const [saving, setSaving] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [progressOpen, setProgressOpen] = useState(false);
 
   const lineItems = (invoice.line_items ?? []) as LineItem[];
@@ -189,6 +191,17 @@ export function InvoiceDetailClient({
             >
               <Send className="w-3.5 h-3.5" />
               Send
+            </Button>
+          )}
+          {invoice.customer_id && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => setShareOpen(true)}
+            >
+              <Link2 className="w-3.5 h-3.5" />
+              Share link
             </Button>
           )}
           <InvoicePDFDownload invoiceId={invoice.id} invoiceNumber={invoice.number} />
@@ -519,6 +532,19 @@ export function InvoiceDetailClient({
           router.refresh();
         }}
       />
+
+      {invoice.customer_id && (
+        <ShareWithCustomerDialog
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+          customerId={invoice.customer_id}
+          customerName={customer?.name ?? null}
+          customerPhone={customer?.phone ?? null}
+          docType="invoice"
+          docId={invoice.id}
+          docNumber={invoice.number}
+        />
+      )}
 
       {!isChild && (
         <ProgressInvoiceModal

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, Edit, Trash2, ArrowRight, MoreHorizontal, Send } from "@/components/ui/icons";
+import { ArrowLeft, Edit, Trash2, ArrowRight, MoreHorizontal, Send, Copy, Link2 } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -12,7 +12,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
-import { deleteQuote, updateQuote, convertQuoteToInvoice, sendQuoteEmail, sendQuoteSms } from "@/lib/actions/quotes";
+import { deleteQuote, updateQuote, convertQuoteToInvoice, sendQuoteEmail, sendQuoteSms, duplicateQuote } from "@/lib/actions/quotes";
+import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
 import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
 import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
 import { scheduleSend } from "@/lib/actions/scheduled-sends";
@@ -36,6 +37,15 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
   const [showDelete, setShowDelete] = useState(false);
   const [converting, setConverting] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  const handleDuplicate = async () => {
+    try {
+      const dup = await duplicateQuote(quote.id);
+      toast.success("Quote duplicated");
+      router.push(`/quotes/${dup.id}`);
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't duplicate"); }
+  };
 
   const lineItems = (quote.line_items ?? []) as LineItem[];
   const customer = customers.find((c) => c.id === quote.customer_id);
@@ -108,6 +118,17 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
               Send
             </Button>
           )}
+          {quote.customer_id && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => setShareOpen(true)}
+            >
+              <Link2 className="w-3.5 h-3.5" />
+              Share link
+            </Button>
+          )}
           <QuotePDFDownload quoteId={quote.id} quoteNumber={quote.number} />
           <Button size="sm" variant="outline" className="gap-1.5" onClick={() => setEditing(true)}>
             <Edit className="w-3.5 h-3.5" />Edit
@@ -120,6 +141,8 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
               <DropdownMenuItem onClick={() => handleStatusChange("sent")}>Mark as sent</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("accepted")}>Mark as accepted</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("rejected")}>Mark as rejected</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleDuplicate} className="gap-2"><Copy className="w-3.5 h-3.5" />Duplicate</DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setShowDelete(true)} className="text-destructive gap-2"><Trash2 className="w-3.5 h-3.5" />Delete</DropdownMenuItem>
             </DropdownMenuContent>
@@ -259,6 +282,19 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
           router.refresh();
         }}
       />
+
+      {quote.customer_id && (
+        <ShareWithCustomerDialog
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+          customerId={quote.customer_id}
+          customerName={customer?.name ?? null}
+          customerPhone={customer?.phone ?? null}
+          docType="quote"
+          docId={quote.id}
+          docNumber={quote.number}
+        />
+      )}
 
       <AlertDialog open={showDelete} onOpenChange={setShowDelete}>
         <AlertDialogContent>

--- a/src/components/reports/report-detail-client.tsx
+++ b/src/components/reports/report-detail-client.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, Download, FileText, Pencil, Check, X, Trash2, CheckCircle, RotateCcw, Mail } from "@/components/ui/icons";
+import { ArrowLeft, Download, FileText, Pencil, Check, X, Trash2, CheckCircle, RotateCcw, Mail, Copy, Link2 } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,7 +11,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
-import { updateReportSection, updateReportStatus, updateReportPhotos, deleteReport } from "@/lib/actions/reports";
+import { updateReportSection, updateReportStatus, updateReportPhotos, deleteReport, duplicateReport } from "@/lib/actions/reports";
+import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
 import { ROOF_INSPECTION_SECTIONS, SECTION_MAP } from "@/lib/templates/roof-inspection";
 import type { Report, ReportPhoto, Customer, Business, RiskItem } from "@/types/database";
 import Link from "next/link";
@@ -37,6 +38,15 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
   const [captionContent, setCaptionContent] = useState("");
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  const handleDuplicate = async () => {
+    try {
+      const dup = await duplicateReport(report.id);
+      toast.success("Report duplicated");
+      router.push(`/reports/${dup.id}`);
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't duplicate"); }
+  };
 
   const sectionMap = Object.fromEntries(report.sections.map((s) => [s.id, s]));
 
@@ -126,8 +136,13 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
           <a href={`/api/docx/report/${report.id}`} target="_blank" rel="noopener noreferrer">
             <Button variant="outline" size="sm"><FileText className="w-3.5 h-3.5 mr-1.5" />DOCX</Button>
           </a>
-          <Button variant="outline" size="sm" onClick={() => toast.info("Email coming soon")}>
-            <Mail className="w-3.5 h-3.5 mr-1.5" />Email
+          {report.customer_id && (
+            <Button variant="outline" size="sm" onClick={() => setShareOpen(true)}>
+              <Link2 className="w-3.5 h-3.5 mr-1.5" />Share link
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={handleDuplicate}>
+            <Copy className="w-3.5 h-3.5 mr-1.5" />Duplicate
           </Button>
           <AlertDialog>
             <AlertDialogTrigger asChild>
@@ -349,6 +364,19 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
           </Card>
         </div>
       </div>
+
+      {report.customer_id && (
+        <ShareWithCustomerDialog
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+          customerId={report.customer_id}
+          customerName={report.customers?.name ?? null}
+          customerPhone={report.customers?.phone ?? null}
+          docType="report"
+          docId={report.id}
+          docNumber={report.title}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/share/share-with-customer-dialog.tsx
+++ b/src/components/share/share-with-customer-dialog.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Copy, Link2 as LinkIcon, ExternalLink, MessageSquare, Loader2 } from "@/components/ui/icons";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { getShareLinks } from "@/lib/actions/customer-portal";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  customerId: string;
+  customerName?: string | null;
+  customerPhone?: string | null;
+  docType: "invoice" | "quote" | "report";
+  docId: string;
+  docNumber: string;
+}
+
+/** Share a single document or the full customer hub via copy / WhatsApp / SMS.
+ *  Reuses any active portal token for that customer so the same link keeps
+ *  working — otherwise mints a fresh 90-day token. */
+export function ShareWithCustomerDialog({
+  open, onOpenChange, customerId, customerName, customerPhone, docType, docId, docNumber,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const [hubUrl, setHubUrl] = useState<string>("");
+  const [docUrl, setDocUrl] = useState<string>("");
+
+  useEffect(() => {
+    if (!open || !customerId) return;
+    setLoading(true);
+    getShareLinks({ customer_id: customerId, doc_type: docType, doc_id: docId })
+      .then((r) => { setHubUrl(r.hub_url); setDocUrl(r.doc_url ?? ""); })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Couldn't generate link"))
+      .finally(() => setLoading(false));
+  }, [open, customerId, docType, docId]);
+
+  const copy = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label} copied`);
+    } catch {
+      toast.error("Couldn't copy — long-press the field and copy manually");
+    }
+  };
+
+  const docLabel = docType[0].toUpperCase() + docType.slice(1);
+  const firstName = customerName?.split(" ")[0] ?? "";
+  const greet = firstName ? `Hi ${firstName}, ` : "";
+  const docMsg = `${greet}here's your ${docType} ${docNumber}: ${docUrl}`;
+  const hubMsg = `${greet}here are all your documents with us: ${hubUrl}`;
+
+  // Strip non-digits so wa.me / sms: get a clean number
+  const phoneE164 = customerPhone?.replace(/[^\d+]/g, "") ?? "";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <LinkIcon className="w-4 h-4" />
+            Share {docLabel} {docNumber}
+          </DialogTitle>
+          <DialogDescription>
+            {customerName ? `Send ${customerName} a private link.` : "Send a private link."} Same token also opens the customer hub with all their invoices, quotes and jobs.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-muted-foreground">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" /> Generating link…
+          </div>
+        ) : (
+          <div className="space-y-5">
+            {/* Doc link */}
+            {docUrl && (
+              <Section
+                label={`${docLabel} link`}
+                hint={`Opens just this ${docType}.`}
+                url={docUrl}
+                onCopy={() => copy(docUrl, `${docLabel} link`)}
+                phoneE164={phoneE164}
+                shareMessage={docMsg}
+              />
+            )}
+
+            {/* Hub link */}
+            <Section
+              label="Customer hub link"
+              hint="Opens everything they have with you (all invoices, quotes, jobs)."
+              url={hubUrl}
+              onCopy={() => copy(hubUrl, "Hub link")}
+              phoneE164={phoneE164}
+              shareMessage={hubMsg}
+            />
+          </div>
+        )}
+
+        <p className="text-[11px] text-muted-foreground pt-2 border-t">
+          Anyone with the link can view — treat it like a password. Revoke from <span className="font-mono">Customer → Portal links</span>.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Section({
+  label, hint, url, onCopy, phoneE164, shareMessage,
+}: {
+  label: string;
+  hint: string;
+  url: string;
+  onCopy: () => void;
+  phoneE164: string;
+  shareMessage: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-xs font-semibold uppercase tracking-wider">{label}</p>
+        <p className="text-[11px] text-muted-foreground">{hint}</p>
+      </div>
+      <div className="flex gap-2">
+        <input
+          readOnly
+          value={url}
+          onFocus={(e) => e.currentTarget.select()}
+          className="flex-1 min-w-0 px-3 py-1.5 text-xs bg-muted rounded-md border border-border font-mono"
+        />
+        <Button size="sm" variant="outline" className="gap-1" onClick={onCopy}>
+          <Copy className="w-3.5 h-3.5" />
+          Copy
+        </Button>
+        <a href={url} target="_blank" rel="noreferrer">
+          <Button size="sm" variant="outline" className="gap-1">
+            <ExternalLink className="w-3.5 h-3.5" />
+            Open
+          </Button>
+        </a>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {phoneE164 && (
+          <a
+            href={`https://wa.me/${phoneE164.replace(/^\+/, "")}?text=${encodeURIComponent(shareMessage)}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Button size="sm" variant="outline" className="gap-1.5 h-8">
+              <MessageSquare className="w-3.5 h-3.5" /> WhatsApp
+            </Button>
+          </a>
+        )}
+        {phoneE164 && (
+          <a href={`sms:${phoneE164}?body=${encodeURIComponent(shareMessage)}`}>
+            <Button size="sm" variant="outline" className="gap-1.5 h-8">
+              <MessageSquare className="w-3.5 h-3.5" /> SMS
+            </Button>
+          </a>
+        )}
+        <a href={`mailto:?body=${encodeURIComponent(shareMessage)}`}>
+          <Button size="sm" variant="outline" className="gap-1.5 h-8">
+            Email
+          </Button>
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/actions/customer-portal.ts
+++ b/src/lib/actions/customer-portal.ts
@@ -4,6 +4,7 @@ import { randomBytes } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
+import { appUrl } from "@/lib/app-url";
 import type { CustomerPortalToken } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,6 +51,54 @@ export async function createPortalLink(
   revalidatePath(`/customers/${customerId}`);
   const base = process.env.NEXT_PUBLIC_APP_URL || "";
   return { token, url: `${base}/portal/${token}` };
+}
+
+/** One-shot helper used by Share buttons on invoice/quote/report detail pages.
+ *  Returns the customer's portal token (reusing any active one, otherwise
+ *  minting a fresh 90-day link), plus deep-link URLs for the hub and the
+ *  specific document. Inputs are flat scalars so this is callable from the
+ *  AI agent layer too. */
+export async function getShareLinks(input: {
+  customer_id: string;
+  doc_type?: "invoice" | "quote" | "report";
+  doc_id?: string;
+}): Promise<{ token: string; hub_url: string; doc_url: string | null }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // Reuse any active, non-expired token first so the same link keeps working.
+  const { data: existing } = await tbl(supabase, "customer_portal_tokens")
+    .select("token")
+    .eq("business_id", businessId)
+    .eq("customer_id", input.customer_id)
+    .is("revoked_at", null)
+    .or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  let token: string | null = existing?.token ?? null;
+  if (!token) {
+    token = "cust_" + randomBytes(24).toString("hex");
+    const { error } = await tbl(supabase, "customer_portal_tokens").insert({
+      token,
+      business_id: businessId,
+      customer_id: input.customer_id,
+      created_by: user.id,
+      expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+    });
+    if (error) throw error;
+  }
+
+  const base = appUrl();
+  const hub_url = `${base}/portal/${token}`;
+  const doc_url = input.doc_type && input.doc_id
+    ? `${base}/portal/${token}/${input.doc_type}/${input.doc_id}`
+    : null;
+
+  return { token, hub_url, doc_url };
 }
 
 export async function revokePortalLink(token: string): Promise<void> {

--- a/src/lib/actions/reports.ts
+++ b/src/lib/actions/reports.ts
@@ -89,6 +89,39 @@ export async function createReport(payload: {
   return data as Report;
 }
 
+/** Clone a report — copies sections, meta, photos and resets status to draft.
+ *  The new report appends "(copy)" to the title and gets today's report_date. */
+export async function duplicateReport(id: string): Promise<Report> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: src, error: srcErr } = await tbl(supabase, "reports")
+    .select("*")
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .single();
+  if (srcErr || !src) throw new Error("Report not found");
+
+  const today = new Date().toISOString().split("T")[0];
+  const { data, error } = await tbl(supabase, "reports").insert({
+    user_id: user.id,
+    business_id: businessId,
+    title: `${src.title} (copy)`,
+    status: "draft",
+    customer_id: src.customer_id,
+    property_address: src.property_address,
+    inspection_date: src.inspection_date,
+    report_date: today,
+    sections: src.sections,
+    photos: src.photos,
+    meta: src.meta,
+  }).select().single();
+  if (error) throw error;
+  return data as Report;
+}
+
 export async function updateReport(id: string, payload: Partial<Omit<Report, "id" | "user_id" | "created_at" | "updated_at">>): Promise<Report> {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
Adds a Share link button on every invoice / quote / report detail with copy + WhatsApp + SMS + Email shortcuts. The dialog returns both a doc deep-link and a customer hub link (lists all their docs with you). Reuses an active portal token so the same link keeps working.

Reports now show in the hub and have their own portal view at /portal/[token]/report/[id]. The PDF route accepts ?token= so portal users can download.

Also adds Duplicate everywhere — quotes lacked it, reports got a new `duplicateReport` action, invoices already had it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)