### PR TITLE
Fix empty Prepared-for + add Reset to draft

### DIFF
--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -32,7 +32,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
       .eq("customer_id", link.customer_id)
       .maybeSingle(),
     tbl(sb, "businesses").select("name, logo_url, currency, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban, phone, email").eq("id", link.business_id).maybeSingle(),
-    tbl(sb, "customers").select("name, company, email, billing_address").eq("id", link.customer_id).maybeSingle(),
+    tbl(sb, "customers").select("name, company, email, phone, address, city, postcode, country").eq("id", link.customer_id).maybeSingle(),
     tbl(sb, "payments")
       .select("amount, date, method, reference")
       .eq("invoice_id", id)
@@ -86,9 +86,12 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
           <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">Billed to</p>
           <p className="text-lg font-semibold mt-1">{customer?.name}</p>
           {customer?.company && <p className="text-sm text-muted-foreground">{customer.company}</p>}
-          {customer?.billing_address && (
-            <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">{customer.billing_address}</p>
+          {(customer?.address || customer?.city) && (
+            <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">
+              {[customer.address, [customer.city, customer.postcode].filter(Boolean).join(" "), customer.country].filter(Boolean).join("\n")}
+            </p>
           )}
+          {customer?.email && <p className="text-sm text-muted-foreground mt-1">{customer.email}</p>}
         </Card>
 
         {/* Line items */}

--- a/src/app/portal/[token]/quote/[id]/page.tsx
+++ b/src/app/portal/[token]/quote/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function PortalQuotePage({ params }: { params: Promise<{ to
       .eq("customer_id", link.customer_id)
       .maybeSingle(),
     tbl(sb, "businesses").select("name, logo_url, currency, phone, email").eq("id", link.business_id).maybeSingle(),
-    tbl(sb, "customers").select("name, company, email, billing_address").eq("id", link.customer_id).maybeSingle(),
+    tbl(sb, "customers").select("name, company, email, phone, address, city, postcode, country").eq("id", link.customer_id).maybeSingle(),
   ]);
 
   if (!quote) notFound();
@@ -82,7 +82,12 @@ export default async function PortalQuotePage({ params }: { params: Promise<{ to
           <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">Prepared for</p>
           <p className="text-lg font-semibold mt-1">{customer?.name}</p>
           {customer?.company && <p className="text-sm text-muted-foreground">{customer.company}</p>}
-          {customer?.billing_address && <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">{customer.billing_address}</p>}
+          {(customer?.address || customer?.city) && (
+            <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">
+              {[customer.address, [customer.city, customer.postcode].filter(Boolean).join(" "), customer.country].filter(Boolean).join("\n")}
+            </p>
+          )}
+          {customer?.email && <p className="text-sm text-muted-foreground mt-1">{customer.email}</p>}
         </Card>
 
         {/* Line items */}

--- a/src/app/portal/[token]/report/[id]/page.tsx
+++ b/src/app/portal/[token]/report/[id]/page.tsx
@@ -31,7 +31,7 @@ export default async function PortalReportPage({ params }: { params: Promise<{ t
       .eq("customer_id", link.customer_id)
       .maybeSingle(),
     tbl(sb, "businesses").select("name, logo_url, license_number, phone, email").eq("id", link.business_id).maybeSingle(),
-    tbl(sb, "customers").select("name, company, billing_address").eq("id", link.customer_id).maybeSingle(),
+    tbl(sb, "customers").select("name, company, email, address, city, postcode, country").eq("id", link.customer_id).maybeSingle(),
   ]);
   if (!report) notFound();
 
@@ -85,7 +85,11 @@ export default async function PortalReportPage({ params }: { params: Promise<{ t
             <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">Prepared for</p>
             <p className="text-lg font-semibold mt-1">{customer.name}</p>
             {customer.company && <p className="text-sm text-muted-foreground">{customer.company}</p>}
-            {customer.billing_address && <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">{customer.billing_address}</p>}
+            {(customer.address || customer.city) && (
+              <p className="text-sm text-muted-foreground whitespace-pre-line mt-1">
+                {[customer.address, [customer.city, customer.postcode].filter(Boolean).join(" "), customer.country].filter(Boolean).join("\n")}
+              </p>
+            )}
           </Card>
         )}
 

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -210,6 +210,7 @@ export function InvoiceDetailClient({
               <Button variant="outline" size="icon" className="h-8 w-8"><MoreHorizontal className="w-4 h-4" /></Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => handleStatusChange("draft")}>Reset to draft</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("sent")}>Mark as sent</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("paid")}>Mark as paid</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("cancelled")}>Mark as cancelled</DropdownMenuItem>

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -138,9 +138,11 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
               <Button variant="outline" size="icon" className="h-8 w-8"><MoreHorizontal className="w-4 h-4" /></Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => handleStatusChange("draft")}>Reset to draft</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("sent")}>Mark as sent</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("accepted")}>Mark as accepted</DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleStatusChange("rejected")}>Mark as rejected</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleStatusChange("expired")}>Mark as expired</DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleDuplicate} className="gap-2"><Copy className="w-3.5 h-3.5" />Duplicate</DropdownMenuItem>
               <DropdownMenuSeparator />


### PR DESCRIPTION
Two fixes:

1. **Prepared-for / Billed-to was empty** — the portal queries asked for a non-existent column `billing_address` so PostgREST silently returned the whole customer row as null. Switched to real columns.
2. **Reset to draft** — added 'Reset to draft' to the status dropdown on both invoice and quote detail pages. Also added 'Mark as expired' for quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)