### PR TITLE
Rebrand: Invoicer → Kirei

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,7 +2,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 RESEND_API_KEY=re_your_resend_key
-RESEND_FROM_EMAIL=Invoicer <noreply@yourdomain.com>
+RESEND_FROM_EMAIL=Kirei <noreply@yourdomain.com>
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Optional — enables server-side voice transcription via Whisper.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "invoicer",
+  "name": "kirei",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Invoicer — Crown Roofers",
-  "short_name": "Invoicer",
-  "description": "Invoices, quotes, leads and work orders for Crown Roofers",
+  "name": "Kirei",
+  "short_name": "Kirei",
+  "description": "Quotes, invoices, leads, jobs and reports — clean, organised, AI-assisted. Built for tradies.",
   "start_url": "/dashboard",
   "display": "standalone",
   "orientation": "portrait",

--- a/src/app/admin/_components/sidebar.tsx
+++ b/src/app/admin/_components/sidebar.tsx
@@ -23,7 +23,7 @@ export function AdminSidebar({ operator }: { operator: Operator }) {
   return (
     <aside className="w-56 shrink-0 border-r border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 min-h-screen">
       <div className="h-14 px-5 flex items-center border-b border-neutral-200 dark:border-neutral-800">
-        <span className="font-semibold text-sm tracking-tight">Invoicer Admin</span>
+        <span className="font-semibold text-sm tracking-tight">Kirei Admin</span>
       </div>
       <nav className="py-3 px-2 space-y-0.5">
         {items.map((n) => {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,7 +6,7 @@ import { AdminSidebar } from "./_components/sidebar";
 import { ImpersonationBanner } from "./_components/impersonation-banner";
 
 export const metadata = {
-  title: "Admin — Invoicer",
+  title: "Admin — Kirei",
   robots: { index: false, follow: false },
 };
 

--- a/src/app/admin/operators/page.tsx
+++ b/src/app/admin/operators/page.tsx
@@ -115,7 +115,7 @@ export default async function OperatorsPage() {
         <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
           <h2 className="text-sm font-medium mb-3">Invite operator</h2>
           <p className="text-xs text-neutral-500 mb-4">
-            The user must already have an Invoicer account. They&apos;ll get admin access the next time they visit /admin.
+            The user must already have a Kirei account. They&apos;ll get admin access the next time they visit /admin.
           </p>
           <form action={inviteOperatorAction} className="space-y-3">
             <div>

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -15,7 +15,7 @@ import { Resend } from "resend";
 
 export const maxDuration = 60;
 
-const FROM = process.env.RESEND_FROM_EMAIL ?? "Invoicer <noreply@resend.dev>";
+const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <noreply@resend.dev>";
 
 function getResend() { return new Resend(process.env.RESEND_API_KEY!); }
 

--- a/src/app/api/cron/invoice-reminders/route.ts
+++ b/src/app/api/cron/invoice-reminders/route.ts
@@ -16,7 +16,7 @@ import { Resend } from "resend";
 
 export const maxDuration = 60;
 
-const FROM = process.env.RESEND_FROM_EMAIL ?? "Invoicer <noreply@resend.dev>";
+const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <noreply@resend.dev>";
 
 function getResend() { return new Resend(process.env.RESEND_API_KEY!); }
 

--- a/src/app/api/cron/quote-followup/route.ts
+++ b/src/app/api/cron/quote-followup/route.ts
@@ -16,7 +16,7 @@ import { Resend } from "resend";
 
 export const maxDuration = 60;
 
-const FROM = process.env.RESEND_FROM_EMAIL ?? "Invoicer <noreply@resend.dev>";
+const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <noreply@resend.dev>";
 
 function getResend() { return new Resend(process.env.RESEND_API_KEY!); }
 

--- a/src/app/api/cron/workorder-complete/route.ts
+++ b/src/app/api/cron/workorder-complete/route.ts
@@ -16,7 +16,7 @@ import { Resend } from "resend";
 
 export const maxDuration = 60;
 
-const FROM = process.env.RESEND_FROM_EMAIL ?? "Invoicer <noreply@resend.dev>";
+const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <noreply@resend.dev>";
 
 function getResend() { return new Resend(process.env.RESEND_API_KEY!); }
 

--- a/src/app/api/places/search/route.ts
+++ b/src/app/api/places/search/route.ts
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const res = await fetch(url.toString(), {
-      headers: { "User-Agent": "Invoicer (admin@invoicer.app)" },
+      headers: { "User-Agent": "Kirei (admin@kireihq.com)" },
       cache: "no-store",
     });
     if (!res.ok) return NextResponse.json([], { status: 200 });

--- a/src/app/api/v1/agent/route.ts
+++ b/src/app/api/v1/agent/route.ts
@@ -2,7 +2,7 @@
  * POST /api/v1/agent
  *
  * API endpoint — allows external applications (Telegram bot, etc.)
- * to interact with the Invoicer using natural language.
+ * to interact with Kirei using natural language.
  *
  * Security:
  *   - Per-business API key required (Authorization: Bearer inv_xxx)

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -12,11 +12,11 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
           <div className="w-10 h-10 rounded-xl bg-blue-500 flex items-center justify-center">
             <FileText className="w-5 h-5 text-white" />
           </div>
-          <span className="text-xl font-semibold tracking-tight">Invoicer</span>
+          <span className="text-xl font-semibold tracking-tight">Kirei</span>
         </div>
         <div className="relative z-10 space-y-6">
           <blockquote className="text-2xl font-light leading-relaxed text-zinc-100">
-            "The cleanest invoicing tool I've ever used. My clients pay faster and I look more professional."
+            &ldquo;Kirei keeps the whole job tidy — quotes, invoices, photos, payments. I stopped chasing paperwork and started chasing leads.&rdquo;
           </blockquote>
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-full bg-zinc-700 flex items-center justify-center text-sm font-medium">
@@ -24,7 +24,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
             </div>
             <div>
               <p className="font-medium text-sm">James Davies</p>
-              <p className="text-sm text-zinc-400">Freelance Designer</p>
+              <p className="text-sm text-zinc-400">Roofing contractor</p>
             </div>
           </div>
         </div>
@@ -37,7 +37,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
             <div className="w-8 h-8 rounded-lg bg-blue-500 flex items-center justify-center">
               <FileText className="w-4 h-4 text-white" />
             </div>
-            <span className="text-lg font-semibold">Invoicer</span>
+            <span className="text-lg font-semibold">Kirei</span>
           </div>
           {children}
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,13 +30,13 @@ const fraunces = Fraunces({
 });
 
 export const metadata: Metadata = {
-  title: "Invoicer — Crown Roofers",
-  description: "Invoices, quotes, leads and work orders for Crown Roofers",
+  title: "Kirei — Tidy your trade business",
+  description: "Quotes, invoices, leads, jobs and reports — clean, organised, and AI-assisted. Built for tradies.",
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
-    title: "Invoicer",
+    title: "Kirei",
   },
   formatDetection: {
     telephone: false,

--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -223,7 +223,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
         </Card>
 
         <footer className="text-center text-xs text-muted-foreground py-6 border-t">
-          Powered by Invoicer
+          Powered by Kirei
         </footer>
       </main>
     </div>

--- a/src/app/portal/[token]/page.tsx
+++ b/src/app/portal/[token]/page.tsx
@@ -252,7 +252,7 @@ export default async function CustomerPortalPage({ params }: { params: Promise<{
         )}
 
         <footer className="text-center text-xs text-muted-foreground py-6 border-t">
-          Powered by Invoicer · This link is private to {customer.name}
+          Powered by Kirei · This link is private to {customer.name}
         </footer>
       </main>
     </div>

--- a/src/app/portal/[token]/quote/[id]/page.tsx
+++ b/src/app/portal/[token]/quote/[id]/page.tsx
@@ -160,7 +160,7 @@ export default async function PortalQuotePage({ params }: { params: Promise<{ to
         ) : null}
 
         <footer className="text-center text-xs text-muted-foreground py-6 border-t">
-          Powered by Invoicer
+          Powered by Kirei
         </footer>
       </main>
     </div>

--- a/src/app/portal/[token]/report/[id]/page.tsx
+++ b/src/app/portal/[token]/report/[id]/page.tsx
@@ -150,7 +150,7 @@ export default async function PortalReportPage({ params }: { params: Promise<{ t
         </Card>
 
         <footer className="text-center text-xs text-muted-foreground py-6 border-t">
-          Powered by Invoicer
+          Powered by Kirei
         </footer>
       </main>
     </div>

--- a/src/components/help/help-client.tsx
+++ b/src/components/help/help-client.tsx
@@ -293,7 +293,7 @@ export function HelpClient() {
           </div>
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Help & feature guide</h1>
-            <p className="text-sm text-muted-foreground">Everything Invoicer can do, and how to drive it — by click or by voice.</p>
+            <p className="text-sm text-muted-foreground">Everything Kirei can do, and how to drive it — by click or by voice.</p>
           </div>
         </div>
       </motion.div>

--- a/src/lib/actions/members.ts
+++ b/src/lib/actions/members.ts
@@ -77,7 +77,7 @@ export async function addMember(email: string, role: MemberRole): Promise<void> 
 
     await sendEmail({
       to: email.toLowerCase().trim(),
-      subject: `You've been invited to ${biz?.name ?? "a team"} on Invoicer`,
+      subject: `You've been invited to ${biz?.name ?? "a team"} on Kirei`,
       html: teamInviteEmailHtml({
         businessName: biz?.name ?? "a team",
         inviterName,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -13,7 +13,7 @@ function getResend(): Resend {
 
 // Default from address — override with RESEND_FROM_EMAIL env var once you verify a domain.
 // During development, Resend allows sending from onboarding@resend.dev to your own email only.
-const FROM = process.env.RESEND_FROM_EMAIL ?? "Invoicer <onboarding@resend.dev>";
+const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <onboarding@resend.dev>";
 
 export type EmailDocType = "invoice" | "quote" | "team_invite" | "lead" | "custom";
 
@@ -41,9 +41,9 @@ export async function sendEmail({
 }) {
   // Resend headers can carry tags for our own webhook handler to read back.
   const headers: Record<string, string> = {};
-  if (tags?.business_id) headers["X-Invoicer-Business"] = tags.business_id;
-  if (tags?.doc_type)    headers["X-Invoicer-Doc-Type"] = tags.doc_type;
-  if (tags?.doc_id)      headers["X-Invoicer-Doc-Id"]   = tags.doc_id;
+  if (tags?.business_id) headers["X-Kirei-Business"] = tags.business_id;
+  if (tags?.doc_type)    headers["X-Kirei-Doc-Type"] = tags.doc_type;
+  if (tags?.doc_id)      headers["X-Kirei-Doc-Id"]   = tags.doc_id;
 
   let resendId: string | null = null;
   let sendError: string | null = null;

--- a/src/lib/emails/base.ts
+++ b/src/lib/emails/base.ts
@@ -21,7 +21,7 @@ export function emailBase(title: string, body: string, accentColor = "#3b82f6"):
         </td></tr>
         <!-- Footer -->
         <tr><td style="padding:16px 32px;border-top:1px solid #e4e4e7;">
-          <p style="margin:0;font-size:12px;color:#71717a;">Sent via Invoicer · Please do not reply to this email.</p>
+          <p style="margin:0;font-size:12px;color:#71717a;">Sent via Kirei · Please do not reply to this email.</p>
         </td></tr>
       </table>
     </td></tr>

--- a/src/lib/emails/team-invite.ts
+++ b/src/lib/emails/team-invite.ts
@@ -20,7 +20,7 @@ export function teamInviteEmailHtml({
   const body = `
     <p style="margin:0 0 16px;font-size:14px;color:#71717a;">
       <strong style="color:#18181b;">${inviterName}</strong> has invited you to join
-      <strong style="color:#18181b;">${businessName}</strong> on Invoicer as an <strong style="color:#18181b;">${roleLabel}</strong>.
+      <strong style="color:#18181b;">${businessName}</strong> on Kirei as an <strong style="color:#18181b;">${roleLabel}</strong>.
     </p>
     ${isWorker && inviteCode ? `
     <!-- Worker code (Connected Hub mobile) -->
@@ -45,7 +45,7 @@ export function teamInviteEmailHtml({
       <span style="color:#3b82f6;word-break:break-all;">${inviteUrl}</span>
     </p>
     <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">
-      If you already have an Invoicer account, the link will sign you in and grant access automatically.
+      If you already have a Kirei account, the link will sign you in and grant access automatically.
     </p>
   `;
 

--- a/src/lib/emails/work-order-submitted.ts
+++ b/src/lib/emails/work-order-submitted.ts
@@ -44,7 +44,7 @@ export function workOrderSubmittedEmailHtml({
 
     <p style="margin:0 0 24px;">${btn("Review work order", viewUrl, "#10b981")}</p>
     <p style="margin:0;font-size:12px;color:#a1a1aa;">
-      Sent from <strong>${businessName}</strong> — Invoicer
+      Sent from <strong>${businessName}</strong> — Kirei
     </p>
   `;
 

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -45,7 +45,7 @@ async function deliverWebhook(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "X-Webhook-Event": payload.event,
-    "User-Agent": "Invoicer-Webhook/1.0",
+    "User-Agent": "Kirei-Webhook/1.0",
   };
 
   if (webhook.secret) {


### PR DESCRIPTION
Full rebrand sweep. New name: **Kirei** (綺麗 — Japanese for *clean, neat, tidy*). Domain: kireihq.com.

Mobile app keeps 'Connected Hub' name. Per-tenant business names (Crown Roofers etc.) untouched — Kirei is the platform brand only.

## Post-merge checklist
- [ ] Update Vercel env: `RESEND_FROM_EMAIL=Kirei <invoices@yourdomain>`
- [ ] Add domain alias `kireihq.com` to Vercel project (and update DNS)
- [ ] Update `NEXT_PUBLIC_APP_URL` if/when you cut over the canonical URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)