### PR TITLE
Rebrand straggler in mobile signup

### DIFF
--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -74,7 +74,7 @@ export default function SignUp() {
         if (signIn.error) {
           setBusy(false); setStage("form");
           return Alert.alert("Account exists",
-            "An Invoicer account with this email already exists. Sign in with your existing password to redeem the code.");
+            "A Kirei account with this email already exists. Sign in with your existing password to redeem the code.");
         }
       } else {
         setBusy(false); setStage("form");


### PR DESCRIPTION
Missed in #212 — one string in mobile/app/(auth)/signup.tsx still said Invoicer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)