### PR TITLE
AI: live workspace context + voice tap-to-toggle

### DIFF
--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1662,8 +1662,75 @@ async function executeTool(
 
 // ── System prompt ────────────────────────────────────────────────────────────
 
-function buildSystemPrompt(businessName: string): string {
-  return `You are a powerful AI assistant built into ${businessName}'s business management app. You have full access to every feature of the system.
+interface ContextSnapshot {
+  business: { name: string; currency: string; phone: string | null; email: string | null; license_number: string | null };
+  current_page: string;
+  recent_customers: Array<{ id: string; name: string; company: string | null }>;
+  recent_invoices: Array<{ id: string; number: string; status: string; total: number; balance: number; customer_name: string | null }>;
+  recent_quotes:   Array<{ id: string; number: string; status: string; total: number; customer_name: string | null }>;
+  todays_jobs:     Array<{ id: string; number: string; title: string; status: string; customer_name: string | null; scheduled_date: string | null }>;
+  open_leads:      Array<{ id: string; name: string; status: string; created_at: string }>;
+  stats: {
+    outstanding: number; overdue: number; jobs_today: number; jobs_this_week: number; draft_quotes: number; new_leads_7d: number;
+  };
+}
+
+function fmtMoney(n: number, currency: string): string {
+  try { return new Intl.NumberFormat("en-GB", { style: "currency", currency }).format(n); } catch { return `${currency} ${n.toFixed(2)}`; }
+}
+
+function renderContext(ctx: ContextSnapshot | null): string {
+  if (!ctx) return "";
+  const c = ctx.business.currency;
+  const lines: string[] = ["", "── LIVE CONTEXT (what's going on right now) ──", `User is currently on: ${ctx.current_page}`];
+
+  lines.push("", "Stats:",
+    `  • Outstanding invoiced: ${fmtMoney(ctx.stats.outstanding, c)}`,
+    `  • Overdue: ${fmtMoney(ctx.stats.overdue, c)}`,
+    `  • Jobs today: ${ctx.stats.jobs_today}, this week: ${ctx.stats.jobs_this_week}`,
+    `  • Draft quotes waiting to send: ${ctx.stats.draft_quotes}`,
+    `  • New leads (7d): ${ctx.stats.new_leads_7d}`,
+  );
+
+  if (ctx.recent_customers.length) {
+    lines.push("", "Recent customers:");
+    for (const r of ctx.recent_customers.slice(0, 5)) lines.push(`  • ${r.name}${r.company ? ` (${r.company})` : ""} — id ${r.id}`);
+  }
+  if (ctx.recent_invoices.length) {
+    lines.push("", "Recent invoices:");
+    for (const i of ctx.recent_invoices.slice(0, 5)) {
+      lines.push(`  • ${i.number} ${i.status} — ${fmtMoney(i.total, c)}${i.balance > 0 ? ` (${fmtMoney(i.balance, c)} due)` : ""}${i.customer_name ? ` — ${i.customer_name}` : ""} — id ${i.id}`);
+    }
+  }
+  if (ctx.recent_quotes.length) {
+    lines.push("", "Recent quotes:");
+    for (const q of ctx.recent_quotes.slice(0, 5)) {
+      lines.push(`  • ${q.number} ${q.status} — ${fmtMoney(q.total, c)}${q.customer_name ? ` — ${q.customer_name}` : ""} — id ${q.id}`);
+    }
+  }
+  if (ctx.todays_jobs.length) {
+    lines.push("", "Upcoming jobs (next 7 days):");
+    for (const w of ctx.todays_jobs.slice(0, 8)) {
+      lines.push(`  • ${w.number} ${w.scheduled_date ?? "unscheduled"} ${w.status} — ${w.title}${w.customer_name ? ` (${w.customer_name})` : ""} — id ${w.id}`);
+    }
+  }
+  if (ctx.open_leads.length) {
+    lines.push("", "Recent leads:");
+    for (const l of ctx.open_leads.slice(0, 5)) lines.push(`  • ${l.name} — ${l.status} — id ${l.id}`);
+  }
+
+  lines.push("",
+    "Use this context when the user refers to 'that customer', 'the invoice I just made',",
+    "'today's jobs', 'this lead' etc — match their pronouns to entries above. If the user",
+    "is on a detail page like /invoices/<id>, prefer that record when they ask about",
+    "'this invoice' / 'this job' / 'this customer' without further qualification.",
+    "──────────────────────────────────────────────",
+  );
+  return lines.join("\n");
+}
+
+function buildSystemPrompt(businessName: string, ctx: ContextSnapshot | null): string {
+  return `You are a powerful AI assistant built into ${businessName}'s Kirei workspace. You have full access to every feature of the system.
 
 DOMAIN MODEL:
 - Account = a customer (company or person). One account can have many Sites and many Contacts.
@@ -1699,7 +1766,8 @@ WORKFLOW RULES:
 9. Voice prompts are transcribed and may have slight errors — interpret intent generously.
 10. Never say you "don't have access" — you can do everything listed above.
 
-Today's date: ${new Date().toISOString().split("T")[0]}`;
+Today's date: ${new Date().toISOString().split("T")[0]}
+${renderContext(ctx)}`;
 }
 
 // ── Route handler ────────────────────────────────────────────────────────────
@@ -1713,8 +1781,12 @@ export async function POST(request: NextRequest) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: business } = await (supabase as any).from("businesses").select("name").eq("id", businessId).single();
 
-  const { messages } = await request.json() as { messages: Anthropic.MessageParam[] };
+  const { messages, context } = await request.json() as {
+    messages: Anthropic.MessageParam[];
+    context?: ContextSnapshot;
+  };
   const ctx: ToolContext = { businessId };
+  const snapshot: ContextSnapshot | null = context ?? null;
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -1733,7 +1805,7 @@ export async function POST(request: NextRequest) {
           const response = await anthropic.messages.create({
             model: "claude-opus-4-6",
             max_tokens: 4096,
-            system: buildSystemPrompt(business?.name ?? "your business"),
+            system: buildSystemPrompt(business?.name ?? "your business", snapshot),
             tools: TOOLS,
             messages: allMessages,
           });

--- a/src/components/agent/agent-panel.tsx
+++ b/src/components/agent/agent-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import {
   Bot, Send, Loader2, CheckCircle2, AlertCircle, ChevronRight,
   Minimize2, Trash2, Sparkles, Mic,
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { motion, AnimatePresence } from "framer-motion";
 import { useVoiceCapture } from "./use-voice-capture";
+import { getAgentContext } from "@/lib/actions/agent-context";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -158,7 +159,7 @@ function EmptyState({ onSuggestion }: { onSuggestion: (text: string) => void }) 
       <div>
         <p className="font-semibold text-sm">What can I help with?</p>
         <p className="text-xs text-muted-foreground mt-1">
-          Type or hold the mic to talk. I can run accounts, sites, contacts, work orders, quotes, invoices and team scheduling.
+          Type or tap the mic to talk. I can see your live data — recent customers, jobs, invoices, leads — and can run anything in the app.
         </p>
       </div>
       <div className="w-full space-y-1.5">
@@ -180,6 +181,7 @@ function EmptyState({ onSuggestion }: { onSuggestion: (text: string) => void }) 
 
 export function AgentPanel() {
   const router = useRouter();
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
@@ -235,10 +237,16 @@ export function AgentPanel() {
     setMessages((prev) => [...prev, assistantMsg]);
 
     try {
+      // Snapshot of current state — recent customers, jobs, stats — so the AI
+      // knows what 'this invoice' / 'today's jobs' refer to without making the
+      // user spell out IDs. Best-effort; non-fatal if it fails.
+      let context: unknown = undefined;
+      try { context = await getAgentContext(pathname || "/"); } catch { /* skip */ }
+
       const response = await fetch("/api/agent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: newApiHistory }),
+        body: JSON.stringify({ messages: newApiHistory, context }),
       });
 
       if (!response.ok || !response.body) {
@@ -456,7 +464,7 @@ export function AgentPanel() {
                     <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-75" />
                     <span className="relative inline-flex h-2 w-2 rounded-full bg-red-600" />
                   </span>
-                  Listening… release to send
+                  Listening… tap mic to send
                 </div>
               )}
               {voice.transcribing && !voice.recording && (
@@ -473,7 +481,7 @@ export function AgentPanel() {
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={handleKeyDown}
-                  placeholder="Type or hold the mic to talk…"
+                  placeholder="Type or tap the mic to talk…"
                   className="resize-none text-sm min-h-[40px] max-h-[120px] flex-1 py-2.5"
                   rows={1}
                   disabled={loading || voice.recording}
@@ -483,11 +491,9 @@ export function AgentPanel() {
                   variant={voice.recording ? "destructive" : "outline"}
                   className="h-10 w-10 flex-shrink-0 select-none touch-none"
                   disabled={loading || voice.transcribing}
-                  onPointerDown={(e) => { e.preventDefault(); voice.start(); }}
-                  onPointerUp={() => voice.stop()}
-                  onPointerLeave={() => { if (voice.recording) voice.stop(); }}
-                  onPointerCancel={() => voice.cancel()}
-                  title="Hold to talk"
+                  onClick={() => { voice.recording ? voice.stop() : voice.start(); }}
+                  title={voice.recording ? "Tap to stop and send" : "Tap to start talking"}
+                  aria-label={voice.recording ? "Stop voice input" : "Start voice input"}
                 >
                   <Mic className={`w-4 h-4 ${voice.recording ? "animate-pulse" : ""}`} />
                 </Button>

--- a/src/components/agent/use-voice-capture.ts
+++ b/src/components/agent/use-voice-capture.ts
@@ -76,7 +76,12 @@ export function useVoiceCapture(onText: (text: string) => void) {
         cleanup();
         if (cancelledRef.current) return;
         const blob = new Blob(chunksRef.current, { type: recorder.mimeType || "audio/webm" });
-        if (blob.size < 500) { return; } // ignore taps shorter than ~half-second
+        if (blob.size < 500) {
+          // Ignore extremely short blips (button bounce, mic permission hiccup)
+          // but tell the user — silent failure is the worst kind.
+          setError("Recording too short — try again and speak for at least a second.");
+          return;
+        }
         setTranscribing(true);
         try {
           const fd = new FormData();

--- a/src/lib/actions/agent-context.ts
+++ b/src/lib/actions/agent-context.ts
@@ -1,0 +1,133 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+
+export interface AgentContextPacket {
+  business: { name: string; currency: string; phone: string | null; email: string | null; license_number: string | null };
+  current_page: string;
+  recent_customers: Array<{ id: string; name: string; company: string | null }>;
+  recent_invoices: Array<{ id: string; number: string; status: string; total: number; balance: number; customer_name: string | null }>;
+  recent_quotes:   Array<{ id: string; number: string; status: string; total: number; customer_name: string | null }>;
+  todays_jobs:     Array<{ id: string; number: string; title: string; status: string; customer_name: string | null; scheduled_date: string | null }>;
+  open_leads:      Array<{ id: string; name: string; status: string; created_at: string }>;
+  stats: {
+    outstanding: number;
+    overdue: number;
+    jobs_today: number;
+    jobs_this_week: number;
+    draft_quotes: number;
+    new_leads_7d: number;
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+const num = (v: unknown) => { const n = typeof v === "number" ? v : parseFloat(String(v ?? 0)); return Number.isFinite(n) ? n : 0; };
+
+/** Build a snapshot of what the user is likely thinking about right now.
+ *  Sent with every AI assistant request so the agent has live context.
+ *  Keep this lightweight — it runs on every chat turn. */
+export async function getAgentContext(currentPage = "/"): Promise<AgentContextPacket> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Unauthorized");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const today    = new Date().toISOString().split("T")[0];
+  const weekAgo  = new Date(Date.now() - 7  * 86_400_000).toISOString();
+  const weekHead = new Date(Date.now() + 7  * 86_400_000).toISOString().split("T")[0];
+
+  const [
+    { data: business },
+    { data: customers },
+    { data: invoices },
+    { data: quotes },
+    { data: jobs },
+    { data: leads },
+  ] = await Promise.all([
+    tbl(supabase, "businesses")
+      .select("name, currency, phone, email, license_number")
+      .eq("id", businessId)
+      .maybeSingle(),
+    tbl(supabase, "customers")
+      .select("id, name, company")
+      .eq("business_id", businessId)
+      .eq("archived", false)
+      .order("updated_at", { ascending: false })
+      .limit(8),
+    tbl(supabase, "invoices")
+      .select("id, number, status, total, amount_paid, customers(name)")
+      .eq("business_id", businessId)
+      .order("created_at", { ascending: false })
+      .limit(10),
+    tbl(supabase, "quotes")
+      .select("id, number, status, total, customers(name)")
+      .eq("business_id", businessId)
+      .order("created_at", { ascending: false })
+      .limit(8),
+    tbl(supabase, "work_orders")
+      .select("id, number, title, status, scheduled_date, customers(name)")
+      .eq("business_id", businessId)
+      .gte("scheduled_date", today)
+      .lte("scheduled_date", weekHead)
+      .order("scheduled_date", { ascending: true })
+      .limit(15),
+    tbl(supabase, "leads")
+      .select("id, name, status, created_at")
+      .eq("business_id", businessId)
+      .gte("created_at", weekAgo)
+      .order("created_at", { ascending: false })
+      .limit(8),
+  ]);
+
+  const invs = (invoices ?? []) as Array<{ id: string; number: string; status: string; total: unknown; amount_paid: unknown; customers: { name: string } | null }>;
+  const qts  = (quotes   ?? []) as Array<{ id: string; number: string; status: string; total: unknown; customers: { name: string } | null }>;
+  const wos  = (jobs     ?? []) as Array<{ id: string; number: string; title: string; status: string; scheduled_date: string | null; customers: { name: string } | null }>;
+  const lds  = (leads    ?? []) as Array<{ id: string; name: string; status: string; created_at: string }>;
+
+  // Derived stats
+  const outstanding = invs
+    .filter((i) => ["sent", "partial", "overdue"].includes(i.status))
+    .reduce((s, i) => s + Math.max(0, num(i.total) - num(i.amount_paid)), 0);
+  const overdue = invs
+    .filter((i) => i.status === "overdue")
+    .reduce((s, i) => s + Math.max(0, num(i.total) - num(i.amount_paid)), 0);
+
+  return {
+    business: {
+      name:           (business as { name?: string } | null)?.name ?? "your business",
+      currency:       (business as { currency?: string } | null)?.currency ?? "AUD",
+      phone:          (business as { phone?: string } | null)?.phone ?? null,
+      email:          (business as { email?: string } | null)?.email ?? null,
+      license_number: (business as { license_number?: string } | null)?.license_number ?? null,
+    },
+    current_page: currentPage,
+    recent_customers: ((customers ?? []) as Array<{ id: string; name: string; company: string | null }>),
+    recent_invoices: invs.map((i) => ({
+      id: i.id, number: i.number, status: i.status,
+      total: num(i.total),
+      balance: Math.max(0, num(i.total) - num(i.amount_paid)),
+      customer_name: i.customers?.name ?? null,
+    })),
+    recent_quotes: qts.map((q) => ({
+      id: q.id, number: q.number, status: q.status,
+      total: num(q.total),
+      customer_name: q.customers?.name ?? null,
+    })),
+    todays_jobs: wos.map((w) => ({
+      id: w.id, number: w.number, title: w.title, status: w.status,
+      scheduled_date: w.scheduled_date,
+      customer_name: w.customers?.name ?? null,
+    })),
+    open_leads: lds,
+    stats: {
+      outstanding,
+      overdue,
+      jobs_today: wos.filter((w) => w.scheduled_date === today).length,
+      jobs_this_week: wos.length,
+      draft_quotes: qts.filter((q) => q.status === "draft").length,
+      new_leads_7d: lds.length,
+    },
+  };
+}


### PR DESCRIPTION
Two improvements to the AI assistant.

**Context** — every prompt now ships a live snapshot of: current page, recent customers, last 10 invoices/quotes, this week's jobs, recent leads, plus stats (outstanding, overdue, draft quotes etc). Means the AI can resolve 'this invoice' / 'today's jobs' to actual records without you spelling out IDs.

**Voice** — mic is now tap-to-toggle (not hold). More reliable on mobile, accessibility-friendly, and short-blip errors now surface instead of silently failing.

To get Whisper transcription instead of browser fallback, set `OPENAI_API_KEY` in Vercel env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)