### PR TITLE
Fix: duplicate invoice / quote

### DIFF
--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -112,8 +112,28 @@ export async function deleteInvoice(id: string): Promise<void> {
 
 export async function duplicateInvoice(id: string): Promise<Invoice> {
   const invoice = await getInvoice(id);
-  const { customers: _, payments: __, ...rest } = invoice;
-  return createInvoice({ ...rest, status: "draft", amount_paid: 0 });
+  // Build the create payload explicitly so we never carry the source id /
+  // number / timestamps / parent link through to the new row. createInvoice
+  // mints fresh values for those.
+  return createInvoice({
+    customer_id:    invoice.customer_id,
+    site_id:        invoice.site_id,
+    issue_date:     new Date().toISOString().split("T")[0],
+    due_date:       invoice.due_date,
+    line_items:     invoice.line_items,
+    subtotal:       invoice.subtotal,
+    discount_type:  invoice.discount_type,
+    discount_value: invoice.discount_value,
+    discount_amount: invoice.discount_amount,
+    tax_total:      invoice.tax_total,
+    total:          invoice.total,
+    notes:          invoice.notes,
+    terms:          invoice.terms,
+    property_address: invoice.property_address,
+    status:         "draft",
+    amount_paid:    0,
+    parent_invoice_id: null,
+  } as unknown as Parameters<typeof createInvoice>[0]);
 }
 
 /**

--- a/src/lib/actions/quotes.ts
+++ b/src/lib/actions/quotes.ts
@@ -110,8 +110,26 @@ export async function deleteQuote(id: string): Promise<void> {
 
 export async function duplicateQuote(id: string): Promise<Quote> {
   const quote = await getQuote(id);
-  const { customers: _, ...rest } = quote;
-  return createQuote({ ...rest, status: "draft", invoice_id: null });
+  // Build the create payload explicitly so source id / number / timestamps
+  // / invoice_id link don't carry over. createQuote mints fresh values.
+  return createQuote({
+    customer_id:    quote.customer_id,
+    site_id:        quote.site_id,
+    issue_date:     new Date().toISOString().split("T")[0],
+    expiry_date:    quote.expiry_date,
+    line_items:     quote.line_items,
+    subtotal:       quote.subtotal,
+    discount_type:  quote.discount_type,
+    discount_value: quote.discount_value,
+    discount_amount: quote.discount_amount,
+    tax_total:      quote.tax_total,
+    total:          quote.total,
+    notes:          quote.notes,
+    terms:          quote.terms,
+    property_address: quote.property_address,
+    status:         "draft",
+    invoice_id:     null,
+  } as unknown as Parameters<typeof createQuote>[0]);
 }
 
 export async function convertQuoteToInvoice(quoteId: string): Promise<Invoice> {


### PR DESCRIPTION
Source id was being carried through to the insert which made the duplicate fail with a constraint violation. Both actions now build the create payload explicitly so only the right fields copy over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)