### PR TITLE
Customer hub link visible on customer detail

### DIFF
--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -52,6 +52,12 @@ Failing items: paste the section number + failing item into a comment on the QA 
 - [ ] Smart Organise button finds duplicates / suggests cleanups
 - [ ] Smart Organise apply works → undo works
 - [ ] Customer detail shows their invoices, quotes, jobs
+- [ ] **Customer hub link** button on detail page (next to Edit)
+  - [ ] Opens dialog with the link already loaded — no "click to generate"
+  - [ ] Reuses any active 90-day token (same link as last time)
+  - [ ] Copy / Open / WhatsApp / SMS / Email shortcuts present
+  - [ ] WhatsApp + SMS only show when customer has a phone on file
+  - [ ] **Rotate** button revokes the old token and mints a fresh one
 
 ## 5. Leads
 

--- a/src/components/customer-portal/portal-link-button.tsx
+++ b/src/components/customer-portal/portal-link-button.tsx
@@ -1,89 +1,153 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Link2, Copy, Check, Loader2 } from "@/components/ui/icons";
+import { Link2, Copy, Check, Loader2, ExternalLink, MessageSquare, RefreshCw } from "@/components/ui/icons";
 import { toast } from "sonner";
-import { createPortalLink } from "@/lib/actions/customer-portal";
+import { getShareLinks, revokePortalLink, createPortalLink } from "@/lib/actions/customer-portal";
 
-export function PortalLinkButton({ customerId, customerName }: { customerId: string; customerName: string }) {
-  const [open, setOpen] = useState(false);
-  const [pending, start] = useTransition();
-  const [link, setLink] = useState<string | null>(null);
-  const [days, setDays] = useState<string>("30");
-  const [copied, setCopied] = useState(false);
+interface Props {
+  customerId:    string;
+  customerName:  string;
+  customerPhone?: string | null;
+}
 
-  const generate = () => {
-    start(async () => {
-      try {
-        const expires = days.trim() === "" ? null : Number(days);
-        const { url } = await createPortalLink(customerId, { expires_in_days: expires ?? null });
-        const fullUrl = url.startsWith("http") ? url : `${window.location.origin}${url}`;
-        setLink(fullUrl);
-        toast.success("Portal link created");
-      } catch (e) {
-        toast.error(e instanceof Error ? e.message : "Failed");
-      }
-    });
-  };
+/** Customer portal link surfaced on the customer detail page.
+ *  Opens with the current active link already visible — reuses any active
+ *  token (90-day default), only mints a fresh one if there isn't one. */
+export function PortalLinkButton({ customerId, customerName, customerPhone }: Props) {
+  const [open,    setOpen]    = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [link,    setLink]    = useState<string>("");
+  const [copied,  setCopied]  = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await getShareLinks({ customer_id: customerId });
+      setLink(r.hub_url);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't load link");
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId]);
+
+  // Fetch the link as soon as the dialog opens so the user never sees a "click to generate" state.
+  useEffect(() => { if (open) load(); }, [open, load]);
 
   const copy = async () => {
     if (!link) return;
     await navigator.clipboard.writeText(link);
     setCopied(true);
-    toast.success("Copied to clipboard");
+    toast.success("Copied");
     setTimeout(() => setCopied(false), 1500);
   };
 
+  /** Revoke the current token and mint a fresh one — useful if the customer
+   *  forwarded the old link to someone else. */
+  const rotate = async () => {
+    setLoading(true);
+    try {
+      // Pull the existing token off the URL we're showing so we can revoke it.
+      const tokenMatch = link.match(/\/portal\/(cust_[a-z0-9]+)/);
+      if (tokenMatch?.[1]) await revokePortalLink(tokenMatch[1]);
+      // Then mint fresh (90 day) — bypasses the reuse path in getShareLinks.
+      const r = await createPortalLink(customerId, { expires_in_days: 90 });
+      const fullUrl = r.url.startsWith("http") ? r.url : `${window.location.origin}${r.url}`;
+      setLink(fullUrl);
+      toast.success("New link generated, old one revoked");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't rotate");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const firstName = customerName?.split(" ")[0] ?? "";
+  const greet = firstName ? `Hi ${firstName}, ` : "";
+  const message = `${greet}here's your customer portal: ${link}`;
+  const phoneE164 = customerPhone?.replace(/[^\d+]/g, "") ?? "";
+
   return (
     <>
-      <Button variant="outline" size="sm" className="gap-1.5" onClick={() => { setOpen(true); setLink(null); }}>
-        <Link2 className="w-3.5 h-3.5" /> Portal link
+      <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
+        <Link2 className="w-3.5 h-3.5" /> Customer hub link
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Customer portal link</DialogTitle>
+            <DialogTitle className="flex items-center gap-2">
+              <Link2 className="w-4 h-4" /> {customerName}&apos;s portal link
+            </DialogTitle>
             <DialogDescription>
-              Generate a private link {customerName} can use to view their quotes, invoices, and jobs.
+              One private URL — opens to a hub showing all of {customerName}&apos;s invoices, quotes, jobs and reports. Reuse this link as much as you like; rotate it if you ever need to invalidate the old one.
             </DialogDescription>
           </DialogHeader>
 
-          {!link ? (
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="days">Expires after (days)</Label>
-                <Input
-                  id="days"
-                  type="number"
-                  min="1"
-                  value={days}
-                  onChange={(e) => setDays(e.target.value)}
-                  placeholder="30"
-                  className="mt-1"
-                />
-                <p className="text-xs text-muted-foreground mt-1">Leave blank for no expiry.</p>
-              </div>
-              <Button onClick={generate} disabled={pending} className="w-full">
-                {pending ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Link2 className="w-4 h-4 mr-2" />}
-                Generate link
-              </Button>
+          {loading && !link ? (
+            <div className="flex items-center justify-center py-8 text-muted-foreground gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading link…
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-4">
+              {/* The link itself */}
               <div className="flex gap-2">
-                <Input value={link} readOnly className="font-mono text-xs" />
-                <Button onClick={copy} variant="outline" size="icon" className="flex-shrink-0">
+                <input
+                  readOnly
+                  value={link}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="flex-1 min-w-0 px-3 py-2 text-xs bg-muted rounded-md border border-border font-mono"
+                />
+                <Button onClick={copy} variant="outline" size="icon" className="flex-shrink-0" title="Copy">
                   {copied ? <Check className="w-4 h-4 text-emerald-500" /> : <Copy className="w-4 h-4" />}
                 </Button>
+                <a href={link} target="_blank" rel="noreferrer">
+                  <Button variant="outline" size="icon" title="Open in new tab">
+                    <ExternalLink className="w-4 h-4" />
+                  </Button>
+                </a>
               </div>
-              <p className="text-xs text-muted-foreground">
-                Send this link via email or SMS. Anyone with the link can view {customerName}&apos;s account.
-              </p>
+
+              {/* Quick share */}
+              <div className="flex flex-wrap gap-2">
+                {phoneE164 && (
+                  <a
+                    href={`https://wa.me/${phoneE164.replace(/^\+/, "")}?text=${encodeURIComponent(message)}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <Button size="sm" variant="outline" className="gap-1.5 h-8">
+                      <MessageSquare className="w-3.5 h-3.5" /> WhatsApp
+                    </Button>
+                  </a>
+                )}
+                {phoneE164 && (
+                  <a href={`sms:${phoneE164}?body=${encodeURIComponent(message)}`}>
+                    <Button size="sm" variant="outline" className="gap-1.5 h-8">
+                      <MessageSquare className="w-3.5 h-3.5" /> SMS
+                    </Button>
+                  </a>
+                )}
+                <a href={`mailto:?subject=Your portal link&body=${encodeURIComponent(message)}`}>
+                  <Button size="sm" variant="outline" className="gap-1.5 h-8">
+                    Email
+                  </Button>
+                </a>
+              </div>
+
+              {/* Rotate */}
+              <div className="flex items-center justify-between pt-2 border-t">
+                <p className="text-[11px] text-muted-foreground">
+                  Anyone with the link can view — treat it like a password.
+                </p>
+                <Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={rotate} disabled={loading}>
+                  <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />
+                  Rotate
+                </Button>
+              </div>
             </div>
           )}
         </DialogContent>

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -531,7 +531,7 @@ export function CustomerDetailClient({
           <Button variant="outline" size="sm" className="flex-1 sm:flex-initial" onClick={() => setEditing(!editing)}>
             <Edit className="w-3.5 h-3.5 mr-1.5" />{editing ? "Cancel" : "Edit"}
           </Button>
-          <PortalLinkButton customerId={customer.id} customerName={customer.name} />
+          <PortalLinkButton customerId={customer.id} customerName={customer.name} customerPhone={customer.phone ?? null} />
           <Link href={`/invoices/new?customer=${customer.id}`} className="flex-1 sm:flex-initial">
             <Button size="sm" className="gap-1.5 w-full sm:w-auto"><Plus className="w-3.5 h-3.5" />New invoice</Button>
           </Link>


### PR DESCRIPTION
Click the 'Customer hub link' button on any customer page → see their portal link immediately, copy or share via WhatsApp/SMS/Email. No more 'generate first' step. Rotate button if you ever need to invalidate the old URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)