### PR TITLE
Back button returns to previous page

### DIFF
--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -421,3 +421,10 @@ Try saying these and verify behaviour:
 - [ ] Worker access enforcement — try to hit `/customers` as worker → redirected
 - [ ] Business deletion / leaving — owner cannot leave their own business
 - [ ] All 200/300 API responses return JSON (no HTML error pages)
+
+### Smart back navigation
+- [ ] On any detail page (invoice / quote / customer / work order / report), the back arrow returns to the **previous page in your browser history**, not always the list
+- [ ] Quote → click customer → press back → returns to the quote (not /customers)
+- [ ] Invoice → click customer → press back → returns to the invoice (not /invoices)
+- [ ] Work order → click customer → back → returns to the work order
+- [ ] Bookmarked detail page (no history) → back falls back to the list view

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -10,6 +10,7 @@ import {
   CreditCard,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { BackButton } from "@/components/layout/back-button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -519,9 +520,7 @@ export function CustomerDetailClient({
       {/* Header */}
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
         <div className="flex items-center gap-4 min-w-0">
-          <Link href="/customers">
-            <Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button>
-          </Link>
+          <BackButton fallbackHref="/customers" />
           <div className="flex-1 min-w-0">
             <h1 className="text-2xl font-bold truncate">{customer.name}</h1>
             {customer.company && <p className="text-sm text-muted-foreground truncate">{customer.company}</p>}

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -25,6 +25,7 @@ import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
 import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
 import { scheduleSend } from "@/lib/actions/scheduled-sends";
 import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
+import { BackButton } from "@/components/layout/back-button";
 
 import { formatCurrency, formatDate, getStatusColor } from "@/lib/utils";
 import type { Business, Customer, Invoice, LineItem, Payment, Product } from "@/types/database";
@@ -150,9 +151,7 @@ export function InvoiceDetailClient({
     <div className="space-y-6">
       {/* Header */}
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <Link href="/invoices">
-          <Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button>
-        </Link>
+        <BackButton fallbackHref="/invoices" />
         <div className="flex-1">
           <div className="flex items-center gap-3 flex-wrap">
             <h1 className="text-2xl font-bold">{invoice.number}</h1>

--- a/src/components/invoices/invoice-editor.tsx
+++ b/src/components/invoices/invoice-editor.tsx
@@ -24,6 +24,7 @@ import type { SmartFillData } from "./smart-fill-modal";
 import { formatCurrency } from "@/lib/utils";
 import { ClientSelect } from "@/components/customers/client-select";
 import { AddressSelect } from "@/components/addresses/address-select";
+import { BackButton } from "@/components/layout/back-button";
 import { PdfSettingsPanel } from "@/components/pdf/pdf-settings-panel";
 import type { Business, Customer, Invoice, LineItem, Product } from "@/types/database";
 import { DEFAULT_PDF_SETTINGS } from "@/types/database";
@@ -174,9 +175,7 @@ export function InvoiceEditor({ customers, products, business, invoice, defaultC
       {/* Header */}
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
         <div className="flex items-center gap-4">
-          <Link href="/invoices">
-            <Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button>
-          </Link>
+          <BackButton fallbackHref="/invoices" />
           <div className="flex-1 min-w-0">
             <h1 className="text-2xl font-bold truncate">{invoice ? `Edit ${invoice.number}` : "New Invoice"}</h1>
           </div>

--- a/src/components/layout/back-button.tsx
+++ b/src/components/layout/back-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  /** Where to send the user if there's no browser history to go back to
+   *  (e.g. they bookmarked the detail page). */
+  fallbackHref: string;
+  className?: string;
+}
+
+/** Smart back button — uses router.back() so the user returns to whatever
+ *  page they came from (a quote, the customer they were viewing, search
+ *  results, etc), instead of always being dumped back to the list view.
+ *  Falls back to fallbackHref when there's nothing in history. */
+export function BackButton({ fallbackHref, className }: Props) {
+  const router = useRouter();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    // history.length is 1 on a fresh tab — going "back" would leave the app.
+    // Anything > 1 means we have somewhere meaningful to go.
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(fallbackHref);
+    }
+  };
+
+  // Render as a real <Link> for right-click "open in new tab" + keyboard users,
+  // but intercept the click for the smart-back behaviour.
+  return (
+    <Link href={fallbackHref} onClick={handleClick} aria-label="Back" className={className}>
+      <Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0">
+        <ArrowLeft className="w-4 h-4" />
+      </Button>
+    </Link>
+  );
+}

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -14,6 +14,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { deleteQuote, updateQuote, convertQuoteToInvoice, sendQuoteEmail, sendQuoteSms, duplicateQuote } from "@/lib/actions/quotes";
 import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
+import { BackButton } from "@/components/layout/back-button";
 import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
 import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
 import { scheduleSend } from "@/lib/actions/scheduled-sends";
@@ -92,7 +93,7 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
   return (
     <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <Link href="/quotes"><Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button></Link>
+        <BackButton fallbackHref="/quotes" />
         <div className="flex-1">
           <div className="flex items-center gap-3 flex-wrap">
             <h1 className="text-2xl font-bold">{quote.number}</h1>

--- a/src/components/quotes/quote-editor.tsx
+++ b/src/components/quotes/quote-editor.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ClientSelect } from "@/components/customers/client-select";
 import { AddressSelect } from "@/components/addresses/address-select";
+import { BackButton } from "@/components/layout/back-button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { createQuote, updateQuote, sendQuoteEmail, sendQuoteSms } from "@/lib/actions/quotes";
@@ -161,7 +162,7 @@ export function QuoteEditor({ customers, products, business, quote, defaultCusto
     <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
         <div className="flex items-center gap-4">
-          <Link href="/quotes"><Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button></Link>
+          <BackButton fallbackHref="/quotes" />
           <div className="flex-1 min-w-0"><h1 className="text-2xl font-bold truncate">{quote ? `Edit ${quote.number}` : "New Quote"}</h1></div>
         </div>
         <div className="flex items-center gap-2 flex-wrap sm:flex-nowrap sm:ml-auto">

--- a/src/components/reports/report-detail-client.tsx
+++ b/src/components/reports/report-detail-client.tsx
@@ -13,6 +13,7 @@ import { Separator } from "@/components/ui/separator";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { updateReportSection, updateReportStatus, updateReportPhotos, deleteReport, duplicateReport } from "@/lib/actions/reports";
 import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
+import { BackButton } from "@/components/layout/back-button";
 import { ROOF_INSPECTION_SECTIONS, SECTION_MAP } from "@/lib/templates/roof-inspection";
 import type { Report, ReportPhoto, Customer, Business, RiskItem } from "@/types/database";
 import Link from "next/link";
@@ -116,7 +117,7 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
     <div className="space-y-6">
       {/* Header */}
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-start gap-4 flex-wrap">
-        <Link href="/reports"><Button variant="ghost" size="icon" className="h-8 w-8 flex-shrink-0"><ArrowLeft className="w-4 h-4" /></Button></Link>
+        <BackButton fallbackHref="/reports" />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="text-2xl font-bold tracking-tight truncate">{report.title}</h1>

--- a/src/components/reports/report-generator.tsx
+++ b/src/components/reports/report-generator.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { ArrowLeft, ArrowRight, ImagePlus, X, Sparkles, Loader2, CheckCircle } from "@/components/ui/icons";
+import { BackButton } from "@/components/layout/back-button";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -276,7 +277,7 @@ export function ReportGenerator({ customers: initialCustomers, business, default
   return (
     <div className="space-y-6">
       <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="flex items-center gap-4">
-        <Link href="/reports"><Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button></Link>
+        <BackButton fallbackHref="/reports" />
         <div>
           <h1 className="text-2xl font-bold tracking-tight">New site report</h1>
           <p className="text-sm text-muted-foreground">Step {step} of 2</p>

--- a/src/components/work-orders/job-portfolio-client.tsx
+++ b/src/components/work-orders/job-portfolio-client.tsx
@@ -33,6 +33,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { canEdit, isOwner, canManageTeam, type Role } from "@/lib/permissions";
+import { BackButton } from "@/components/layout/back-button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Check, ChevronDown, Pencil } from "@/components/ui/icons";
 import { updateWorkOrder, updateWorkOrderStatus, deleteWorkOrder, submitWorkOrder } from "@/lib/actions/work-orders";
@@ -363,7 +364,7 @@ function PortfolioHeader({
   return (
     <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} className="space-y-4">
       <div className="flex items-center gap-3">
-        <Link href="/work-orders"><Button variant="ghost" size="icon" className="h-8 w-8"><ArrowLeft className="w-4 h-4" /></Button></Link>
+        <BackButton fallbackHref="/work-orders" />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-xs font-mono text-muted-foreground">{workOrder.number}</span>


### PR DESCRIPTION
Detail-page back buttons were hardcoded to the parent list (/invoices, /customers etc). Replaced with a BackButton component that uses router.back() when there's history, falls back to the parent route for direct-URL hits. Wired into all 8 detail/editor pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)