### PR TITLE
Per-country address layouts + state field + AU template

### DIFF
--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -44,6 +44,15 @@ Failing items: paste the section number + failing item into a comment on the QA 
 
 ## 4. Customers
 
+### Address fields (per-country format)
+- [ ] When the active business is set to **Australia**, address forms show: Street address, **Suburb**, **State (dropdown: ACT/NSW/NT/QLD/SA/TAS/VIC/WA)**, Postcode, Country — in that order
+- [ ] Address autocomplete (street line) populates suburb / state / postcode / country on selection
+- [ ] Other countries (US/UK) show appropriate labels (City, ZIP / County, Postcode)
+- [ ] Settings → Business → Address uses the same per-country layout
+- [ ] Customer detail → Add property → autocomplete works (was broken before)
+- [ ] Edit customer → Address card uses per-country layout + autocomplete
+
+### General customer flows
 - [ ] List shows customers with stats columns (invoice count, billed, outstanding)
 - [ ] Search filters live
 - [ ] Multi-select checkboxes → bulk archive works

--- a/src/app/(dashboard)/customers/new/page.tsx
+++ b/src/app/(dashboard)/customers/new/page.tsx
@@ -1,13 +1,15 @@
 import { CustomerForm } from "@/components/customers/customer-form";
+import { getBusiness } from "@/lib/actions/business";
 
-export default function NewCustomerPage() {
+export default async function NewCustomerPage() {
+  const business = await getBusiness().catch(() => null);
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6">
         <h1 className="text-2xl font-bold">New Customer</h1>
         <p className="text-sm text-muted-foreground mt-1">Add a new customer to your account</p>
       </div>
-      <CustomerForm />
+      <CustomerForm businessCountry={business?.country ?? null} />
     </div>
   );
 }

--- a/src/app/api/places/search/route.ts
+++ b/src/app/api/places/search/route.ts
@@ -57,6 +57,7 @@ export async function GET(req: NextRequest) {
         label: r.display_name,
         address: street || a.road || "",
         city,
+        state: a.state || "",
         postcode: a.postcode || "",
         country: a.country || "",
         lat: r.lat,

--- a/src/components/addresses/address-fields.tsx
+++ b/src/components/addresses/address-fields.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { AddressAutocomplete, type AddressSuggestion } from "@/components/ui/address-autocomplete";
+import { getAddressFormat, type AddressFieldKey } from "@/lib/country-formats";
+
+export interface AddressValues {
+  address: string;
+  city:    string;
+  state:   string;
+  postcode:string;
+  country: string;
+}
+
+interface Props {
+  /** Country code or name from the active business — drives the field
+   *  layout, labels and placeholders. */
+  country: string | null | undefined;
+  values:  AddressValues;
+  onChange: (next: AddressValues) => void;
+  /** Set false to render plain inputs only (no autocomplete on address). */
+  autocomplete?: boolean;
+  /** Extra className on the wrapper div. */
+  className?: string;
+  /** Hide the Country field even if the format includes it (for forms where
+   *  country is implied by the parent business). */
+  hideCountry?: boolean;
+}
+
+/** Renders address inputs in the right order and with the right labels for
+ *  the active business's country. The street line uses AddressAutocomplete
+ *  by default — selecting a result populates city/state/postcode/country. */
+export function AddressFields({
+  country, values, onChange, autocomplete = true, className, hideCountry,
+}: Props) {
+  const fmt = getAddressFormat(country);
+  const set = <K extends keyof AddressValues>(k: K, v: AddressValues[K]) =>
+    onChange({ ...values, [k]: v });
+
+  const handleSuggestion = (s: AddressSuggestion) => {
+    onChange({
+      address:  s.address  || values.address,
+      city:     s.city     || values.city,
+      state:    s.state    || values.state,
+      postcode: s.postcode || values.postcode,
+      country:  s.country  || values.country,
+    });
+  };
+
+  // Render fields in the order the format dictates. We special-case the
+  // street line (autocomplete + full width) and the state line (preset list
+  // for known countries like AU).
+  const renderField = (key: AddressFieldKey) => {
+    if (key === "country" && hideCountry) return null;
+    const label       = fmt.labels[key]       ?? key;
+    const placeholder = fmt.placeholders[key] ?? "";
+
+    if (key === "address") {
+      return (
+        <div key={key} className="col-span-2 space-y-1.5">
+          <Label>{label}</Label>
+          {autocomplete ? (
+            <AddressAutocomplete
+              value={values.address}
+              onChange={(v) => set("address", v)}
+              onSelect={handleSuggestion}
+              placeholder={placeholder}
+            />
+          ) : (
+            <Input value={values.address} onChange={(e) => set("address", e.target.value)} placeholder={placeholder} />
+          )}
+        </div>
+      );
+    }
+
+    if (key === "state" && fmt.states && fmt.states.length > 0) {
+      return (
+        <div key={key} className="space-y-1.5">
+          <Label>{label}</Label>
+          <Select value={values.state || undefined} onValueChange={(v) => set("state", v)}>
+            <SelectTrigger><SelectValue placeholder={placeholder || "Select"} /></SelectTrigger>
+            <SelectContent>
+              {fmt.states.map((s) => (
+                <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      );
+    }
+
+    return (
+      <div key={key} className="space-y-1.5">
+        <Label>{label}</Label>
+        <Input
+          value={values[key]}
+          onChange={(e) => set(key, e.target.value)}
+          placeholder={placeholder}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className={`grid grid-cols-1 sm:grid-cols-2 gap-3 ${className ?? ""}`}>
+      {fmt.fields.map(renderField)}
+    </div>
+  );
+}

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { BackButton } from "@/components/layout/back-button";
+import { AddressFields } from "@/components/addresses/address-fields";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -56,6 +57,8 @@ interface Props {
   notes: CustomerNote[];
   billingProfiles: BillingProfile[];
   currency?: string;
+  /** Country of the active business — drives address-field layout. */
+  businessCountry?: string | null;
 }
 
 // ── Property Modal ─────────────────────────────────────────────────────────────
@@ -63,18 +66,21 @@ interface Props {
 interface PropertyModalProps {
   customerId: string;
   property?: CustomerProperty;
+  /** Country of the active business — drives the address field layout. */
+  businessCountry?: string | null;
   onSave: (p: CustomerProperty) => void;
   onClose: () => void;
 }
 
-function PropertyModal({ customerId, property, onSave, onClose }: PropertyModalProps) {
+function PropertyModal({ customerId, property, businessCountry, onSave, onClose }: PropertyModalProps) {
   const [isPending, start] = useTransition();
   const [form, setForm] = useState({
     label: property?.label ?? "",
     address: property?.address ?? "",
     city: property?.city ?? "",
+    state: (property as { state?: string } | undefined)?.state ?? "",
     postcode: property?.postcode ?? "",
-    country: property?.country ?? "",
+    country: property?.country ?? (businessCountry ?? ""),
     notes: property?.notes ?? "",
   });
 
@@ -87,6 +93,7 @@ function PropertyModal({ customerId, property, onSave, onClose }: PropertyModalP
               label: form.label || null,
               address: form.address,
               city: form.city || null,
+              state: form.state || null,
               postcode: form.postcode || null,
               country: form.country || null,
               notes: form.notes || null,
@@ -95,6 +102,7 @@ function PropertyModal({ customerId, property, onSave, onClose }: PropertyModalP
               label: form.label || undefined,
               address: form.address,
               city: form.city || undefined,
+              state: form.state || undefined,
               postcode: form.postcode || undefined,
               country: form.country || undefined,
               notes: form.notes || undefined,
@@ -117,31 +125,25 @@ function PropertyModal({ customerId, property, onSave, onClose }: PropertyModalP
           <DialogTitle>{property ? "Edit property" : "Add property"}</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div className="col-span-2 space-y-1.5">
-              <Label>Label</Label>
-              <Input placeholder="e.g. Main Residence, Investment Property" value={form.label} onChange={f("label")} />
-            </div>
-            <div className="col-span-2 space-y-1.5">
-              <Label>Street address *</Label>
-              <Input placeholder="123 High Street" value={form.address} onChange={f("address")} autoFocus />
-            </div>
-            <div className="space-y-1.5">
-              <Label>City</Label>
-              <Input placeholder="Sydney" value={form.city} onChange={f("city")} />
-            </div>
-            <div className="space-y-1.5">
-              <Label>Postcode</Label>
-              <Input placeholder="2000" value={form.postcode} onChange={f("postcode")} />
-            </div>
-            <div className="col-span-2 space-y-1.5">
-              <Label>Country</Label>
-              <Input placeholder="Australia" value={form.country} onChange={f("country")} />
-            </div>
-            <div className="col-span-2 space-y-1.5">
-              <Label>Notes</Label>
-              <Textarea placeholder="Access info, site notes..." rows={2} value={form.notes} onChange={f("notes")} />
-            </div>
+          <div className="space-y-1.5">
+            <Label>Label</Label>
+            <Input placeholder="e.g. Main Residence, Investment Property" value={form.label} onChange={f("label")} />
+          </div>
+          <AddressFields
+            country={businessCountry}
+            values={{
+              address: form.address, city: form.city, state: form.state,
+              postcode: form.postcode, country: form.country,
+            }}
+            onChange={(next) => setForm((p) => ({
+              ...p,
+              address: next.address, city: next.city, state: next.state,
+              postcode: next.postcode, country: next.country,
+            }))}
+          />
+          <div className="space-y-1.5">
+            <Label>Notes</Label>
+            <Textarea placeholder="Access info, site notes..." rows={2} value={form.notes} onChange={f("notes")} />
           </div>
           <div className="flex gap-2 pt-1">
             <Button variant="outline" className="flex-1" onClick={onClose}>Cancel</Button>
@@ -454,6 +456,7 @@ export function CustomerDetailClient({
   notes: initialNotes,
   billingProfiles: initialBillingProfiles,
   currency = "AUD",
+  businessCountry = null,
 }: Props) {
   const [customer, setCustomer] = useState(initial);
   const [editing, setEditing] = useState(false);
@@ -539,7 +542,7 @@ export function CustomerDetailClient({
 
       {editing ? (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-          <CustomerForm customer={customer} onSuccess={(updated) => { setCustomer(updated); setEditing(false); }} />
+          <CustomerForm customer={customer} businessCountry={businessCountry} onSuccess={(updated) => { setCustomer(updated); setEditing(false); }} />
         </motion.div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
@@ -984,6 +987,7 @@ export function CustomerDetailClient({
         <PropertyModal
           customerId={customer.id}
           property={propertyModal.item}
+          businessCountry={businessCountry}
           onSave={(saved) => {
             setProperties((p) =>
               propertyModal.item ? p.map((x) => x.id === saved.id ? saved : x) : [...p, saved]

--- a/src/components/customers/customer-form.tsx
+++ b/src/components/customers/customer-form.tsx
@@ -13,7 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { AddressAutocomplete } from "@/components/ui/address-autocomplete";
+import { AddressFields } from "@/components/addresses/address-fields";
 import type { Customer } from "@/types/database";
 
 const ACCOUNT_TYPES: { value: Customer["account_type"]; label: string; hint?: string }[] = [
@@ -49,6 +49,7 @@ const schema = z.object({
   preferred_contact: z.string().optional(),
   address: z.string().optional(),
   city: z.string().optional(),
+  state: z.string().optional(),
   postcode: z.string().optional(),
   country: z.string().optional(),
   notes: z.string().optional(),
@@ -59,9 +60,11 @@ type FormData = z.infer<typeof schema>;
 interface CustomerFormProps {
   customer?: Customer;
   onSuccess?: (customer: Customer) => void;
+  /** Country of the active business — drives address-field labels + states. */
+  businessCountry?: string | null;
 }
 
-export function CustomerForm({ customer, onSuccess }: CustomerFormProps) {
+export function CustomerForm({ customer, onSuccess, businessCountry }: CustomerFormProps) {
   const router = useRouter();
   const { register, handleSubmit, control, setValue, watch, formState: { errors, isSubmitting } } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -78,6 +81,7 @@ export function CustomerForm({ customer, onSuccess }: CustomerFormProps) {
       preferred_contact: customer?.preferred_contact ?? "any",
       address: customer?.address ?? "",
       city: customer?.city ?? "",
+      state: customer?.state ?? "",
       postcode: customer?.postcode ?? "",
       country: customer?.country ?? "",
       notes: customer?.notes ?? "",
@@ -209,41 +213,24 @@ export function CustomerForm({ customer, onSuccess }: CustomerFormProps) {
       <Card>
         <CardContent className="p-5 space-y-4">
           <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">Address</h3>
-          <div className="space-y-1.5">
-            <Label>Search address</Label>
-            <Controller
-              name="address"
-              control={control}
-              render={({ field }) => (
-                <AddressAutocomplete
-                  value={field.value || ""}
-                  onChange={field.onChange}
-                  onSelect={(s) => {
-                    setValue("address", s.address || s.label.split(",")[0]);
-                    if (s.city) setValue("city", s.city);
-                    if (s.postcode) setValue("postcode", s.postcode);
-                    if (s.country) setValue("country", s.country);
-                  }}
-                  placeholder="Start typing — 123 High Street, London..."
-                />
-              )}
-            />
-            <p className="text-xs text-muted-foreground">Pick a suggestion to auto-fill city, postcode, and country.</p>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <div className="space-y-1.5">
-              <Label>City</Label>
-              <Input placeholder="London" {...register("city")} />
-            </div>
-            <div className="space-y-1.5">
-              <Label>Postcode</Label>
-              <Input placeholder="SW1A 1AA" {...register("postcode")} />
-            </div>
-            <div className="space-y-1.5">
-              <Label>Country</Label>
-              <Input placeholder="United Kingdom" {...register("country")} />
-            </div>
-          </div>
+          <p className="text-xs text-muted-foreground">Start typing the street address to autofill city, state, postcode and country.</p>
+          <AddressFields
+            country={watch("country") || businessCountry}
+            values={{
+              address:  watch("address")  ?? "",
+              city:     watch("city")     ?? "",
+              state:    watch("state")    ?? "",
+              postcode: watch("postcode") ?? "",
+              country:  watch("country")  ?? "",
+            }}
+            onChange={(next) => {
+              setValue("address",  next.address);
+              setValue("city",     next.city);
+              setValue("state",    next.state);
+              setValue("postcode", next.postcode);
+              setValue("country",  next.country);
+            }}
+          />
         </CardContent>
       </Card>
 

--- a/src/components/settings/settings-client.tsx
+++ b/src/components/settings/settings-client.tsx
@@ -24,6 +24,7 @@ import { TeamSettings } from "@/components/settings/team-settings";
 import { ApiKeysSettings } from "@/components/settings/api-keys-settings";
 import { EmailSettings } from "@/components/settings/email-settings";
 import { WebhooksSettings } from "@/components/settings/webhooks-settings";
+import { AddressFields } from "@/components/addresses/address-fields";
 import type { Business, BusinessMember, BusinessApiKey, BusinessEmailConfig, BusinessWebhook } from "@/types/database";
 import type { Role } from "@/lib/permissions";
 
@@ -74,6 +75,7 @@ const businessSchema = z.object({
   phone: z.string().optional(),
   address: z.string().optional(),
   city: z.string().optional(),
+  state: z.string().optional(),
   postcode: z.string().optional(),
   country: z.string().optional(),
   website: z.string().optional(),
@@ -127,6 +129,7 @@ export function SettingsClient({ business: initial, members, apiKeys, emailConfi
       phone: business.phone ?? "",
       address: business.address ?? "",
       city: business.city ?? "",
+      state: business.state ?? "",
       postcode: business.postcode ?? "",
       country: business.country ?? "",
       website: business.website ?? "",
@@ -305,12 +308,23 @@ export function SettingsClient({ business: initial, members, apiKeys, emailConfi
                   <div className="space-y-1.5"><Label>Phone</Label><Input {...businessForm.register("phone")} /></div>
                 </div>
                 <div className="space-y-1.5"><Label>Website</Label><Input placeholder="https://..." {...businessForm.register("website")} /></div>
-                <div className="space-y-1.5"><Label>Address</Label><Input {...businessForm.register("address")} /></div>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                  <div className="space-y-1.5"><Label>City</Label><Input {...businessForm.register("city")} /></div>
-                  <div className="space-y-1.5"><Label>Postcode</Label><Input {...businessForm.register("postcode")} /></div>
-                  <div className="space-y-1.5"><Label>Country</Label><Input {...businessForm.register("country")} /></div>
-                </div>
+                <AddressFields
+                  country={businessForm.watch("country") || business.country}
+                  values={{
+                    address:  businessForm.watch("address")  ?? "",
+                    city:     businessForm.watch("city")     ?? "",
+                    state:    businessForm.watch("state")    ?? "",
+                    postcode: businessForm.watch("postcode") ?? "",
+                    country:  businessForm.watch("country")  ?? "",
+                  }}
+                  onChange={(next) => {
+                    businessForm.setValue("address",  next.address);
+                    businessForm.setValue("city",     next.city);
+                    businessForm.setValue("state",    next.state);
+                    businessForm.setValue("postcode", next.postcode);
+                    businessForm.setValue("country",  next.country);
+                  }}
+                />
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-1.5"><Label>VAT / Tax number</Label><Input {...businessForm.register("tax_number")} /></div>
                   <div className="space-y-1.5"><Label>Licence number</Label><Input placeholder="e.g. 471250C" {...businessForm.register("license_number")} /></div>

--- a/src/components/ui/address-autocomplete.tsx
+++ b/src/components/ui/address-autocomplete.tsx
@@ -8,6 +8,7 @@ export type AddressSuggestion = {
   label: string;
   address: string;
   city: string;
+  state: string;
   postcode: string;
   country: string;
 };

--- a/src/lib/actions/customer-hub.ts
+++ b/src/lib/actions/customer-hub.ts
@@ -38,6 +38,7 @@ function siteToProperty(s: Site): CustomerProperty {
     label: s.label,
     address: s.address ?? '',
     city: s.city,
+    state: s.state,
     postcode: s.postcode,
     country: s.country,
     notes: s.access_notes,
@@ -70,12 +71,13 @@ export async function getCustomerProperties(customerId: string): Promise<Custome
 
 export async function createCustomerProperty(
   customerId: string,
-  payload: { label?: string; address: string; city?: string; postcode?: string; country?: string; notes?: string }
+  payload: { label?: string; address: string; city?: string; state?: string; postcode?: string; country?: string; notes?: string }
 ): Promise<CustomerProperty> {
   const site = await createSite(customerId, {
     label: payload.label ?? null,
     address: payload.address,
     city: payload.city ?? null,
+    state: payload.state ?? null,
     postcode: payload.postcode ?? null,
     country: payload.country ?? null,
     access_notes: payload.notes ?? null,
@@ -86,12 +88,13 @@ export async function createCustomerProperty(
 export async function updateCustomerProperty(
   id: string,
   customerId: string,
-  payload: Partial<Pick<CustomerProperty, "label" | "address" | "city" | "postcode" | "country" | "notes">>
+  payload: Partial<Pick<CustomerProperty, "label" | "address" | "city" | "postcode" | "country" | "notes"> & { state: string | null }>
 ): Promise<CustomerProperty> {
   const site = await updateSite(id, {
     ...(payload.label !== undefined ? { label: payload.label } : {}),
     ...(payload.address !== undefined ? { address: payload.address } : {}),
     ...(payload.city !== undefined ? { city: payload.city } : {}),
+    ...(payload.state !== undefined ? { state: payload.state } : {}),
     ...(payload.postcode !== undefined ? { postcode: payload.postcode } : {}),
     ...(payload.country !== undefined ? { country: payload.country } : {}),
     ...(payload.notes !== undefined ? { access_notes: payload.notes } : {}),

--- a/src/lib/actions/customers.ts
+++ b/src/lib/actions/customers.ts
@@ -46,8 +46,8 @@ export async function getCustomer(id: string): Promise<Customer> {
 }
 
 type CreateCustomerInput =
-  Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact">
-  & Partial<Pick<Customer, "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact">>;
+  Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state">
+  & Partial<Pick<Customer, "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state">>;
 
 export async function createCustomer(payload: CreateCustomerInput): Promise<Customer> {
   const supabase = await createClient();

--- a/src/lib/actions/sites.ts
+++ b/src/lib/actions/sites.ts
@@ -73,6 +73,7 @@ export type SitePayload = {
   label?: string | null;
   address?: string | null;
   city?: string | null;
+  state?: string | null;
   postcode?: string | null;
   country?: string | null;
   access_notes?: string | null;

--- a/src/lib/country-formats.ts
+++ b/src/lib/country-formats.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-country address layouts.
+ *
+ * The active business's `country` determines which template is used across
+ * every address form (customer, property, site, business profile). For
+ * countries without an explicit template we fall back to GENERIC.
+ *
+ * To add a country: drop a new entry into FORMATS keyed by ISO-2 code or
+ * the natural-language country name (lowercased). Also list a label for
+ * each field so the form copy reads naturally for that country.
+ */
+
+export type AddressFieldKey = "address" | "city" | "state" | "postcode" | "country";
+
+export interface AddressFormat {
+  /** Order the fields render in. Always includes 'address' first. */
+  fields: AddressFieldKey[];
+  /** Per-field label override. Keys not present use the generic fallback. */
+  labels: Partial<Record<AddressFieldKey, string>>;
+  /** Per-field placeholder hint. */
+  placeholders: Partial<Record<AddressFieldKey, string>>;
+  /** Optional preset list for the state dropdown. Empty = free text input. */
+  states?: { value: string; label: string }[];
+  /** ISO-2 code for biasing autocomplete (passed to /api/places/search). */
+  countryCode: string;
+}
+
+const GENERIC: AddressFormat = {
+  fields: ["address", "city", "postcode", "country"],
+  labels: {
+    address: "Street address",
+    city:    "City",
+    postcode:"Postcode",
+    country: "Country",
+  },
+  placeholders: {
+    address: "123 Main Street",
+    city:    "City",
+    postcode:"Postcode",
+    country: "Country",
+  },
+  countryCode: "",
+};
+
+const AU: AddressFormat = {
+  fields: ["address", "city", "state", "postcode", "country"],
+  labels: {
+    address: "Street address",
+    city:    "Suburb",
+    state:   "State",
+    postcode:"Postcode",
+    country: "Country",
+  },
+  placeholders: {
+    address: "12 Smith Street",
+    city:    "Bondi",
+    state:   "NSW",
+    postcode:"2026",
+    country: "Australia",
+  },
+  states: [
+    { value: "ACT", label: "ACT" },
+    { value: "NSW", label: "NSW" },
+    { value: "NT",  label: "NT"  },
+    { value: "QLD", label: "QLD" },
+    { value: "SA",  label: "SA"  },
+    { value: "TAS", label: "TAS" },
+    { value: "VIC", label: "VIC" },
+    { value: "WA",  label: "WA"  },
+  ],
+  countryCode: "au",
+};
+
+const US: AddressFormat = {
+  fields: ["address", "city", "state", "postcode", "country"],
+  labels: {
+    address: "Street address",
+    city:    "City",
+    state:   "State",
+    postcode:"ZIP code",
+    country: "Country",
+  },
+  placeholders: {
+    address: "123 Main Street",
+    city:    "City",
+    state:   "CA",
+    postcode:"94103",
+    country: "United States",
+  },
+  countryCode: "us",
+};
+
+const UK: AddressFormat = {
+  fields: ["address", "city", "state", "postcode", "country"],
+  labels: {
+    address: "Street address",
+    city:    "Town / city",
+    state:   "County",
+    postcode:"Postcode",
+    country: "Country",
+  },
+  placeholders: {
+    address: "10 Downing Street",
+    city:    "London",
+    state:   "Greater London",
+    postcode:"SW1A 2AA",
+    country: "United Kingdom",
+  },
+  countryCode: "gb",
+};
+
+const FORMATS: Record<string, AddressFormat> = {
+  // ISO-2 codes
+  au: AU, us: US, gb: UK,
+  // Common spellings
+  australia:        AU,
+  "united states":  US,
+  usa:              US,
+  "united kingdom": UK,
+  uk:               UK,
+  britain:          UK,
+};
+
+/** Resolve the format for a given country string (free-text or ISO-2). */
+export function getAddressFormat(country?: string | null): AddressFormat {
+  if (!country) return GENERIC;
+  const key = country.trim().toLowerCase();
+  return FORMATS[key] ?? GENERIC;
+}
+
+export const DEFAULT_AU_FORMAT = AU;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -42,6 +42,7 @@ export interface Business {
   phone: string | null;
   address: string | null;
   city: string | null;
+  state: string | null;
   postcode: string | null;
   country: string | null;
   website: string | null;
@@ -79,6 +80,7 @@ export interface Customer {
   phone: string | null;
   address: string | null;
   city: string | null;
+  state: string | null;
   postcode: string | null;
   country: string | null;
   company: string | null;
@@ -436,6 +438,7 @@ export interface CustomerProperty {
   label: string | null;
   address: string;
   city: string | null;
+  state: string | null;
   postcode: string | null;
   country: string | null;
   notes: string | null;
@@ -482,6 +485,7 @@ export interface Site {
   label: string | null;
   address: string | null;
   city: string | null;
+  state: string | null;
   postcode: string | null;
   country: string | null;
   lat: number | null;

--- a/supabase/migrations/20260507000002_address_state.sql
+++ b/supabase/migrations/20260507000002_address_state.sql
@@ -1,0 +1,10 @@
+-- Australian (and many other countries) addresses need a state component
+-- between suburb/city and postcode. Add it across every entity that
+-- captures a postal address.
+
+-- customer_properties is a virtual concept that maps to public.sites in code
+-- (see lib/actions/customer-hub.ts → siteToProperty). So adding state to
+-- sites is enough; no separate customer_properties table exists.
+alter table public.businesses add column if not exists state text;
+alter table public.customers  add column if not exists state text;
+alter table public.sites      add column if not exists state text;


### PR DESCRIPTION
Three fixes:
- State was missing from autocomplete responses (silently dropped)
- New per-country address layouts driven by business.country (AU has its own template with the proper field order + state dropdown)
- Customer 'Add property' dialog had broken autocomplete — fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)