### PR TITLE
Address fix: keep house number, default AU, normalize state

### DIFF
--- a/src/components/addresses/address-fields.tsx
+++ b/src/components/addresses/address-fields.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AddressAutocomplete, type AddressSuggestion } from "@/components/ui/address-autocomplete";
-import { getAddressFormat, type AddressFieldKey } from "@/lib/country-formats";
+import { getAddressFormat, normalizeState, type AddressFieldKey } from "@/lib/country-formats";
 
 export interface AddressValues {
   address: string;
@@ -40,10 +40,36 @@ export function AddressFields({
     onChange({ ...values, [k]: v });
 
   const handleSuggestion = (s: AddressSuggestion) => {
+    // Preserve any house/unit number the user typed if Nominatim's result
+    // didn't include one. Many AU streets are indexed without house numbers,
+    // so picking a suggestion would otherwise wipe the '22' from '22 Smith St'.
+    let finalAddress = s.address || values.address;
+    const suggestionHasNumber = /^\s*\d/.test(s.address);
+    if (!suggestionHasNumber && s.address) {
+      // Common patterns the user might have typed before the street name:
+      //   "22 Desborough Road"
+      //   "Unit 3 / 22 Smith St"
+      //   "Lot 14 Old Pines Rd"
+      // Capture everything up to the first word that matches the start of
+      // the suggestion's road, and prepend it.
+      const firstWord = (s.address.split(/\s+/)[0] ?? "").toLowerCase();
+      const typed = values.address.toLowerCase();
+      const idx   = firstWord ? typed.indexOf(firstWord) : -1;
+      if (idx > 0) {
+        const prefix = values.address.slice(0, idx).trim();
+        if (prefix) finalAddress = `${prefix} ${s.address}`;
+      } else {
+        // Couldn't align with the suggestion — fall back to leading-digit grab
+        // (e.g. 'Unit 3 / 22' → '22') prepended to the suggestion.
+        const leading = values.address.match(/^([\w\s/-]*?\d[\w/-]*)\s+/);
+        if (leading?.[1]) finalAddress = `${leading[1].trim()} ${s.address}`;
+      }
+    }
+
     onChange({
-      address:  s.address  || values.address,
+      address:  finalAddress,
       city:     s.city     || values.city,
-      state:    s.state    || values.state,
+      state:    normalizeState(country, s.state) || values.state,
       postcode: s.postcode || values.postcode,
       country:  s.country  || values.country,
     });

--- a/src/lib/country-formats.ts
+++ b/src/lib/country-formats.ts
@@ -42,6 +42,20 @@ const GENERIC: AddressFormat = {
   countryCode: "",
 };
 
+/** Nominatim returns 'New South Wales', our dropdown holds 'NSW'. Map both
+ *  full names and abbreviations to the canonical code so the picked
+ *  suggestion's state pre-selects the right option. */
+const AU_STATE_NORMALIZE: Record<string, string> = {
+  "australian capital territory": "ACT", "act": "ACT",
+  "new south wales": "NSW",              "nsw": "NSW",
+  "northern territory": "NT",            "nt": "NT",
+  "queensland": "QLD",                   "qld": "QLD",
+  "south australia": "SA",               "sa": "SA",
+  "tasmania": "TAS",                     "tas": "TAS",
+  "victoria": "VIC",                     "vic": "VIC",
+  "western australia": "WA",             "wa": "WA",
+};
+
 const AU: AddressFormat = {
   fields: ["address", "city", "state", "postcode", "country"],
   labels: {
@@ -121,11 +135,27 @@ const FORMATS: Record<string, AddressFormat> = {
   britain:          UK,
 };
 
-/** Resolve the format for a given country string (free-text or ISO-2). */
+/** Resolve the format for a given country string (free-text or ISO-2).
+ *  Defaults to Australia when the business hasn't set a country yet — the
+ *  app is currently AU-only and falling back to a generic 4-field layout
+ *  costs the user the State field. */
 export function getAddressFormat(country?: string | null): AddressFormat {
-  if (!country) return GENERIC;
+  if (!country) return AU;
   const key = country.trim().toLowerCase();
-  return FORMATS[key] ?? GENERIC;
+  return FORMATS[key] ?? AU;
+}
+
+/** Normalize a state value against the format's known states. Returns the
+ *  matched canonical value, or the input if no match. Used to convert
+ *  Nominatim's full state names into our short codes. */
+export function normalizeState(country: string | null | undefined, raw: string): string {
+  if (!raw) return raw;
+  const fmt = getAddressFormat(country);
+  if (fmt === AU) {
+    const code = AU_STATE_NORMALIZE[raw.trim().toLowerCase()];
+    if (code) return code;
+  }
+  return raw;
 }
 
 export const DEFAULT_AU_FORMAT = AU;


### PR DESCRIPTION
Three follow-on fixes for the address forms.

1. Default to AU template when business country is empty — was falling to generic 4-field layout that drops State.
2. Preserve typed house number when Nominatim's suggestion doesn't include one (very common for AU streets).
3. Normalize 'New South Wales' → 'NSW' so the state dropdown actually selects after autocomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)