### PR TITLE
Logo: bigger, no text, no border

### DIFF
--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -8,11 +8,8 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       {/* Left panel */}
       <div className="hidden lg:flex flex-col bg-zinc-900 dark:bg-zinc-950 text-white p-12 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-blue-600/20 to-indigo-600/20" />
-        <div className="relative z-10 flex items-center gap-3 mb-auto">
-          <div className="w-12 h-12 rounded-xl bg-white p-1.5 flex items-center justify-center">
-            <Image src="/kirei-logo.png" alt="Kirei" width={36} height={36} className="object-contain" priority />
-          </div>
-          <span className="text-xl font-semibold tracking-tight">Kirei</span>
+        <div className="relative z-10 flex items-center mb-auto">
+          <Image src="/kirei-logo.png" alt="Kirei" width={72} height={72} className="object-contain" priority />
         </div>
         <div className="relative z-10 space-y-6">
           <blockquote className="text-2xl font-light leading-relaxed text-zinc-100">
@@ -33,9 +30,8 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       {/* Right panel */}
       <div className="flex items-center justify-center p-8 bg-background">
         <div className="w-full max-w-sm">
-          <div className="flex items-center gap-2 mb-8 lg:hidden">
-            <Image src="/kirei-logo.png" alt="Kirei" width={32} height={32} className="object-contain" priority />
-            <span className="text-lg font-semibold">Kirei</span>
+          <div className="flex items-center mb-8 lg:hidden">
+            <Image src="/kirei-logo.png" alt="Kirei" width={56} height={56} className="object-contain" priority />
           </div>
           {children}
         </div>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -89,9 +89,7 @@ export function AppSidebar({ business, businesses, userRole, open, onClose }: Ap
                 <Image src={business.logo_url} alt={business.name} width={40} height={40} className="object-contain w-full h-full" />
               </div>
             ) : (
-              <div className="w-10 h-10 rounded-xl bg-white p-1 ring-2 ring-sidebar-primary/30 shadow-lg shadow-sidebar-primary/10 flex items-center justify-center">
-                <Image src="/kirei-logo.png" alt="Kirei" width={36} height={36} className="object-contain" />
-              </div>
+              <Image src="/kirei-logo.png" alt="Kirei" width={48} height={48} className="object-contain w-12 h-12" />
             )}
             <span className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-emerald-400 border-2 border-sidebar" />
           </motion.div>
@@ -198,11 +196,8 @@ export function AppSidebar({ business, businesses, userRole, open, onClose }: Ap
           <span className="text-[10px] font-semibold uppercase tracking-widest text-sidebar-foreground/40">
             {ROLE_LABELS[userRole]}
           </span>
-          {/* Kirei platform attribution — always visible at the bottom of the sidebar */}
-          <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-sidebar-foreground/40">
-            <Image src="/kirei-logo.png" alt="Kirei" width={14} height={14} className="object-contain rounded-sm" />
-            Kirei
-          </span>
+          {/* Kirei platform attribution — logo only, no text, no border */}
+          <Image src="/kirei-logo.png" alt="Kirei" width={28} height={28} className="object-contain opacity-70" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Bumped logo sizes everywhere it appears, removed the Kirei wordmark text alongside, and dropped the white card / ring border treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)