### PR TITLE
Leads: custom source values + dashboard widget

### DIFF
--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -34,7 +34,8 @@ Failing items: paste the section number + failing item into a comment on the QA 
 - [ ] Recent invoices table — clicking a row navigates to that invoice
 - [ ] Quick actions tile on the right
 - [ ] **Your todos** widget under Quick actions — open tasks with one-click complete
-- [ ] **Operations widget** under Tasks — Team / Recurring jobs / Agents running, each clickable
+- [ ] **New leads widget** — most recent unconverted leads (status=new or contacted), shows source + suburb + age
+- [ ] **Operations widget** — Team / Recurring jobs / Agents running, each clickable
 - [ ] Today's jobs list shows scheduled jobs
 
 ## 3. Dashboard (worker view)
@@ -76,11 +77,14 @@ Failing items: paste the section number + failing item into a comment on the QA 
 
 - [ ] List view with status colour-tinted cards
 - [ ] Add lead manually
+- [ ] **Source field accepts custom values** (e.g. "HiPages", "ServiceSeeking", "word-of-mouth", or anything else)
+- [ ] Source dropdown shows: built-in presets + any sources used on this business's past leads + free-text input
 - [ ] Convert lead → customer
 - [ ] Convert lead → quote
 - [ ] Convert lead → work order
 - [ ] Lead status changes (new → contacted → quoted → won/lost)
 - [ ] Smart Organise on leads
+- [ ] **Source badge** on the lead card renders friendly label (e.g. "HiPages" not "hipages")
 
 ## 6. Quotes
 

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -12,6 +12,7 @@ import { formatCurrency, getStatusColor } from "@/lib/utils";
 import { BriefingWidget } from "@/components/briefing/briefing-widget";
 import { TasksWidget } from "@/components/tasks/tasks-widget";
 import { OutlookWidget } from "@/components/dashboard/outlook-widget";
+import { NewLeadsWidget } from "@/components/dashboard/new-leads-widget";
 import type { WorkOrderWithCustomer, WorkOrderStatus } from "@/types/database";
 
 const STATUS_TO_PILL: Record<WorkOrderStatus, string> = {
@@ -250,6 +251,9 @@ export function DashboardClient({ stats, currency = "GBP", todayJobs }: Dashboar
               </div>
             </div>
           </div>
+
+          {/* New leads — most recent unconverted */}
+          <NewLeadsWidget />
 
           {/* Your todos — open tasks from the kanban board */}
           <TasksWidget />

--- a/src/components/dashboard/new-leads-widget.tsx
+++ b/src/components/dashboard/new-leads-widget.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { UserPlus, ArrowRight, MapPin } from "@/components/ui/icons";
+import { getLeads } from "@/lib/actions/leads";
+import type { Lead } from "@/types/database";
+
+const SOURCE_LABELS: Record<string, string> = {
+  "landing-page":   "Landing Page",
+  "website":        "Website",
+  "referral":       "Referral",
+  "telegram":       "Telegram",
+  "email":          "Email",
+  "phone":          "Phone",
+  "manual":         "Manual",
+  "hipages":        "HiPages",
+  "service-seeking":"ServiceSeeking",
+  "google":         "Google",
+  "facebook":       "Facebook",
+  "instagram":      "Instagram",
+  "word-of-mouth":  "Word of mouth",
+};
+
+function fmtSource(s: string | null | undefined): string {
+  if (!s) return "—";
+  return SOURCE_LABELS[s] ?? s.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function fmtAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** Dashboard widget — most recent leads with status=new + status=contacted.
+ *  Surfaces leads that haven't been actioned yet so the owner sees them
+ *  immediately on landing. Clicking a row jumps to the lead. */
+export function NewLeadsWidget() {
+  const [leads, setLeads] = useState<Lead[] | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const all = await getLeads();
+      // Most recent unconverted leads first.
+      const filtered = all
+        .filter((l) => l.status === "new" || l.status === "contacted")
+        .slice(0, 5);
+      setLeads(filtered);
+    } catch { setLeads([]); }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <UserPlus className="w-3.5 h-3.5 text-muted-foreground" />
+          New leads
+          {leads && leads.length > 0 && (
+            <span className="ch-pill in-progress">{leads.length}</span>
+          )}
+        </h3>
+        <Link href="/leads" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+          All leads <ArrowRight className="w-3 h-3" />
+        </Link>
+      </div>
+
+      {leads === null ? (
+        <div className="p-4 text-xs text-muted-foreground">Loading…</div>
+      ) : leads.length === 0 ? (
+        <div className="ch-empty">
+          <h4>No new leads</h4>
+          <p>Once a lead comes in (manual or via a landing page), it&apos;ll appear here.</p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-border">
+          {leads.map((lead) => (
+            <li key={lead.id} className="px-4 py-3 hover:bg-muted/40 transition-colors">
+              <Link href={`/leads/${lead.id}`} className="flex items-center gap-3 group">
+                <div className="w-9 h-9 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-semibold flex-shrink-0">
+                  {lead.name?.split(/\s+/).slice(0, 2).map((p) => p[0]?.toUpperCase()).join("") || "?"}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm font-medium truncate">{lead.name}</p>
+                    {lead.status === "contacted" && (
+                      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">contacted</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-0.5 text-[11px] text-muted-foreground">
+                    <span>{fmtSource(lead.source)}</span>
+                    {lead.suburb && (
+                      <span className="inline-flex items-center gap-0.5"><MapPin className="w-3 h-3" />{lead.suburb}</span>
+                    )}
+                    <span>· {fmtAge(lead.created_at)}</span>
+                  </div>
+                </div>
+                <ArrowRight className="w-4 h-4 text-muted-foreground/40 group-hover:text-foreground group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -31,6 +31,7 @@ import { useRouter } from "next/navigation";
 import { updateLeadStatus, deleteLead, createLead, updateLead, convertLeadToCustomer, convertLeadToQuote, convertLeadToWorkOrder } from "@/lib/actions/leads";
 import { addLeadAsContact } from "@/lib/actions/contacts";
 import type { Lead, LeadStatus, LeadSource } from "@/types/database";
+import { BUILT_IN_LEAD_SOURCES } from "@/types/database";
 
 const COLUMNS: { status: LeadStatus; label: string; color: string; dot: string }[] = [
   { status: "new",       label: "New",       color: "bg-blue-50 dark:bg-blue-950/30",   dot: "bg-blue-500" },
@@ -48,15 +49,26 @@ const STATUS_BADGE: Record<LeadStatus, string> = {
   lost:      "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
 };
 
-const SOURCE_LABELS: Record<LeadSource, string> = {
-  "landing-page": "Landing Page",
-  website:        "Website",
-  referral:       "Referral",
-  telegram:       "Telegram",
-  email:          "Email",
-  phone:          "Phone",
-  manual:         "Manual",
+/** Friendly labels for known sources. Anything not in here renders as-is. */
+const SOURCE_LABELS: Record<string, string> = {
+  "landing-page":   "Landing Page",
+  "website":        "Website",
+  "referral":       "Referral",
+  "telegram":       "Telegram",
+  "email":          "Email",
+  "phone":          "Phone",
+  "manual":         "Manual",
+  "hipages":        "HiPages",
+  "service-seeking":"ServiceSeeking",
+  "google":         "Google",
+  "facebook":       "Facebook",
+  "instagram":      "Instagram",
+  "word-of-mouth":  "Word of mouth",
 };
+
+function formatSourceLabel(s: string): string {
+  return SOURCE_LABELS[s] ?? s.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-AU", { day: "numeric", month: "short" });
@@ -361,14 +373,24 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
             </div>
             <div className="space-y-1.5">
               <Label>Source</Label>
-              <Select value={form.source} onValueChange={(v) => setForm((f) => ({ ...f, source: v as LeadSource }))}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {(Object.entries(SOURCE_LABELS) as [LeadSource, string][]).map(([k, v]) => (
-                    <SelectItem key={k} value={k}>{v}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Input
+                list="lead-source-suggestions"
+                value={form.source}
+                onChange={(e) => setForm((f) => ({ ...f, source: e.target.value }))}
+                placeholder="e.g. HiPages, referral, walk-in"
+              />
+              <datalist id="lead-source-suggestions">
+                {/* Built-in presets */}
+                {BUILT_IN_LEAD_SOURCES.map((s) => (
+                  <option key={`builtin-${s}`} value={s}>{formatSourceLabel(s)}</option>
+                ))}
+                {/* Sources already used on this business's leads — keeps the
+                    list tidy and lets typing 'Hi…' autocomplete to a past value. */}
+                {Array.from(new Set(leads.map((l) => l.source).filter(Boolean) as string[]))
+                  .filter((s) => !(BUILT_IN_LEAD_SOURCES as readonly string[]).includes(s))
+                  .map((s) => <option key={`past-${s}`} value={s}>{formatSourceLabel(s)}</option>)}
+              </datalist>
+              <p className="text-[11px] text-muted-foreground">Pick a suggestion or type your own.</p>
             </div>
             <div className="col-span-2 space-y-1.5">
               <Label>Notes</Label>
@@ -577,7 +599,7 @@ function LeadCard({
       {lead.source && lead.source !== "manual" && (
         <div className="pt-0">
           <span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
-            {SOURCE_LABELS[lead.source] ?? lead.source}
+            {formatSourceLabel(lead.source)}
           </span>
         </div>
       )}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -395,7 +395,15 @@ export type WorkOrderWithDetails = WorkOrder & {
 // ----------------------------------------------------------------
 
 export type LeadStatus = "new" | "contacted" | "quoted" | "won" | "lost";
-export type LeadSource = "landing-page" | "website" | "referral" | "telegram" | "email" | "phone" | "manual";
+/** Built-in lead source presets. The DB column is now free-text, so any
+ *  string is valid — these are just the suggestions the UI offers in the
+ *  source dropdown alongside whatever past values exist for the business. */
+export const BUILT_IN_LEAD_SOURCES = [
+  "manual", "website", "landing-page", "referral", "phone",
+  "email", "telegram", "hipages", "service-seeking", "google",
+  "facebook", "instagram", "word-of-mouth",
+] as const;
+export type LeadSource = string;
 
 export interface Lead {
   id: string;

--- a/supabase/migrations/20260508000001_lead_source_open.sql
+++ b/supabase/migrations/20260508000001_lead_source_open.sql
@@ -1,0 +1,6 @@
+-- Allow arbitrary lead sources — was locked to 7 hardcoded values via CHECK
+-- but tradies need to capture HiPages, ServiceSeeking, Yellow Pages, word-
+-- of-mouth, etc. Free-text now; the UI offers a dropdown of past sources
+-- plus a 'type your own' input.
+
+alter table public.leads drop constraint if exists leads_source_check;


### PR DESCRIPTION
Lead source is now free-text with built-in presets + auto-complete from past values. New 'New leads' widget on the dashboard surfaces unconverted leads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)