### PR TITLE
Mobile Phase 1: multi-business + role-aware index + owner dashboard

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -69,11 +69,14 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Signup with invite code | ✅ | shipped | |
 | Forgot password | ❌ | 1 | Existing web flow — wire deep-link |
 | **Foundation** |
-| Multi-business switcher | ❌ | 1 | AsyncStorage-backed |
-| Active business sync | ❌ | 1 | Match web behaviour |
-| Role-aware navigation | 🟡 | 1 | Worker view exists; need owner view |
+| Multi-business switcher | ✅ | 1 | AsyncStorage-backed, sits above the index tab |
+| Active business sync | ✅ | 1 | useActiveBusiness hook |
+| Role-aware navigation | ✅ | 1 | Index tab branches: OwnerDashboard vs WorkerJobsList |
+| Mirrored permissions | ✅ | 1 | mobile/src/lib/permissions.ts |
 | **Dashboard** |
-| Owner dashboard (KPIs, briefing, todos, outlook, leads) | ❌ | 1 | Same widgets as web |
+| Owner dashboard (KPIs, overdue strip, leads strip) | ✅ | 1 | Phase 1 skeleton |
+| Owner dashboard (briefing widget) | ❌ | 1.5 | Coming |
+| Owner dashboard (tasks, outlook, full widgets) | ❌ | 1.5 | Coming |
 | Worker dashboard | ✅ | shipped | |
 | Briefing widget | ❌ | 1 | Mobile version of `/assistant` |
 | Header bell briefing | ❌ | 1 | Top-bar icon with unread count |

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -5,9 +5,38 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchMyWorkOrders } from "@/lib/jobs";
 import { scheduleJobReminders } from "@/lib/notifications";
 import { JobCard } from "@/components/JobCard";
+import { BusinessSwitcher } from "@/components/BusinessSwitcher";
+import { OwnerDashboard } from "@/components/OwnerDashboard";
+import { useActiveBusiness } from "@/lib/active-business";
+import { isWorker } from "@/lib/permissions";
 import { colors, space } from "@/lib/theme";
 
-export default function JobsScreen() {
+/** Tab 1 (index) — role-aware:
+ *  - Owners / admins / editors / viewers see the OwnerDashboard with KPIs.
+ *  - Workers see the existing 'My jobs' list.
+ *  Same tab, different content based on the active business + role. */
+export default function HomeTab() {
+  const { active, businesses, role, switchTo, loading } = useActiveBusiness();
+
+  if (loading || !active) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas, alignItems: "center", justifyContent: "center" }}>
+        <ActivityIndicator color={colors.primary} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <View style={{ paddingHorizontal: space.lg, paddingTop: space.sm }}>
+        <BusinessSwitcher active={active} businesses={businesses} role={role} onSwitch={switchTo} />
+      </View>
+      {isWorker(role) ? <WorkerJobsList /> : <OwnerDashboard business={active} />}
+    </SafeAreaView>
+  );
+}
+
+function WorkerJobsList() {
   const { data: jobs, isLoading, isRefetching, refetch, error } = useQuery({
     queryKey: ["work-orders"],
     queryFn:  fetchMyWorkOrders,
@@ -33,14 +62,14 @@ export default function JobsScreen() {
 
   if (isLoading) {
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas, alignItems: "center", justifyContent: "center" }}>
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
         <ActivityIndicator color={colors.primary} />
-      </SafeAreaView>
+      </View>
     );
   }
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+    <View style={{ flex: 1 }}>
       <FlatList
         contentContainerStyle={{ paddingHorizontal: space.lg, paddingBottom: space.xxl }}
         ListHeaderComponent={
@@ -73,7 +102,7 @@ export default function JobsScreen() {
           </View>
         }
       />
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/mobile/src/components/BusinessSwitcher.tsx
+++ b/mobile/src/components/BusinessSwitcher.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { Modal, Pressable, ScrollView, Text, View, Image } from "react-native";
+import { ChevronDown, Check, Building2 } from "lucide-react-native";
+import { colors, radius, space } from "@/lib/theme";
+import type { MobileBusiness } from "@/lib/active-business";
+import { ROLE_LABELS, type Role } from "@/lib/permissions";
+
+interface Props {
+  active: MobileBusiness | null;
+  businesses: MobileBusiness[];
+  role: Role;
+  onSwitch: (businessId: string) => void | Promise<void>;
+}
+
+/** Top-of-screen pill showing the active business + role with a tap-to-switch
+ *  modal listing every business the user has access to. */
+export function BusinessSwitcher({ active, businesses, role, onSwitch }: Props) {
+  const [open, setOpen] = useState(false);
+
+  if (!active) return null;
+
+  const initials = active.name.split(/\s+/).slice(0, 2).map((p) => p[0]?.toUpperCase()).join("");
+
+  return (
+    <>
+      <Pressable
+        onPress={() => businesses.length > 1 && setOpen(true)}
+        style={({ pressed }) => ({
+          flexDirection: "row",
+          alignItems: "center",
+          gap: space.sm,
+          padding: space.sm,
+          borderRadius: radius.lg,
+          backgroundColor: pressed ? colors.muted : "transparent",
+          opacity: pressed ? 0.85 : 1,
+        })}
+      >
+        {active.logo_url ? (
+          <Image source={{ uri: active.logo_url }} style={{ width: 32, height: 32, borderRadius: radius.md }} />
+        ) : (
+          <View style={{
+            width: 32, height: 32, borderRadius: radius.md,
+            backgroundColor: colors.primarySoft,
+            alignItems: "center", justifyContent: "center",
+          }}>
+            <Text style={{ color: colors.primary, fontWeight: "700", fontSize: 12 }}>{initials}</Text>
+          </View>
+        )}
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text numberOfLines={1} style={{ fontSize: 15, fontWeight: "600", color: colors.text }}>{active.name}</Text>
+          <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6 }}>
+            {ROLE_LABELS[role]}
+          </Text>
+        </View>
+        {businesses.length > 1 && <ChevronDown size={16} color={colors.muted} />}
+      </Pressable>
+
+      <Modal visible={open} animationType="slide" transparent onRequestClose={() => setOpen(false)}>
+        <Pressable style={{ flex: 1, backgroundColor: "rgba(0,0,0,0.4)" }} onPress={() => setOpen(false)}>
+          <View style={{ marginTop: "auto", backgroundColor: colors.card, borderTopLeftRadius: radius.xl, borderTopRightRadius: radius.xl, padding: space.lg, gap: space.md, maxHeight: "70%" }}>
+            <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>Switch business</Text>
+            <ScrollView>
+              {businesses.map((b) => {
+                const selected = b.id === active.id;
+                const init = b.name.split(/\s+/).slice(0, 2).map((p) => p[0]?.toUpperCase()).join("");
+                return (
+                  <Pressable
+                    key={b.id}
+                    onPress={async () => { await onSwitch(b.id); setOpen(false); }}
+                    style={({ pressed }) => ({
+                      flexDirection: "row", alignItems: "center", gap: space.md,
+                      padding: space.md, borderRadius: radius.lg,
+                      backgroundColor: selected ? colors.primarySoft : pressed ? colors.muted : "transparent",
+                    })}
+                  >
+                    {b.logo_url ? (
+                      <Image source={{ uri: b.logo_url }} style={{ width: 36, height: 36, borderRadius: radius.md }} />
+                    ) : (
+                      <View style={{
+                        width: 36, height: 36, borderRadius: radius.md,
+                        backgroundColor: colors.primarySoft,
+                        alignItems: "center", justifyContent: "center",
+                      }}>
+                        <Text style={{ color: colors.primary, fontWeight: "700", fontSize: 13 }}>{init || "?"}</Text>
+                      </View>
+                    )}
+                    <View style={{ flex: 1, minWidth: 0 }}>
+                      <Text numberOfLines={1} style={{ fontSize: 15, fontWeight: "600", color: colors.text }}>{b.name}</Text>
+                      <Text style={{ fontSize: 11, color: colors.muted }}>{b.currency ?? "AUD"}</Text>
+                    </View>
+                    {selected && <Check size={18} color={colors.primary} />}
+                  </Pressable>
+                );
+              })}
+              {businesses.length === 1 && (
+                <View style={{ alignItems: "center", padding: space.lg, gap: space.sm }}>
+                  <Building2 size={28} color={colors.muted} />
+                  <Text style={{ fontSize: 13, color: colors.muted, textAlign: "center" }}>
+                    You only have one business. Accept another invite or create a new one to switch.
+                  </Text>
+                </View>
+              )}
+            </ScrollView>
+          </View>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}

--- a/mobile/src/components/OwnerDashboard.tsx
+++ b/mobile/src/components/OwnerDashboard.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from "react";
+import { ScrollView, Text, View, Pressable, RefreshControl } from "react-native";
+import { useRouter } from "expo-router";
+import { AlertTriangle, Clock, DollarSign, FileCheck, Wrench, UserPlus } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+import type { MobileBusiness } from "@/lib/active-business";
+
+interface Stats {
+  outstanding: number;
+  overdue: number;
+  jobs_today: number;
+  draft_quotes: number;
+  new_leads_7d: number;
+}
+
+const ZERO: Stats = { outstanding: 0, overdue: 0, jobs_today: 0, draft_quotes: 0, new_leads_7d: 0 };
+
+const num = (v: unknown) => {
+  const n = typeof v === "number" ? v : parseFloat(String(v ?? 0));
+  return Number.isFinite(n) ? n : 0;
+};
+
+function fmtMoney(n: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat("en-AU", { style: "currency", currency, maximumFractionDigits: 0 }).format(n);
+  } catch {
+    return `${currency} ${n.toFixed(0)}`;
+  }
+}
+
+/** Owner-flavored landing screen — KPI strip + headline counts + quick actions.
+ *  Pulls live from Supabase using RLS, no server actions needed. */
+export function OwnerDashboard({ business }: { business: MobileBusiness }) {
+  const router = useRouter();
+  const [stats, setStats] = useState<Stats>(ZERO);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const currency = business.currency ?? "AUD";
+  const today = new Date().toISOString().split("T")[0];
+  const weekAgo = new Date(Date.now() - 7 * 86_400_000).toISOString();
+
+  const load = async () => {
+    const [{ data: invoices }, { data: jobs }, { data: quotes }, { data: leads }] = await Promise.all([
+      supabase.from("invoices")
+        .select("status, total, amount_paid, due_date")
+        .eq("business_id", business.id)
+        .in("status", ["sent", "partial", "overdue"]),
+      supabase.from("work_orders")
+        .select("id")
+        .eq("business_id", business.id)
+        .eq("scheduled_date", today),
+      supabase.from("quotes")
+        .select("id")
+        .eq("business_id", business.id)
+        .eq("status", "draft"),
+      supabase.from("leads")
+        .select("id")
+        .eq("business_id", business.id)
+        .gte("created_at", weekAgo),
+    ]);
+
+    const now = new Date();
+    let outstanding = 0;
+    let overdue = 0;
+    for (const inv of (invoices ?? []) as Array<{ status: string; total: unknown; amount_paid: unknown; due_date: string | null }>) {
+      const balance = Math.max(0, num(inv.total) - num(inv.amount_paid));
+      outstanding += balance;
+      if (inv.due_date && new Date(inv.due_date) < now) overdue += balance;
+    }
+
+    setStats({
+      outstanding,
+      overdue,
+      jobs_today: (jobs ?? []).length,
+      draft_quotes: (quotes ?? []).length,
+      new_leads_7d: (leads ?? []).length,
+    });
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, [business.id]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={{ padding: space.lg, gap: space.md }}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
+    >
+      {/* Greeting */}
+      <View>
+        <Text style={{ fontSize: 22, fontWeight: "700", color: colors.text, letterSpacing: -0.4 }}>
+          {greeting()}.
+        </Text>
+        <Text style={{ fontSize: 13, color: colors.muted, marginTop: 4 }}>
+          Here&apos;s what&apos;s happening today.
+        </Text>
+      </View>
+
+      {/* Overdue strip */}
+      {stats.overdue > 0 && (
+        <Pressable
+          onPress={() => {/* Navigate to invoices filter overdue when that screen exists */}}
+          style={{
+            flexDirection: "row", alignItems: "center", gap: space.md,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: "#fef2f2", borderWidth: 1, borderColor: "#fecaca",
+          }}
+        >
+          <View style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: "#fee2e2", alignItems: "center", justifyContent: "center" }}>
+            <AlertTriangle size={18} color="#b91c1c" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 14, fontWeight: "600", color: "#7f1d1d" }}>{fmtMoney(stats.overdue, currency)} overdue</Text>
+            <Text style={{ fontSize: 12, color: "#991b1b" }}>Send reminders to bring these in</Text>
+          </View>
+        </Pressable>
+      )}
+
+      {/* KPI grid */}
+      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: space.sm }}>
+        <Stat icon={<DollarSign size={14} color={colors.muted} />} label="Outstanding" value={loading ? "…" : fmtMoney(stats.outstanding, currency)} />
+        <Stat icon={<Clock size={14} color="#b45309" />} label="Overdue" value={loading ? "…" : fmtMoney(stats.overdue, currency)} accent="#b45309" />
+        <Stat icon={<Wrench size={14} color={colors.muted} />} label="Jobs today" value={loading ? "…" : String(stats.jobs_today)} />
+        <Stat icon={<FileCheck size={14} color={colors.muted} />} label="Draft quotes" value={loading ? "…" : String(stats.draft_quotes)} />
+      </View>
+
+      {/* New leads strip */}
+      {stats.new_leads_7d > 0 && (
+        <Pressable
+          onPress={() => {/* navigate to leads */}}
+          style={{
+            flexDirection: "row", alignItems: "center", gap: space.md,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: colors.primarySoft,
+          }}
+        >
+          <View style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: colors.primary, alignItems: "center", justifyContent: "center" }}>
+            <UserPlus size={18} color="#fff" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 14, fontWeight: "600", color: colors.primaryText }}>
+              {stats.new_leads_7d} new lead{stats.new_leads_7d === 1 ? "" : "s"} this week
+            </Text>
+            <Text style={{ fontSize: 12, color: colors.primaryText, opacity: 0.8 }}>Follow up before they go cold</Text>
+          </View>
+        </Pressable>
+      )}
+
+      {/* Hint */}
+      <Text style={{ fontSize: 11, color: colors.muted, textAlign: "center", marginTop: space.md }}>
+        Phase 1 mobile dashboard · more coming
+      </Text>
+    </ScrollView>
+  );
+}
+
+function Stat({ icon, label, value, accent }: { icon: React.ReactNode; label: string; value: string; accent?: string }) {
+  return (
+    <View style={{
+      flexBasis: "48%", flexGrow: 1,
+      padding: space.md, borderRadius: radius.lg,
+      backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline,
+      gap: 4,
+    }}>
+      <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+        {icon}
+        <Text style={{ fontSize: 11, fontWeight: "600", color: colors.muted, textTransform: "uppercase", letterSpacing: 0.5 }}>{label}</Text>
+      </View>
+      <Text style={{ fontSize: 22, fontWeight: "700", color: accent ?? colors.text, letterSpacing: -0.5 }}>{value}</Text>
+    </View>
+  );
+}
+
+function greeting(): string {
+  const h = new Date().getHours();
+  if (h < 5) return "Late night";
+  if (h < 12) return "Good morning";
+  if (h < 18) return "Good afternoon";
+  return "Good evening";
+}

--- a/mobile/src/lib/active-business.ts
+++ b/mobile/src/lib/active-business.ts
@@ -1,0 +1,120 @@
+import { useEffect, useState, useCallback } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { supabase } from "./supabase";
+import type { Role } from "./permissions";
+
+export interface MobileBusiness {
+  id: string;
+  name: string;
+  logo_url: string | null;
+  currency: string | null;
+  user_id: string; // owner
+}
+
+const ACTIVE_KEY = "kirei.active_business";
+
+/** Pull every business this user has access to — businesses they own AND
+ *  business_members rows where they have an active membership. Same logic
+ *  as the web app's getAllBusinessesForUser, kept simple for mobile. */
+async function fetchAccessibleBusinesses(userId: string): Promise<MobileBusiness[]> {
+  // Owned
+  const { data: owned } = await supabase
+    .from("businesses")
+    .select("id, name, logo_url, currency, user_id")
+    .eq("user_id", userId);
+
+  // Memberships
+  const { data: memberRows } = await supabase
+    .from("business_members")
+    .select("business_id")
+    .eq("user_id", userId)
+    .eq("status", "active");
+
+  const memberIds = (memberRows ?? []).map((r) => r.business_id);
+  let memberBizzes: MobileBusiness[] = [];
+  if (memberIds.length > 0) {
+    const { data } = await supabase
+      .from("businesses")
+      .select("id, name, logo_url, currency, user_id")
+      .in("id", memberIds);
+    memberBizzes = (data ?? []) as MobileBusiness[];
+  }
+
+  // Dedupe by id (owner could also be a member somehow)
+  const seen = new Set<string>();
+  const merged: MobileBusiness[] = [];
+  for (const b of [...(owned ?? []), ...memberBizzes]) {
+    if (seen.has(b.id)) continue;
+    seen.add(b.id);
+    merged.push(b as MobileBusiness);
+  }
+  return merged;
+}
+
+/** Resolve the caller's role within a business: owner if user_id matches,
+ *  otherwise the role on business_members. Defaults to 'viewer'. */
+async function fetchRoleForBusiness(userId: string, business: MobileBusiness): Promise<Role> {
+  if (business.user_id === userId) return "owner";
+  const { data } = await supabase
+    .from("business_members")
+    .select("role")
+    .eq("business_id", business.id)
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .maybeSingle();
+  return (data?.role ?? "viewer") as Role;
+}
+
+export interface UseActiveBusinessResult {
+  loading: boolean;
+  businesses: MobileBusiness[];
+  active: MobileBusiness | null;
+  role: Role;
+  /** Switch to a different business by id; persists across launches. */
+  switchTo: (businessId: string) => Promise<void>;
+  /** Force a re-fetch (after creating a new business / accepting an invite). */
+  refresh: () => Promise<void>;
+}
+
+/** Single source of truth on the device for which business the user is in.
+ *  Components consume this to render the right tabs / fetch the right data. */
+export function useActiveBusiness(): UseActiveBusinessResult {
+  const [loading, setLoading] = useState(true);
+  const [businesses, setBusinesses] = useState<MobileBusiness[]>([]);
+  const [active, setActive] = useState<MobileBusiness | null>(null);
+  const [role, setRole] = useState<Role>("viewer");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { setLoading(false); return; }
+
+      const all = await fetchAccessibleBusinesses(user.id);
+      setBusinesses(all);
+      if (all.length === 0) { setActive(null); setRole("viewer"); return; }
+
+      // Try the persisted choice; fall back to first
+      const persisted = await AsyncStorage.getItem(ACTIVE_KEY);
+      const found = persisted ? all.find((b) => b.id === persisted) : null;
+      const chosen = found ?? all[0];
+      setActive(chosen);
+      setRole(await fetchRoleForBusiness(user.id, chosen));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const switchTo = useCallback(async (businessId: string) => {
+    const next = businesses.find((b) => b.id === businessId);
+    if (!next) return;
+    await AsyncStorage.setItem(ACTIVE_KEY, businessId);
+    setActive(next);
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) setRole(await fetchRoleForBusiness(user.id, next));
+  }, [businesses]);
+
+  return { loading, businesses, active, role, switchTo, refresh: load };
+}

--- a/mobile/src/lib/permissions.ts
+++ b/mobile/src/lib/permissions.ts
@@ -1,0 +1,40 @@
+/**
+ * MIRROR of src/lib/permissions.ts in the web app. Keep these in sync —
+ * the policy in CLAUDE.md / docs/MOBILE_PARITY_PLAN.md requires it.
+ */
+
+export type MemberRole = 'admin' | 'editor' | 'viewer' | 'worker';
+export type Role = 'owner' | MemberRole;
+
+export function canEdit(role: Role): boolean {
+  return role === 'owner' || role === 'admin' || role === 'editor';
+}
+
+export function canManageTeam(role: Role): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+export function canManageSettings(role: Role): boolean {
+  return role === 'owner' || role === 'admin';
+}
+
+export function isOwner(role: Role): boolean {
+  return role === 'owner';
+}
+
+export function isWorker(role: Role): boolean {
+  return role === 'worker';
+}
+
+/** Tabs/pages a worker should never see. */
+export function canSeeFinancials(role: Role): boolean {
+  return role !== 'worker';
+}
+
+export const ROLE_LABELS: Record<Role, string> = {
+  owner:  'Owner',
+  admin:  'Admin',
+  editor: 'Editor',
+  viewer: 'Viewer',
+  worker: 'Worker',
+};


### PR DESCRIPTION
First slice of the mobile parity plan. Owners now get a real dashboard on mobile (KPIs, overdue alert, leads strip). Workers see the same job list as before. Multi-business switcher works across both views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)