### PR TITLE
Mobile Phase 1.5: briefing + tasks + outlook widgets

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -74,9 +74,10 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Role-aware navigation | ✅ | 1 | Index tab branches: OwnerDashboard vs WorkerJobsList |
 | Mirrored permissions | ✅ | 1 | mobile/src/lib/permissions.ts |
 | **Dashboard** |
-| Owner dashboard (KPIs, overdue strip, leads strip) | ✅ | 1 | Phase 1 skeleton |
-| Owner dashboard (briefing widget) | ❌ | 1.5 | Coming |
-| Owner dashboard (tasks, outlook, full widgets) | ❌ | 1.5 | Coming |
+| Owner dashboard (KPIs, overdue strip, leads strip) | ✅ | 1 | |
+| Owner dashboard (briefing widget) | ✅ | 1.5 | Inline supabase queries; snooze deferred to phase 2 |
+| Owner dashboard (tasks widget) | ✅ | 1.5 | Top 6 open tasks, one-tap complete |
+| Owner dashboard (outlook widget) | ✅ | 1.5 | Team / recurring / agents counts |
 | Worker dashboard | ✅ | shipped | |
 | Briefing widget | ❌ | 1 | Mobile version of `/assistant` |
 | Header bell briefing | ❌ | 1 | Top-bar icon with unread count |

--- a/mobile/src/components/BriefingWidget.tsx
+++ b/mobile/src/components/BriefingWidget.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from "react";
+import { Pressable, Text, View, ActivityIndicator } from "react-native";
+import { Sparkles, ChevronRight } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+
+interface BriefingItem {
+  id:       string;
+  type:     "overdue_invoice" | "stale_quote" | "new_lead" | "today_job_unassigned" | "submitted_workorder";
+  priority: "high" | "med" | "low";
+  title:    string;
+  subtitle: string;
+}
+
+const TYPE_LABEL: Record<BriefingItem["type"], string> = {
+  overdue_invoice:       "Chase",
+  stale_quote:           "Follow up",
+  new_lead:              "Call",
+  today_job_unassigned:  "Assign",
+  submitted_workorder:   "Review",
+};
+
+const PRIORITY_BAR: Record<BriefingItem["priority"], string> = {
+  high: "#ef4444",
+  med:  "#f59e0b",
+  low:  "#60a5fa",
+};
+
+const num = (v: unknown) => {
+  const n = typeof v === "number" ? v : parseFloat(String(v ?? 0));
+  return Number.isFinite(n) ? n : 0;
+};
+const daysAgo = (iso: string) => Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000));
+
+/** Mobile briefing — runs the same logic as the web getMyBriefing server
+ *  action but inline against Supabase (RLS scopes to active business).
+ *  Snoozes/dismissals deferred to Phase 2. */
+export function BriefingWidget({ businessId, onItemPress }: { businessId: string; onItemPress?: () => void }) {
+  const [items, setItems]     = useState<BriefingItem[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const todayStr     = new Date().toISOString().split("T")[0];
+      const sevenDaysAgo = new Date(Date.now() - 7 * 86_400_000).toISOString();
+
+      const [{ data: invoices }, { data: quotes }, { data: leads }, { data: jobsToday }, { data: submitted }] = await Promise.all([
+        supabase.from("invoices").select("id, number, status, total, amount_paid, due_date, customers(name)")
+          .eq("business_id", businessId).in("status", ["sent", "partial", "overdue"]),
+        supabase.from("quotes").select("id, number, status, updated_at, customers(name)")
+          .eq("business_id", businessId).eq("status", "sent").lt("updated_at", sevenDaysAgo),
+        supabase.from("leads").select("id, name, status, created_at")
+          .eq("business_id", businessId).eq("status", "new"),
+        supabase.from("work_orders").select("id, number, title, status, customers(name), work_order_assignments(member_profile_id)")
+          .eq("business_id", businessId).eq("scheduled_date", todayStr),
+        supabase.from("work_orders").select("id, number, title, customers(name), updated_at")
+          .eq("business_id", businessId).eq("status", "submitted"),
+      ]);
+
+      const out: BriefingItem[] = [];
+      const now = new Date();
+
+      for (const inv of (invoices ?? []) as unknown as Array<{ id: string; number: string; total: unknown; amount_paid: unknown; due_date: string | null; customers: { name: string } | null }>) {
+        if (!inv.due_date || new Date(inv.due_date) >= now) continue;
+        const balance = Math.max(0, num(inv.total) - num(inv.amount_paid));
+        if (balance < 0.01) continue;
+        const days = daysAgo(inv.due_date);
+        out.push({
+          id: `oi:${inv.id}`, type: "overdue_invoice",
+          priority: days > 30 ? "high" : days > 14 ? "med" : "low",
+          title:    `${inv.number} · ${days}d overdue`,
+          subtitle: `${inv.customers?.name ?? "—"} · ${balance.toFixed(2)}`,
+        });
+      }
+
+      for (const q of (quotes ?? []) as unknown as Array<{ id: string; number: string; updated_at: string; customers: { name: string } | null }>) {
+        const days = daysAgo(q.updated_at);
+        out.push({
+          id: `sq:${q.id}`, type: "stale_quote",
+          priority: days > 14 ? "med" : "low",
+          title:    `${q.number} · sent ${days}d ago`,
+          subtitle: q.customers?.name ?? "No customer",
+        });
+      }
+
+      for (const l of (leads ?? []) as Array<{ id: string; name: string; created_at: string }>) {
+        const days = daysAgo(l.created_at);
+        out.push({
+          id: `nl:${l.id}`, type: "new_lead",
+          priority: days > 2 ? "high" : "med",
+          title:    l.name,
+          subtitle: days === 0 ? "New today" : `${days}d ago`,
+        });
+      }
+
+      for (const j of (jobsToday ?? []) as unknown as Array<{ id: string; number: string; title: string; status: string; customers: { name: string } | null; work_order_assignments: Array<{ member_profile_id: string }> }>) {
+        const unassigned = !j.work_order_assignments || j.work_order_assignments.length === 0;
+        if (unassigned) {
+          out.push({
+            id: `tu:${j.id}`, type: "today_job_unassigned",
+            priority: "high",
+            title:    `${j.number} today`,
+            subtitle: `${j.title}${j.customers?.name ? ` · ${j.customers.name}` : ""}`,
+          });
+        }
+      }
+
+      for (const w of (submitted ?? []) as unknown as Array<{ id: string; number: string; title: string; customers: { name: string } | null; updated_at: string }>) {
+        const days = daysAgo(w.updated_at);
+        out.push({
+          id: `sw:${w.id}`, type: "submitted_workorder",
+          priority: days > 1 ? "high" : "med",
+          title:    `${w.number} submitted`,
+          subtitle: `${w.title}${w.customers?.name ? ` · ${w.customers.name}` : ""}`,
+        });
+      }
+
+      const PRI = { high: 0, med: 1, low: 2 };
+      out.sort((a, b) => PRI[a.priority] - PRI[b.priority]);
+      if (!cancelled) setItems(out.slice(0, 5));
+    })().catch(() => { if (!cancelled) setItems([]); });
+    return () => { cancelled = true; };
+  }, [businessId]);
+
+  return (
+    <View style={{ backgroundColor: colors.card, borderRadius: radius.lg, borderWidth: 1, borderColor: colors.hairline, overflow: "hidden" }}>
+      <View style={{ flexDirection: "row", alignItems: "center", padding: space.md, borderBottomWidth: items && items.length > 0 ? 1 : 0, borderBottomColor: colors.hairline, gap: space.sm }}>
+        <Sparkles size={14} color={colors.primary} />
+        <Text style={{ flex: 1, fontSize: 14, fontWeight: "600", color: colors.text }}>Your briefing</Text>
+        {items && items.length > 0 && (
+          <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 999, backgroundColor: colors.primarySoft }}>
+            <Text style={{ fontSize: 11, fontWeight: "700", color: colors.primary }}>{items.length}</Text>
+          </View>
+        )}
+      </View>
+      {items === null ? (
+        <View style={{ padding: space.lg, alignItems: "center" }}>
+          <ActivityIndicator color={colors.muted} />
+        </View>
+      ) : items.length === 0 ? (
+        <View style={{ padding: space.lg, alignItems: "center", gap: 4 }}>
+          <Text style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>Inbox zero</Text>
+          <Text style={{ fontSize: 12, color: colors.muted }}>Nothing overdue. Take a break.</Text>
+        </View>
+      ) : (
+        items.map((item) => (
+          <Pressable
+            key={item.id}
+            onPress={onItemPress}
+            style={({ pressed }) => ({
+              flexDirection: "row", alignItems: "center", gap: space.sm,
+              paddingHorizontal: space.md, paddingVertical: space.sm,
+              backgroundColor: pressed ? colors.muted : "transparent",
+              borderLeftWidth: 3, borderLeftColor: PRIORITY_BAR[item.priority],
+            })}
+          >
+            <Text style={{ fontSize: 10, fontWeight: "700", color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, width: 64 }}>
+              {TYPE_LABEL[item.type]}
+            </Text>
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <Text numberOfLines={1} style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>{item.title}</Text>
+              <Text numberOfLines={1} style={{ fontSize: 11, color: colors.muted }}>{item.subtitle}</Text>
+            </View>
+            <ChevronRight size={14} color={colors.muted} />
+          </Pressable>
+        ))
+      )}
+    </View>
+  );
+}

--- a/mobile/src/components/OutlookWidget.tsx
+++ b/mobile/src/components/OutlookWidget.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+import { Users2, Repeat, Bot } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+
+const AGENT_LABEL: Record<string, string> = {
+  "daily-digest":      "Daily digest",
+  "invoice-reminders": "Invoice reminders",
+  "quote-followup":    "Quote follow-up",
+  "workorder-complete":"Job complete",
+  "recurring-jobs":    "Recurring",
+  reminders:           "Reminders",
+};
+
+interface Counts {
+  membersActive:  number;
+  membersPending: number;
+  recurringActive: number;
+  agents: string[];
+}
+
+/** Compact ops snapshot — team / recurring / agents — mirrors web OutlookWidget. */
+export function OutlookWidget({ businessId }: { businessId: string }) {
+  const [c, setC] = useState<Counts | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [{ data: members }, { data: recurring }, { data: agents }] = await Promise.all([
+        supabase.from("business_members").select("status").eq("business_id", businessId),
+        supabase.from("recurring_jobs").select("active").eq("business_id", businessId),
+        supabase.from("business_agent_installs").select("agent_id, enabled").eq("business_id", businessId).eq("enabled", true),
+      ]);
+      if (cancelled) return;
+      setC({
+        membersActive:  (members ?? []).filter((m: { status: string }) => m.status === "active").length,
+        membersPending: (members ?? []).filter((m: { status: string }) => m.status === "pending").length,
+        recurringActive:(recurring ?? []).filter((r: { active: boolean }) => r.active).length,
+        agents:         (agents ?? []).map((a: { agent_id: string }) => AGENT_LABEL[a.agent_id] ?? a.agent_id),
+      });
+    })().catch(() => { if (!cancelled) setC({ membersActive: 0, membersPending: 0, recurringActive: 0, agents: [] }); });
+    return () => { cancelled = true; };
+  }, [businessId]);
+
+  return (
+    <View style={{ backgroundColor: colors.card, borderRadius: radius.lg, borderWidth: 1, borderColor: colors.hairline, overflow: "hidden" }}>
+      <View style={{ paddingHorizontal: space.md, paddingTop: space.md, paddingBottom: 8 }}>
+        <Text style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>Operations</Text>
+        <Text style={{ fontSize: 11, color: colors.muted, marginTop: 2 }}>Team, recurring jobs, automations</Text>
+      </View>
+      <Row
+        icon={<Users2 size={16} color="#1d4ed8" />}
+        label="Team"
+        value={c === null ? "Loading…" :
+          c.membersActive === 0 ? "No team members yet" :
+          `${c.membersActive} active${c.membersPending ? ` · ${c.membersPending} pending` : ""}`}
+      />
+      <Row
+        icon={<Repeat size={16} color="#7c3aed" />}
+        label="Recurring jobs"
+        value={c === null ? "Loading…" : c.recurringActive === 0 ? "None set up" : `${c.recurringActive} active`}
+      />
+      <Row
+        icon={<Bot size={16} color="#059669" />}
+        label="Agents running"
+        value={c === null ? "Loading…" :
+          c.agents.length === 0 ? "No automations on" :
+          c.agents.slice(0, 3).join(" · ") + (c.agents.length > 3 ? ` +${c.agents.length - 3}` : "")}
+        last
+      />
+    </View>
+  );
+}
+
+function Row({ icon, label, value, last }: { icon: React.ReactNode; label: string; value: string; last?: boolean }) {
+  return (
+    <View style={{
+      flexDirection: "row", alignItems: "center", gap: space.sm,
+      paddingHorizontal: space.md, paddingVertical: space.sm + 2,
+      borderTopWidth: 1, borderTopColor: colors.hairline,
+      ...(last ? {} : {}),
+    }}>
+      <View style={{ width: 32, height: 32, borderRadius: radius.md, backgroundColor: colors.muted + "22", alignItems: "center", justifyContent: "center" }}>
+        {icon}
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>{label}</Text>
+        <Text numberOfLines={1} style={{ fontSize: 11, color: colors.muted }}>{value}</Text>
+      </View>
+    </View>
+  );
+}

--- a/mobile/src/components/OwnerDashboard.tsx
+++ b/mobile/src/components/OwnerDashboard.tsx
@@ -5,6 +5,9 @@ import { AlertTriangle, Clock, DollarSign, FileCheck, Wrench, UserPlus } from "l
 import { supabase } from "@/lib/supabase";
 import { colors, radius, space } from "@/lib/theme";
 import type { MobileBusiness } from "@/lib/active-business";
+import { BriefingWidget } from "./BriefingWidget";
+import { TasksWidget } from "./TasksWidget";
+import { OutlookWidget } from "./OutlookWidget";
 
 interface Stats {
   outstanding: number;
@@ -154,10 +157,14 @@ export function OwnerDashboard({ business }: { business: MobileBusiness }) {
         </Pressable>
       )}
 
-      {/* Hint */}
-      <Text style={{ fontSize: 11, color: colors.muted, textAlign: "center", marginTop: space.md }}>
-        Phase 1 mobile dashboard · more coming
-      </Text>
+      {/* Briefing */}
+      <BriefingWidget businessId={business.id} />
+
+      {/* Tasks */}
+      <TasksWidget businessId={business.id} />
+
+      {/* Operations */}
+      <OutlookWidget businessId={business.id} />
     </ScrollView>
   );
 }

--- a/mobile/src/components/TasksWidget.tsx
+++ b/mobile/src/components/TasksWidget.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { Pressable, Text, View, ActivityIndicator } from "react-native";
+import { Columns3, Check, Clock } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+
+interface MobileTask {
+  id:        string;
+  title:     string;
+  status:    "todo" | "in_progress" | "in_review" | "done";
+  priority:  "low" | "normal" | "high" | "urgent";
+  due_date:  string | null;
+  tags:      string[] | null;
+}
+
+const PRIORITY_DOT: Record<MobileTask["priority"], string> = {
+  urgent: "#ef4444",
+  high:   "#f59e0b",
+  normal: "#60a5fa",
+  low:    "#9ca3af",
+};
+
+/** Mobile tasks widget — shows up to 6 open tasks (todo + in_progress) with
+ *  one-tap complete. Mirrors the web TasksWidget. */
+export function TasksWidget({ businessId }: { businessId: string }) {
+  const [tasks, setTasks] = useState<MobileTask[] | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = async () => {
+    const { data } = await supabase
+      .from("tasks")
+      .select("id, title, status, priority, due_date, tags")
+      .eq("business_id", businessId)
+      .neq("status", "done")
+      .order("position", { ascending: true })
+      .limit(6);
+    setTasks((data ?? []) as MobileTask[]);
+  };
+
+  useEffect(() => { refresh().catch(() => setTasks([])); }, [businessId]);
+
+  const complete = async (id: string) => {
+    setBusyId(id);
+    await supabase.from("tasks").update({ status: "done", completed_at: new Date().toISOString() }).eq("id", id);
+    await refresh();
+    setBusyId(null);
+  };
+
+  const todayStr = new Date().toISOString().split("T")[0];
+
+  return (
+    <View style={{ backgroundColor: colors.card, borderRadius: radius.lg, borderWidth: 1, borderColor: colors.hairline, overflow: "hidden" }}>
+      <View style={{ flexDirection: "row", alignItems: "center", padding: space.md, borderBottomWidth: tasks && tasks.length > 0 ? 1 : 0, borderBottomColor: colors.hairline, gap: space.sm }}>
+        <Columns3 size={14} color={colors.muted} />
+        <Text style={{ flex: 1, fontSize: 14, fontWeight: "600", color: colors.text }}>Your todos</Text>
+        {tasks && tasks.length > 0 && (
+          <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 999, backgroundColor: colors.muted + "33" }}>
+            <Text style={{ fontSize: 11, fontWeight: "700", color: colors.text }}>{tasks.length}</Text>
+          </View>
+        )}
+      </View>
+      {tasks === null ? (
+        <View style={{ padding: space.lg, alignItems: "center" }}>
+          <ActivityIndicator color={colors.muted} />
+        </View>
+      ) : tasks.length === 0 ? (
+        <View style={{ padding: space.lg, alignItems: "center", gap: 4 }}>
+          <Text style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>Nothing on your list</Text>
+          <Text style={{ fontSize: 12, color: colors.muted, textAlign: "center" }}>Open the Tasks tab to add one.</Text>
+        </View>
+      ) : (
+        tasks.map((t) => {
+          const overdue = t.due_date && t.due_date < todayStr;
+          return (
+            <View key={t.id} style={{ flexDirection: "row", alignItems: "flex-start", gap: space.sm, paddingHorizontal: space.md, paddingVertical: space.sm }}>
+              <Pressable
+                onPress={() => complete(t.id)}
+                disabled={busyId === t.id}
+                style={{
+                  width: 18, height: 18, borderRadius: 9,
+                  borderWidth: 2, borderColor: colors.hairline,
+                  alignItems: "center", justifyContent: "center", marginTop: 2,
+                }}
+                hitSlop={8}
+              >
+                {busyId === t.id && <ActivityIndicator size="small" color="#10b981" />}
+              </Pressable>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                  <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: PRIORITY_DOT[t.priority] }} />
+                  <Text numberOfLines={1} style={{ flex: 1, fontSize: 13, fontWeight: "600", color: colors.text }}>{t.title}</Text>
+                </View>
+                {(t.due_date || (t.tags && t.tags.length > 0)) && (
+                  <View style={{ flexDirection: "row", alignItems: "center", gap: 8, marginTop: 2 }}>
+                    {t.due_date && (
+                      <View style={{ flexDirection: "row", alignItems: "center", gap: 3 }}>
+                        <Clock size={10} color={overdue ? "#dc2626" : colors.muted} />
+                        <Text style={{ fontSize: 10, color: overdue ? "#dc2626" : colors.muted }}>
+                          {overdue ? `${t.due_date} (overdue)` : t.due_date}
+                        </Text>
+                      </View>
+                    )}
+                    {t.tags?.slice(0, 2).map((tag) => (
+                      <View key={tag} style={{ paddingHorizontal: 6, paddingVertical: 1, borderRadius: 4, backgroundColor: colors.muted + "22" }}>
+                        <Text style={{ fontSize: 10, color: colors.muted }}>{tag}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+            </View>
+          );
+        })
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
Mobile owner dashboard now has the three core widgets matching the web: briefing of priority items, your todos with one-tap complete, and the operations outlook (team/recurring/agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)