### PR TITLE
feat(mobile): phase 2d — conversions (lead→customer, quote→invoice)

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -86,13 +86,15 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | **Sales** |
 | Leads list (search + status filters + tap-to-call/email) | ✅ | 2a | |
 | Lead detail (status changer + quick contact) | ✅ | 2a | |
-| Add lead (with custom source) | ❌ | 2b | Coming |
-| Convert lead → customer/quote/work-order | ❌ | 2b | Coming |
+| Add lead (with custom source) | ✅ | 2c | |
+| Convert lead → customer | ✅ | 2d | UserCheck button on lead detail; mints customer + marks lead won |
+| Convert lead → quote/work-order | ❌ | 3 | Defer with quote/WO creators |
+| Convert quote → invoice | ✅ | 2d | FileCheck button on quote detail; mints invoice number, copies line items |
 | Quotes list + detail | ❌ | 2 | |
 | New quote (with line items) | ❌ | 2 | Reuse line-items editor pattern |
 | Send quote email/SMS | ❌ | 2 | |
 | Duplicate quote | ❌ | 2 | |
-| Convert quote → invoice | ❌ | 2 | |
+| Convert quote → invoice (matrix anchor) | ✅ | 2d | See above |
 | Invoices list + detail | ❌ | 2 | |
 | New invoice | ❌ | 2 | |
 | Send invoice email/SMS | ❌ | 2 | |

--- a/mobile/app/leads/[id].tsx
+++ b/mobile/app/leads/[id].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { ActivityIndicator, Linking, Pressable, ScrollView, Text, View, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { ArrowLeft, Phone, Mail, MapPin, Clock, MessageSquare } from "lucide-react-native";
+import { ArrowLeft, Phone, Mail, MapPin, Clock, MessageSquare, UserCheck } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { colors, radius, space } from "@/lib/theme";
@@ -70,6 +70,38 @@ export default function LeadDetail() {
     await supabase.from("leads").update({ status }).eq("id", lead.id);
     setLead({ ...lead, status });
     setBusy(false);
+  };
+
+  /** Convert this lead into a customer, then open the customer detail page.
+   *  Marks the lead as 'won'. Mirrors the web convertLeadToCustomer action
+   *  (lib/actions/leads.ts) inline against supabase + RLS. */
+  const convertToCustomer = async () => {
+    if (!lead || !active) return;
+    setBusy(true);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      const { data: created, error } = await supabase
+        .from("customers")
+        .insert({
+          business_id: active.id, user_id: user?.id,
+          name: lead.name,
+          phone: lead.phone,
+          email: lead.email,
+          city: lead.suburb,
+          country: "Australia",
+          notes: lead.notes,
+          archived: false,
+        })
+        .select("id").single();
+      if (error) throw error;
+      await supabase.from("leads").update({ status: "won", converted_at: new Date().toISOString() }).eq("id", lead.id);
+      Alert.alert("Customer created", `${lead.name} added to your customer list.`);
+      router.replace(`/customers/${(created as { id: string }).id}` as never);
+    } catch (e) {
+      Alert.alert("Couldn't convert", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
   };
 
   if (!lead) {
@@ -161,9 +193,22 @@ export default function LeadDetail() {
           </View>
         )}
 
-        <Text style={{ fontSize: 11, color: colors.muted, textAlign: "center", marginTop: space.md }}>
-          Convert to customer / quote / job — coming in next mobile phase
-        </Text>
+        <Pressable
+          onPress={convertToCustomer}
+          disabled={busy || lead.status === "won"}
+          style={({ pressed }) => ({
+            flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: lead.status === "won" ? colors.muted : pressed ? "#0d6e6a" : colors.primary,
+            opacity: busy ? 0.6 : 1,
+            marginTop: space.sm,
+          })}
+        >
+          <UserCheck size={18} color="#fff" />
+          <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>
+            {lead.status === "won" ? "Already converted" : "Convert to customer"}
+          </Text>
+        </Pressable>
       </ScrollView>
     </SafeAreaView>
   );

--- a/mobile/app/quotes/[id].tsx
+++ b/mobile/app/quotes/[id].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View, Linking, Share } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { ArrowLeft, Send, Copy, MessageSquare, Mail, RotateCcw, ExternalLink } from "lucide-react-native";
+import { ArrowLeft, Send, Copy, MessageSquare, Mail, RotateCcw, FileCheck } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { colors, radius, space } from "@/lib/theme";
@@ -25,6 +25,7 @@ interface QuoteFull {
   total: unknown;
   notes: string | null;
   terms: string | null;
+  invoice_id: string | null;
   customers: { id: string; name: string; email: string | null; phone: string | null } | null;
 }
 
@@ -107,6 +108,53 @@ export default function QuoteDetail() {
       router.replace(`/quotes/${(created as { id: string }).id}` as never);
     } catch (e) {
       Alert.alert("Couldn't duplicate", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /** Convert this accepted quote into a fresh invoice. Mints a new invoice
+   *  number, copies line items + totals + customer, links the two, and routes
+   *  to the new invoice. Mirrors web convertQuoteToInvoice. */
+  const convertToInvoice = async () => {
+    if (!quote || !active) return;
+    setBusy(true);
+    try {
+      const { data: biz } = await supabase
+        .from("businesses").select("invoice_prefix, invoice_next_number")
+        .eq("id", active.id).single();
+      const prefix = (biz as { invoice_prefix?: string; invoice_next_number?: number })?.invoice_prefix ?? "INV";
+      const nextNum = (biz as { invoice_prefix?: string; invoice_next_number?: number })?.invoice_next_number ?? 1;
+      const number = `${prefix}-${String(nextNum).padStart(4, "0")}`;
+      await supabase.from("businesses").update({ invoice_next_number: nextNum + 1 }).eq("id", active.id);
+
+      const { data: { user } } = await supabase.auth.getUser();
+      const today = new Date().toISOString().split("T")[0];
+      const due = new Date(Date.now() + 14 * 86_400_000).toISOString().split("T")[0];
+
+      const { data: created, error } = await supabase
+        .from("invoices")
+        .insert({
+          user_id: user?.id, business_id: active.id, number,
+          status: "draft",
+          customer_id: quote.customer_id,
+          issue_date: today, due_date: due,
+          line_items: quote.line_items,
+          subtotal: quote.subtotal, tax_total: quote.tax_total, total: quote.total,
+          amount_paid: 0, notes: quote.notes, terms: quote.terms,
+        })
+        .select("id").single();
+      if (error) throw error;
+
+      // Link the quote → invoice + mark accepted (idempotent if already)
+      await supabase.from("quotes")
+        .update({ invoice_id: (created as { id: string }).id, status: "accepted" })
+        .eq("id", quote.id);
+
+      Alert.alert("Invoice created", `Created ${number} from quote ${quote.number}`);
+      router.replace(`/invoices/${(created as { id: string }).id}` as never);
+    } catch (e) {
+      Alert.alert("Couldn't convert", e instanceof Error ? e.message : "Unknown error");
     } finally {
       setBusy(false);
     }
@@ -199,6 +247,23 @@ export default function QuoteDetail() {
           <SmallBtn icon={<RotateCcw size={14} color={colors.text} />} label="Reset to draft" onPress={() => setStatus("draft")} disabled={busy || quote.status === "draft"} />
           <SmallBtn icon={<Copy size={14} color={colors.text} />} label="Duplicate" onPress={duplicate} disabled={busy} />
         </View>
+
+        {/* Convert to invoice */}
+        <Pressable
+          onPress={convertToInvoice}
+          disabled={busy || !!quote.invoice_id}
+          style={({ pressed }) => ({
+            flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: quote.invoice_id ? colors.muted : pressed ? "#0d6e6a" : colors.primary,
+            opacity: busy ? 0.6 : 1,
+          })}
+        >
+          <FileCheck size={18} color="#fff" />
+          <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>
+            {quote.invoice_id ? "Already converted" : "Convert to invoice"}
+          </Text>
+        </Pressable>
 
         {/* Status changer */}
         <View style={{ padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: space.sm }}>


### PR DESCRIPTION
## Summary
- **Lead detail** gets a primary "Convert to customer" CTA — mints a customer record with the lead's contact + suburb, marks the lead as won with converted_at, routes to new customer.
- **Quote detail** gets a "Convert to invoice" CTA — mints a fresh invoice number from the business prefix counter, copies line items + totals + customer + notes + terms, links quote→invoice, marks quote accepted, routes to new invoice.
- Disabled when already converted (lead.status === "won" / quote.invoice_id set).
- Parity matrix updated.

## Test plan
- [ ] Open a lead, tap Convert to customer → customer page loads, lead is won
- [ ] Open an accepted quote, tap Convert to invoice → invoice page loads with same line items + totals
- [ ] Re-tap shows "Already converted" disabled state
- [ ] Web parity rows in MOBILE_PARITY_PLAN.md flipped to ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)