### PR TITLE
feat(mobile): new quote + invoice creators + forgot-password

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -67,7 +67,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | **Auth** |
 | Login | ✅ | shipped | |
 | Signup with invite code | ✅ | shipped | |
-| Forgot password | ❌ | 1 | Existing web flow — wire deep-link |
+| Forgot password | ✅ | 2f | Sends Supabase recovery email; reset link opens on web |
 | **Foundation** |
 | Multi-business switcher | ✅ | 1 | AsyncStorage-backed, sits above the index tab |
 | Active business sync | ✅ | 1 | useActiveBusiness hook |
@@ -91,12 +91,12 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Convert lead → quote/work-order | ❌ | 3 | Defer with quote/WO creators |
 | Convert quote → invoice | ✅ | 2d | FileCheck button on quote detail; mints invoice number, copies line items |
 | Quotes list + detail | ❌ | 2 | |
-| New quote (with line items) | ❌ | 2 | Reuse line-items editor pattern |
+| New quote (with line items) | ✅ | 2f | LineItemsEditor + CustomerPicker; mints number from prefix counter |
 | Send quote email/SMS | ❌ | 2 | |
 | Duplicate quote | ❌ | 2 | |
 | Convert quote → invoice (matrix anchor) | ✅ | 2d | See above |
 | Invoices list + detail | ❌ | 2 | |
-| New invoice | ❌ | 2 | |
+| New invoice | ✅ | 2f | LineItemsEditor + CustomerPicker; due defaults to issue + 14d |
 | Send invoice email/SMS | ❌ | 2 | |
 | Record payment | ❌ | 2 | |
 | Deposit / progress invoice | ❌ | 3 | More complex, defer |

--- a/mobile/app/(auth)/forgot.tsx
+++ b/mobile/app/(auth)/forgot.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import {
+  Alert, KeyboardAvoidingView, Platform, Pressable,
+  ScrollView, Text, TextInput, View, ActivityIndicator,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Link, useRouter } from "expo-router";
+import { ArrowLeft } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+
+/** Forgot-password — sends a Supabase recovery email. The reset link
+ *  itself opens in the web (kireihq.com) — once the user picks a new
+ *  password they sign in here normally. */
+export default function ForgotPassword() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const submit = async () => {
+    const e = email.trim().toLowerCase();
+    if (!e) { Alert.alert("Enter your email", "We need it to send the reset link."); return; }
+    setBusy(true);
+    const base = process.env.EXPO_PUBLIC_APP_URL ?? "https://kireihq.com";
+    const { error } = await supabase.auth.resetPasswordForEmail(e, {
+      redirectTo: `${base}/reset-password`,
+    });
+    setBusy(false);
+    if (error) { Alert.alert("Couldn't send", error.message); return; }
+    setSent(true);
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} style={{ flex: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1, justifyContent: "center", padding: space.xl }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Pressable onPress={() => router.back()} hitSlop={10} style={{ alignSelf: "flex-start", marginBottom: space.lg }}>
+            <ArrowLeft size={22} color={colors.text} />
+          </Pressable>
+
+          <View style={{ marginBottom: space.xxl }}>
+            <Text style={{ fontSize: 30, fontWeight: "700", color: colors.text, letterSpacing: -0.5 }}>
+              Forgot password?
+            </Text>
+            <Text style={{ fontSize: 14, color: colors.muted, marginTop: 6 }}>
+              We'll email you a link to set a new one.
+            </Text>
+          </View>
+
+          {sent ? (
+            <View style={{ backgroundColor: colors.card, borderRadius: radius.xl, padding: space.lg, borderWidth: 1, borderColor: colors.hairline, gap: space.sm }}>
+              <Text style={{ fontSize: 16, fontWeight: "700", color: colors.text }}>Check your inbox</Text>
+              <Text style={{ fontSize: 13, color: colors.muted, lineHeight: 19 }}>
+                If an account exists for {email}, a password-reset link is on its way. Open it on any device, set a new password, then come back and sign in.
+              </Text>
+              <Link href="/(auth)/login" asChild>
+                <Pressable
+                  style={({ pressed }) => ({
+                    backgroundColor: colors.primary, borderRadius: radius.pill,
+                    paddingVertical: 12, alignItems: "center", marginTop: space.sm,
+                    opacity: pressed ? 0.85 : 1,
+                  })}>
+                  <Text style={{ color: "#fff", fontWeight: "700", fontSize: 14 }}>Back to sign in</Text>
+                </Pressable>
+              </Link>
+            </View>
+          ) : (
+            <View style={{ backgroundColor: colors.card, borderRadius: radius.xl, padding: space.lg, borderWidth: 1, borderColor: colors.hairline, gap: space.md }}>
+              <View style={{ gap: 6 }}>
+                <Text style={{ fontSize: 11, color: colors.muted, fontWeight: "600", textTransform: "uppercase", letterSpacing: 0.5 }}>Email</Text>
+                <TextInput
+                  value={email}
+                  onChangeText={setEmail}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="email-address"
+                  placeholder="you@example.com"
+                  placeholderTextColor={colors.muted}
+                  onSubmitEditing={submit}
+                  style={{
+                    backgroundColor: "#fafaf3", borderRadius: radius.lg,
+                    paddingHorizontal: 14, paddingVertical: 12,
+                    fontSize: 15, color: colors.text,
+                    borderWidth: 1, borderColor: colors.hairline,
+                  }}
+                />
+              </View>
+
+              <Pressable
+                onPress={submit}
+                disabled={busy}
+                style={({ pressed }) => ({
+                  backgroundColor: colors.primary, borderRadius: radius.pill,
+                  paddingVertical: 14, alignItems: "center", marginTop: space.sm,
+                  opacity: pressed || busy ? 0.85 : 1,
+                })}
+              >
+                {busy
+                  ? <ActivityIndicator color="#fff" />
+                  : <Text style={{ color: "#fff", fontWeight: "700", fontSize: 15 }}>Send reset link</Text>}
+              </Pressable>
+            </View>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -108,7 +108,14 @@ export default function Login() {
             </Pressable>
           </View>
 
-          <View style={{ marginTop: space.xl, alignItems: "center", gap: 6 }}>
+          <View style={{ marginTop: space.xl, alignItems: "center", gap: 8 }}>
+            <Link href="/(auth)/forgot" asChild>
+              <Pressable hitSlop={10}>
+                <Text style={{ color: colors.muted, fontWeight: "600", fontSize: 13 }}>
+                  Forgot password?
+                </Text>
+              </Pressable>
+            </Link>
             <Link href="/(auth)/signup" asChild>
               <Pressable hitSlop={10}>
                 <Text style={{ color: colors.primary, fontWeight: "600", fontSize: 13 }}>

--- a/mobile/app/invoices/index.tsx
+++ b/mobile/app/invoices/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack, useRouter } from "expo-router";
-import { ArrowLeft } from "lucide-react-native";
+import { ArrowLeft, Plus } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { colors, radius, space } from "@/lib/theme";
@@ -80,6 +80,10 @@ export default function InvoicesList() {
         <Text style={{ fontSize: 20, fontWeight: "700", color: colors.text }}>Invoices</Text>
         <View style={{ flex: 1 }} />
         <Text style={{ fontSize: 12, color: colors.muted }}>{invoices?.length ?? 0}</Text>
+        <Pressable onPress={() => router.push("/invoices/new" as never)} hitSlop={8}
+          style={({ pressed }) => ({ padding: 6, borderRadius: 999, backgroundColor: pressed ? colors.muted : colors.primary })}>
+          <Plus size={18} color="#fff" />
+        </Pressable>
       </View>
       <View style={{ flexDirection: "row", gap: 6, paddingHorizontal: space.lg, paddingBottom: space.sm, flexWrap: "wrap" }}>
         {TABS.map((t) => (

--- a/mobile/app/invoices/new.tsx
+++ b/mobile/app/invoices/new.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { ArrowLeft, Save } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { useActiveBusiness } from "@/lib/active-business";
+import { CustomerPicker } from "@/components/CustomerPicker";
+import { LineItemsEditor, LineItem, newLineItem, totalsFor } from "@/components/LineItemsEditor";
+import { colors, radius, space } from "@/lib/theme";
+
+/** Compose a new invoice — customer + line items + notes/terms.
+ *  Mints a fresh number from the business prefix counter. Defaults
+ *  due-date to issue + 14 days (matches web). */
+export default function NewInvoice() {
+  const router = useRouter();
+  const { active } = useActiveBusiness();
+
+  const [customer, setCustomer] = useState<{ id: string; name: string } | null>(null);
+  const [items,    setItems]    = useState<LineItem[]>([newLineItem()]);
+  const [notes,    setNotes]    = useState("");
+  const [terms,    setTerms]    = useState("");
+  const [busy,     setBusy]     = useState(false);
+
+  const currency = active?.currency ?? "AUD";
+  const totals   = totalsFor(items);
+
+  const save = async () => {
+    if (!active) return;
+    if (!customer) { Alert.alert("Pick a customer", "Invoices need a customer attached."); return; }
+    const validItems = items.filter((li) => li.name.trim().length > 0);
+    if (validItems.length === 0) { Alert.alert("Add a line item", "Invoices need at least one line item with a name."); return; }
+
+    setBusy(true);
+    try {
+      const { data: biz } = await supabase
+        .from("businesses").select("invoice_prefix, invoice_next_number")
+        .eq("id", active.id).single();
+      const prefix = (biz as { invoice_prefix?: string; invoice_next_number?: number })?.invoice_prefix ?? "INV";
+      const nextNum = (biz as { invoice_prefix?: string; invoice_next_number?: number })?.invoice_next_number ?? 1;
+      const number = `${prefix}-${String(nextNum).padStart(4, "0")}`;
+      await supabase.from("businesses").update({ invoice_next_number: nextNum + 1 }).eq("id", active.id);
+
+      const { data: { user } } = await supabase.auth.getUser();
+      const today = new Date().toISOString().split("T")[0];
+      const due = new Date(Date.now() + 14 * 86_400_000).toISOString().split("T")[0];
+
+      const { data: created, error } = await supabase
+        .from("invoices")
+        .insert({
+          user_id: user?.id, business_id: active.id, number,
+          status: "draft",
+          customer_id: customer.id,
+          issue_date: today, due_date: due,
+          line_items: validItems,
+          subtotal: totals.subtotal, tax_total: totals.tax, total: totals.total,
+          amount_paid: 0,
+          notes: notes.trim() || null, terms: terms.trim() || null,
+        })
+        .select("id").single();
+      if (error) throw error;
+      router.replace(`/invoices/${(created as { id: string }).id}` as never);
+    } catch (e) {
+      Alert.alert("Couldn't create invoice", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}><ArrowLeft size={22} color={colors.text} /></Pressable>
+        <Text style={{ fontSize: 20, fontWeight: "700", color: colors.text }}>New invoice</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+        <View style={{ gap: 6 }}>
+          <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>Customer *</Text>
+          {active && <CustomerPicker businessId={active.id} value={customer} onChange={setCustomer} />}
+        </View>
+
+        <LineItemsEditor items={items} onChange={setItems} currency={currency} />
+
+        <View style={{ padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: 4 }}>
+          <Row label="Subtotal" value={fmt(totals.subtotal, currency)} />
+          {totals.tax > 0 && <Row label="Tax" value={fmt(totals.tax, currency)} />}
+          <View style={{ borderTopWidth: 1, borderTopColor: colors.hairline, paddingTop: 6, marginTop: 4 }}>
+            <Row label="Total" value={fmt(totals.total, currency)} bold />
+          </View>
+        </View>
+
+        <Field label="Notes" value={notes} onChangeText={setNotes} multiline />
+        <Field label="Terms" value={terms} onChangeText={setTerms} multiline />
+
+        <Pressable
+          onPress={save}
+          disabled={busy}
+          style={({ pressed }) => ({
+            flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: pressed ? "#0d6e6a" : colors.primary,
+            opacity: busy ? 0.6 : 1,
+            marginTop: space.sm,
+          })}
+        >
+          <Save size={18} color="#fff" />
+          <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>{busy ? "Saving…" : "Create invoice"}</Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Field({ label, value, onChangeText, multiline }: { label: string; value: string; onChangeText: (v: string) => void; multiline?: boolean }) {
+  return (
+    <View style={{ gap: 6 }}>
+      <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        multiline={multiline}
+        style={{
+          padding: space.sm + 2, borderRadius: radius.md,
+          backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline,
+          color: colors.text, fontSize: 14,
+          minHeight: multiline ? 70 : undefined,
+          textAlignVertical: multiline ? "top" : "auto",
+        }}
+      />
+    </View>
+  );
+}
+
+function Row({ label, value, bold }: { label: string; value: string; bold?: boolean }) {
+  return (
+    <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+      <Text style={{ fontSize: bold ? 14 : 13, color: bold ? colors.text : colors.muted, fontWeight: bold ? "700" : "400" }}>{label}</Text>
+      <Text style={{ fontSize: bold ? 16 : 13, color: colors.text, fontWeight: bold ? "700" : "500" }}>{value}</Text>
+    </View>
+  );
+}
+
+function fmt(n: number, currency: string): string {
+  try { return new Intl.NumberFormat("en-AU", { style: "currency", currency }).format(n); }
+  catch { return `${currency} ${n.toFixed(2)}`; }
+}

--- a/mobile/app/quotes/index.tsx
+++ b/mobile/app/quotes/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack, useRouter } from "expo-router";
-import { ArrowLeft } from "lucide-react-native";
+import { ArrowLeft, Plus } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { colors, radius, space } from "@/lib/theme";
@@ -73,6 +73,10 @@ export default function QuotesList() {
         <Text style={{ fontSize: 20, fontWeight: "700", color: colors.text }}>Quotes</Text>
         <View style={{ flex: 1 }} />
         <Text style={{ fontSize: 12, color: colors.muted }}>{quotes?.length ?? 0}</Text>
+        <Pressable onPress={() => router.push("/quotes/new" as never)} hitSlop={8}
+          style={({ pressed }) => ({ padding: 6, borderRadius: 999, backgroundColor: pressed ? colors.muted : colors.primary })}>
+          <Plus size={18} color="#fff" />
+        </Pressable>
       </View>
       <View style={{ flexDirection: "row", gap: 6, paddingHorizontal: space.lg, paddingBottom: space.sm, flexWrap: "wrap" }}>
         {TABS.map((t) => (

--- a/mobile/app/quotes/new.tsx
+++ b/mobile/app/quotes/new.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { ArrowLeft, Save } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { useActiveBusiness } from "@/lib/active-business";
+import { CustomerPicker } from "@/components/CustomerPicker";
+import { LineItemsEditor, LineItem, newLineItem, totalsFor } from "@/components/LineItemsEditor";
+import { colors, radius, space } from "@/lib/theme";
+
+/** Compose a new quote — customer + line items + notes/terms.
+ *  Mints a fresh number from the business prefix counter. */
+export default function NewQuote() {
+  const router = useRouter();
+  const { active } = useActiveBusiness();
+
+  const [customer, setCustomer] = useState<{ id: string; name: string } | null>(null);
+  const [items,    setItems]    = useState<LineItem[]>([newLineItem()]);
+  const [notes,    setNotes]    = useState("");
+  const [terms,    setTerms]    = useState("");
+  const [busy,     setBusy]     = useState(false);
+
+  const currency = active?.currency ?? "AUD";
+  const totals   = totalsFor(items);
+
+  const save = async () => {
+    if (!active) return;
+    if (!customer) { Alert.alert("Pick a customer", "Quotes need a customer attached."); return; }
+    const validItems = items.filter((li) => li.name.trim().length > 0);
+    if (validItems.length === 0) { Alert.alert("Add a line item", "Quotes need at least one line item with a name."); return; }
+
+    setBusy(true);
+    try {
+      const { data: biz } = await supabase
+        .from("businesses").select("quote_prefix, quote_next_number")
+        .eq("id", active.id).single();
+      const prefix = (biz as { quote_prefix?: string; quote_next_number?: number })?.quote_prefix ?? "QT";
+      const nextNum = (biz as { quote_prefix?: string; quote_next_number?: number })?.quote_next_number ?? 1;
+      const number = `${prefix}-${String(nextNum).padStart(4, "0")}`;
+      await supabase.from("businesses").update({ quote_next_number: nextNum + 1 }).eq("id", active.id);
+
+      const { data: { user } } = await supabase.auth.getUser();
+      const today = new Date().toISOString().split("T")[0];
+      const expiry = new Date(Date.now() + 30 * 86_400_000).toISOString().split("T")[0];
+
+      const { data: created, error } = await supabase
+        .from("quotes")
+        .insert({
+          user_id: user?.id, business_id: active.id, number,
+          status: "draft",
+          customer_id: customer.id,
+          issue_date: today, expiry_date: expiry,
+          line_items: validItems,
+          subtotal: totals.subtotal, tax_total: totals.tax, total: totals.total,
+          notes: notes.trim() || null, terms: terms.trim() || null,
+        })
+        .select("id").single();
+      if (error) throw error;
+      router.replace(`/quotes/${(created as { id: string }).id}` as never);
+    } catch (e) {
+      Alert.alert("Couldn't create quote", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}><ArrowLeft size={22} color={colors.text} /></Pressable>
+        <Text style={{ fontSize: 20, fontWeight: "700", color: colors.text }}>New quote</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+        <View style={{ gap: 6 }}>
+          <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>Customer *</Text>
+          {active && <CustomerPicker businessId={active.id} value={customer} onChange={setCustomer} />}
+        </View>
+
+        <LineItemsEditor items={items} onChange={setItems} currency={currency} />
+
+        <View style={{ padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: 4 }}>
+          <Row label="Subtotal" value={fmt(totals.subtotal, currency)} />
+          {totals.tax > 0 && <Row label="Tax" value={fmt(totals.tax, currency)} />}
+          <View style={{ borderTopWidth: 1, borderTopColor: colors.hairline, paddingTop: 6, marginTop: 4 }}>
+            <Row label="Total" value={fmt(totals.total, currency)} bold />
+          </View>
+        </View>
+
+        <Field label="Notes" value={notes} onChangeText={setNotes} multiline />
+        <Field label="Terms" value={terms} onChangeText={setTerms} multiline />
+
+        <Pressable
+          onPress={save}
+          disabled={busy}
+          style={({ pressed }) => ({
+            flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: pressed ? "#0d6e6a" : colors.primary,
+            opacity: busy ? 0.6 : 1,
+            marginTop: space.sm,
+          })}
+        >
+          <Save size={18} color="#fff" />
+          <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>{busy ? "Saving…" : "Create quote"}</Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Field({ label, value, onChangeText, multiline }: { label: string; value: string; onChangeText: (v: string) => void; multiline?: boolean }) {
+  return (
+    <View style={{ gap: 6 }}>
+      <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        multiline={multiline}
+        style={{
+          padding: space.sm + 2, borderRadius: radius.md,
+          backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline,
+          color: colors.text, fontSize: 14,
+          minHeight: multiline ? 70 : undefined,
+          textAlignVertical: multiline ? "top" : "auto",
+        }}
+      />
+    </View>
+  );
+}
+
+function Row({ label, value, bold }: { label: string; value: string; bold?: boolean }) {
+  return (
+    <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+      <Text style={{ fontSize: bold ? 14 : 13, color: bold ? colors.text : colors.muted, fontWeight: bold ? "700" : "400" }}>{label}</Text>
+      <Text style={{ fontSize: bold ? 16 : 13, color: colors.text, fontWeight: bold ? "700" : "500" }}>{value}</Text>
+    </View>
+  );
+}
+
+function fmt(n: number, currency: string): string {
+  try { return new Intl.NumberFormat("en-AU", { style: "currency", currency }).format(n); }
+  catch { return `${currency} ${n.toFixed(2)}`; }
+}

--- a/mobile/src/components/CustomerPicker.tsx
+++ b/mobile/src/components/CustomerPicker.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from "react";
+import { FlatList, Modal, Pressable, Text, TextInput, View } from "react-native";
+import { ChevronDown, Search, X } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { colors, radius, space } from "@/lib/theme";
+
+interface CustomerLite {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+}
+
+/** Inline dropdown trigger + modal customer picker with live search. */
+export function CustomerPicker({
+  businessId, value, onChange,
+}: {
+  businessId: string;
+  value: { id: string; name: string } | null;
+  onChange: (c: { id: string; name: string } | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [all, setAll] = useState<CustomerLite[]>([]);
+  const [q, setQ] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    supabase.from("customers")
+      .select("id, name, email, phone")
+      .eq("business_id", businessId)
+      .eq("archived", false)
+      .order("name", { ascending: true })
+      .then(({ data }) => setAll((data ?? []) as CustomerLite[]));
+  }, [open, businessId]);
+
+  const filtered = useMemo(() => {
+    const term = q.trim().toLowerCase();
+    if (!term) return all;
+    return all.filter((c) =>
+      c.name.toLowerCase().includes(term) ||
+      (c.email ?? "").toLowerCase().includes(term) ||
+      (c.phone ?? "").toLowerCase().includes(term)
+    );
+  }, [all, q]);
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        style={({ pressed }) => ({
+          flexDirection: "row", alignItems: "center", gap: 8,
+          padding: space.sm + 2, borderRadius: radius.md,
+          backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline,
+          opacity: pressed ? 0.85 : 1,
+        })}
+      >
+        <Text style={{ flex: 1, fontSize: 14, color: value ? colors.text : colors.muted }}>
+          {value?.name ?? "Pick a customer…"}
+        </Text>
+        <ChevronDown size={16} color={colors.muted} />
+      </Pressable>
+
+      <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
+        <View style={{ flex: 1, backgroundColor: colors.canvas, padding: space.lg, paddingTop: space.xl }}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm, marginBottom: space.md }}>
+            <Text style={{ flex: 1, fontSize: 18, fontWeight: "700", color: colors.text }}>Pick a customer</Text>
+            <Pressable onPress={() => setOpen(false)} hitSlop={8}>
+              <X size={22} color={colors.text} />
+            </Pressable>
+          </View>
+
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 6, paddingHorizontal: 10, paddingVertical: 8, borderRadius: radius.md, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, marginBottom: space.sm }}>
+            <Search size={14} color={colors.muted} />
+            <TextInput
+              placeholder="Search by name, email or phone"
+              placeholderTextColor={colors.muted}
+              value={q}
+              onChangeText={setQ}
+              autoFocus
+              style={{ flex: 1, fontSize: 14, color: colors.text }}
+            />
+          </View>
+
+          <FlatList
+            data={filtered}
+            keyExtractor={(c) => c.id}
+            ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: colors.hairline }} />}
+            ListEmptyComponent={<Text style={{ color: colors.muted, textAlign: "center", marginTop: space.xl }}>No customers</Text>}
+            renderItem={({ item }) => (
+              <Pressable
+                onPress={() => { onChange({ id: item.id, name: item.name }); setOpen(false); }}
+                style={({ pressed }) => ({ paddingVertical: space.sm + 2, opacity: pressed ? 0.6 : 1 })}
+              >
+                <Text style={{ fontSize: 15, fontWeight: "600", color: colors.text }}>{item.name}</Text>
+                {(item.email || item.phone) && (
+                  <Text style={{ fontSize: 12, color: colors.muted, marginTop: 2 }}>
+                    {[item.phone, item.email].filter(Boolean).join(" · ")}
+                  </Text>
+                )}
+              </Pressable>
+            )}
+          />
+        </View>
+      </Modal>
+    </>
+  );
+}

--- a/mobile/src/components/LineItemsEditor.tsx
+++ b/mobile/src/components/LineItemsEditor.tsx
@@ -1,0 +1,126 @@
+import { Pressable, Text, TextInput, View } from "react-native";
+import { Plus, Trash2 } from "lucide-react-native";
+import { colors, radius, space } from "@/lib/theme";
+
+export interface LineItem {
+  id: string;
+  name: string;
+  description?: string;
+  quantity: number;
+  unit_price: number;
+  tax_rate: number;
+  total: number;
+}
+
+const num = (v: string): number => {
+  const n = parseFloat(v.replace(/,/g, ""));
+  return Number.isFinite(n) ? n : 0;
+};
+
+function recalc(li: LineItem): LineItem {
+  const subtotal = li.quantity * li.unit_price;
+  return { ...li, total: subtotal + (subtotal * li.tax_rate) / 100 };
+}
+
+export function newLineItem(): LineItem {
+  return recalc({
+    id: Math.random().toString(36).slice(2),
+    name: "", description: "",
+    quantity: 1, unit_price: 0, tax_rate: 0, total: 0,
+  });
+}
+
+export function totalsFor(items: LineItem[]): { subtotal: number; tax: number; total: number } {
+  let subtotal = 0, tax = 0;
+  for (const li of items) {
+    const sub = li.quantity * li.unit_price;
+    subtotal += sub;
+    tax += (sub * li.tax_rate) / 100;
+  }
+  return { subtotal, tax, total: subtotal + tax };
+}
+
+/** Editable list of line items — mirrors the web LineItemsEditor (basic). */
+export function LineItemsEditor({
+  items, onChange, currency,
+}: {
+  items: LineItem[];
+  onChange: (items: LineItem[]) => void;
+  currency: string;
+}) {
+  const update = (idx: number, patch: Partial<LineItem>) => {
+    const next = items.slice();
+    next[idx] = recalc({ ...next[idx], ...patch });
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(items.filter((_, i) => i !== idx));
+  const add = () => onChange([...items, newLineItem()]);
+
+  return (
+    <View style={{ borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, overflow: "hidden" }}>
+      <View style={{ paddingHorizontal: space.md, paddingTop: space.md, paddingBottom: 8, flexDirection: "row", alignItems: "center" }}>
+        <Text style={{ flex: 1, fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>Line items</Text>
+        <Pressable onPress={add} hitSlop={8} style={({ pressed }) => ({ flexDirection: "row", alignItems: "center", gap: 4, opacity: pressed ? 0.7 : 1 })}>
+          <Plus size={14} color={colors.primary} />
+          <Text style={{ fontSize: 12, color: colors.primary, fontWeight: "700" }}>Add</Text>
+        </Pressable>
+      </View>
+      {items.length === 0 ? (
+        <View style={{ padding: space.md }}>
+          <Text style={{ fontSize: 12, color: colors.muted }}>Tap Add to insert a line item</Text>
+        </View>
+      ) : items.map((li, idx) => (
+        <View key={li.id} style={{ padding: space.md, gap: 6, borderTopWidth: 1, borderTopColor: colors.hairline }}>
+          <View style={{ flexDirection: "row", gap: space.sm, alignItems: "center" }}>
+            <TextInput
+              placeholder="Item name"
+              placeholderTextColor={colors.muted}
+              value={li.name}
+              onChangeText={(v) => update(idx, { name: v })}
+              style={inputStyle}
+            />
+            <Pressable onPress={() => remove(idx)} hitSlop={8}>
+              <Trash2 size={16} color="#991b1b" />
+            </Pressable>
+          </View>
+          <TextInput
+            placeholder="Description (optional)"
+            placeholderTextColor={colors.muted}
+            value={li.description ?? ""}
+            onChangeText={(v) => update(idx, { description: v })}
+            style={[inputStyle, { fontSize: 12 }]}
+          />
+          <View style={{ flexDirection: "row", gap: space.sm }}>
+            <Field label="Qty" value={String(li.quantity)} onChange={(v) => update(idx, { quantity: num(v) })} flex={1} />
+            <Field label="Unit price" value={String(li.unit_price)} onChange={(v) => update(idx, { unit_price: num(v) })} flex={1.4} />
+            <Field label="Tax %" value={String(li.tax_rate)} onChange={(v) => update(idx, { tax_rate: num(v) })} flex={0.8} />
+          </View>
+          <Text style={{ textAlign: "right", fontSize: 13, fontWeight: "700", color: colors.text }}>
+            = {fmt(li.total, currency)}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function Field({ label, value, onChange, flex }: { label: string; value: string; onChange: (v: string) => void; flex: number }) {
+  return (
+    <View style={{ flex, gap: 2 }}>
+      <Text style={{ fontSize: 10, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.5 }}>{label}</Text>
+      <TextInput value={value} onChangeText={onChange} keyboardType="decimal-pad" style={inputStyle} />
+    </View>
+  );
+}
+
+const inputStyle = {
+  flex: 1,
+  paddingHorizontal: 10, paddingVertical: 8, borderRadius: radius.md,
+  backgroundColor: colors.canvas, borderWidth: 1, borderColor: colors.hairline,
+  color: colors.text, fontSize: 14,
+} as const;
+
+function fmt(n: number, currency: string): string {
+  try { return new Intl.NumberFormat("en-AU", { style: "currency", currency }).format(n); }
+  catch { return `${currency} ${n.toFixed(2)}`; }
+}


### PR DESCRIPTION
## Summary
- New shared **LineItemsEditor** (qty/unit price/tax, live totals) and **CustomerPicker** (modal with search)
- **/quotes/new** and **/invoices/new** — full creation flows that mint numbers from the business prefix counter
- + buttons in quote and invoice list headers
- **/(auth)/forgot** — sends Supabase recovery email; reset link opens on web
- Parity matrix updated.

## Test plan
- [ ] Quotes list → tap + → fill customer + items → Create → land on new quote
- [ ] Invoices list → tap + → fill customer + items → Create → land on new invoice
- [ ] Login → tap "Forgot password?" → enter email → confirmation card appears
- [ ] Receive email and reset on web

🤖 Generated with [Claude Code](https://claude.com/claude-code)