### PR TITLE
feat(mobile): full Assistant briefing inbox

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -128,7 +128,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | **Workspace** |
 | Tasks (kanban) | 🟡 | shipped (basic) | Polish: drag-drop on mobile, link to job |
 | Messages (SMS inbox) | ❌ | 4 | Inbound replies |
-| Assistant page | ❌ | 1 | Briefing list |
+| Assistant page | ✅ | 2g | Full briefing inbox with deep-links + pull-to-refresh |
 | AI agent chat | ❌ | 4 | Native voice |
 | **Settings** |
 | Business profile | ✅ | 2d | Name, contact, ABN, currency, address — owner/admin only |

--- a/mobile/app/(tabs)/sales.tsx
+++ b/mobile/app/(tabs)/sales.tsx
@@ -1,7 +1,7 @@
 import { ScrollView, Text, View, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { Users, UserPlus, FileCheck, FileText, ChevronRight, ClipboardList, Repeat, TrendingUp, Bot } from "lucide-react-native";
+import { Users, UserPlus, FileCheck, FileText, ChevronRight, ClipboardList, Repeat, TrendingUp, Bot, Sparkles } from "lucide-react-native";
 import { colors, radius, space } from "@/lib/theme";
 import { BusinessSwitcher } from "@/components/BusinessSwitcher";
 import { useActiveBusiness } from "@/lib/active-business";
@@ -56,6 +56,7 @@ export default function SalesHub() {
     { href: "/invoices",  label: "Invoices",  hint: "Bill and collect",              icon: <FileText size={20} color="#16a34a" />, bg: "#dcfce7", fg: "#16a34a" },
   ];
   const ops: Section[] = [
+    { href: "/assistant", label: "Assistant",    hint: "Briefing — what needs you next",  icon: <Sparkles size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },
     { href: "/reports",   label: "Site reports", hint: "Inspection & condition reports", icon: <ClipboardList size={20} color="#b45309" />, bg: "#fef3c7", fg: "#b45309" },
     { href: "/recurring", label: "Recurring jobs", hint: "Auto-scheduled work",          icon: <Repeat size={20} color="#7c3aed" />, bg: "#ede9fe", fg: "#7c3aed" },
     { href: "/analytics", label: "Analytics",    hint: "Revenue, leads, quotes won",     icon: <TrendingUp size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },

--- a/mobile/app/assistant/index.tsx
+++ b/mobile/app/assistant/index.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState, useCallback } from "react";
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { ArrowLeft, Sparkles, ChevronRight } from "lucide-react-native";
+import { useActiveBusiness } from "@/lib/active-business";
+import { loadBriefing, BriefingItem, TYPE_LABEL, PRIORITY_BAR } from "@/lib/briefing";
+import { colors, radius, space } from "@/lib/theme";
+
+/** Full briefing inbox — same source as the dashboard widget but
+ *  unbounded, deep-linked, and pull-to-refresh. */
+export default function AssistantPage() {
+  const router = useRouter();
+  const { active } = useActiveBusiness();
+  const [items, setItems] = useState<BriefingItem[] | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!active) return;
+    const out = await loadBriefing(active.id);
+    setItems(out);
+  }, [active?.id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}><ArrowLeft size={22} color={colors.text} /></Pressable>
+        <Sparkles size={18} color={colors.primary} />
+        <Text style={{ fontSize: 20, fontWeight: "700", color: colors.text }}>Assistant</Text>
+        <View style={{ flex: 1 }} />
+        {items && (
+          <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 999, backgroundColor: items.length > 0 ? "#fee2e2" : "#dcfce7" }}>
+            <Text style={{ fontSize: 11, fontWeight: "700", color: items.length > 0 ? "#991b1b" : "#166534" }}>{items.length}</Text>
+          </View>
+        )}
+      </View>
+
+      {items === null ? (
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <ActivityIndicator color={colors.primary} />
+        </View>
+      ) : items.length === 0 ? (
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: space.xl, gap: 6 }}>
+          <Text style={{ fontSize: 18, fontWeight: "700", color: colors.text }}>Inbox zero</Text>
+          <Text style={{ fontSize: 13, color: colors.muted, textAlign: "center" }}>
+            Nothing overdue, no stale quotes, no unhandled leads. You're all caught up.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(i) => i.id}
+          contentContainerStyle={{ paddingBottom: space.xl }}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={async () => { setRefreshing(true); await load(); setRefreshing(false); }} tintColor={colors.primary} />}
+          ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: colors.hairline, marginHorizontal: space.lg }} />}
+          renderItem={({ item }) => (
+            <Pressable
+              onPress={() => router.push(item.deepLink as never)}
+              style={({ pressed }) => ({
+                flexDirection: "row", alignItems: "center", gap: space.sm,
+                paddingHorizontal: space.lg, paddingVertical: space.md,
+                backgroundColor: pressed ? colors.muted : "transparent",
+                borderLeftWidth: 4, borderLeftColor: PRIORITY_BAR[item.priority],
+              })}
+            >
+              <Text style={{ fontSize: 10, fontWeight: "700", color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, width: 64 }}>
+                {TYPE_LABEL[item.type]}
+              </Text>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text numberOfLines={1} style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>{item.title}</Text>
+                <Text numberOfLines={1} style={{ fontSize: 12, color: colors.muted, marginTop: 2 }}>{item.subtitle}</Text>
+              </View>
+              <ChevronRight size={16} color={colors.muted} />
+            </Pressable>
+          )}
+        />
+      )}
+
+      <View style={{ padding: space.md, alignItems: "center", borderTopWidth: 1, borderTopColor: colors.hairline, backgroundColor: colors.card }}>
+        <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
+          <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: PRIORITY_BAR.high }} />
+          <Text style={{ fontSize: 11, color: colors.muted }}>High</Text>
+          <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: PRIORITY_BAR.med, marginLeft: space.sm }} />
+          <Text style={{ fontSize: 11, color: colors.muted }}>Medium</Text>
+          <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: PRIORITY_BAR.low, marginLeft: space.sm }} />
+          <Text style={{ fontSize: 11, color: colors.muted }}>Low</Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/mobile/src/components/OwnerDashboard.tsx
+++ b/mobile/src/components/OwnerDashboard.tsx
@@ -158,7 +158,7 @@ export function OwnerDashboard({ business }: { business: MobileBusiness }) {
       )}
 
       {/* Briefing */}
-      <BriefingWidget businessId={business.id} />
+      <BriefingWidget businessId={business.id} onItemPress={() => router.push("/assistant" as never)} />
 
       {/* Tasks */}
       <TasksWidget businessId={business.id} />

--- a/mobile/src/lib/briefing.ts
+++ b/mobile/src/lib/briefing.ts
@@ -1,0 +1,127 @@
+import { supabase } from "./supabase";
+
+export type BriefingType =
+  | "overdue_invoice" | "stale_quote" | "new_lead"
+  | "today_job_unassigned" | "submitted_workorder";
+
+export interface BriefingItem {
+  id:        string;
+  type:      BriefingType;
+  priority:  "high" | "med" | "low";
+  title:     string;
+  subtitle:  string;
+  /** Where to send the user when they tap this item. */
+  deepLink:  string;
+}
+
+const num = (v: unknown) => {
+  const n = typeof v === "number" ? v : parseFloat(String(v ?? 0));
+  return Number.isFinite(n) ? n : 0;
+};
+const daysAgo = (iso: string) => Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000));
+
+/** Mirror of web getMyBriefing — returns the active business's
+ *  punch-list of overdue invoices, stale quotes, new leads,
+ *  unassigned jobs today, and submitted work-orders awaiting review.
+ *  RLS scopes to the active business. */
+export async function loadBriefing(businessId: string): Promise<BriefingItem[]> {
+  const todayStr     = new Date().toISOString().split("T")[0];
+  const sevenDaysAgo = new Date(Date.now() - 7 * 86_400_000).toISOString();
+
+  const [
+    { data: invoices }, { data: quotes }, { data: leads },
+    { data: jobsToday }, { data: submitted },
+  ] = await Promise.all([
+    supabase.from("invoices").select("id, number, status, total, amount_paid, due_date, customers(name)")
+      .eq("business_id", businessId).in("status", ["sent", "partial", "overdue"]),
+    supabase.from("quotes").select("id, number, status, updated_at, customers(name)")
+      .eq("business_id", businessId).eq("status", "sent").lt("updated_at", sevenDaysAgo),
+    supabase.from("leads").select("id, name, status, created_at")
+      .eq("business_id", businessId).eq("status", "new"),
+    supabase.from("work_orders").select("id, number, title, status, customers(name), work_order_assignments(member_profile_id)")
+      .eq("business_id", businessId).eq("scheduled_date", todayStr),
+    supabase.from("work_orders").select("id, number, title, customers(name), updated_at")
+      .eq("business_id", businessId).eq("status", "submitted"),
+  ]);
+
+  const out: BriefingItem[] = [];
+  const now = new Date();
+
+  for (const inv of (invoices ?? []) as unknown as Array<{ id: string; number: string; total: unknown; amount_paid: unknown; due_date: string | null; customers: { name: string } | null }>) {
+    if (!inv.due_date || new Date(inv.due_date) >= now) continue;
+    const balance = Math.max(0, num(inv.total) - num(inv.amount_paid));
+    if (balance < 0.01) continue;
+    const days = daysAgo(inv.due_date);
+    out.push({
+      id: `oi:${inv.id}`, type: "overdue_invoice",
+      priority: days > 30 ? "high" : days > 14 ? "med" : "low",
+      title:    `${inv.number} · ${days}d overdue`,
+      subtitle: `${inv.customers?.name ?? "—"} · ${balance.toFixed(2)}`,
+      deepLink: `/invoices/${inv.id}`,
+    });
+  }
+
+  for (const q of (quotes ?? []) as unknown as Array<{ id: string; number: string; updated_at: string; customers: { name: string } | null }>) {
+    const days = daysAgo(q.updated_at);
+    out.push({
+      id: `sq:${q.id}`, type: "stale_quote",
+      priority: days > 14 ? "med" : "low",
+      title:    `${q.number} · sent ${days}d ago`,
+      subtitle: q.customers?.name ?? "No customer",
+      deepLink: `/quotes/${q.id}`,
+    });
+  }
+
+  for (const l of (leads ?? []) as Array<{ id: string; name: string; created_at: string }>) {
+    const days = daysAgo(l.created_at);
+    out.push({
+      id: `nl:${l.id}`, type: "new_lead",
+      priority: days > 2 ? "high" : "med",
+      title:    l.name,
+      subtitle: days === 0 ? "New today" : `${days}d ago`,
+      deepLink: `/leads/${l.id}`,
+    });
+  }
+
+  for (const j of (jobsToday ?? []) as unknown as Array<{ id: string; number: string; title: string; status: string; customers: { name: string } | null; work_order_assignments: Array<{ member_profile_id: string }> }>) {
+    const unassigned = !j.work_order_assignments || j.work_order_assignments.length === 0;
+    if (unassigned) {
+      out.push({
+        id: `tu:${j.id}`, type: "today_job_unassigned",
+        priority: "high",
+        title:    `${j.number} today`,
+        subtitle: `${j.title}${j.customers?.name ? ` · ${j.customers.name}` : ""}`,
+        deepLink: `/job/${j.id}`,
+      });
+    }
+  }
+
+  for (const w of (submitted ?? []) as unknown as Array<{ id: string; number: string; title: string; customers: { name: string } | null; updated_at: string }>) {
+    const days = daysAgo(w.updated_at);
+    out.push({
+      id: `sw:${w.id}`, type: "submitted_workorder",
+      priority: days > 1 ? "high" : "med",
+      title:    `${w.number} submitted`,
+      subtitle: `${w.title}${w.customers?.name ? ` · ${w.customers.name}` : ""}`,
+      deepLink: `/job/${w.id}`,
+    });
+  }
+
+  const PRI = { high: 0, med: 1, low: 2 };
+  out.sort((a, b) => PRI[a.priority] - PRI[b.priority]);
+  return out;
+}
+
+export const TYPE_LABEL: Record<BriefingType, string> = {
+  overdue_invoice:       "Chase",
+  stale_quote:           "Follow up",
+  new_lead:              "Call",
+  today_job_unassigned:  "Assign",
+  submitted_workorder:   "Review",
+};
+
+export const PRIORITY_BAR: Record<BriefingItem["priority"], string> = {
+  high: "#ef4444",
+  med:  "#f59e0b",
+  low:  "#60a5fa",
+};


### PR DESCRIPTION
## Summary
- New /assistant — full-screen briefing list with deep-links, pull-to-refresh, priority colour bars
- Extracts briefing logic into shared lib so widget + page agree
- Dashboard widget tap now opens /assistant
- Linked from Sales tab → Operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)