### PR TITLE
feat(mobile): Smart Fill + bank settings + lead→quote

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -88,7 +88,8 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Lead detail (status changer + quick contact) | ✅ | 2a | |
 | Add lead (with custom source) | ✅ | 2c | |
 | Convert lead → customer | ✅ | 2d | UserCheck button on lead detail; mints customer + marks lead won |
-| Convert lead → quote/work-order | ❌ | 3 | Defer with quote/WO creators |
+| Convert lead → quote | ✅ | 3a | Find/create customer + draft quote, mark lead 'quoted' |
+| Convert lead → work-order | ❌ | 3 | Needs work-order create flow |
 | Convert quote → invoice | ✅ | 2d | FileCheck button on quote detail; mints invoice number, copies line items |
 | Quotes list + detail | ❌ | 2 | |
 | New quote (with line items) | ✅ | 2f | LineItemsEditor + CustomerPicker; mints number from prefix counter |
@@ -103,7 +104,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Send remainder | ❌ | 3 | |
 | Duplicate invoice | ❌ | 2 | |
 | Reset to draft | ❌ | 2 | |
-| Smart Fill (paste → form) | ❌ | 3 | Hits same `/api/ai` endpoint |
+| Smart Fill (paste → form) | ✅ | 3a | Modal on /quotes/new + /invoices/new; hits /api/ai smart_fill_document |
 | **Service** |
 | Work orders list | 🟡 | 1 | Worker sees only theirs; owner sees all |
 | Work order detail (full portfolio) | 🟡 | 1 | Has basics; need: Workers picker, financials, share link |
@@ -132,7 +133,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | AI agent chat | ❌ | 4 | Native voice |
 | **Settings** |
 | Business profile | ✅ | 2d | Name, contact, ABN, currency, address — owner/admin only |
-| Bank details | ❌ | 4 | |
+| Bank details | ✅ | 3a | /settings/bank — name, account name/number, BSB/sort, IBAN |
 | Team management | ✅ | 2g | List + add (email/role) + change role + remove; pending → active on first login |
 | API keys | ❌ | 5 | Power-user only |
 | Webhooks | ❌ | 5 | Power-user only |

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { LogOut, Bell, Building2, ChevronRight, Users } from "lucide-react-native";
+import { LogOut, Bell, Building2, ChevronRight, Users, Landmark } from "lucide-react-native";
 import { useRouter } from "expo-router";
 import { supabase } from "@/lib/supabase";
 import { ensureNotificationPermissions } from "@/lib/notifications";
@@ -92,6 +92,28 @@ export default function ProfileScreen() {
           >
             <Users size={18} color={colors.text} />
             <Text style={{ flex: 1, color: colors.text, fontWeight: "600", fontSize: 15 }}>Team</Text>
+            <ChevronRight size={16} color={colors.muted} />
+          </Pressable>
+        )}
+
+        {canEditBusiness && (
+          <Pressable
+            onPress={() => router.push("/settings/bank" as never)}
+            style={({ pressed }) => ({
+              backgroundColor: colors.card,
+              borderRadius: radius.xl,
+              padding: space.lg,
+              marginTop: space.sm,
+              borderWidth: 1,
+              borderColor: colors.hairline,
+              flexDirection: "row",
+              alignItems: "center",
+              gap: space.sm,
+              opacity: pressed ? 0.85 : 1,
+            })}
+          >
+            <Landmark size={18} color={colors.text} />
+            <Text style={{ flex: 1, color: colors.text, fontWeight: "600", fontSize: 15 }}>Bank details</Text>
             <ChevronRight size={16} color={colors.muted} />
           </Pressable>
         )}

--- a/mobile/app/invoices/new.tsx
+++ b/mobile/app/invoices/new.tsx
@@ -7,6 +7,7 @@ import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { CustomerPicker } from "@/components/CustomerPicker";
 import { LineItemsEditor, LineItem, newLineItem, totalsFor } from "@/components/LineItemsEditor";
+import { SmartFillButton } from "@/components/SmartFillButton";
 import { colors, radius, space } from "@/lib/theme";
 
 /** Compose a new invoice — customer + line items + notes/terms.
@@ -76,6 +77,20 @@ export default function NewInvoice() {
       </View>
 
       <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+        {active && (
+          <SmartFillButton
+            businessId={active.id}
+            mode="invoice"
+            preselectedCustomer={customer}
+            onApply={({ customer: c, items: i, notes: n, terms: t }) => {
+              if (c) setCustomer(c);
+              setItems(i);
+              if (n) setNotes(n);
+              if (t) setTerms(t);
+            }}
+          />
+        )}
+
         <View style={{ gap: 6 }}>
           <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>Customer *</Text>
           {active && <CustomerPicker businessId={active.id} value={customer} onChange={setCustomer} />}

--- a/mobile/app/leads/[id].tsx
+++ b/mobile/app/leads/[id].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { ActivityIndicator, Linking, Pressable, ScrollView, Text, View, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { ArrowLeft, Phone, Mail, MapPin, Clock, MessageSquare, UserCheck } from "lucide-react-native";
+import { ArrowLeft, Phone, Mail, MapPin, Clock, MessageSquare, UserCheck, FileCheck } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { colors, radius, space } from "@/lib/theme";
@@ -99,6 +99,75 @@ export default function LeadDetail() {
       router.replace(`/customers/${(created as { id: string }).id}` as never);
     } catch (e) {
       Alert.alert("Couldn't convert", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /** Convert this lead into a draft quote. Reuses an existing customer
+   *  matched by email or phone, otherwise mints a fresh one. Marks the
+   *  lead 'quoted' and routes to the new quote so the user can fill
+   *  line items. Mirrors web convertLeadToQuote. */
+  const convertToQuote = async () => {
+    if (!lead || !active) return;
+    setBusy(true);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+
+      // Find or create a customer for this lead
+      let customerId: string | null = null;
+      if (lead.email || lead.phone) {
+        const filters = [lead.email && `email.eq.${lead.email}`, lead.phone && `phone.eq.${lead.phone}`].filter(Boolean).join(",");
+        const { data: existing } = await supabase
+          .from("customers").select("id")
+          .eq("business_id", active.id).eq("archived", false)
+          .or(filters).limit(1).maybeSingle();
+        customerId = (existing as { id: string } | null)?.id ?? null;
+      }
+      if (!customerId) {
+        const { data: created, error: cErr } = await supabase
+          .from("customers")
+          .insert({
+            business_id: active.id, user_id: user?.id,
+            name: lead.name, phone: lead.phone, email: lead.email,
+            city: lead.suburb, country: "Australia", notes: lead.notes,
+            archived: false,
+          })
+          .select("id").single();
+        if (cErr) throw cErr;
+        customerId = (created as { id: string }).id;
+      }
+
+      // Mint a fresh quote number
+      const { data: biz } = await supabase
+        .from("businesses").select("quote_prefix, quote_next_number")
+        .eq("id", active.id).single();
+      const prefix = (biz as { quote_prefix?: string; quote_next_number?: number })?.quote_prefix ?? "QT";
+      const nextNum = (biz as { quote_prefix?: string; quote_next_number?: number })?.quote_next_number ?? 1;
+      const number = `${prefix}-${String(nextNum).padStart(4, "0")}`;
+      await supabase.from("businesses").update({ quote_next_number: nextNum + 1 }).eq("id", active.id);
+
+      const today = new Date().toISOString().split("T")[0];
+      const expiry = new Date(Date.now() + 30 * 86_400_000).toISOString().split("T")[0];
+      const { data: quote, error: qErr } = await supabase
+        .from("quotes")
+        .insert({
+          user_id: user?.id, business_id: active.id, number,
+          status: "draft",
+          customer_id: customerId,
+          issue_date: today, expiry_date: expiry,
+          line_items: [],
+          subtotal: 0, tax_total: 0, total: 0,
+          notes: lead.notes ?? null, terms: null,
+        })
+        .select("id").single();
+      if (qErr) throw qErr;
+
+      await supabase.from("leads").update({ status: "quoted" }).eq("id", lead.id);
+      Alert.alert("Quote drafted", `${number} created — add line items next.`);
+      router.replace(`/quotes/${(quote as { id: string }).id}` as never);
+    } catch (e) {
+      Alert.alert("Couldn't create quote", e instanceof Error ? e.message : "Unknown error");
     } finally {
       setBusy(false);
     }
@@ -207,6 +276,24 @@ export default function LeadDetail() {
           <UserCheck size={18} color="#fff" />
           <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>
             {lead.status === "won" ? "Already converted" : "Convert to customer"}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={convertToQuote}
+          disabled={busy || lead.status === "quoted" || lead.status === "won"}
+          style={({ pressed }) => ({
+            flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+            padding: space.md, borderRadius: radius.lg,
+            backgroundColor: lead.status === "quoted" || lead.status === "won"
+              ? colors.muted
+              : pressed ? "#5b21b6" : "#7c3aed",
+            opacity: busy ? 0.6 : 1,
+          })}
+        >
+          <FileCheck size={18} color="#fff" />
+          <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>
+            {lead.status === "quoted" ? "Already quoted" : "Convert to quote"}
           </Text>
         </Pressable>
       </ScrollView>

--- a/mobile/app/quotes/new.tsx
+++ b/mobile/app/quotes/new.tsx
@@ -7,6 +7,7 @@ import { supabase } from "@/lib/supabase";
 import { useActiveBusiness } from "@/lib/active-business";
 import { CustomerPicker } from "@/components/CustomerPicker";
 import { LineItemsEditor, LineItem, newLineItem, totalsFor } from "@/components/LineItemsEditor";
+import { SmartFillButton } from "@/components/SmartFillButton";
 import { colors, radius, space } from "@/lib/theme";
 
 /** Compose a new quote — customer + line items + notes/terms.
@@ -74,6 +75,20 @@ export default function NewQuote() {
       </View>
 
       <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+        {active && (
+          <SmartFillButton
+            businessId={active.id}
+            mode="quote"
+            preselectedCustomer={customer}
+            onApply={({ customer: c, items: i, notes: n, terms: t }) => {
+              if (c) setCustomer(c);
+              setItems(i);
+              if (n) setNotes(n);
+              if (t) setTerms(t);
+            }}
+          />
+        )}
+
         <View style={{ gap: 6 }}>
           <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>Customer *</Text>
           {active && <CustomerPicker businessId={active.id} value={customer} onChange={setCustomer} />}

--- a/mobile/app/settings/bank.tsx
+++ b/mobile/app/settings/bank.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+import { ActivityIndicator, Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { ArrowLeft, Save, Landmark } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { useActiveBusiness } from "@/lib/active-business";
+import { colors, radius, space } from "@/lib/theme";
+
+interface BankRow {
+  bank_name:           string | null;
+  bank_account_name:   string | null;
+  bank_account_number: string | null;
+  bank_sort_code:      string | null;
+  bank_iban:           string | null;
+}
+
+/** Bank details — appears on invoice PDFs / payment instructions.
+ *  Owner/admin only. AU + UK + EU friendly (BSB doubles as sort code). */
+export default function BankSettings() {
+  const router = useRouter();
+  const { active, role } = useActiveBusiness();
+  const canEdit = role === "owner" || role === "admin";
+
+  const [row,  setRow]  = useState<BankRow | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!active) return;
+    supabase.from("businesses")
+      .select("bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban")
+      .eq("id", active.id).maybeSingle()
+      .then(({ data }) => setRow((data as BankRow) ?? {
+        bank_name: null, bank_account_name: null, bank_account_number: null,
+        bank_sort_code: null, bank_iban: null,
+      }));
+  }, [active?.id]);
+
+  const save = async () => {
+    if (!row || !active || !canEdit) return;
+    setBusy(true);
+    const { error } = await supabase.from("businesses").update({
+      bank_name:           row.bank_name?.trim() || null,
+      bank_account_name:   row.bank_account_name?.trim() || null,
+      bank_account_number: row.bank_account_number?.trim() || null,
+      bank_sort_code:      row.bank_sort_code?.trim() || null,
+      bank_iban:           row.bank_iban?.trim() || null,
+    }).eq("id", active.id);
+    setBusy(false);
+    if (error) { Alert.alert("Couldn't save", error.message); return; }
+    Alert.alert("Saved", "Bank details updated.");
+    router.back();
+  };
+
+  if (!row) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas, alignItems: "center", justifyContent: "center" }}>
+        <ActivityIndicator color={colors.primary} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}>
+          <ArrowLeft size={22} color={colors.text} />
+        </Pressable>
+        <Landmark size={18} color={colors.text} />
+        <Text style={{ fontSize: 18, fontWeight: "700", color: colors.text }}>Bank details</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+        <Text style={{ fontSize: 12, color: colors.muted, lineHeight: 18 }}>
+          Shown on invoice PDFs and customer hub payment screens. Leave a field blank to hide it.
+        </Text>
+
+        <Field label="Bank name"      value={row.bank_name ?? ""}           onChangeText={(v) => setRow({ ...row, bank_name: v })} />
+        <Field label="Account name"   value={row.bank_account_name ?? ""}   onChangeText={(v) => setRow({ ...row, bank_account_name: v })} />
+        <Field label="Account number" value={row.bank_account_number ?? ""} onChangeText={(v) => setRow({ ...row, bank_account_number: v })} keyboardType="numeric" />
+        <Field label="BSB / Sort code" value={row.bank_sort_code ?? ""}     onChangeText={(v) => setRow({ ...row, bank_sort_code: v })} keyboardType="numeric" />
+        <Field label="IBAN / SWIFT (optional)" value={row.bank_iban ?? ""}  onChangeText={(v) => setRow({ ...row, bank_iban: v })} autoCapitalize="characters" />
+
+        {canEdit ? (
+          <Pressable onPress={save} disabled={busy}
+            style={({ pressed }) => ({
+              flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+              padding: space.md, borderRadius: radius.lg,
+              backgroundColor: pressed ? "#0d6e6a" : colors.primary,
+              opacity: busy ? 0.6 : 1, marginTop: space.md,
+            })}>
+            <Save size={18} color="#fff" />
+            <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>{busy ? "Saving…" : "Save bank details"}</Text>
+          </Pressable>
+        ) : (
+          <Text style={{ fontSize: 12, color: colors.muted, textAlign: "center", marginTop: space.md }}>
+            Read-only — owner or admin can edit.
+          </Text>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Field({ label, value, onChangeText, keyboardType, autoCapitalize }: {
+  label: string; value: string; onChangeText: (v: string) => void;
+  keyboardType?: "default" | "numeric";
+  autoCapitalize?: "none" | "sentences" | "words" | "characters";
+}) {
+  return (
+    <View style={{ gap: 6 }}>
+      <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        keyboardType={keyboardType}
+        autoCapitalize={autoCapitalize}
+        style={{
+          padding: space.sm + 2, borderRadius: radius.md,
+          backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline,
+          color: colors.text, fontSize: 14,
+        }}
+      />
+    </View>
+  );
+}

--- a/mobile/src/components/SmartFillButton.tsx
+++ b/mobile/src/components/SmartFillButton.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { ActivityIndicator, Alert, Modal, Pressable, Text, TextInput, View } from "react-native";
+import { Sparkles, X } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { LineItem, newLineItem } from "./LineItemsEditor";
+import { colors, radius, space } from "@/lib/theme";
+
+interface SmartFillResult {
+  existing_customer_id: string | null;
+  new_customer: {
+    name?: string; company?: string | null; email?: string | null;
+    phone?: string | null; address?: string | null; city?: string | null;
+    postcode?: string | null; country?: string | null;
+  } | null;
+  issue_date: string | null;
+  due_date?: string | null;
+  expiry_date?: string | null;
+  line_items: Array<{ name: string; description?: string; quantity: number; unit_price: number; tax_rate: number }>;
+  notes: string;
+  terms: string;
+}
+
+/** Paste-text → AI extracts customer + line items + notes.
+ *  Hits the existing /api/ai endpoint (smart_fill_document). The
+ *  endpoint doesn't require auth — public-shaped API for the AI
+ *  helper. */
+export function SmartFillButton({
+  businessId, mode, preselectedCustomer, onApply,
+}: {
+  businessId: string;
+  mode: "quote" | "invoice";
+  preselectedCustomer: { id: string; name: string } | null;
+  onApply: (patch: {
+    customer: { id: string; name: string } | null;
+    items: LineItem[];
+    notes: string;
+    terms: string;
+  }) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const run = async () => {
+    if (!text.trim()) { Alert.alert("Paste something first", "Drop in an email, scope of works, or rough notes."); return; }
+    setBusy(true);
+    try {
+      // Pull customer list so the AI can match an existing one
+      const { data: customersData } = await supabase
+        .from("customers").select("id, name, company, email")
+        .eq("business_id", businessId).eq("archived", false).limit(500);
+      const customers = (customersData ?? []) as Array<{ id: string; name: string; company: string | null; email: string | null }>;
+
+      const base = process.env.EXPO_PUBLIC_APP_URL ?? "https://kireihq.com";
+      const res = await fetch(`${base}/api/ai`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "smart_fill_document",
+          mode,
+          text,
+          customers,
+          defaultTaxRate: 10,
+          today: new Date().toISOString().split("T")[0],
+          preselected_customer: preselectedCustomer
+            ? { id: preselectedCustomer.id, name: preselectedCustomer.name }
+            : null,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.text();
+        throw new Error(err || `AI returned ${res.status}`);
+      }
+      const { result } = await res.json() as { result: SmartFillResult };
+
+      // Resolve customer
+      let resolved: { id: string; name: string } | null = preselectedCustomer;
+      if (result.existing_customer_id) {
+        const c = customers.find((x) => x.id === result.existing_customer_id);
+        if (c) resolved = { id: c.id, name: c.name };
+      } else if (result.new_customer?.name) {
+        // Mint the new customer right here so the form has a real id
+        const { data: { user } } = await supabase.auth.getUser();
+        const { data: created, error: cErr } = await supabase
+          .from("customers").insert({
+            business_id: businessId, user_id: user?.id,
+            name:    result.new_customer.name,
+            company: result.new_customer.company ?? null,
+            email:   result.new_customer.email ?? null,
+            phone:   result.new_customer.phone ?? null,
+            address: result.new_customer.address ?? null,
+            city:    result.new_customer.city ?? null,
+            postcode: result.new_customer.postcode ?? null,
+            country: result.new_customer.country ?? "Australia",
+            archived: false,
+          })
+          .select("id, name").single();
+        if (!cErr && created) resolved = created as { id: string; name: string };
+      }
+
+      const items: LineItem[] = (result.line_items ?? []).map((li) => {
+        const base = newLineItem();
+        const sub = (li.quantity ?? 1) * (li.unit_price ?? 0);
+        return {
+          ...base,
+          name: li.name ?? "",
+          description: li.description ?? "",
+          quantity: li.quantity ?? 1,
+          unit_price: li.unit_price ?? 0,
+          tax_rate: li.tax_rate ?? 0,
+          total: sub + (sub * (li.tax_rate ?? 0)) / 100,
+        };
+      });
+
+      onApply({
+        customer: resolved,
+        items: items.length > 0 ? items : [newLineItem()],
+        notes: result.notes ?? "",
+        terms: result.terms ?? "",
+      });
+      setOpen(false);
+      setText("");
+    } catch (e) {
+      Alert.alert("Smart Fill failed", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Pressable onPress={() => setOpen(true)}
+        style={({ pressed }) => ({
+          flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+          padding: space.sm + 2, borderRadius: radius.md,
+          backgroundColor: pressed ? colors.primarySoft : colors.card,
+          borderWidth: 1, borderColor: colors.primary, borderStyle: "dashed",
+        })}>
+        <Sparkles size={14} color={colors.primary} />
+        <Text style={{ fontSize: 12, fontWeight: "700", color: colors.primary }}>Smart Fill from text</Text>
+      </Pressable>
+
+      <Modal visible={open} animationType="slide" onRequestClose={() => setOpen(false)}>
+        <View style={{ flex: 1, backgroundColor: colors.canvas, padding: space.lg, paddingTop: space.xl }}>
+          <View style={{ flexDirection: "row", alignItems: "center", marginBottom: space.md }}>
+            <Sparkles size={20} color={colors.primary} />
+            <Text style={{ flex: 1, fontSize: 18, fontWeight: "700", color: colors.text, marginLeft: 8 }}>Smart Fill</Text>
+            <Pressable onPress={() => setOpen(false)} hitSlop={8}><X size={22} color={colors.text} /></Pressable>
+          </View>
+
+          <Text style={{ fontSize: 12, color: colors.muted, marginBottom: space.sm, lineHeight: 18 }}>
+            Paste an email, scope of works, or rough notes — the AI extracts the customer, line items, and notes for this {mode}.
+          </Text>
+
+          <TextInput
+            value={text}
+            onChangeText={setText}
+            multiline
+            placeholder={`e.g.\n\nHi — quote for Sarah Johnson, 12 Beach Rd Bondi.\n- Replace 4 panels\n- Repaint trim, 2 days @ $480/day\n- 10% gst\nDue end of month.`}
+            placeholderTextColor={colors.muted}
+            style={{
+              flex: 1,
+              padding: space.sm + 2, borderRadius: radius.md,
+              backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline,
+              color: colors.text, fontSize: 14,
+              textAlignVertical: "top",
+              minHeight: 200,
+              maxHeight: 400,
+            }}
+          />
+
+          <Pressable onPress={run} disabled={busy}
+            style={({ pressed }) => ({
+              flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+              padding: space.md, borderRadius: radius.lg,
+              backgroundColor: pressed ? "#0d6e6a" : colors.primary,
+              opacity: busy ? 0.6 : 1, marginTop: space.md,
+            })}>
+            {busy ? <ActivityIndicator color="#fff" /> : <Sparkles size={18} color="#fff" />}
+            <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>
+              {busy ? "Extracting…" : "Extract & fill form"}
+            </Text>
+          </Pressable>
+        </View>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- **Smart Fill** modal on /quotes/new and /invoices/new — paste any text, AI extracts customer + line items + notes + terms
- **/settings/bank** — bank name, account name/number, BSB/sort, IBAN; owner/admin only
- **Convert to quote** button on lead detail — finds or mints customer, drafts a quote, marks lead 'quoted'
- Parity matrix updated.

## Test plan
- [ ] New quote → tap "Smart Fill from text" → paste an email → form populates
- [ ] New invoice → same flow
- [ ] Profile → Bank details → fill, save, reopen — values persist
- [ ] Open a 'new' lead → Convert to quote → lands on draft quote with the customer attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)