### PR TITLE
feat(mobile): work-order portfolio + camera direct-capture

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -106,8 +106,8 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Reset to draft | ❌ | 2 | |
 | Smart Fill (paste → form) | ✅ | 3a | Modal on /quotes/new + /invoices/new; hits /api/ai smart_fill_document |
 | **Service** |
-| Work orders list | 🟡 | 1 | Worker sees only theirs; owner sees all |
-| Work order detail (full portfolio) | 🟡 | 1 | Has basics; need: Workers picker, financials, share link |
+| Work orders list | ✅ | 3d | Owner /work-orders/index; status filter pills; worker /jobs unchanged |
+| Work order detail (full portfolio) | ✅ | 3d | /work-orders/[id]: workers picker (multi-select), financials with link-out, share toggle, "create invoice" affordance |
 | Site reports list | ✅ | 3 | |
 | Site report detail (sections, photos, PDF, share) | ✅ | 3 | |
 | New site report (AI generated) | ❌ | 3+ | Defer — AI generator is heavy lift |
@@ -148,7 +148,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | **Mobile-native bonuses** |
 | Push notifications | ❌ | 4 | Briefing alerts, new leads |
 | Offline-first (jobs / photos) | ❌ | 5 | Power feature |
-| Camera direct-capture for invoices | ❌ | 3 | Tap → photo → AI line items |
+| Camera direct-capture for invoices | ✅ | 3d | Camera/library buttons in Smart Fill modal — runs describe_images then smart_fill_document |
 
 ---
 

--- a/mobile/app/(tabs)/sales.tsx
+++ b/mobile/app/(tabs)/sales.tsx
@@ -1,7 +1,7 @@
 import { ScrollView, Text, View, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { Users, UserPlus, FileCheck, FileText, ChevronRight, ClipboardList, Repeat, TrendingUp, Bot, Sparkles, Package } from "lucide-react-native";
+import { Users, UserPlus, FileCheck, FileText, ChevronRight, ClipboardList, Repeat, TrendingUp, Bot, Sparkles, Package, Briefcase } from "lucide-react-native";
 import { colors, radius, space } from "@/lib/theme";
 import { BusinessSwitcher } from "@/components/BusinessSwitcher";
 import { useActiveBusiness } from "@/lib/active-business";
@@ -56,7 +56,8 @@ export default function SalesHub() {
     { href: "/invoices",  label: "Invoices",  hint: "Bill and collect",              icon: <FileText size={20} color="#16a34a" />, bg: "#dcfce7", fg: "#16a34a" },
   ];
   const ops: Section[] = [
-    { href: "/assistant", label: "Assistant",    hint: "Briefing — what needs you next",  icon: <Sparkles size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },
+    { href: "/assistant",    label: "Assistant",    hint: "Briefing — what needs you next",  icon: <Sparkles size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },
+    { href: "/work-orders",  label: "Jobs",         hint: "Workers, financials, share link", icon: <Briefcase size={20} color="#1d4ed8" />, bg: "#dbeafe", fg: "#1d4ed8" },
     { href: "/reports",   label: "Site reports", hint: "Inspection & condition reports", icon: <ClipboardList size={20} color="#b45309" />, bg: "#fef3c7", fg: "#b45309" },
     { href: "/recurring", label: "Recurring jobs", hint: "Auto-scheduled work",          icon: <Repeat size={20} color="#7c3aed" />, bg: "#ede9fe", fg: "#7c3aed" },
     { href: "/analytics", label: "Analytics",    hint: "Revenue, leads, quotes won",     icon: <TrendingUp size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },

--- a/mobile/app/work-orders/[id].tsx
+++ b/mobile/app/work-orders/[id].tsx
@@ -1,0 +1,431 @@
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator, Alert, FlatList, Linking, Modal, Pressable,
+  RefreshControl, ScrollView, Share, Switch, Text, View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import {
+  ArrowLeft, Users, FileCheck, FileText, Send, MapPin, Briefcase,
+  Plus, X, Check, Phone, Mail,
+} from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { useActiveBusiness } from "@/lib/active-business";
+import { colors, radius, space } from "@/lib/theme";
+
+interface WorkOrderFull {
+  id:               string;
+  number:           string;
+  title:            string | null;
+  status:           string;
+  scheduled_date:   string | null;
+  share_token:      string | null;
+  customer_id:      string | null;
+  customers:        { id: string; name: string; email: string | null; phone: string | null } | null;
+  work_order_assignments: Array<{
+    member_profile_id: string;
+    member_profiles:   { id: string; name: string; email: string; avatar_url: string | null } | null;
+  }>;
+}
+
+interface Linked {
+  id: string; number: string; status: string; total: unknown;
+  amount_paid?: unknown; due_date?: string | null;
+}
+
+interface MemberLite {
+  id: string; name: string; email: string; avatar_url: string | null;
+}
+
+const num = (v: unknown) => { const n = typeof v === "number" ? v : parseFloat(String(v ?? 0)); return Number.isFinite(n) ? n : 0; };
+function fmt(n: number, currency: string): string {
+  try { return new Intl.NumberFormat("en-AU", { style: "currency", currency }).format(n); }
+  catch { return `${currency} ${n.toFixed(2)}`; }
+}
+
+/** Owner / admin work-order portfolio. Workers picker, linked
+ *  financials, share link toggle. The worker-flavoured /job/[id]
+ *  stays as the field UI; this is the ops view. */
+export default function WorkOrderPortfolio() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { active, role } = useActiveBusiness();
+  const canEdit = role === "owner" || role === "admin" || role === "editor";
+
+  const [wo,         setWo]         = useState<WorkOrderFull | null>(null);
+  const [quotes,     setQuotes]     = useState<Linked[]>([]);
+  const [invoices,   setInvoices]   = useState<Linked[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [busy,       setBusy]       = useState(false);
+
+  const currency = active?.currency ?? "AUD";
+
+  const load = async () => {
+    if (!id || !active) return;
+    const [{ data: woRaw }, { data: qts }, { data: invs }] = await Promise.all([
+      supabase.from("work_orders")
+        .select("id, number, title, status, scheduled_date, share_token, customer_id, customers(id, name, email, phone), work_order_assignments(member_profile_id, member_profiles(id, name, email, avatar_url))")
+        .eq("id", id).eq("business_id", active.id).maybeSingle(),
+      supabase.from("quotes")
+        .select("id, number, status, total")
+        .eq("business_id", active.id).eq("work_order_id", id)
+        .order("created_at", { ascending: false }),
+      supabase.from("invoices")
+        .select("id, number, status, total, amount_paid, due_date")
+        .eq("business_id", active.id).eq("work_order_id", id)
+        .order("created_at", { ascending: false }),
+    ]);
+    setWo((woRaw ?? null) as unknown as WorkOrderFull | null);
+    setQuotes((qts ?? []) as Linked[]);
+    setInvoices((invs ?? []) as Linked[]);
+  };
+
+  useEffect(() => { load(); }, [id, active?.id]);
+
+  const toggleShare = async (next: boolean) => {
+    if (!wo || !canEdit) return;
+    setBusy(true);
+    if (next) {
+      const token = wo.share_token ?? "wo_" + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+      await supabase.from("work_orders").update({ share_token: token, share_enabled_at: new Date().toISOString() }).eq("id", wo.id);
+    } else {
+      await supabase.from("work_orders").update({ share_token: null, share_enabled_at: null }).eq("id", wo.id);
+    }
+    setBusy(false);
+    load();
+  };
+
+  const shareLink = async () => {
+    if (!wo?.share_token) return;
+    const base = process.env.EXPO_PUBLIC_APP_URL ?? "https://kireihq.com";
+    const url = `${base}/wo/${wo.share_token}`;
+    await Share.share({
+      message: `Job ${wo.number}${wo.title ? ` — ${wo.title}` : ""}: ${url}`,
+      url, title: `Job ${wo.number}`,
+    });
+  };
+
+  /** Mint a draft invoice prefilled with this WO's customer; the WO is linked
+   *  via work_order_id so it shows up on the portfolio. */
+  const billUnbilled = async () => {
+    if (!wo || !active || !wo.customer_id) {
+      Alert.alert("Customer required", "Attach a customer to the work order first.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const { data: biz } = await supabase
+        .from("businesses").select("invoice_prefix, invoice_next_number")
+        .eq("id", active.id).single();
+      const prefix = (biz as { invoice_prefix?: string; invoice_next_number?: number })?.invoice_prefix ?? "INV";
+      const nextNum = (biz as { invoice_prefix?: string; invoice_next_number?: number })?.invoice_next_number ?? 1;
+      const number = `${prefix}-${String(nextNum).padStart(4, "0")}`;
+      await supabase.from("businesses").update({ invoice_next_number: nextNum + 1 }).eq("id", active.id);
+
+      const { data: { user } } = await supabase.auth.getUser();
+      const today = new Date().toISOString().split("T")[0];
+      const due = new Date(Date.now() + 14 * 86_400_000).toISOString().split("T")[0];
+
+      const { data: created, error } = await supabase
+        .from("invoices")
+        .insert({
+          user_id: user?.id, business_id: active.id, number,
+          status: "draft", customer_id: wo.customer_id,
+          work_order_id: wo.id,
+          issue_date: today, due_date: due,
+          line_items: [],
+          subtotal: 0, tax_total: 0, total: 0, amount_paid: 0,
+        })
+        .select("id").single();
+      if (error) throw error;
+      router.push(`/invoices/${(created as { id: string }).id}` as never);
+    } catch (e) {
+      Alert.alert("Couldn't create invoice", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!wo) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas, alignItems: "center", justifyContent: "center" }}>
+        <ActivityIndicator color={colors.primary} />
+      </SafeAreaView>
+    );
+  }
+
+  const assigned = (wo.work_order_assignments ?? [])
+    .map((a) => a.member_profiles)
+    .filter((m): m is MemberLite => !!m);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}><ArrowLeft size={22} color={colors.text} /></Pressable>
+        <Briefcase size={18} color={colors.text} />
+        <Text style={{ flex: 1, fontSize: 18, fontWeight: "700", color: colors.text }} numberOfLines={1}>{wo.number}</Text>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={{ padding: space.lg, gap: space.md }}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={async () => { setRefreshing(true); await load(); setRefreshing(false); }} tintColor={colors.primary} />}
+      >
+        {/* Header card */}
+        <View style={{ padding: space.lg, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: 6 }}>
+          <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>{wo.status}</Text>
+          <Text style={{ fontSize: 18, fontWeight: "700", color: colors.text }}>{wo.title ?? "Untitled"}</Text>
+          {wo.customers && (
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 8, marginTop: 4 }}>
+              <MapPin size={13} color={colors.muted} />
+              <Pressable onPress={() => router.push(`/customers/${wo.customers!.id}` as never)}>
+                <Text style={{ fontSize: 13, color: colors.primary }}>{wo.customers.name}</Text>
+              </Pressable>
+            </View>
+          )}
+          {wo.scheduled_date && (
+            <Text style={{ fontSize: 12, color: colors.muted, marginTop: 2 }}>Scheduled {new Date(wo.scheduled_date).toLocaleDateString()}</Text>
+          )}
+          <Pressable onPress={() => router.push(`/job/${wo.id}` as never)}
+            style={({ pressed }) => ({ marginTop: space.sm, paddingVertical: 6, opacity: pressed ? 0.6 : 1 })}>
+            <Text style={{ fontSize: 12, color: colors.primary, fontWeight: "700" }}>Open field view →</Text>
+          </Pressable>
+        </View>
+
+        {/* Workers */}
+        <View style={{ padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: space.sm }}>
+          <View style={{ flexDirection: "row", alignItems: "center" }}>
+            <Users size={14} color={colors.muted} />
+            <Text style={{ flex: 1, marginLeft: 6, fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>
+              Workers · {assigned.length}
+            </Text>
+            {canEdit && (
+              <Pressable onPress={() => setPickerOpen(true)} hitSlop={8}
+                style={({ pressed }) => ({ flexDirection: "row", alignItems: "center", gap: 4, opacity: pressed ? 0.7 : 1 })}>
+                <Plus size={14} color={colors.primary} />
+                <Text style={{ fontSize: 12, color: colors.primary, fontWeight: "700" }}>Edit</Text>
+              </Pressable>
+            )}
+          </View>
+          {assigned.length === 0 ? (
+            <Text style={{ fontSize: 12, color: colors.muted }}>No one assigned yet.</Text>
+          ) : assigned.map((m) => (
+            <View key={m.id} style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+              <View style={{ width: 30, height: 30, borderRadius: 15, backgroundColor: colors.muted + "33", alignItems: "center", justifyContent: "center" }}>
+                <Text style={{ fontSize: 12, fontWeight: "700", color: colors.text }}>{m.name.slice(0, 1).toUpperCase()}</Text>
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>{m.name}</Text>
+                <Text style={{ fontSize: 11, color: colors.muted }}>{m.email}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* Financials */}
+        <View style={{ padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: space.sm }}>
+          <Text style={{ fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>Financials</Text>
+
+          {quotes.length === 0 && invoices.length === 0 ? (
+            <Text style={{ fontSize: 12, color: colors.muted }}>No quotes or invoices linked.</Text>
+          ) : (
+            <>
+              {quotes.map((q) => (
+                <Pressable key={q.id} onPress={() => router.push(`/quotes/${q.id}` as never)}
+                  style={({ pressed }) => ({ flexDirection: "row", alignItems: "center", paddingVertical: 6, opacity: pressed ? 0.6 : 1 })}>
+                  <FileCheck size={14} color="#7c3aed" />
+                  <Text style={{ marginLeft: 8, flex: 1, fontSize: 13, color: colors.text }}>{q.number}</Text>
+                  <Text style={{ fontSize: 11, color: colors.muted, marginRight: 8 }}>{q.status}</Text>
+                  <Text style={{ fontSize: 13, fontWeight: "700", color: colors.text }}>{fmt(num(q.total), currency)}</Text>
+                </Pressable>
+              ))}
+              {invoices.map((inv) => {
+                const balance = Math.max(0, num(inv.total) - num(inv.amount_paid));
+                return (
+                  <Pressable key={inv.id} onPress={() => router.push(`/invoices/${inv.id}` as never)}
+                    style={({ pressed }) => ({ flexDirection: "row", alignItems: "center", paddingVertical: 6, opacity: pressed ? 0.6 : 1 })}>
+                    <FileText size={14} color="#16a34a" />
+                    <Text style={{ marginLeft: 8, flex: 1, fontSize: 13, color: colors.text }}>{inv.number}</Text>
+                    <Text style={{ fontSize: 11, color: colors.muted, marginRight: 8 }}>
+                      {balance > 0 ? `${fmt(balance, currency)} due` : "paid"}
+                    </Text>
+                    <Text style={{ fontSize: 13, fontWeight: "700", color: colors.text }}>{fmt(num(inv.total), currency)}</Text>
+                  </Pressable>
+                );
+              })}
+            </>
+          )}
+
+          {canEdit && (
+            <Pressable onPress={billUnbilled} disabled={busy}
+              style={({ pressed }) => ({
+                flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+                paddingVertical: 8, borderRadius: radius.md,
+                backgroundColor: pressed ? colors.muted : "transparent",
+                borderWidth: 1, borderColor: colors.hairline, borderStyle: "dashed",
+                opacity: busy ? 0.6 : 1, marginTop: 4,
+              })}>
+              <Plus size={14} color={colors.primary} />
+              <Text style={{ fontSize: 12, fontWeight: "700", color: colors.primary }}>Create invoice for this job</Text>
+            </Pressable>
+          )}
+        </View>
+
+        {/* Share link */}
+        {canEdit && (
+          <View style={{ padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, gap: space.sm }}>
+            <View style={{ flexDirection: "row", alignItems: "center" }}>
+              <Send size={14} color={colors.muted} />
+              <Text style={{ flex: 1, marginLeft: 6, fontSize: 11, color: colors.muted, textTransform: "uppercase", letterSpacing: 0.6, fontWeight: "700" }}>
+                Share link
+              </Text>
+              <Switch
+                value={!!wo.share_token}
+                onValueChange={toggleShare}
+                disabled={busy}
+                trackColor={{ true: colors.primary, false: colors.muted + "55" }}
+              />
+            </View>
+            <Text style={{ fontSize: 12, color: colors.muted, lineHeight: 18 }}>
+              Customer can see job status, photos, and signed updates without logging in.
+            </Text>
+            {wo.share_token && (
+              <Pressable onPress={shareLink}
+                style={({ pressed }) => ({
+                  flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+                  padding: space.sm + 2, borderRadius: radius.md,
+                  backgroundColor: pressed ? "#0d6e6a" : colors.primary,
+                })}>
+                <Send size={14} color="#fff" />
+                <Text style={{ color: "#fff", fontSize: 13, fontWeight: "700" }}>Share with customer</Text>
+              </Pressable>
+            )}
+          </View>
+        )}
+
+        {/* Quick contact */}
+        {wo.customers && (wo.customers.phone || wo.customers.email) && (
+          <View style={{ flexDirection: "row", gap: space.sm }}>
+            {wo.customers.phone && (
+              <Pressable onPress={() => Linking.openURL(`tel:${wo.customers!.phone!.replace(/\s/g, "")}`)}
+                style={({ pressed }) => ({
+                  flex: 1, flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+                  padding: space.md, borderRadius: radius.lg,
+                  backgroundColor: pressed ? "#0d4a47" : colors.primary,
+                })}>
+                <Phone size={16} color="#fff" />
+                <Text style={{ color: "#fff", fontSize: 13, fontWeight: "700" }}>Call</Text>
+              </Pressable>
+            )}
+            {wo.customers.email && (
+              <Pressable onPress={() => Linking.openURL(`mailto:${wo.customers!.email}`)}
+                style={({ pressed }) => ({
+                  flex: 1, flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+                  padding: space.md, borderRadius: radius.lg,
+                  backgroundColor: pressed ? "#1e3a8a" : "#1d4ed8",
+                })}>
+                <Mail size={16} color="#fff" />
+                <Text style={{ color: "#fff", fontSize: 13, fontWeight: "700" }}>Email</Text>
+              </Pressable>
+            )}
+          </View>
+        )}
+      </ScrollView>
+
+      {pickerOpen && active && (
+        <WorkerPickerModal
+          businessId={active.id}
+          workOrderId={wo.id}
+          currentlyAssigned={(wo.work_order_assignments ?? []).map((a) => a.member_profile_id)}
+          onClose={() => { setPickerOpen(false); load(); }}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+function WorkerPickerModal({ businessId, workOrderId, currentlyAssigned, onClose }: {
+  businessId: string; workOrderId: string;
+  currentlyAssigned: string[];
+  onClose: () => void;
+}) {
+  const [members, setMembers] = useState<MemberLite[]>([]);
+  const [picked,  setPicked]  = useState<Set<string>>(new Set(currentlyAssigned));
+  const [saving,  setSaving]  = useState(false);
+
+  useEffect(() => {
+    supabase.from("member_profiles")
+      .select("id, name, email, avatar_url")
+      .eq("business_id", businessId).eq("is_active", true)
+      .order("name", { ascending: true })
+      .then(({ data }) => setMembers((data ?? []) as MemberLite[]));
+  }, [businessId]);
+
+  const save = async () => {
+    setSaving(true);
+    // Wipe + reinsert — simpler than diffing
+    await supabase.from("work_order_assignments").delete().eq("work_order_id", workOrderId);
+    if (picked.size > 0) {
+      const rows = Array.from(picked).map((mpId) => ({
+        work_order_id: workOrderId, member_profile_id: mpId,
+      }));
+      await supabase.from("work_order_assignments").insert(rows);
+    }
+    setSaving(false);
+    onClose();
+  };
+
+  return (
+    <Modal visible animationType="slide" onRequestClose={onClose}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }}>
+        <View style={{ flex: 1, padding: space.lg }}>
+          <View style={{ flexDirection: "row", alignItems: "center", marginBottom: space.md }}>
+            <Text style={{ flex: 1, fontSize: 18, fontWeight: "700", color: colors.text }}>Assign workers</Text>
+            <Pressable onPress={onClose} hitSlop={8}><X size={22} color={colors.text} /></Pressable>
+          </View>
+          <FlatList
+            data={members}
+            keyExtractor={(m) => m.id}
+            ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: colors.hairline }} />}
+            ListEmptyComponent={<Text style={{ color: colors.muted, textAlign: "center", marginTop: space.xl }}>No team members yet. Add some in Settings → Team.</Text>}
+            renderItem={({ item }) => {
+              const selected = picked.has(item.id);
+              return (
+                <Pressable
+                  onPress={() => {
+                    const next = new Set(picked);
+                    if (next.has(item.id)) next.delete(item.id); else next.add(item.id);
+                    setPicked(next);
+                  }}
+                  style={({ pressed }) => ({
+                    flexDirection: "row", alignItems: "center", gap: space.sm,
+                    paddingVertical: space.md,
+                    opacity: pressed ? 0.6 : 1,
+                  })}>
+                  <View style={{ width: 30, height: 30, borderRadius: 15, backgroundColor: colors.muted + "33", alignItems: "center", justifyContent: "center" }}>
+                    <Text style={{ fontSize: 12, fontWeight: "700", color: colors.text }}>{item.name.slice(0, 1).toUpperCase()}</Text>
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ fontSize: 14, fontWeight: "600", color: colors.text }}>{item.name}</Text>
+                    <Text style={{ fontSize: 12, color: colors.muted }}>{item.email}</Text>
+                  </View>
+                  {selected && <Check size={18} color={colors.primary} />}
+                </Pressable>
+              );
+            }}
+          />
+          <Pressable onPress={save} disabled={saving}
+            style={({ pressed }) => ({
+              flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+              padding: space.md, borderRadius: radius.lg,
+              backgroundColor: pressed ? "#0d6e6a" : colors.primary,
+              opacity: saving ? 0.6 : 1,
+            })}>
+            <Text style={{ color: "#fff", fontSize: 15, fontWeight: "700" }}>{saving ? "Saving…" : `Save (${picked.size})`}</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}

--- a/mobile/app/work-orders/index.tsx
+++ b/mobile/app/work-orders/index.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState, useMemo } from "react";
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { ArrowLeft, Briefcase } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { useActiveBusiness } from "@/lib/active-business";
+import { colors, radius, space } from "@/lib/theme";
+
+interface Row {
+  id: string;
+  number: string;
+  title: string | null;
+  status: string;
+  scheduled_date: string | null;
+  customers: { name: string } | null;
+}
+
+const STATUS_COLOUR: Record<string, { bg: string; fg: string }> = {
+  scheduled:   { bg: "#dbeafe", fg: "#1d4ed8" },
+  in_progress: { bg: "#fef3c7", fg: "#92400e" },
+  submitted:   { bg: "#ede9fe", fg: "#6d28d9" },
+  completed:   { bg: "#dcfce7", fg: "#166534" },
+  cancelled:   { bg: "#fee2e2", fg: "#991b1b" },
+};
+
+const TABS: Array<{ id: string; label: string }> = [
+  { id: "all",         label: "All" },
+  { id: "scheduled",   label: "Scheduled" },
+  { id: "in_progress", label: "In progress" },
+  { id: "submitted",   label: "Submitted" },
+  { id: "completed",   label: "Done" },
+];
+
+/** Owner / admin work-orders list. Tapping a row opens the portfolio
+ *  view (workers, financials, share). The /job/[id] route is the
+ *  worker-flavoured field UI used from the Jobs tab. */
+export default function WorkOrdersList() {
+  const router = useRouter();
+  const { active } = useActiveBusiness();
+  const [rows, setRows] = useState<Row[] | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [tab, setTab] = useState<string>("all");
+
+  const load = async () => {
+    if (!active) return;
+    const { data } = await supabase
+      .from("work_orders")
+      .select("id, number, title, status, scheduled_date, customers(name)")
+      .eq("business_id", active.id)
+      .order("scheduled_date", { ascending: false, nullsFirst: false });
+    setRows((data ?? []) as unknown as Row[]);
+  };
+
+  useEffect(() => { load(); }, [active?.id]);
+
+  const filtered = useMemo(() => {
+    if (!rows) return null;
+    if (tab === "all") return rows;
+    return rows.filter((r) => r.status === tab);
+  }, [rows, tab]);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}><ArrowLeft size={22} color={colors.text} /></Pressable>
+        <Briefcase size={18} color={colors.text} />
+        <Text style={{ fontSize: 20, fontWeight: "700", color: colors.text }}>Jobs</Text>
+        <View style={{ flex: 1 }} />
+        <Text style={{ fontSize: 12, color: colors.muted }}>{rows?.length ?? 0}</Text>
+      </View>
+
+      <View style={{ flexDirection: "row", gap: 6, paddingHorizontal: space.lg, paddingBottom: space.sm, flexWrap: "wrap" }}>
+        {TABS.map((t) => (
+          <Pressable key={t.id} onPress={() => setTab(t.id)}
+            style={({ pressed }) => ({
+              paddingHorizontal: 12, paddingVertical: 6, borderRadius: 999,
+              backgroundColor: tab === t.id ? colors.primary : pressed ? colors.muted : colors.card,
+              borderWidth: 1, borderColor: tab === t.id ? colors.primary : colors.hairline,
+            })}>
+            <Text style={{ fontSize: 12, fontWeight: "600", color: tab === t.id ? "#fff" : colors.text }}>{t.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {!rows ? (
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}><ActivityIndicator color={colors.primary} /></View>
+      ) : (
+        <FlatList
+          data={filtered ?? []}
+          keyExtractor={(r) => r.id}
+          contentContainerStyle={{ padding: space.lg, gap: space.sm }}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={async () => { setRefreshing(true); await load(); setRefreshing(false); }} tintColor={colors.primary} />}
+          ListEmptyComponent={<Text style={{ color: colors.muted, textAlign: "center", marginTop: space.xl }}>No jobs.</Text>}
+          renderItem={({ item }) => {
+            const c = STATUS_COLOUR[item.status] ?? { bg: colors.muted, fg: colors.text };
+            return (
+              <Pressable
+                onPress={() => router.push(`/work-orders/${item.id}` as never)}
+                style={({ pressed }) => ({
+                  padding: space.md, borderRadius: radius.lg,
+                  backgroundColor: pressed ? colors.muted : colors.card,
+                  borderWidth: 1, borderColor: colors.hairline,
+                })}>
+                <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
+                  <Text style={{ fontFamily: "monospace", fontSize: 12, color: colors.muted }}>{item.number}</Text>
+                  <View style={{ flex: 1 }} />
+                  <View style={{ paddingHorizontal: 8, paddingVertical: 2, borderRadius: 999, backgroundColor: c.bg }}>
+                    <Text style={{ fontSize: 10, fontWeight: "700", color: c.fg, textTransform: "uppercase", letterSpacing: 0.5 }}>{item.status}</Text>
+                  </View>
+                </View>
+                <Text style={{ fontSize: 15, fontWeight: "600", color: colors.text, marginTop: 4 }} numberOfLines={1}>{item.title ?? "Untitled"}</Text>
+                <Text style={{ fontSize: 12, color: colors.muted, marginTop: 2 }} numberOfLines={1}>
+                  {item.customers?.name ?? "No customer"}
+                  {item.scheduled_date ? ` · ${new Date(item.scheduled_date).toLocaleDateString()}` : ""}
+                </Text>
+              </Pressable>
+            );
+          }}
+        />
+      )}
+    </SafeAreaView>
+  );
+}

--- a/mobile/src/components/SmartFillButton.tsx
+++ b/mobile/src/components/SmartFillButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ActivityIndicator, Alert, Modal, Pressable, Text, TextInput, View } from "react-native";
-import { Sparkles, X } from "lucide-react-native";
+import * as ImagePicker from "expo-image-picker";
+import { Sparkles, X, Camera, ImagePlus } from "lucide-react-native";
 import { supabase } from "@/lib/supabase";
 import { LineItem, newLineItem } from "./LineItemsEditor";
 import { colors, radius, space } from "@/lib/theme";
@@ -40,6 +41,42 @@ export function SmartFillButton({
   const [open, setOpen] = useState(false);
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
+
+  /** Take/pick a photo, run describe_images to get a scope of works, then
+   *  feed that scope text into the existing Smart Fill flow. */
+  const fillFromPhoto = async (source: "camera" | "library") => {
+    try {
+      const perm = source === "camera"
+        ? await ImagePicker.requestCameraPermissionsAsync()
+        : await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert("Permission required", "Allow access to use this.");
+        return;
+      }
+      const picked = source === "camera"
+        ? await ImagePicker.launchCameraAsync({ base64: true, quality: 0.6, mediaTypes: ImagePicker.MediaTypeOptions.Images })
+        : await ImagePicker.launchImageLibraryAsync({ base64: true, quality: 0.6, mediaTypes: ImagePicker.MediaTypeOptions.Images });
+      if (picked.canceled || !picked.assets?.[0]?.base64) return;
+
+      setBusy(true);
+      const base = process.env.EXPO_PUBLIC_APP_URL ?? "https://kireihq.com";
+      const r1 = await fetch(`${base}/api/ai`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "describe_images",
+          images: [{ base64: picked.assets[0].base64, mediaType: picked.assets[0].mimeType ?? "image/jpeg" }],
+        }),
+      });
+      if (!r1.ok) throw new Error(`Describe images failed: ${r1.status}`);
+      const { result: scope } = await r1.json() as { result: string };
+      setText((prev) => (prev ? prev + "\n\n" : "") + (scope ?? ""));
+    } catch (e) {
+      Alert.alert("Couldn't read photo", e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const run = async () => {
     if (!text.trim()) { Alert.alert("Paste something first", "Drop in an email, scope of works, or rough notes."); return; }
@@ -149,8 +186,33 @@ export function SmartFillButton({
           </View>
 
           <Text style={{ fontSize: 12, color: colors.muted, marginBottom: space.sm, lineHeight: 18 }}>
-            Paste an email, scope of works, or rough notes — the AI extracts the customer, line items, and notes for this {mode}.
+            Paste an email, scope of works, or rough notes — the AI extracts the customer, line items, and notes for this {mode}. Or snap a job photo and let it write the scope for you.
           </Text>
+
+          <View style={{ flexDirection: "row", gap: space.sm, marginBottom: space.sm }}>
+            <Pressable onPress={() => fillFromPhoto("camera")} disabled={busy}
+              style={({ pressed }) => ({
+                flex: 1, flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+                padding: space.sm + 2, borderRadius: radius.md,
+                backgroundColor: pressed ? colors.muted : colors.card,
+                borderWidth: 1, borderColor: colors.hairline,
+                opacity: busy ? 0.6 : 1,
+              })}>
+              <Camera size={14} color={colors.text} />
+              <Text style={{ fontSize: 12, fontWeight: "700", color: colors.text }}>From camera</Text>
+            </Pressable>
+            <Pressable onPress={() => fillFromPhoto("library")} disabled={busy}
+              style={({ pressed }) => ({
+                flex: 1, flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 6,
+                padding: space.sm + 2, borderRadius: radius.md,
+                backgroundColor: pressed ? colors.muted : colors.card,
+                borderWidth: 1, borderColor: colors.hairline,
+                opacity: busy ? 0.6 : 1,
+              })}>
+              <ImagePlus size={14} color={colors.text} />
+              <Text style={{ fontSize: 12, fontWeight: "700", color: colors.text }}>From library</Text>
+            </Pressable>
+          </View>
 
           <TextInput
             value={text}


### PR DESCRIPTION
## Summary
**Work-order portfolio (owner/admin/editor):**
- /work-orders/index — list with status filter pills
- /work-orders/[id] — workers picker (multi-select), financials with link-out, share toggle, "create invoice for this job" affordance, quick call/email
- Worker /jobs unchanged

**Camera direct-capture:**
- Camera + library buttons inside Smart Fill modal
- Snap a job photo → /api/ai describe_images → scope appended to paste box → user runs Extract → quote/invoice populated

**Deferred:**
- AI agent chat — needs server-side bearer-auth refactor on /api/agent and nested server actions; flagged for dedicated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)