### PR TITLE
feat(mobile): AI agent chat — bearer-auth endpoint + UI

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -130,7 +130,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Tasks (kanban) | 🟡 | shipped (basic) | Polish: drag-drop on mobile, link to job |
 | Messages (SMS inbox) | ❌ | 4 | Inbound replies |
 | Assistant page | ✅ | 2g | Full briefing inbox with deep-links + pull-to-refresh |
-| AI agent chat | ❌ | 4 | Native voice |
+| AI agent chat | ✅ | 3e | /agent text chat hits new /api/mobile/agent (bearer auth, 9-tool surface). Native voice deferred. |
 | **Settings** |
 | Business profile | ✅ | 2d | Name, contact, ABN, currency, address — owner/admin only |
 | Bank details | ✅ | 3a | /settings/bank — name, account name/number, BSB/sort, IBAN |

--- a/mobile/app/(tabs)/sales.tsx
+++ b/mobile/app/(tabs)/sales.tsx
@@ -56,7 +56,8 @@ export default function SalesHub() {
     { href: "/invoices",  label: "Invoices",  hint: "Bill and collect",              icon: <FileText size={20} color="#16a34a" />, bg: "#dcfce7", fg: "#16a34a" },
   ];
   const ops: Section[] = [
-    { href: "/assistant",    label: "Assistant",    hint: "Briefing — what needs you next",  icon: <Sparkles size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },
+    { href: "/agent",        label: "Ask",          hint: "AI assistant — ask anything",     icon: <Sparkles size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },
+    { href: "/assistant",    label: "Briefing",     hint: "Punch list — what needs you",     icon: <Sparkles size={20} color={colors.primary} />, bg: colors.primarySoft, fg: colors.primary },
     { href: "/work-orders",  label: "Jobs",         hint: "Workers, financials, share link", icon: <Briefcase size={20} color="#1d4ed8" />, bg: "#dbeafe", fg: "#1d4ed8" },
     { href: "/reports",   label: "Site reports", hint: "Inspection & condition reports", icon: <ClipboardList size={20} color="#b45309" />, bg: "#fef3c7", fg: "#b45309" },
     { href: "/recurring", label: "Recurring jobs", hint: "Auto-scheduled work",          icon: <Repeat size={20} color="#7c3aed" />, bg: "#ede9fe", fg: "#7c3aed" },

--- a/mobile/app/agent/index.tsx
+++ b/mobile/app/agent/index.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator, Alert, KeyboardAvoidingView, Platform, Pressable,
+  ScrollView, Text, TextInput, View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import { ArrowLeft, Send, Sparkles } from "lucide-react-native";
+import { supabase } from "@/lib/supabase";
+import { useActiveBusiness } from "@/lib/active-business";
+import { colors, radius, space } from "@/lib/theme";
+
+interface Message {
+  role: "user" | "assistant";
+  text: string;
+}
+
+const SUGGESTIONS = [
+  "What's overdue?",
+  "Who hasn't paid this month?",
+  "What's on today?",
+  "Any new leads?",
+  "Show stale quotes",
+];
+
+/** On-the-go AI assistant. Hits /api/mobile/agent with a bearer token,
+ *  small read-mostly tool surface (search, briefing, schedule, status updates). */
+export default function AgentChat() {
+  const router = useRouter();
+  const { active } = useActiveBusiness();
+
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput]       = useState("");
+  const [busy, setBusy]         = useState(false);
+  const scrollRef = useRef<ScrollView | null>(null);
+
+  useEffect(() => {
+    setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 50);
+  }, [messages.length]);
+
+  const send = async (text: string) => {
+    if (!active || !text.trim() || busy) return;
+    const next: Message[] = [...messages, { role: "user", text }];
+    setMessages(next);
+    setInput("");
+    setBusy(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const accessToken = session?.access_token;
+      if (!accessToken) throw new Error("Not signed in");
+
+      const base = process.env.EXPO_PUBLIC_APP_URL ?? "https://kireihq.com";
+      const res = await fetch(`${base}/api/mobile/agent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          business_id: active.id,
+          // Only send simplified text history; the server doesn't need our tool round-trips
+          messages: next.map((m) => ({ role: m.role, content: m.text })),
+        }),
+      });
+      if (!res.ok) {
+        const txt = await res.text();
+        throw new Error(txt || `Server returned ${res.status}`);
+      }
+      const { text: reply } = await res.json() as { text: string };
+      setMessages([...next, { role: "assistant", text: reply ?? "(no reply)" }]);
+    } catch (e) {
+      Alert.alert("Couldn't reach assistant", e instanceof Error ? e.message : "Unknown error");
+      setMessages(messages); // rollback so user can retry
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.canvas }} edges={["top", "left", "right"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: space.lg, paddingTop: space.sm, paddingBottom: space.sm, gap: space.sm }}>
+        <Pressable onPress={() => router.back()} hitSlop={10}><ArrowLeft size={22} color={colors.text} /></Pressable>
+        <Sparkles size={18} color={colors.primary} />
+        <Text style={{ fontSize: 18, fontWeight: "700", color: colors.text }}>Assistant</Text>
+        <View style={{ flex: 1 }} />
+        {messages.length > 0 && (
+          <Pressable onPress={() => setMessages([])} hitSlop={8}>
+            <Text style={{ fontSize: 12, color: colors.muted }}>Clear</Text>
+          </Pressable>
+        )}
+      </View>
+
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} style={{ flex: 1 }}>
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={{ padding: space.lg, gap: space.md, flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {messages.length === 0 ? (
+            <View style={{ flex: 1, gap: space.md }}>
+              <View style={{ alignItems: "center", marginTop: space.xl, gap: 6 }}>
+                <Sparkles size={36} color={colors.primary} />
+                <Text style={{ fontSize: 18, fontWeight: "700", color: colors.text }}>Ask anything about your business</Text>
+                <Text style={{ fontSize: 13, color: colors.muted, textAlign: "center", maxWidth: 280 }}>
+                  I can look up customers, invoices, quotes, leads, today's schedule, and update statuses.
+                </Text>
+              </View>
+              <View style={{ gap: space.sm, marginTop: space.md }}>
+                {SUGGESTIONS.map((s) => (
+                  <Pressable key={s} onPress={() => send(s)}
+                    style={({ pressed }) => ({
+                      padding: space.md, borderRadius: radius.lg,
+                      backgroundColor: pressed ? colors.muted : colors.card,
+                      borderWidth: 1, borderColor: colors.hairline,
+                    })}>
+                    <Text style={{ fontSize: 14, color: colors.text }}>{s}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          ) : messages.map((m, i) => (
+            <View key={i} style={{
+              alignSelf: m.role === "user" ? "flex-end" : "flex-start",
+              maxWidth: "85%",
+              padding: space.md,
+              borderRadius: radius.lg,
+              backgroundColor: m.role === "user" ? colors.primary : colors.card,
+              borderWidth: m.role === "user" ? 0 : 1,
+              borderColor: colors.hairline,
+            }}>
+              <Text style={{ fontSize: 14, color: m.role === "user" ? "#fff" : colors.text, lineHeight: 20 }}>
+                {m.text}
+              </Text>
+            </View>
+          ))}
+          {busy && (
+            <View style={{ alignSelf: "flex-start", padding: space.md, borderRadius: radius.lg, backgroundColor: colors.card, borderWidth: 1, borderColor: colors.hairline, flexDirection: "row", gap: 8, alignItems: "center" }}>
+              <ActivityIndicator size="small" color={colors.muted} />
+              <Text style={{ fontSize: 13, color: colors.muted }}>Thinking…</Text>
+            </View>
+          )}
+        </ScrollView>
+
+        <View style={{ flexDirection: "row", padding: space.sm, gap: space.sm, borderTopWidth: 1, borderTopColor: colors.hairline, backgroundColor: colors.card }}>
+          <TextInput
+            value={input}
+            onChangeText={setInput}
+            placeholder="Ask anything…"
+            placeholderTextColor={colors.muted}
+            multiline
+            onSubmitEditing={() => send(input)}
+            editable={!busy}
+            style={{
+              flex: 1, paddingHorizontal: space.md, paddingVertical: 10,
+              borderRadius: radius.lg, backgroundColor: colors.canvas,
+              borderWidth: 1, borderColor: colors.hairline,
+              color: colors.text, fontSize: 14,
+              maxHeight: 120,
+            }}
+          />
+          <Pressable
+            onPress={() => send(input)}
+            disabled={busy || !input.trim()}
+            style={({ pressed }) => ({
+              padding: 12, borderRadius: radius.lg,
+              backgroundColor: !input.trim() || busy ? colors.muted : pressed ? "#0d6e6a" : colors.primary,
+              alignItems: "center", justifyContent: "center",
+            })}>
+            <Send size={18} color="#fff" />
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/src/app/api/mobile/agent/route.ts
+++ b/src/app/api/mobile/agent/route.ts
@@ -1,0 +1,328 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient as createSupaClient, SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Mobile-flavoured agent endpoint.
+ *
+ * Authenticates via Authorization: Bearer <access_token>, then talks to
+ * Postgres through a Supabase client that forwards that token — RLS scopes
+ * everything to the caller. Tool set is intentionally small and read-mostly
+ * so we don't need to plumb cookie-bound server actions through here.
+ *
+ * Mirrors the spirit of /api/agent without the 30+ tool surface — this one
+ * answers "what's overdue", "who hasn't paid", "find quote QT-0042", and
+ * applies a few low-risk write actions (mark invoice paid / quote sent /
+ * lead status).
+ */
+
+const anthropic = new Anthropic();
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+interface ToolContext {
+  supa:        SupabaseClient;
+  businessId:  string;
+  userId:      string;
+}
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: "search_customers",
+    description: "Find customers by name, email, or company. Always call before giving the user a customer answer.",
+    input_schema: { type: "object" as const, properties: { query: { type: "string" } }, required: ["query"] },
+  },
+  {
+    name: "search_invoices",
+    description: "Search invoices by number, customer name, or filter by status (draft|sent|partial|paid|overdue). Returns balance + due date.",
+    input_schema: {
+      type: "object" as const,
+      properties: { query: { type: "string" }, status: { type: "string" } },
+    },
+  },
+  {
+    name: "search_quotes",
+    description: "Search quotes by number / customer name, optionally filter by status (draft|sent|accepted|rejected|expired).",
+    input_schema: {
+      type: "object" as const,
+      properties: { query: { type: "string" }, status: { type: "string" } },
+    },
+  },
+  {
+    name: "search_leads",
+    description: "Search leads by name, optionally filter by status (new|contacted|quoted|won|lost).",
+    input_schema: {
+      type: "object" as const,
+      properties: { query: { type: "string" }, status: { type: "string" } },
+    },
+  },
+  {
+    name: "get_briefing",
+    description: "Today's punch list — overdue invoices, stale quotes, new leads, unassigned jobs, submitted work orders awaiting review.",
+    input_schema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "get_today",
+    description: "What's on today — scheduled jobs, who they're assigned to.",
+    input_schema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "mark_invoice_paid",
+    description: "Mark an invoice as fully paid. Use after the user confirms.",
+    input_schema: { type: "object" as const, properties: { invoice_id: { type: "string" } }, required: ["invoice_id"] },
+  },
+  {
+    name: "mark_quote_status",
+    description: "Update a quote's status. Use after user confirms.",
+    input_schema: {
+      type: "object" as const,
+      properties: { quote_id: { type: "string" }, status: { type: "string", enum: ["draft", "sent", "accepted", "rejected", "expired"] } },
+      required: ["quote_id", "status"],
+    },
+  },
+  {
+    name: "set_lead_status",
+    description: "Update a lead's status (new, contacted, quoted, won, lost).",
+    input_schema: {
+      type: "object" as const,
+      properties: { lead_id: { type: "string" }, status: { type: "string", enum: ["new", "contacted", "quoted", "won", "lost"] } },
+      required: ["lead_id", "status"],
+    },
+  },
+];
+
+const num = (v: unknown) => { const n = typeof v === "number" ? v : parseFloat(String(v ?? 0)); return Number.isFinite(n) ? n : 0; };
+const daysAgo = (iso: string) => Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000));
+
+async function runTool(name: string, input: Record<string, unknown>, ctx: ToolContext): Promise<unknown> {
+  const { supa, businessId } = ctx;
+
+  if (name === "search_customers") {
+    const q = String(input.query ?? "").trim();
+    let query = supa.from("customers")
+      .select("id, name, company, email, phone, archived")
+      .eq("business_id", businessId)
+      .eq("archived", false)
+      .limit(20);
+    if (q) query = query.or(`name.ilike.%${q}%,company.ilike.%${q}%,email.ilike.%${q}%`);
+    const { data } = await query;
+    return data ?? [];
+  }
+
+  if (name === "search_invoices") {
+    const q = String(input.query ?? "").trim();
+    const status = input.status as string | undefined;
+    let query = supa.from("invoices")
+      .select("id, number, status, total, amount_paid, due_date, customers(name)")
+      .eq("business_id", businessId)
+      .order("created_at", { ascending: false })
+      .limit(30);
+    if (status) query = query.eq("status", status);
+    if (q) query = query.or(`number.ilike.%${q}%`);
+    const { data } = await query;
+    return (data ?? []).map((inv: { id: string; number: string; status: string; total: unknown; amount_paid: unknown; due_date: string | null; customers: unknown }) => {
+      const cust = inv.customers as { name: string } | { name: string }[] | null;
+      const custName = Array.isArray(cust) ? cust[0]?.name : cust?.name;
+      return {
+        id: inv.id, number: inv.number, status: inv.status,
+        total: num(inv.total), balance: Math.max(0, num(inv.total) - num(inv.amount_paid)),
+        due_date: inv.due_date, customer: custName ?? null,
+      };
+    });
+  }
+
+  if (name === "search_quotes") {
+    const q = String(input.query ?? "").trim();
+    const status = input.status as string | undefined;
+    let query = supa.from("quotes")
+      .select("id, number, status, total, expiry_date, customers(name)")
+      .eq("business_id", businessId)
+      .order("created_at", { ascending: false })
+      .limit(30);
+    if (status) query = query.eq("status", status);
+    if (q) query = query.or(`number.ilike.%${q}%`);
+    const { data } = await query;
+    return (data ?? []).map((q: { id: string; number: string; status: string; total: unknown; expiry_date: string | null; customers: unknown }) => {
+      const cust = q.customers as { name: string } | { name: string }[] | null;
+      const custName = Array.isArray(cust) ? cust[0]?.name : cust?.name;
+      return { id: q.id, number: q.number, status: q.status, total: num(q.total), expiry_date: q.expiry_date, customer: custName ?? null };
+    });
+  }
+
+  if (name === "search_leads") {
+    const q = String(input.query ?? "").trim();
+    const status = input.status as string | undefined;
+    let query = supa.from("leads")
+      .select("id, name, status, source, suburb, email, phone, created_at")
+      .eq("business_id", businessId)
+      .order("created_at", { ascending: false })
+      .limit(30);
+    if (status) query = query.eq("status", status);
+    if (q) query = query.or(`name.ilike.%${q}%`);
+    const { data } = await query;
+    return data ?? [];
+  }
+
+  if (name === "get_briefing") {
+    const today = new Date().toISOString().split("T")[0];
+    const sevenDaysAgo = new Date(Date.now() - 7 * 86_400_000).toISOString();
+    const [
+      { data: invoices }, { data: quotes }, { data: leads },
+      { data: jobsToday }, { data: submitted },
+    ] = await Promise.all([
+      supa.from("invoices").select("id, number, status, total, amount_paid, due_date, customers(name)").eq("business_id", businessId).in("status", ["sent", "partial", "overdue"]),
+      supa.from("quotes").select("id, number, updated_at, customers(name)").eq("business_id", businessId).eq("status", "sent").lt("updated_at", sevenDaysAgo),
+      supa.from("leads").select("id, name, created_at").eq("business_id", businessId).eq("status", "new"),
+      supa.from("work_orders").select("id, number, title, customers(name), work_order_assignments(member_profile_id)").eq("business_id", businessId).eq("scheduled_date", today),
+      supa.from("work_orders").select("id, number, title, customers(name), updated_at").eq("business_id", businessId).eq("status", "submitted"),
+    ]);
+
+    const out: Array<{ kind: string; title: string; subtitle: string; priority: string }> = [];
+    for (const inv of (invoices ?? []) as Array<{ id: string; number: string; total: unknown; amount_paid: unknown; due_date: string | null; customers: unknown }>) {
+      if (!inv.due_date || new Date(inv.due_date) >= new Date()) continue;
+      const balance = Math.max(0, num(inv.total) - num(inv.amount_paid));
+      if (balance < 0.01) continue;
+      const days = daysAgo(inv.due_date);
+      const cust = inv.customers as { name: string } | { name: string }[] | null;
+      const custName = Array.isArray(cust) ? cust[0]?.name : cust?.name;
+      out.push({ kind: "overdue_invoice", title: `${inv.number} · ${days}d overdue`, subtitle: `${custName ?? "—"} · $${balance.toFixed(2)}`, priority: days > 30 ? "high" : days > 14 ? "med" : "low" });
+    }
+    for (const q of (quotes ?? []) as Array<{ id: string; number: string; updated_at: string; customers: unknown }>) {
+      const days = daysAgo(q.updated_at);
+      const cust = q.customers as { name: string } | { name: string }[] | null;
+      const custName = Array.isArray(cust) ? cust[0]?.name : cust?.name;
+      out.push({ kind: "stale_quote", title: `${q.number} · sent ${days}d ago`, subtitle: custName ?? "No customer", priority: days > 14 ? "med" : "low" });
+    }
+    for (const l of (leads ?? []) as Array<{ id: string; name: string; created_at: string }>) {
+      const days = daysAgo(l.created_at);
+      out.push({ kind: "new_lead", title: l.name, subtitle: days === 0 ? "New today" : `${days}d ago`, priority: days > 2 ? "high" : "med" });
+    }
+    for (const j of (jobsToday ?? []) as Array<{ id: string; number: string; title: string; customers: unknown; work_order_assignments: Array<unknown> }>) {
+      if (!j.work_order_assignments || j.work_order_assignments.length === 0) {
+        const cust = j.customers as { name: string } | { name: string }[] | null;
+        const custName = Array.isArray(cust) ? cust[0]?.name : cust?.name;
+        out.push({ kind: "today_job_unassigned", title: `${j.number} today`, subtitle: `${j.title}${custName ? ` · ${custName}` : ""}`, priority: "high" });
+      }
+    }
+    for (const w of (submitted ?? []) as Array<{ id: string; number: string; title: string; customers: unknown; updated_at: string }>) {
+      const days = daysAgo(w.updated_at);
+      const cust = w.customers as { name: string } | { name: string }[] | null;
+      const custName = Array.isArray(cust) ? cust[0]?.name : cust?.name;
+      out.push({ kind: "submitted_workorder", title: `${w.number} submitted`, subtitle: `${w.title}${custName ? ` · ${custName}` : ""}`, priority: days > 1 ? "high" : "med" });
+    }
+    return out;
+  }
+
+  if (name === "get_today") {
+    const today = new Date().toISOString().split("T")[0];
+    const { data } = await supa.from("work_orders")
+      .select("id, number, title, status, scheduled_date, customers(name), work_order_assignments(member_profiles(name))")
+      .eq("business_id", businessId).eq("scheduled_date", today);
+    return (data ?? []).map((w: { id: string; number: string; title: string; status: string; customers: unknown; work_order_assignments: Array<{ member_profiles: unknown }> }) => {
+      const cust = w.customers as { name: string } | { name: string }[] | null;
+      const workers = (w.work_order_assignments ?? []).map((a) => {
+        const m = a.member_profiles as { name: string } | { name: string }[] | null;
+        return Array.isArray(m) ? m[0]?.name : m?.name;
+      }).filter(Boolean);
+      return {
+        number: w.number, title: w.title, status: w.status,
+        customer: Array.isArray(cust) ? cust[0]?.name : cust?.name,
+        workers,
+      };
+    });
+  }
+
+  if (name === "mark_invoice_paid") {
+    const id = String(input.invoice_id);
+    const { data: inv } = await supa.from("invoices").select("total").eq("id", id).eq("business_id", businessId).single();
+    const total = num((inv as { total: unknown } | null)?.total);
+    const { error } = await supa.from("invoices").update({ amount_paid: total, status: "paid" }).eq("id", id);
+    return error ? { error: error.message } : { ok: true, total };
+  }
+
+  if (name === "mark_quote_status") {
+    const { error } = await supa.from("quotes").update({ status: input.status }).eq("id", input.quote_id).eq("business_id", businessId);
+    return error ? { error: error.message } : { ok: true };
+  }
+
+  if (name === "set_lead_status") {
+    const { error } = await supa.from("leads").update({ status: input.status }).eq("id", input.lead_id).eq("business_id", businessId);
+    return error ? { error: error.message } : { ok: true };
+  }
+
+  return { error: `Unknown tool: ${name}` };
+}
+
+export async function POST(request: NextRequest) {
+  // Bearer auth
+  const auth = request.headers.get("authorization") ?? "";
+  const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  if (!token) return NextResponse.json({ error: "Missing Authorization header" }, { status: 401 });
+
+  // Build a supabase client that forwards this token — RLS scopes everything
+  const supa = createSupaClient(SUPABASE_URL, SUPABASE_ANON, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: { user }, error: userErr } = await supa.auth.getUser(token);
+  if (userErr || !user) return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+
+  const { messages, business_id } = await request.json() as { messages: Anthropic.MessageParam[]; business_id: string };
+  if (!business_id) return NextResponse.json({ error: "business_id required" }, { status: 400 });
+
+  // Confirm membership — RLS will also reject but cleanest to fail fast
+  const { data: businessOwn } = await supa.from("businesses").select("id, name").eq("id", business_id).maybeSingle();
+  const { data: businessMember } = await supa.from("business_members").select("business_id").eq("business_id", business_id).eq("user_id", user.id).eq("status", "active").maybeSingle();
+  if (!businessOwn && !businessMember) return NextResponse.json({ error: "Not a member of this business" }, { status: 403 });
+  const businessName = (businessOwn as { name: string } | null)?.name ?? "your business";
+
+  const ctx: ToolContext = { supa, businessId: business_id, userId: user.id };
+
+  const today = new Date().toISOString().split("T")[0];
+  const system = `You are the on-the-go assistant for ${businessName}, a trades business.
+Today is ${today}. The user is the owner or admin running ops from their phone.
+
+Use the tools to look up customers, invoices, quotes, leads, briefings, today's schedule.
+Be brief — phone screens are small. Lead with the answer, then key supporting numbers.
+If asked to update something, confirm before calling write tools.
+Money is in AUD unless otherwise specified.`;
+
+  const allMessages: Anthropic.MessageParam[] = [...messages];
+  let iterations = 0;
+  while (iterations < 10) {
+    iterations++;
+    const response = await anthropic.messages.create({
+      model: "claude-opus-4-6",
+      max_tokens: 2048,
+      system,
+      tools: TOOLS,
+      messages: allMessages,
+    });
+
+    const hasToolUse = response.content.some((b) => b.type === "tool_use");
+    if (!hasToolUse) {
+      const text = response.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      return NextResponse.json({ text });
+    }
+
+    // Execute tool calls and feed results back
+    allMessages.push({ role: "assistant", content: response.content });
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const block of response.content) {
+      if (block.type !== "tool_use") continue;
+      const result = await runTool(block.name, block.input as Record<string, unknown>, ctx);
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: JSON.stringify(result),
+      });
+    }
+    allMessages.push({ role: "user", content: toolResults });
+  }
+
+  return NextResponse.json({ text: "I ran out of steps. Try a simpler question." });
+}


### PR DESCRIPTION
## Summary
- New POST /api/mobile/agent — bearer-auth, RLS-scoped agent with a 9-tool read-mostly surface (search invoices/quotes/leads/customers, briefing, today, status updates)
- Avoids the cookie-bound server actions /api/agent uses, so no server-wide refactor
- Mobile UI at /agent — chat bubbles, suggestions, keyboard-avoiding input
- Sales tab → "Ask" routes here

## Test plan
- [ ] Open /agent → tap a suggestion → assistant answers from your real data
- [ ] Ask "what's overdue?" → should list overdue invoices with amounts
- [ ] Ask "who hasn't paid?" → should list unpaid invoices
- [ ] Ask "show stale quotes" → lists quotes sent >7 days ago
- [ ] Ask "what's on today" → shows today's scheduled jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)