### PR TITLE
fix(invoices): roll child deposit payments up to the parent

### DIFF
--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -339,29 +339,51 @@ export async function addPayment(invoiceId: string, payment: { amount: number; d
     .single();
   if (!invoice) throw new Error("Invoice not found");
 
-  const newAmountPaid = (invoice.amount_paid ?? 0) + payment.amount;
-  const newStatus = newAmountPaid >= invoice.total ? "paid" : "partial";
-
   await tbl(supabase, "payments").insert({ ...payment, invoice_id: invoiceId, user_id: user.id, business_id: businessId });
+
+  // Recompute this invoice's amount_paid from truth (payments table + any
+  // children's collections if it's a parent of a progress-billed job). This
+  // handles direct-payment-on-parent-with-children correctly without
+  // double-counting prior rollups stored in amount_paid.
+  const { data: directPayments } = await tbl(supabase, "payments")
+    .select("amount")
+    .eq("invoice_id", invoiceId)
+    .eq("business_id", businessId);
+  const directSum = ((directPayments ?? []) as { amount: unknown }[])
+    .reduce((s, r) => s + Number(r.amount ?? 0), 0);
+  const { data: childCollections } = await tbl(supabase, "invoices")
+    .select("amount_paid")
+    .eq("parent_invoice_id", invoiceId)
+    .eq("business_id", businessId);
+  const childSum = ((childCollections ?? []) as { amount_paid: unknown }[])
+    .reduce((s, r) => s + Number(r.amount_paid ?? 0), 0);
+  const newAmountPaid = directSum + childSum;
+  const newStatus = newAmountPaid >= invoice.total - 0.01 ? "paid" : "partial";
+
   await tbl(supabase, "invoices").update({ amount_paid: newAmountPaid, status: newStatus }).eq("id", invoiceId);
 
   // If this invoice is a child of a progress-billed parent, roll the new
-  // payment up. Once the sum of all sibling collections plus the parent's own
-  // direct payments covers the parent's total, auto-mark the parent paid so
-  // it stops appearing in outstanding lists.
+  // payment up so the parent reflects everything collected toward the job.
+  // The parent's amount_paid is recomputed as: sum of direct payments against
+  // the parent + sum of amount_paid across all child invoices. Idempotent —
+  // safe to call repeatedly, no double-counting.
   const { data: childRow } = await tbl(supabase, "invoices")
     .select("parent_invoice_id")
     .eq("id", invoiceId)
     .maybeSingle();
   const parentId = childRow?.parent_invoice_id as string | null;
   if (parentId) {
-    const [{ data: siblings }, { data: parentRow }] = await Promise.all([
+    const [{ data: siblings }, { data: parentDirectPayments }, { data: parentRow }] = await Promise.all([
       tbl(supabase, "invoices")
         .select("amount_paid")
         .eq("parent_invoice_id", parentId)
         .eq("business_id", businessId),
+      tbl(supabase, "payments")
+        .select("amount")
+        .eq("invoice_id", parentId)
+        .eq("business_id", businessId),
       tbl(supabase, "invoices")
-        .select("total, amount_paid, status")
+        .select("total, status")
         .eq("id", parentId)
         .eq("business_id", businessId)
         .maybeSingle(),
@@ -369,11 +391,25 @@ export async function addPayment(invoiceId: string, payment: { amount: number; d
     if (parentRow) {
       const collectedFromChildren = ((siblings ?? []) as { amount_paid: unknown }[])
         .reduce((s, r) => s + Number(r.amount_paid ?? 0), 0);
-      const parentTotal     = Number(parentRow.total ?? 0);
-      const parentDirect    = Number(parentRow.amount_paid ?? 0);
-      const fullyCovered    = collectedFromChildren + parentDirect >= parentTotal - 0.01;
-      if (fullyCovered && parentRow.status !== "paid" && parentRow.status !== "cancelled") {
-        await tbl(supabase, "invoices").update({ status: "paid" }).eq("id", parentId);
+      const parentDirect = ((parentDirectPayments ?? []) as { amount: unknown }[])
+        .reduce((s, r) => s + Number(r.amount ?? 0), 0);
+      const totalCollected = parentDirect + collectedFromChildren;
+      const parentTotal    = Number(parentRow.total ?? 0);
+      const fullyCovered   = totalCollected >= parentTotal - 0.01;
+
+      // Decide the parent's new status. Don't fight cancelled or draft.
+      const currentStatus = parentRow.status as string;
+      let nextStatus = currentStatus;
+      if (currentStatus !== "cancelled" && currentStatus !== "draft") {
+        if (fullyCovered)               nextStatus = "paid";
+        else if (totalCollected > 0.01) nextStatus = "partial";
+      }
+
+      await tbl(supabase, "invoices")
+        .update({ amount_paid: totalCollected, status: nextStatus })
+        .eq("id", parentId);
+
+      if (nextStatus === "paid" && currentStatus !== "paid") {
         dispatchWebhook(businessId, "invoice.paid", { id: parentId, total: parentTotal, via_progress: true });
       }
       revalidatePath(`/invoices/${parentId}`);

--- a/supabase/migrations/20260510232842_progress_invoice_parent_rollup_backfill.sql
+++ b/supabase/migrations/20260510232842_progress_invoice_parent_rollup_backfill.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- Backfill: parent invoices of progress-billed jobs should reflect everything
+-- collected toward the job (direct payments + sum of children's amount_paid).
+--
+-- Prior to the addPayment fix that lands with this migration, paying a
+-- child deposit invoice did not update the parent's amount_paid or flip the
+-- parent to 'partial'. Run this once to reconcile existing data.
+--
+-- Idempotent — safe to re-run.
+-- ============================================================================
+
+UPDATE public.invoices p
+SET
+  amount_paid = COALESCE(rollup.total_collected, 0),
+  status = CASE
+    -- Don't fight cancelled / draft
+    WHEN p.status IN ('cancelled', 'draft')                                       THEN p.status
+    WHEN COALESCE(rollup.total_collected, 0) >= p.total - 0.01                    THEN 'paid'
+    WHEN COALESCE(rollup.total_collected, 0) >  0.01                              THEN 'partial'
+    ELSE p.status
+  END
+FROM (
+  SELECT
+    parent.id AS parent_id,
+    COALESCE((
+      SELECT SUM(pay.amount)
+      FROM   public.payments pay
+      WHERE  pay.invoice_id = parent.id
+    ), 0)
+    + COALESCE((
+      SELECT SUM(child.amount_paid)
+      FROM   public.invoices child
+      WHERE  child.parent_invoice_id = parent.id
+    ), 0)
+    AS total_collected
+  FROM public.invoices parent
+  WHERE EXISTS (
+    SELECT 1 FROM public.invoices c WHERE c.parent_invoice_id = parent.id
+  )
+) AS rollup
+WHERE p.id = rollup.parent_id
+  AND (
+    -- Only touch rows that are genuinely out of sync to keep the migration cheap
+    p.amount_paid IS DISTINCT FROM COALESCE(rollup.total_collected, 0)
+    OR (
+      COALESCE(rollup.total_collected, 0) >= p.total - 0.01
+      AND p.status NOT IN ('paid', 'cancelled', 'draft')
+    )
+    OR (
+      COALESCE(rollup.total_collected, 0) > 0.01
+      AND COALESCE(rollup.total_collected, 0) < p.total - 0.01
+      AND p.status NOT IN ('partial', 'cancelled', 'draft')
+    )
+  );


### PR DESCRIPTION
## The bug
Pay a deposit child invoice → parent stays at amount_paid=0 and stays sent/draft. Parent should be 'partial' (or 'paid' once fully covered) and reflect the running total.

## The fix
Both addPayment paths now recompute amount_paid from truth — sum of direct payments to this invoice + sum of amount_paid across child invoices. Idempotent, no double-counting. When the invoice being paid is a child, the parent gets the same recomputation. Status auto-flips between draft → partial → paid (cancelled and draft are left alone).

Backfill migration reconciles existing parent invoices in one pass so you don't need to wait for new payments.

## Test plan
- [ ] Create parent invoice $1000 → bill 30% deposit ($300 child) → mark child paid → parent shows partial with $300 paid, $700 due
- [ ] Bill remaining 70% ($700 child) → mark paid → parent flips to paid
- [ ] Existing data: run migration, parents that already had paid children should reflect totals
- [ ] Direct payment on parent that has children still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)