### PR TITLE
fix(work-orders): prefill property address from selected customer

### DIFF
--- a/src/app/(dashboard)/work-orders/new/page.tsx
+++ b/src/app/(dashboard)/work-orders/new/page.tsx
@@ -25,7 +25,12 @@ export default async function NewWorkOrderPage({ searchParams }: { searchParams:
   if (!canEdit(userRole)) redirect("/work-orders");
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: customersRaw } = await (supabase as any).from("customers").select("id, name, company, email").eq("business_id", businessId).eq("archived", false).order("name");
+  const { data: customersRaw } = await (supabase as any)
+    .from("customers")
+    .select("id, name, company, email, phone, address, city, state, postcode, country")
+    .eq("business_id", businessId)
+    .eq("archived", false)
+    .order("name");
   const customers = (customersRaw ?? []) as Customer[];
   const profiles = await getAssignableProfiles().catch(() => []) as Pick<MemberProfile, 'id' | 'name' | 'email' | 'avatar_url' | 'role_title'>[];
 

--- a/src/components/work-orders/work-order-new-client.tsx
+++ b/src/components/work-orders/work-order-new-client.tsx
@@ -102,6 +102,18 @@ export function WorkOrderNewClient({
 
         // Auto-select single site
         if (!siteId && s.length === 1) setSiteId(s[0].id);
+
+        // Prefill property address from the customer record itself if:
+        //  - no site has been auto-selected (the site effect below would overwrite this anyway)
+        //  - the address field is currently empty (don't stomp on user input)
+        if (s.length !== 1 && !propertyAddress.trim()) {
+          const cust = customers.find((x) => x.id === accountId);
+          if (cust) {
+            const composed = [cust.address, cust.city, cust.state, cust.postcode, cust.country]
+              .filter(Boolean).join(", ");
+            if (composed) setPropertyAddress(composed);
+          }
+        }
       } catch (e) {
         console.error("Failed to load account context", e);
       } finally {


### PR DESCRIPTION
Two bugs in /work-orders/new: address columns weren't being fetched, and the prefill only fired for sites (not direct customer addresses). Now customers without sites also prefill the address field, without stomping user input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)