### PR TITLE
fix(voice): stop Whisper repetition + bias hallucination

### DIFF
--- a/mobile/app/agent/index.tsx
+++ b/mobile/app/agent/index.tsx
@@ -40,7 +40,11 @@ export default function AgentChat() {
   const [recording, setRecording] = useState(false);
   const [transcribing, setTranscribing] = useState(false);
   const scrollRef = useRef<ScrollView | null>(null);
-  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  // Speech-grade preset — 22kHz mono is more than enough for Whisper and
+  // produces dramatically smaller uploads + fewer compression artifacts than
+  // HIGH_QUALITY (44kHz stereo 320kbps).
+  const recorder = useAudioRecorder(RecordingPresets.LOW_QUALITY);
+  const recordStartedAtRef = useRef<number>(0);
 
   useEffect(() => {
     setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 50);
@@ -56,6 +60,16 @@ export default function AgentChat() {
         setRecording(false);
         const uri = recorder.uri;
         if (!uri) return;
+
+        // Skip very short recordings — Whisper hallucinates on < 0.6s clips
+        // ("you you you", repeated word patterns, etc.) which costs a round
+        // trip and confuses the user.
+        const ms = Date.now() - recordStartedAtRef.current;
+        if (ms < 600) {
+          Alert.alert("Too short", "Hold the mic for at least a second.");
+          return;
+        }
+
         setTranscribing(true);
         const { data: { session } } = await supabase.auth.getSession();
         const accessToken = session?.access_token;
@@ -88,6 +102,7 @@ export default function AgentChat() {
         if (!status.granted) { Alert.alert("Mic permission required"); return; }
         await recorder.prepareToRecordAsync();
         recorder.record();
+        recordStartedAtRef.current = Date.now();
         setRecording(true);
       } catch (e) {
         Alert.alert("Couldn't start recording", e instanceof Error ? e.message : "Unknown error");

--- a/src/app/api/ai/transcribe/route.ts
+++ b/src/app/api/ai/transcribe/route.ts
@@ -49,12 +49,19 @@ export async function POST(request: NextRequest) {
   const filename = audio.name || "voice.webm";
   upstream.append("file", audio, filename);
   upstream.append("model", "whisper-1");
-  upstream.append("response_format", "json");
-  // Optional: bias toward business jargon
-  upstream.append(
-    "prompt",
-    "Field service business commands. Common terms: work order, invoice, quote, customer, site, property, contact, billing profile, schedule, assign worker, tomorrow, next week."
-  );
+  // verbose_json gives us per-segment confidence + no_speech_prob so we can
+  // filter Whisper's known hallucination pattern (it repeats words / phrases
+  // when the audio is silent or mostly noise).
+  upstream.append("response_format", "verbose_json");
+  // Deterministic — temperature > 0 makes the repetition problem worse.
+  upstream.append("temperature", "0");
+  // Skip language auto-detect (it's wrong often on short clips and biases
+  // toward weird output). Set this from a header if you ever need non-en.
+  upstream.append("language", "en");
+  // No vocabulary-stuffing prompt — that was forcing Whisper to repeat the
+  // bias words ("work order, invoice, customer…") when the actual audio was
+  // unclear. Keep it short + stylistic only.
+  upstream.append("prompt", "Conversational voice command.");
 
   try {
     const res = await fetch("https://api.openai.com/v1/audio/transcriptions", {
@@ -66,12 +73,55 @@ export async function POST(request: NextRequest) {
       const errText = await res.text();
       return NextResponse.json({ error: `Whisper error: ${errText}` }, { status: 502 });
     }
-    const data = await res.json();
-    return NextResponse.json({ text: data.text ?? "" });
+    type Segment = { text: string; no_speech_prob?: number; avg_logprob?: number };
+    const data = (await res.json()) as { text?: string; segments?: Segment[]; duration?: number };
+    let text = (data.text ?? "").trim();
+
+    // Repetition guard — Whisper's classic failure mode on silence is to
+    // output the same word/phrase 10+ times. Detect and blank it.
+    if (text && isLikelyHallucination(text, data.segments)) {
+      text = "";
+    }
+
+    return NextResponse.json({ text });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Transcription failed" },
       { status: 500 }
     );
   }
+}
+
+/** Returns true if the transcript looks like a Whisper repetition artefact:
+ *  - The same short word/phrase repeated > 4×
+ *  - Or every segment is mostly silence (no_speech_prob > 0.8)
+ *  - Or fewer than 2 unique tokens for a long-ish transcript */
+function isLikelyHallucination(text: string, segments?: Array<{ no_speech_prob?: number }>): boolean {
+  const lower = text.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, "").trim();
+  const words = lower.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return true;
+
+  // All segments flagged as silence
+  if (segments && segments.length > 0) {
+    const silent = segments.filter((s) => (s.no_speech_prob ?? 0) > 0.8).length;
+    if (silent / segments.length > 0.7) return true;
+  }
+
+  // Same 1-3-word phrase ≥ 4× in a row
+  for (const span of [1, 2, 3]) {
+    if (words.length < span * 4) continue;
+    const first = words.slice(0, span).join(" ");
+    let repeats = 1;
+    for (let i = span; i + span <= words.length; i += span) {
+      if (words.slice(i, i + span).join(" ") !== first) break;
+      repeats++;
+    }
+    if (repeats >= 4) return true;
+  }
+
+  // Very low unique-token ratio over a long transcript = repetition spam
+  const unique = new Set(words);
+  if (words.length > 10 && unique.size / words.length < 0.25) return true;
+
+  return false;
 }


### PR DESCRIPTION
Removed the aggressive vocabulary-stuffing prompt that was making Whisper inject/repeat those exact business terms, added temperature=0 + language=en + repetition guard + minimum recording length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)