### PR TITLE
fix(mobile): dark-mode contrast — kill white-on-white buttons + inputs

### DIFF
--- a/mobile/app/(auth)/forgot.tsx
+++ b/mobile/app/(auth)/forgot.tsx
@@ -82,7 +82,7 @@ export default function ForgotPassword() {
                   placeholderTextColor={colors.muted}
                   onSubmitEditing={submit}
                   style={{
-                    backgroundColor: "#fafaf3", borderRadius: radius.lg,
+                    backgroundColor: colors.surface2, borderRadius: radius.lg,
                     paddingHorizontal: 14, paddingVertical: 12,
                     fontSize: 15, color: colors.text,
                     borderWidth: 1, borderColor: colors.hairline,

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -91,7 +91,7 @@ export default function Login() {
                   keyboardType="email-address"
                   placeholder="you@example.com"
                   placeholderTextColor={colors.muted}
-                  style={inputStyle}
+                  style={inputStyle()}
                 />
               </Field>
               <Field label="Password">
@@ -101,7 +101,7 @@ export default function Login() {
                   secureTextEntry
                   placeholder="••••••••"
                   placeholderTextColor={colors.muted}
-                  style={inputStyle}
+                  style={inputStyle()}
                   onSubmitEditing={submit}
                 />
               </Field>
@@ -151,8 +151,8 @@ export default function Login() {
   );
 }
 
-const inputStyle = {
-  backgroundColor: "#fafaf3",
+const inputStyle = () => ({
+  backgroundColor: colors.surface2,
   borderRadius: radius.lg,
   paddingHorizontal: 14,
   paddingVertical: 12,
@@ -160,7 +160,7 @@ const inputStyle = {
   color: colors.text,
   borderWidth: 1,
   borderColor: colors.hairline,
-};
+});
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/mobile/app/(auth)/signup.tsx
+++ b/mobile/app/(auth)/signup.tsx
@@ -158,7 +158,7 @@ export default function SignUp() {
                 autoCorrect={false}
                 placeholder="A1B2C3D4"
                 placeholderTextColor={colors.muted}
-                style={{ ...inputStyle, fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace", letterSpacing: 4, fontSize: 18 }}
+                style={{ ...inputStyle(), fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace", letterSpacing: 4, fontSize: 18 }}
                 maxLength={12}
               />
               {/* Live preview pill */}
@@ -200,7 +200,7 @@ export default function SignUp() {
                 keyboardType="email-address"
                 placeholder={preview?.email ?? "you@example.com"}
                 placeholderTextColor={colors.muted}
-                style={inputStyle}
+                style={inputStyle()}
               />
             </Field>
 
@@ -211,7 +211,7 @@ export default function SignUp() {
                 secureTextEntry
                 placeholder="At least 6 characters"
                 placeholderTextColor={colors.muted}
-                style={inputStyle}
+                style={inputStyle()}
                 onSubmitEditing={submit}
               />
             </Field>
@@ -249,8 +249,8 @@ export default function SignUp() {
   );
 }
 
-const inputStyle = {
-  backgroundColor: "#fafaf3",
+const inputStyle = () => ({
+  backgroundColor: colors.surface2,
   borderRadius: radius.lg,
   paddingHorizontal: 14,
   paddingVertical: 12,
@@ -258,7 +258,7 @@ const inputStyle = {
   color: colors.text,
   borderWidth: 1,
   borderColor: colors.hairline,
-};
+});
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/mobile/app/(tabs)/tasks.tsx
+++ b/mobile/app/(tabs)/tasks.tsx
@@ -215,13 +215,13 @@ function TabPill({ active, label, onPress }: { active: boolean; label: string; o
       style={({ pressed }) => ({
         paddingHorizontal: 12, paddingVertical: 6,
         borderRadius: radius.pill,
-        backgroundColor: active ? colors.text : colors.card,
+        backgroundColor: active ? colors.primary : colors.card,
         borderWidth: 1,
-        borderColor: active ? colors.text : colors.hairline,
+        borderColor: active ? colors.primary : colors.hairline,
         opacity: pressed ? 0.85 : 1,
       })}
     >
-      <Text style={{ fontSize: 12, fontWeight: "700", color: active ? colors.white : colors.muted }}>
+      <Text style={{ fontSize: 12, fontWeight: "700", color: active ? "#fff" : colors.muted }}>
         {label}
       </Text>
     </Pressable>

--- a/mobile/app/job/[id].tsx
+++ b/mobile/app/job/[id].tsx
@@ -334,7 +334,7 @@ export default function JobDetail() {
               minHeight: 100,
               textAlignVertical: "top",
               borderRadius: radius.md,
-              backgroundColor: "#fafaf3",
+              backgroundColor: colors.surface2,
               padding: 12,
               fontSize: 14,
               color: colors.text,
@@ -351,11 +351,11 @@ export default function JobDetail() {
               paddingHorizontal: 14,
               paddingVertical: 8,
               borderRadius: radius.pill,
-              backgroundColor: colors.text,
+              backgroundColor: colors.primary,
               opacity: pressed || savingNotes || !notes.trim() ? 0.5 : 1,
             })}
           >
-            <Text style={{ color: colors.white, fontWeight: "600", fontSize: 13 }}>
+            <Text style={{ color: "#fff", fontWeight: "700", fontSize: 13 }}>
               {savingNotes ? "Saving…" : "Save notes"}
             </Text>
           </Pressable>
@@ -454,7 +454,7 @@ const center = {
 const backBtn = {
   marginTop: 12,
   paddingHorizontal: 16, paddingVertical: 10,
-  backgroundColor: colors.text, borderRadius: 999,
+  backgroundColor: colors.primary, borderRadius: 999,
 };
 const openMapsBtn = {
   marginTop: 12,
@@ -534,7 +534,7 @@ function PhotoButton({ icon, label, onPress, disabled }: { icon: React.ReactNode
         borderRadius: radius.pill,
         borderWidth: 1,
         borderColor: colors.hairline,
-        backgroundColor: "#fafaf3",
+        backgroundColor: colors.surface2,
         opacity: pressed || disabled ? 0.6 : 1,
       })}
     >


### PR DESCRIPTION
Fixed hardcoded `#fafaf3` input backgrounds and `colors.text` filled-pill backgrounds across auth, worker job view, and tasks tab. Module-scope style consts converted to functions so they pick up the live theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)