### PR TITLE
fix(mobile): Sales hub portrait layout

### DIFF
--- a/mobile/app/(tabs)/sales.tsx
+++ b/mobile/app/(tabs)/sales.tsx
@@ -20,13 +20,24 @@ interface Section {
 
 function SectionList({ sections, onPress, baseDelay = 0 }: { sections: Section[]; onPress: (href: string) => void; baseDelay?: number }) {
   const r = useResponsive();
-  // On tablet/landscape, lay out as a grid so we use the extra width.
-  const multiCol = r.isWide;
+  // sectionColumns is derived from width directly: 1 col on portrait phones,
+  // 2 on landscape phones / tablet portrait, 3 on tablet landscape. No more
+  // flexBasis 100% inside flexDirection: row which collapsed cards on some
+  // portrait phones.
+  const isGrid = r.sectionColumns > 1;
   return (
-    <View style={{ flexDirection: multiCol ? "row" : "column", flexWrap: "wrap", gap: space.sm }}>
+    <View style={{
+      flexDirection: isGrid ? "row" : "column",
+      flexWrap: isGrid ? "wrap" : "nowrap",
+      gap: space.sm,
+    }}>
       {sections.map((s, idx) => (
-        <FadeIn key={s.href} delay={baseDelay + idx * 50}
-          style={multiCol ? { flexBasis: r.isTablet ? "48%" : "100%", flexGrow: 1 } : undefined}
+        <FadeIn
+          key={s.href}
+          delay={baseDelay + idx * 50}
+          style={isGrid
+            ? { flexBasis: r.sectionBasis, flexGrow: 1, minWidth: 0 }
+            : { width: "100%" }}
         >
           <AnimatedPress
             onPress={() => onPress(s.href)}
@@ -35,23 +46,35 @@ function SectionList({ sections, onPress, baseDelay = 0 }: { sections: Section[]
               padding: space.md, borderRadius: radius.lg,
               backgroundColor: colors.card,
               borderWidth: 1, borderColor: colors.hairline,
+              width: "100%",
             }}
           >
             <LinearGradient
               colors={gradients[s.gradient] as unknown as readonly [string, string, ...string[]]}
               start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
               style={{
-                width: 46, height: 46, borderRadius: radius.lg,
+                width: 48, height: 48, borderRadius: radius.lg,
                 alignItems: "center", justifyContent: "center",
+                flexShrink: 0,
               }}
             >
               {s.icon}
             </LinearGradient>
             <View style={{ flex: 1, minWidth: 0 }}>
-              <Text style={{ fontSize: 16, fontWeight: "700", color: colors.text }}>{s.label}</Text>
-              <Text style={{ fontSize: 12, color: colors.muted, marginTop: 2 }}>{s.hint}</Text>
+              <Text
+                numberOfLines={1}
+                style={{ fontSize: 16, fontWeight: "700", color: colors.text }}
+              >
+                {s.label}
+              </Text>
+              <Text
+                numberOfLines={2}
+                style={{ fontSize: 12, color: colors.muted, marginTop: 2 }}
+              >
+                {s.hint}
+              </Text>
             </View>
-            <ChevronRight size={18} color={colors.muted} />
+            <ChevronRight size={18} color={colors.muted} style={{ flexShrink: 0 }} />
           </AnimatedPress>
         </FadeIn>
       ))}

--- a/mobile/src/lib/responsive.ts
+++ b/mobile/src/lib/responsive.ts
@@ -22,7 +22,18 @@ export interface Responsive {
   gridColumns:  2 | 3 | 4;
   /** flexBasis percentage to pair with `gridColumns` and `flexWrap: "wrap"`. */
   gridBasis:    `${number}%`;
-  /** Common container style: caps width on wide screens, centres horizontally. */
+  /** Columns for the Sales/Operations card grid. Deterministic by width so
+   *  the layout never collapses on portrait phones:
+   *    < 600px  → 1 (phone portrait)
+   *    600–900  → 2 (phone landscape, tablet portrait)
+   *    ≥ 900px  → 3 (tablet landscape) */
+  sectionColumns: 1 | 2 | 3;
+  /** flexBasis paired with sectionColumns + `flexWrap: "wrap"`. Includes a
+   *  small gap allowance so cards wrap cleanly. */
+  sectionBasis:   `${number}%`;
+  /** Common container style: caps width on tablets / landscape, centres
+   *  horizontally. On phone portrait this is a no-op (width is already
+   *  below CONTENT_MAX_WIDTH). */
   containerStyle: { maxWidth: number; width: "100%"; alignSelf: "center" };
 }
 
@@ -36,16 +47,23 @@ export function useResponsive(): Responsive {
   const isTablet    = smallest >= TABLET_MIN_DIMENSION;
   const isWide      = isTablet || isLandscape;
 
-  // Grid sizing — 4 columns on tablet, 3 on landscape phone, 2 elsewhere.
-  // flexBasis values include small gaps so the columns wrap cleanly.
+  // KPI grid — 4 cols on tablet, 3 on landscape phone, 2 elsewhere.
   let gridColumns: 2 | 3 | 4 = 2;
   let gridBasis: `${number}%` = "48%";
   if (isTablet)             { gridColumns = 4; gridBasis = "23%"; }
   else if (isLandscape)     { gridColumns = 3; gridBasis = "31%"; }
 
+  // Section card grid — derived from width directly so portrait phones
+  // never end up in the "wide" two-column path.
+  let sectionColumns: 1 | 2 | 3 = 1;
+  let sectionBasis: `${number}%` = "100%";
+  if (width >= 900)        { sectionColumns = 3; sectionBasis = "31%"; }
+  else if (width >= 600)   { sectionColumns = 2; sectionBasis = "48%"; }
+
   return {
     width, height, isLandscape, isTablet, isWide,
     gridColumns, gridBasis,
+    sectionColumns, sectionBasis,
     containerStyle: { maxWidth: CONTENT_MAX_WIDTH, width: "100%", alignSelf: "center" },
   };
 }


### PR DESCRIPTION
Sales tab cards were collapsing on portrait phones. New width-driven column logic in useResponsive(): 1 col under 600px, 2 cols under 900px, 3 cols above. Cards now render at full width whether stacked or grid.