### PR TITLE
feat: customer quote download + email delivery hints

### DIFF
--- a/src/app/api/pdf/quote/[id]/route.ts
+++ b/src/app/api/pdf/quote/[id]/route.ts
@@ -1,19 +1,66 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getQuote } from "@/lib/actions/quotes";
 import { getBusiness } from "@/lib/actions/business";
 
-export async function GET(_: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const token = req.nextUrl.searchParams.get("token");
 
-    const [quoteData, business] = await Promise.all([getQuote(id), getBusiness()]);
+  try {
+    // Two paths: tokenised (customer portal "Download" link — no auth, validate
+    // the portal token then fetch via the admin client) or signed-in user.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const quote = quoteData as any;
-    const customer = quote.customers ?? null;
+    let quote: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let business: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let customer: any;
+
+    if (token) {
+      const sb = createAdminClient();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tbl = (s: any, n: string) => s.from(n);
+
+      const { data: link } = await tbl(sb, "customer_portal_tokens")
+        .select("business_id, customer_id, expires_at, revoked_at")
+        .eq("token", token)
+        .maybeSingle();
+
+      if (!link || link.revoked_at) {
+        return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      }
+      if (link.expires_at && new Date(link.expires_at) < new Date()) {
+        return NextResponse.json({ error: "Token expired" }, { status: 401 });
+      }
+
+      const [{ data: q }, { data: biz }, { data: cust }] = await Promise.all([
+        tbl(sb, "quotes")
+          .select("*")
+          .eq("id", id)
+          .eq("business_id", link.business_id)
+          .eq("customer_id", link.customer_id)
+          .maybeSingle(),
+        tbl(sb, "businesses").select("*").eq("id", link.business_id).maybeSingle(),
+        tbl(sb, "customers").select("*").eq("id", link.customer_id).maybeSingle(),
+      ]);
+
+      if (!q) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      quote = q;
+      business = biz;
+      customer = cust;
+    } else {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+      const [quoteData, biz] = await Promise.all([getQuote(id), getBusiness()]);
+      quote = quoteData;
+      business = biz;
+      customer = (quoteData as { customers?: unknown }).customers ?? null;
+    }
+
     const lineItems = quote.line_items ?? [];
 
     const { renderToStream } = await import("@react-pdf/renderer");
@@ -25,7 +72,7 @@ export async function GET(_: Request, { params }: { params: Promise<{ id: string
       customer,
       business,
       lineItems,
-      pdfSettings: business.pdf_settings ?? null,
+      pdfSettings: business?.pdf_settings ?? null,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/portal/[token]/quote/[id]/page.tsx
+++ b/src/app/portal/[token]/quote/[id]/page.tsx
@@ -4,7 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { formatCurrency, formatDate } from "@/lib/utils";
-import { ArrowLeft, FileCheck } from "@/components/ui/icons";
+import { ArrowLeft, FileCheck, Download } from "@/components/ui/icons";
 import { AcceptQuoteButton } from "@/components/customer-portal/accept-quote-button";
 import type { LineItem } from "@/types/database";
 
@@ -74,7 +74,17 @@ export default async function PortalQuotePage({ params }: { params: Promise<{ to
               From {business?.name} · Issued {formatDate(quote.issue_date)} · Expires {formatDate(quote.expiry_date)}
             </p>
           </div>
-          <StatusBadge status={quote.status} />
+          <div className="flex items-center gap-2 flex-wrap">
+            <a
+              href={`/api/pdf/quote/${quote.id}?token=${token}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+            >
+              <Download className="w-3.5 h-3.5" /> Download PDF
+            </a>
+            <StatusBadge status={quote.status} />
+          </div>
         </div>
 
         {/* Customer */}

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -508,9 +508,12 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
   }
   const pdfBuffer = Buffer.concat(chunks);
 
-  // Mint/reuse a portal token so the customer can pay/view online
+  // Mint/reuse a portal token so the customer can pay/view online + tokenised
+  // /api/pdf/invoice link so they can re-download even when email clients strip
+  // the attachment.
   const businessId = await getActiveBizId(supabase, user.id);
   let portalUrl: string | null = null;
+  let pdfUrl: string | null = null;
   if (customer?.id) {
     const { data: existing } = await tbl(supabase, "customer_portal_tokens")
       .select("token")
@@ -530,13 +533,16 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
       });
     }
     const base = appUrl();
-    if (base && token) portalUrl = `${base}/portal/${token}/invoice/${invoiceData.id}`;
+    if (base && token) {
+      portalUrl = `${base}/portal/${token}/invoice/${invoiceData.id}`;
+      pdfUrl    = `${base}/api/pdf/invoice/${invoiceData.id}?token=${token}`;
+    }
   }
 
   await sendEmail({
     to: recipients,
     subject: opts?.subject ?? `Invoice ${invoiceData.number} from ${businessData.name}`,
-    html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl }),
+    html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl, pdfUrl }),
     attachments: [{ filename: `${invoiceData.number}.pdf`, content: pdfBuffer }],
     tags: { business_id: businessId, doc_type: "invoice", doc_id: invoiceData.id },
   });

--- a/src/lib/actions/quotes.ts
+++ b/src/lib/actions/quotes.ts
@@ -228,9 +228,12 @@ export async function sendQuoteEmail(id: string, opts?: { recipients?: string[];
   }
   const pdfBuffer = Buffer.concat(chunks);
 
-  // Issue (or reuse) a portal token so the customer can review & accept online
+  // Issue (or reuse) a portal token so the customer can review & accept online,
+  // plus a tokenised /api/pdf/quote link so they can re-download the PDF even
+  // when email clients strip the attachment.
   const businessId = await getActiveBizId(supabase, user.id);
   let acceptUrl: string | null = null;
+  let pdfUrl: string | null = null;
   if (customer?.id) {
     const { data: existing } = await tbl(supabase, "customer_portal_tokens")
       .select("token")
@@ -250,13 +253,16 @@ export async function sendQuoteEmail(id: string, opts?: { recipients?: string[];
       });
     }
     const base = appUrl();
-    if (base && token) acceptUrl = `${base}/portal/${token}/quote/${quoteData.id}`;
+    if (base && token) {
+      acceptUrl = `${base}/portal/${token}/quote/${quoteData.id}`;
+      pdfUrl    = `${base}/api/pdf/quote/${quoteData.id}?token=${token}`;
+    }
   }
 
   await sendEmail({
     to: recipients,
     subject: opts?.subject ?? `Quote ${quoteData.number} from ${businessData.name}`,
-    html: quoteEmailHtml({ quote: quoteData, customer, business: businessData, lineItems, acceptUrl }),
+    html: quoteEmailHtml({ quote: quoteData, customer, business: businessData, lineItems, acceptUrl, pdfUrl }),
     attachments: [{ filename: `${quoteData.number}.pdf`, content: pdfBuffer }],
     tags: { business_id: businessId, doc_type: "quote", doc_id: quoteData.id },
   });

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,8 +12,16 @@ function getResend(): Resend {
 }
 
 // Default from address — override with RESEND_FROM_EMAIL env var once you verify a domain.
-// During development, Resend allows sending from onboarding@resend.dev to your own email only.
+// During development, Resend allows sending from onboarding@resend.dev to your own
+// account-owner mailbox only. Any other recipient will silently fail.
 const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <onboarding@resend.dev>";
+
+/** True when the configured FROM address is the dev fallback. In that case
+ *  Resend rejects sends to anyone except the API key owner. Surfaced in error
+ *  messages so the user knows to verify their domain. */
+function isDevFromAddress(): boolean {
+  return /onboarding@resend\.dev/i.test(FROM);
+}
 
 export type EmailDocType = "invoice" | "quote" | "team_invite" | "lead" | "custom";
 
@@ -84,6 +92,14 @@ export async function sendEmail({
     }
   }
 
-  if (sendError) throw new Error(sendError);
+  if (sendError) {
+    // Enrich the most common silent-failure mode: trying to send from the
+    // dev sandbox address. Resend's own error text doesn't always say this
+    // clearly, so the user just sees "failed" with no path forward.
+    const hint = isDevFromAddress()
+      ? " — RESEND_FROM_EMAIL isn't set or still uses the resend.dev sandbox, which only delivers to the API key owner's mailbox. Verify your domain in Resend, then set RESEND_FROM_EMAIL to a verified address."
+      : "";
+    throw new Error(sendError + hint);
+  }
   return { id: resendId };
 }

--- a/src/lib/emails/invoice.ts
+++ b/src/lib/emails/invoice.ts
@@ -7,12 +7,17 @@ export function invoiceEmailHtml({
   business,
   lineItems,
   portalUrl,
+  pdfUrl,
 }: {
   invoice: Invoice;
   customer: Customer | null;
   business: Business;
   lineItems: LineItem[];
   portalUrl?: string | null;
+  /** Direct PDF download link (tokenised). Renders a 'Download PDF' button
+   *  in the body so the customer can grab the PDF even when their email
+   *  client strips attachments. */
+  pdfUrl?: string | null;
 }): string {
   // Coerce numbers — Postgres returns numeric columns as strings via PostgREST,
   // so plain subtraction was producing NaN in the email Total field.
@@ -62,10 +67,11 @@ export function invoiceEmailHtml({
       </tr>
     </table>
 
-    ${portalUrl ? `
+    ${portalUrl || pdfUrl ? `
     <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
       <tr><td align="center">
-        <a href="${portalUrl}" style="display:inline-block;background:#3b82f6;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:6px;">View invoice online</a>
+        ${portalUrl ? `<a href="${portalUrl}" style="display:inline-block;background:#3b82f6;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;margin:0 4px 8px;">View invoice online</a>` : ""}
+        ${pdfUrl ? `<a href="${pdfUrl}" style="display:inline-block;background:#ffffff;color:#3b82f6;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;border:1px solid #3b82f6;margin:0 4px 8px;">Download PDF</a>` : ""}
       </td></tr>
     </table>` : ""}
 

--- a/src/lib/emails/quote.ts
+++ b/src/lib/emails/quote.ts
@@ -7,12 +7,15 @@ export function quoteEmailHtml({
   business,
   lineItems,
   acceptUrl,
+  pdfUrl,
 }: {
   quote: Quote;
   customer: Customer | null;
   business: Business;
   lineItems: LineItem[];
   acceptUrl?: string | null;
+  /** Direct PDF download link (tokenised). */
+  pdfUrl?: string | null;
 }): string {
   const fmt = (n: number) =>
     new Intl.NumberFormat("en-GB", { style: "currency", currency: business.currency }).format(n);
@@ -54,13 +57,12 @@ export function quoteEmailHtml({
     ${quote.notes ? `<p style="margin:24px 0 0;font-size:13px;color:#71717a;"><strong>Notes:</strong> ${quote.notes}</p>` : ""}
     ${quote.terms ? `<p style="margin:8px 0 0;font-size:13px;color:#71717a;"><strong>Terms:</strong> ${quote.terms}</p>` : ""}
 
-    ${acceptUrl ? `
+    ${acceptUrl || pdfUrl ? `
     <table width="100%" cellpadding="0" cellspacing="0" style="margin:32px 0 0;">
       <tr>
         <td align="center">
-          <a href="${acceptUrl}" style="display:inline-block;background:#8b5cf6;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:8px;">
-            Review &amp; accept quote
-          </a>
+          ${acceptUrl ? `<a href="${acceptUrl}" style="display:inline-block;background:#8b5cf6;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 28px;border-radius:8px;margin:0 4px 8px;">Review &amp; accept</a>` : ""}
+          ${pdfUrl ? `<a href="${pdfUrl}" style="display:inline-block;background:#ffffff;color:#8b5cf6;font-size:15px;font-weight:600;text-decoration:none;padding:14px 28px;border-radius:8px;border:1px solid #8b5cf6;margin:0 4px 8px;">Download PDF</a>` : ""}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Adds the missing Download PDF button on the customer-facing quote portal, makes the matching email render the link too, and surfaces a much clearer error when Resend FROM is the dev sandbox.