### PR TITLE
fix: worker photo upload + list responsiveness

### DIFF
--- a/src/components/briefing/briefing-widget.tsx
+++ b/src/components/briefing/briefing-widget.tsx
@@ -125,30 +125,32 @@ export function BriefingWidget({ compact = false }: Props) {
 
 function Row({ item, onSnooze }: { item: BriefingItem; onSnooze: (item: BriefingItem, hours: number) => void }) {
   return (
-    <div className="flex items-center gap-3 p-3 rounded-lg bg-card border border-border/70 hover:border-primary/30 transition-colors group">
+    <div className="flex flex-wrap items-center gap-3 p-3 rounded-lg bg-card border border-border/70 hover:border-primary/30 transition-colors group">
       <GradientTile gradient={PRIORITY_GRADIENT[item.priority]} size={36} radius={10}>
         <span className="text-[9px] font-bold uppercase tracking-wider">
           {TYPE_LABEL[item.type].slice(0, 4)}
         </span>
       </GradientTile>
-      <div className="flex-1 min-w-0">
+      <div className="flex-1 min-w-[140px] basis-0">
         <p className="text-sm font-semibold truncate">{item.title}</p>
         <p className="text-xs text-muted-foreground truncate">{item.subtitle}</p>
       </div>
-      <div className="flex items-center gap-1 flex-shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
+      <div className="flex items-center gap-1 ml-auto flex-shrink-0 opacity-80 group-hover:opacity-100 transition-opacity">
         <button
           onClick={() => onSnooze(item, 24)}
           className="inline-flex items-center gap-1 px-2 py-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground text-xs"
           title="Snooze 24h"
+          aria-label="Snooze 24h"
         >
-          <Clock className="w-3.5 h-3.5" /> Snooze
+          <Clock className="w-3.5 h-3.5" /><span className="hidden sm:inline">Snooze</span>
         </button>
         <button
           onClick={() => onSnooze(item, 0)}
           className="inline-flex items-center gap-1 px-2 py-1.5 rounded-md hover:bg-emerald-50 dark:hover:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 text-xs"
-          title="Mark done — hide until something changes"
+          title="Mark done"
+          aria-label="Mark done"
         >
-          <Check className="w-3.5 h-3.5" /> Done
+          <Check className="w-3.5 h-3.5" /><span className="hidden sm:inline">Done</span>
         </button>
         <Link href={item.action_url}>
           <AnimatedPress className="inline-flex items-center gap-1 px-3 py-1.5 rounded-xl bg-primary text-primary-foreground text-xs font-semibold cursor-pointer">

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -211,7 +211,7 @@ export function CustomersClient({
                 <div
                   key={customer.id}
                   onClick={() => router.push(`/customers/${customer.id}`)}
-                  className="group flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
+                  className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
                 >
                   <input
                     type="checkbox"
@@ -227,7 +227,7 @@ export function CustomersClient({
                     className="w-4 h-4 rounded border-border accent-primary cursor-pointer"
                   />
                   <KireiAvatar name={customer.name} size={40} />
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-[140px] basis-0">
                     <div className="font-semibold truncate">{customer.name}</div>
                     {customer.company && (
                       <div className="text-xs text-muted-foreground truncate inline-flex items-center gap-1 mt-0.5">
@@ -249,7 +249,7 @@ export function CustomersClient({
                   <div className="hidden md:block w-24 text-right text-sm tabular-nums">
                     {s?.outstanding ? <span className="font-semibold text-amber-700 dark:text-amber-400">{formatCurrency(s.outstanding, currency)}</span> : <span className="text-muted-foreground">—</span>}
                   </div>
-                  <div className="w-16 text-right">
+                  <div className="ml-auto text-right">
                     <KireiPill tone={customer.archived ? "archived" : "active"} />
                   </div>
                   <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -310,13 +310,13 @@ function ScheduleCard({ wo }: { wo: WorkOrderWithCustomer }) {
             <span className="text-xs font-mono font-semibold text-foreground tabular-nums">{time}</span>
             <span className="text-sm font-medium text-foreground truncate">{wo.customers?.name ?? wo.title}</span>
           </div>
-          <div className="text-xs text-muted-foreground truncate flex items-center gap-3 mt-0.5">
-            <span className="inline-flex items-center gap-1">
-              <MapPin className="w-3 h-3" />{wo.property_address ?? "—"}
+          <div className="text-xs text-muted-foreground flex items-center gap-3 mt-0.5 min-w-0">
+            <span className="inline-flex items-center gap-1 min-w-0 truncate">
+              <MapPin className="w-3 h-3 shrink-0" /><span className="truncate">{wo.property_address ?? "—"}</span>
             </span>
             {wo.assigned_to_email && (
-              <span className="inline-flex items-center gap-1">
-                <User className="w-3 h-3" />{wo.assigned_to_email}
+              <span className="hidden sm:inline-flex items-center gap-1 min-w-0 truncate">
+                <User className="w-3 h-3 shrink-0" /><span className="truncate">{wo.assigned_to_email}</span>
               </span>
             )}
           </div>

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -177,12 +177,12 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
                 key={invoice.id}
                 onClick={() => router.push(`/invoices/${invoice.id}`)}
                 onAuxClick={(e) => { if (e.button === 1) window.open(`/invoices/${invoice.id}`, "_blank"); }}
-                className="group flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
+                className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
                 <GradientTile gradient={STATUS_GRADIENT[invoice.status] ?? "primary"} size={40} radius={10}>
                   <FileText className="w-4 h-4" />
                 </GradientTile>
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-[140px] basis-0">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-xs text-muted-foreground">{invoice.number}</span>
                   </div>
@@ -190,10 +190,10 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
                 </div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(invoice.issue_date)}</div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(invoice.due_date)}</div>
-                <div className="w-24 text-right">
+                <div className="ml-auto md:ml-0 md:w-24 text-right">
                   <KireiPill tone={invoice.status} />
                 </div>
-                <div className="w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(invoice.total, currency)}</div>
+                <div className="md:w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(invoice.total, currency)}</div>
                 <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -142,12 +142,12 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
               <div
                 key={product.id}
                 onClick={() => setEditProduct(product)}
-                className="group flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
+                className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
                 <GradientTile gradient="emerald" size={40} radius={10}>
                   <Package className="w-4 h-4" />
                 </GradientTile>
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-[140px] basis-0">
                   <div className="text-sm font-semibold truncate">{product.name}</div>
                   {product.description && (
                     <div className="text-xs text-muted-foreground truncate max-w-md">{product.description}</div>
@@ -155,10 +155,10 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
                 </div>
                 <div className="hidden md:block w-20 text-xs text-muted-foreground truncate">{product.unit ?? "—"}</div>
                 <div className="hidden md:block w-16 text-right text-xs text-muted-foreground">{product.tax_rate}%</div>
-                <div className="w-24 text-right">
+                <div className="ml-auto md:ml-0 md:w-24 text-right">
                   <KireiPill tone={product.archived ? "archived" : "active"} />
                 </div>
-                <div className="w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(product.unit_price, currency)}</div>
+                <div className="md:w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(product.unit_price, currency)}</div>
                 <div className="w-16 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                   <div className="flex items-center justify-end gap-1">
                     <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground" onClick={() => setEditProduct(product)}>

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -164,21 +164,21 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
               <div
                 key={quote.id}
                 onClick={() => router.push(`/quotes/${quote.id}`)}
-                className="group flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
+                className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
                 <GradientTile gradient={STATUS_GRADIENT[quote.status] ?? "primary"} size={40} radius={10}>
                   <FileCheck className="w-4 h-4" />
                 </GradientTile>
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-[140px] basis-0">
                   <div className="font-mono text-xs text-muted-foreground">{quote.number}</div>
                   <div className="text-sm font-semibold truncate">{quote.customers?.name ?? "No client"}</div>
                 </div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(quote.issue_date)}</div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(quote.expiry_date)}</div>
-                <div className="w-24 text-right">
+                <div className="ml-auto md:ml-0 md:w-24 text-right">
                   <KireiPill tone={quote.status} />
                 </div>
-                <div className="w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(quote.total, currency)}</div>
+                <div className="md:w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(quote.total, currency)}</div>
                 <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/src/components/ui/kirei/tabs.tsx
+++ b/src/components/ui/kirei/tabs.tsx
@@ -21,7 +21,10 @@ interface Props<T extends string> {
 
 export function KireiTabs<T extends string>({ tabs, value, onChange, className }: Props<T>) {
   return (
-    <div className={`inline-flex items-center gap-1 p-1 rounded-xl bg-muted/60 border border-border ${className ?? ""}`}>
+    <div
+      className={`flex items-center gap-1 p-1 rounded-xl bg-muted/60 border border-border overflow-x-auto max-w-full scrollbar-thin ${className ?? ""}`}
+      style={{ scrollbarWidth: "thin" }}
+    >
       {tabs.map((t) => {
         const active = t.value === value;
         return (
@@ -29,7 +32,7 @@ export function KireiTabs<T extends string>({ tabs, value, onChange, className }
             key={t.value}
             type="button"
             onClick={() => onChange(t.value)}
-            className={`relative inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors ${
+            className={`relative inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors flex-shrink-0 ${
               active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
             }`}
           >

--- a/src/components/work-orders/job-portfolio-client.tsx
+++ b/src/components/work-orders/job-portfolio-client.tsx
@@ -32,7 +32,7 @@ import { Badge } from "@/components/ui/badge";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
-import { canEdit, isOwner, canManageTeam, type Role } from "@/lib/permissions";
+import { canEdit, isOwner, canManageTeam, canCaptureJobData, type Role } from "@/lib/permissions";
 import { BackButton } from "@/components/layout/back-button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Check, ChevronDown, Pencil } from "@/components/ui/icons";
@@ -174,9 +174,10 @@ export function JobPortfolioClient(props: JobPortfolioProps) {
   } = props;
 
   const router = useRouter();
-  const editable = canEdit(userRole);
-  const deletable = canManageTeam(userRole); // owners + admins
-  const canAssign = canManageTeam(userRole); // who can change job assignments
+  const editable = canEdit(userRole);             // can change scope, status, etc.
+  const canCapture = canCaptureJobData(userRole); // can upload from-site work (workers too)
+  const deletable = canManageTeam(userRole);      // owners + admins
+  const canAssign = canManageTeam(userRole);      // who can change job assignments
 
   // Local state mirrors so optimistic updates feel snappy
   const [photos, setPhotos] = useState<JobPhoto[]>(initialPhotos);
@@ -228,7 +229,7 @@ export function JobPortfolioClient(props: JobPortfolioProps) {
           <PhotosSection
             workOrderId={workOrder.id}
             photos={photos}
-            editable={editable}
+            editable={canCapture}
             currentUserId={currentUserId}
             onAdd={(p) => setPhotos((prev) => [...prev, p])}
             onUpdate={(id, patch) => setPhotos((prev) => prev.map((p) => p.id === id ? { ...p, ...patch } : p))}
@@ -237,7 +238,7 @@ export function JobPortfolioClient(props: JobPortfolioProps) {
           <TimeSection
             workOrderId={workOrder.id}
             entries={timeEntries}
-            editable={editable}
+            editable={canCapture}
             onAdd={(e) => setTimeEntries((prev) => [...prev, e])}
             onUpdate={(id, patch) => setTimeEntries((prev) => prev.map((e) => e.id === id ? { ...e, ...patch } : e))}
             onDelete={(id) => setTimeEntries((prev) => prev.filter((e) => e.id !== id))}
@@ -245,14 +246,14 @@ export function JobPortfolioClient(props: JobPortfolioProps) {
           <MaterialsSection
             workOrderId={workOrder.id}
             materials={materials}
-            editable={editable}
+            editable={canCapture}
             onAdd={(m) => setMaterials((prev) => [...prev, m])}
             onDelete={(id) => setMaterials((prev) => prev.filter((m) => m.id !== id))}
           />
           <DocumentsSection
             workOrderId={workOrder.id}
             documents={documents}
-            editable={editable}
+            editable={canCapture}
             currentUserId={currentUserId}
             onAdd={(d) => setDocuments((prev) => [d, ...prev])}
             onDelete={(id) => setDocuments((prev) => prev.filter((d) => d.id !== id))}
@@ -260,7 +261,7 @@ export function JobPortfolioClient(props: JobPortfolioProps) {
           <SignaturesSection
             workOrderId={workOrder.id}
             signatures={signatures}
-            editable={editable}
+            editable={canCapture}
             currentUserId={currentUserId}
             onAdd={(s) => setSignatures((prev) => [...prev, s])}
             onDelete={(id) => setSignatures((prev) => prev.filter((s) => s.id !== id))}

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -137,14 +137,19 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
               <div
                 key={wo.id}
                 onClick={() => router.push(`/work-orders/${wo.id}`)}
-                className="group flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
+                className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
                 <GradientTile gradient={STATUS_GRADIENT[wo.status] ?? "primary"} size={40} radius={10}>
                   <Briefcase className="w-4 h-4" />
                 </GradientTile>
-                <div className="flex-1 min-w-0">
+                <div className="flex-1 min-w-[140px] basis-0">
                   <div className="text-sm font-semibold truncate">{wo.title}</div>
-                  <div className="font-mono text-xs text-muted-foreground">{wo.number}</div>
+                  <div className="font-mono text-xs text-muted-foreground truncate">
+                    {wo.number}
+                    <span className="md:hidden text-muted-foreground/70">
+                      {wo.customers?.name ? ` · ${wo.customers.name}` : ""}
+                    </span>
+                  </div>
                 </div>
                 <div className="hidden lg:block w-44 text-xs text-muted-foreground truncate">{wo.customers?.name ?? "—"}</div>
                 <div className="hidden md:block w-44 text-xs text-muted-foreground truncate">
@@ -162,7 +167,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
                     <span className="inline-flex items-center gap-0.5"><Camera className="w-3 h-3" />{wo.photos?.length}</span>
                   ) : "—"}
                 </div>
-                <div className="w-24 text-right">
+                <div className="ml-auto text-right">
                   <KireiPill tone={wo.status} />
                 </div>
                 <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -7,6 +7,14 @@ export function canEdit(role: Role): boolean {
   return role === 'owner' || role === 'admin' || role === 'editor';
 }
 
+/** Can capture from-site job data on a work order — photos, time, materials,
+ *  documents, signatures, notes. Workers need this on jobs they're assigned
+ *  to; viewers stay read-only. RLS already restricts workers to their own
+ *  jobs so we don't need to filter further here. */
+export function canCaptureJobData(role: Role): boolean {
+  return role === 'owner' || role === 'admin' || role === 'editor' || role === 'worker';
+}
+
 export function canManageTeam(role: Role): boolean {
   return role === 'owner' || role === 'admin';
 }


### PR DESCRIPTION
Workers can now capture from-site work (photos/time/materials/docs/signatures) on their assigned jobs. Status tabs scroll on mobile. List rows wrap instead of squeezing title text.