### PR TITLE
fix: stop truncating list-card text on mobile

### DIFF
--- a/mobile/app/work-orders/index.tsx
+++ b/mobile/app/work-orders/index.tsx
@@ -114,8 +114,8 @@ export default function WorkOrdersList() {
                     <Text style={{ fontSize: 10, fontWeight: "700", color: c.fg, textTransform: "uppercase", letterSpacing: 0.5 }}>{item.status}</Text>
                   </View>
                 </View>
-                <Text style={{ fontSize: 15, fontWeight: "600", color: colors.text, marginTop: 4 }} numberOfLines={1}>{item.title ?? "Untitled"}</Text>
-                <Text style={{ fontSize: 12, color: colors.muted, marginTop: 2 }} numberOfLines={1}>
+                <Text style={{ fontSize: 15, fontWeight: "600", color: colors.text, marginTop: 4 }} numberOfLines={3}>{item.title ?? "Untitled"}</Text>
+                <Text style={{ fontSize: 12, color: colors.muted, marginTop: 2 }} numberOfLines={3}>
                   {item.customers?.name ?? "No customer"}
                   {item.scheduled_date ? ` · ${new Date(item.scheduled_date).toLocaleDateString()}` : ""}
                 </Text>

--- a/src/components/briefing/briefing-widget.tsx
+++ b/src/components/briefing/briefing-widget.tsx
@@ -132,8 +132,8 @@ function Row({ item, onSnooze }: { item: BriefingItem; onSnooze: (item: Briefing
         </span>
       </GradientTile>
       <div className="flex-1 min-w-[140px] basis-0">
-        <p className="text-sm font-semibold truncate">{item.title}</p>
-        <p className="text-xs text-muted-foreground truncate">{item.subtitle}</p>
+        <p className="text-sm font-semibold break-words">{item.title}</p>
+        <p className="text-xs text-muted-foreground break-words">{item.subtitle}</p>
       </div>
       <div className="flex items-center gap-1 ml-auto flex-shrink-0 opacity-80 group-hover:opacity-100 transition-opacity">
         <button

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -579,7 +579,7 @@ export function CustomerDetailClient({
                 {customer.email && (
                   <div className="flex items-center gap-2 text-sm">
                     <Mail className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-                    <a href={`mailto:${customer.email}`} className="text-primary hover:underline truncate">{customer.email}</a>
+                    <a href={`mailto:${customer.email}`} className="text-primary hover:underline break-words">{customer.email}</a>
                   </div>
                 )}
                 {customer.phone && (

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -228,19 +228,19 @@ export function CustomersClient({
                   />
                   <KireiAvatar name={customer.name} size={40} />
                   <div className="flex-1 min-w-[140px] basis-0">
-                    <div className="font-semibold truncate">{customer.name}</div>
+                    <div className="font-semibold break-words">{customer.name}</div>
                     {customer.company && (
-                      <div className="text-xs text-muted-foreground truncate inline-flex items-center gap-1 mt-0.5">
+                      <div className="text-xs text-muted-foreground break-words inline-flex items-center gap-1 mt-0.5">
                         <Building2 className="w-3 h-3" /> {customer.company}
                       </div>
                     )}
                   </div>
                   <div className="hidden md:block w-44 min-w-0 text-xs text-muted-foreground space-y-0.5">
                     {customer.email && (
-                      <div className="truncate inline-flex items-center gap-1.5"><Mail className="w-3 h-3 shrink-0" /> {customer.email}</div>
+                      <div className="break-words inline-flex items-center gap-1.5"><Mail className="w-3 h-3 shrink-0" /> {customer.email}</div>
                     )}
                     {customer.phone && (
-                      <div className="truncate inline-flex items-center gap-1.5"><Phone className="w-3 h-3 shrink-0" /> {customer.phone}</div>
+                      <div className="break-words inline-flex items-center gap-1.5"><Phone className="w-3 h-3 shrink-0" /> {customer.phone}</div>
                     )}
                   </div>
                   <div className="hidden md:block w-20 text-right text-sm tabular-nums">

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -308,15 +308,15 @@ function ScheduleCard({ wo }: { wo: WorkOrderWithCustomer }) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="text-xs font-mono font-semibold text-foreground tabular-nums">{time}</span>
-            <span className="text-sm font-medium text-foreground truncate">{wo.customers?.name ?? wo.title}</span>
+            <span className="text-sm font-medium text-foreground break-words">{wo.customers?.name ?? wo.title}</span>
           </div>
           <div className="text-xs text-muted-foreground flex items-center gap-3 mt-0.5 min-w-0">
-            <span className="inline-flex items-center gap-1 min-w-0 truncate">
-              <MapPin className="w-3 h-3 shrink-0" /><span className="truncate">{wo.property_address ?? "—"}</span>
+            <span className="inline-flex items-center gap-1 min-w-0 break-words">
+              <MapPin className="w-3 h-3 shrink-0" /><span className="break-words">{wo.property_address ?? "—"}</span>
             </span>
             {wo.assigned_to_email && (
-              <span className="hidden sm:inline-flex items-center gap-1 min-w-0 truncate">
-                <User className="w-3 h-3 shrink-0" /><span className="truncate">{wo.assigned_to_email}</span>
+              <span className="hidden sm:inline-flex items-center gap-1 min-w-0 break-words">
+                <User className="w-3 h-3 shrink-0" /><span className="break-words">{wo.assigned_to_email}</span>
               </span>
             )}
           </div>

--- a/src/components/dashboard/new-leads-widget.tsx
+++ b/src/components/dashboard/new-leads-widget.tsx
@@ -97,7 +97,7 @@ export function NewLeadsWidget() {
                 <KireiAvatar name={lead.name ?? "?"} size={40} />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <p className="text-sm font-semibold truncate">{lead.name}</p>
+                    <p className="text-sm font-semibold break-words">{lead.name}</p>
                     {lead.status === "contacted" && (
                       <span className="text-[10px] uppercase tracking-wide font-bold text-muted-foreground">contacted</span>
                     )}

--- a/src/components/dashboard/worker-dashboard.tsx
+++ b/src/components/dashboard/worker-dashboard.tsx
@@ -191,7 +191,7 @@ function JobRow({ job, showDate }: { job: WorkOrderWithCustomer; showDate?: bool
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <p className="text-sm font-medium truncate">{job.title}</p>
+            <p className="text-sm font-medium break-words">{job.title}</p>
             <span className={`ch-pill ${STATUS_PILL[job.status]}`}>{job.status.replace("_", " ")}</span>
             {showDate && job.scheduled_date && (
               <span className="text-[11px] text-muted-foreground">· {job.scheduled_date}</span>
@@ -200,7 +200,7 @@ function JobRow({ job, showDate }: { job: WorkOrderWithCustomer; showDate?: bool
           <div className="flex items-center gap-3 mt-1 text-[11px] text-muted-foreground">
             <span className="ch-mono">{job.number}</span>
             {job.property_address && (
-              <span className="flex items-center gap-1 truncate">
+              <span className="flex items-center gap-1 break-words">
                 <MapPin className="w-3 h-3 flex-shrink-0" />{job.property_address}
               </span>
             )}

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -312,7 +312,7 @@ export function InvoiceDetailClient({
                         <div className="flex items-center gap-2 min-w-0">
                           <span className="font-mono text-xs text-muted-foreground">{c.number}</span>
                           <KireiPill tone={c.status} />
-                          <span className="text-xs text-muted-foreground truncate">
+                          <span className="text-xs text-muted-foreground break-words">
                             {(c.line_items?.[0] as LineItem | undefined)?.description ?? ""}
                           </span>
                         </div>

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -186,7 +186,7 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-xs text-muted-foreground">{invoice.number}</span>
                   </div>
-                  <div className="text-sm font-semibold truncate">{invoice.customers?.name ?? "No client"}</div>
+                  <div className="text-sm font-semibold break-words">{invoice.customers?.name ?? "No client"}</div>
                 </div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(invoice.issue_date)}</div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(invoice.due_date)}</div>

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -526,7 +526,7 @@ function LeadCard({
       <div className="flex items-start justify-between gap-1">
         <div className="flex items-center gap-1.5 min-w-0">
           <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          <span className="font-medium text-sm truncate">{lead.name}</span>
+          <span className="font-medium text-sm break-words">{lead.name}</span>
         </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -568,23 +568,23 @@ function LeadCard({
         {lead.phone && (
           <a href={`tel:${lead.phone.replace(/\s/g, "")}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
             <Phone className="h-3 w-3 shrink-0" />
-            <span className="truncate">{lead.phone}</span>
+            <span className="break-words">{lead.phone}</span>
           </a>
         )}
         {lead.email && (
           <a href={`mailto:${lead.email}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
             <Mail className="h-3 w-3 shrink-0" />
-            <span className="truncate">{lead.email}</span>
+            <span className="break-words">{lead.email}</span>
           </a>
         )}
         {lead.suburb && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <MapPin className="h-3 w-3 shrink-0" />
-            <span className="truncate">{lead.suburb}</span>
+            <span className="break-words">{lead.suburb}</span>
           </div>
         )}
         {lead.service && (
-          <div className="text-xs text-muted-foreground truncate">{lead.service}</div>
+          <div className="text-xs text-muted-foreground break-words">{lead.service}</div>
         )}
       </div>
 

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -148,12 +148,12 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
                   <Package className="w-4 h-4" />
                 </GradientTile>
                 <div className="flex-1 min-w-[140px] basis-0">
-                  <div className="text-sm font-semibold truncate">{product.name}</div>
+                  <div className="text-sm font-semibold break-words">{product.name}</div>
                   {product.description && (
-                    <div className="text-xs text-muted-foreground truncate max-w-md">{product.description}</div>
+                    <div className="text-xs text-muted-foreground break-words max-w-md">{product.description}</div>
                   )}
                 </div>
-                <div className="hidden md:block w-20 text-xs text-muted-foreground truncate">{product.unit ?? "—"}</div>
+                <div className="hidden md:block w-20 text-xs text-muted-foreground break-words">{product.unit ?? "—"}</div>
                 <div className="hidden md:block w-16 text-right text-xs text-muted-foreground">{product.tax_rate}%</div>
                 <div className="ml-auto md:ml-0 md:w-24 text-right">
                   <KireiPill tone={product.archived ? "archived" : "active"} />

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -171,7 +171,7 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
                 </GradientTile>
                 <div className="flex-1 min-w-[140px] basis-0">
                   <div className="font-mono text-xs text-muted-foreground">{quote.number}</div>
-                  <div className="text-sm font-semibold truncate">{quote.customers?.name ?? "No client"}</div>
+                  <div className="text-sm font-semibold break-words">{quote.customers?.name ?? "No client"}</div>
                 </div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(quote.issue_date)}</div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(quote.expiry_date)}</div>

--- a/src/components/tasks/tasks-widget.tsx
+++ b/src/components/tasks/tasks-widget.tsx
@@ -96,7 +96,7 @@ export function TasksWidget() {
                 <Link href="/tasks" className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${PRIORITY_DOT[t.priority]}`} />
-                    <p className="text-sm font-medium truncate">{t.title}</p>
+                    <p className="text-sm font-medium break-words">{t.title}</p>
                   </div>
                   {(t.due_date || t.tags?.length > 0) && (
                     <div className="flex items-center gap-2 mt-0.5 text-[11px] text-muted-foreground flex-wrap">

--- a/src/components/ui/kirei/card-list-row.tsx
+++ b/src/components/ui/kirei/card-list-row.tsx
@@ -31,8 +31,8 @@ export function CardListRow({ href, gradient = "primary", icon, title, meta, tra
         </GradientTile>
       )}
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-foreground truncate">{title}</div>
-        {meta && <div className="text-xs text-muted-foreground mt-0.5 truncate">{meta}</div>}
+        <div className="text-sm font-medium text-foreground break-words">{title}</div>
+        {meta && <div className="text-xs text-muted-foreground mt-0.5 break-words">{meta}</div>}
       </div>
       {trailing && <div className="text-sm font-semibold text-foreground tabular-nums shrink-0">{trailing}</div>}
       {href && <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />}

--- a/src/components/ui/kirei/detail-hero.tsx
+++ b/src/components/ui/kirei/detail-hero.tsx
@@ -53,7 +53,7 @@ export function DetailHero({
             {eyebrow && <span className="font-mono text-xs text-muted-foreground">{eyebrow}</span>}
             {status && <KireiPill tone={status}>{statusLabel}</KireiPill>}
           </div>
-          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight truncate mt-0.5">{title}</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight break-words mt-0.5">{title}</h1>
           {subtitle && <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>}
         </div>
         {actions && <div className="flex items-center gap-2 flex-wrap">{actions}</div>}

--- a/src/components/ui/kirei/fact-card.tsx
+++ b/src/components/ui/kirei/fact-card.tsx
@@ -32,7 +32,7 @@ export function FactCard({ icon, gradient = "primary", label, value, href, onCli
       )}
       <div className="min-w-0">
         <p className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">{label}</p>
-        <div className="text-sm font-semibold text-foreground truncate mt-0.5">{value}</div>
+        <div className="text-sm font-semibold text-foreground break-words mt-0.5">{value}</div>
       </div>
     </AnimatedPress>
   );

--- a/src/components/ui/kirei/hub-tile.tsx
+++ b/src/components/ui/kirei/hub-tile.tsx
@@ -31,7 +31,7 @@ export function HubTile({ href, gradient, icon, label, hint, trailing }: HubTile
           {icon}
         </GradientTile>
         <div className="flex-1 min-w-0">
-          <p className="text-base font-semibold text-foreground truncate">{label}</p>
+          <p className="text-base font-semibold text-foreground break-words">{label}</p>
           {hint && <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{hint}</p>}
         </div>
         {trailing ? (

--- a/src/components/work-orders/job-portfolio-client.tsx
+++ b/src/components/work-orders/job-portfolio-client.tsx
@@ -374,7 +374,7 @@ function PortfolioHeader({
             <span className="text-xs font-mono text-muted-foreground">{workOrder.number}</span>
             <Badge className={`${STATUS_COLORS[status]} border-0`}>{STATUS_LABELS[status]}</Badge>
           </div>
-          <h1 className="text-2xl font-bold truncate">{workOrder.title}</h1>
+          <h1 className="text-2xl font-bold break-words">{workOrder.title}</h1>
         </div>
         <div className="flex items-center gap-2 flex-wrap w-full sm:w-auto">
           <a href={`/api/pdf/work-order/${workOrder.id}`} target="_blank" rel="noopener noreferrer">
@@ -618,8 +618,8 @@ function AssignWorkersDialog({
                     {w.name?.split(/\s+/).filter(Boolean).slice(0, 2).map((p) => p[0]?.toUpperCase()).join("") || "?"}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{w.name}</p>
-                    <p className="text-xs text-muted-foreground truncate">{w.role_title ?? w.email ?? "Worker"}</p>
+                    <p className="text-sm font-medium break-words">{w.name}</p>
+                    <p className="text-xs text-muted-foreground break-words">{w.role_title ?? w.email ?? "Worker"}</p>
                   </div>
                   {sel && <Check className="w-4 h-4 text-primary flex-shrink-0" />}
                 </button>
@@ -653,7 +653,7 @@ function FactCard({ icon: Icon, label, value, href, onClick }: {
       <Icon className="w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0" />
       <div className="min-w-0 flex-1">
         <p className="text-[11px] text-muted-foreground uppercase tracking-wide font-medium">{label}</p>
-        <div className="text-sm font-medium truncate">{value}</div>
+        <div className="text-sm font-medium break-words">{value}</div>
       </div>
       {onClick && <Pencil className="w-3 h-3 text-muted-foreground/60 ml-auto flex-shrink-0" />}
     </div>
@@ -1190,7 +1190,7 @@ function DocumentsSection({
             <div key={d.id} className="flex items-center justify-between py-1.5 border-b last:border-0 text-sm">
               <div className="flex items-center gap-2 flex-1 min-w-0">
                 <FileText className="w-4 h-4 text-muted-foreground flex-shrink-0" />
-                <a href={d.url} target="_blank" rel="noopener noreferrer" className="font-medium hover:underline truncate">{d.name}</a>
+                <a href={d.url} target="_blank" rel="noopener noreferrer" className="font-medium hover:underline break-words">{d.name}</a>
                 <Badge variant="outline" className="text-[10px]">{d.category}</Badge>
                 {d.customer_visible ? <Eye className="w-3 h-3 text-muted-foreground" /> : <EyeOff className="w-3 h-3 text-muted-foreground" />}
               </div>
@@ -1263,7 +1263,7 @@ function SignaturesSection({
                   <img src={s.signature_url} alt="signature" className="h-12 w-24 object-contain bg-white border rounded" />
                 </a>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{s.signed_by_name}{s.signed_by_role ? ` (${s.signed_by_role})` : ""}</p>
+                  <p className="text-sm font-medium break-words">{s.signed_by_name}{s.signed_by_role ? ` (${s.signed_by_role})` : ""}</p>
                   <p className="text-xs text-muted-foreground">
                     {SIG_PURPOSES.find((p) => p.key === s.purpose)?.label ?? s.purpose} · {fmtDateTime(s.signed_at)}
                   </p>

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -143,16 +143,16 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
                   <Briefcase className="w-4 h-4" />
                 </GradientTile>
                 <div className="flex-1 min-w-[140px] basis-0">
-                  <div className="text-sm font-semibold truncate">{wo.title}</div>
-                  <div className="font-mono text-xs text-muted-foreground truncate">
+                  <div className="text-sm font-semibold break-words">{wo.title}</div>
+                  <div className="font-mono text-xs text-muted-foreground break-words">
                     {wo.number}
                     <span className="md:hidden text-muted-foreground/70">
                       {wo.customers?.name ? ` · ${wo.customers.name}` : ""}
                     </span>
                   </div>
                 </div>
-                <div className="hidden lg:block w-44 text-xs text-muted-foreground truncate">{wo.customers?.name ?? "—"}</div>
-                <div className="hidden md:block w-44 text-xs text-muted-foreground truncate">
+                <div className="hidden lg:block w-44 text-xs text-muted-foreground break-words">{wo.customers?.name ?? "—"}</div>
+                <div className="hidden md:block w-44 text-xs text-muted-foreground break-words">
                   {wo.property_address ? (
                     <span className="inline-flex items-center gap-1"><MapPin className="w-3 h-3 shrink-0" />{wo.property_address}</span>
                   ) : "—"}


### PR DESCRIPTION
Long text now wraps instead of being clipped with an ellipsis. Cards grow vertically; layouts already flex-wrap so the right-side actions stay placed correctly.