### PR TITLE
feat(email): per-business sender — <slug>.kireihq.com

### DIFF
--- a/src/app/api/cron/process-scheduled-sends/route.ts
+++ b/src/app/api/cron/process-scheduled-sends/route.ts
@@ -11,7 +11,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "node:crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { sendSms } from "@/lib/actions/sms";
 import { invoiceEmailHtml } from "@/lib/emails/invoice";
 import { quoteEmailHtml } from "@/lib/emails/quote";
@@ -105,6 +105,8 @@ async function dispatchInvoice(
       subject: row.subject ?? `Invoice ${invoice.number} from ${business?.name ?? ""}`,
       html: invoiceEmailHtml({ invoice, customer: invoice.customers, business, lineItems, portalUrl }),
       attachments: [{ filename: `${invoice.number}.pdf`, content: pdfBuffer }],
+      from: business?.name ? buildBusinessFrom({ name: business.name, localPart: "invoices" }) : undefined,
+      replyTo: business?.email || undefined,
       tags: { business_id: row.business_id, doc_type: "invoice", doc_id: invoice.id },
     });
 
@@ -166,6 +168,8 @@ async function dispatchQuote(
       subject: row.subject ?? `Quote ${quote.number} from ${business?.name ?? ""}`,
       html: quoteEmailHtml({ quote, customer: quote.customers, business, lineItems, acceptUrl }),
       attachments: [{ filename: `${quote.number}.pdf`, content: pdfBuffer }],
+      from: business?.name ? buildBusinessFrom({ name: business.name, localPart: "quotes" }) : undefined,
+      replyTo: business?.email || undefined,
       tags: { business_id: row.business_id, doc_type: "quote", doc_id: quote.id },
     });
 

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { dispatchWebhook } from "@/lib/webhooks";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { invoiceEmailHtml } from "@/lib/emails/invoice";
 import { appUrl } from "@/lib/app-url";
 import { randomBytes } from "node:crypto";
@@ -544,6 +544,8 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
     subject: opts?.subject ?? `Invoice ${invoiceData.number} from ${businessData.name}`,
     html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl, pdfUrl }),
     attachments: [{ filename: `${invoiceData.number}.pdf`, content: pdfBuffer }],
+    from: buildBusinessFrom({ name: businessData.name, localPart: "invoices" }),
+    replyTo: businessData.email || undefined,
     tags: { business_id: businessId, doc_type: "invoice", doc_id: invoiceData.id },
   });
 

--- a/src/lib/actions/member-profiles.ts
+++ b/src/lib/actions/member-profiles.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { canManageTeam, isOwner } from "@/lib/permissions";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { teamInviteEmailHtml } from "@/lib/emails/team-invite";
 import type { MemberProfile, MemberRole } from "@/types/database";
 
@@ -142,6 +142,7 @@ export async function createMemberProfile(payload: {
           inviteUrl,
           inviteCode: inviteToken!,
         }),
+        from: biz?.name ? buildBusinessFrom({ name: biz.name, localPart: "team" }) : undefined,
         tags: { business_id: businessId, doc_type: "team_invite" },
       });
     } catch {

--- a/src/lib/actions/members.ts
+++ b/src/lib/actions/members.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { canManageTeam, isOwner, type Role } from "@/lib/permissions";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { teamInviteEmailHtml } from "@/lib/emails/team-invite";
 import type { BusinessMember, MemberRole } from "@/types/database";
 
@@ -84,6 +84,8 @@ export async function addMember(email: string, role: MemberRole): Promise<void> 
         inviteUrl,
         inviteCode: inviteToken,
       }),
+      from: biz?.name ? buildBusinessFrom({ name: biz.name, localPart: "team" }) : undefined,
+      tags: { business_id: businessId, doc_type: "team_invite" },
     });
   } catch {
     // Email failure is non-fatal — the invite link can still be copied manually

--- a/src/lib/actions/quotes.ts
+++ b/src/lib/actions/quotes.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { dispatchWebhook } from "@/lib/webhooks";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { appUrl } from "@/lib/app-url";
 import { quoteEmailHtml } from "@/lib/emails/quote";
 import { randomBytes } from "node:crypto";
@@ -264,6 +264,8 @@ export async function sendQuoteEmail(id: string, opts?: { recipients?: string[];
     subject: opts?.subject ?? `Quote ${quoteData.number} from ${businessData.name}`,
     html: quoteEmailHtml({ quote: quoteData, customer, business: businessData, lineItems, acceptUrl, pdfUrl }),
     attachments: [{ filename: `${quoteData.number}.pdf`, content: pdfBuffer }],
+    from: buildBusinessFrom({ name: businessData.name, localPart: "quotes" }),
+    replyTo: businessData.email || undefined,
     tags: { business_id: businessId, doc_type: "quote", doc_id: quoteData.id },
   });
 

--- a/src/lib/actions/work-orders.ts
+++ b/src/lib/actions/work-orders.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { dispatchWebhook } from "@/lib/webhooks";
-import { sendEmail } from "@/lib/email";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { workOrderSubmittedEmailHtml } from "@/lib/emails/work-order-submitted";
 import { getRecipientsForRoles } from "@/lib/notifications/recipients";
 import { logJobEvent } from "./job-timeline";
@@ -307,6 +307,8 @@ export async function submitWorkOrder(id: string, workerNotes: string): Promise<
           workerNotes: workerNotes || null,
           viewUrl: `${appUrl}/work-orders/${id}`,
         }),
+        from: bizRow?.name ? buildBusinessFrom({ name: bizRow.name, localPart: "jobs" }) : undefined,
+        tags: { business_id: businessId, doc_type: "custom" },
       });
     }
   } catch {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -11,16 +11,72 @@ function getResend(): Resend {
   return _resend;
 }
 
-// Default from address — override with RESEND_FROM_EMAIL env var once you verify a domain.
-// During development, Resend allows sending from onboarding@resend.dev to your own
-// account-owner mailbox only. Any other recipient will silently fail.
-const FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <onboarding@resend.dev>";
+/** Root domain we send from. Override with KIREI_EMAIL_DOMAIN if you ever
+ *  migrate. Verified once in Resend; wildcard subdomains (*.kireihq.com)
+ *  are also covered if you add the DKIM/SPF records for them. */
+const ROOT_DOMAIN = process.env.KIREI_EMAIL_DOMAIN ?? "kireihq.com";
+
+/** Default catch-all FROM when no business is associated with the send
+ *  (system / dev-sandbox path). */
+const FALLBACK_FROM = process.env.RESEND_FROM_EMAIL ?? "Kirei <onboarding@resend.dev>";
+
+/** Sanitize a business name into a usable local-part / subdomain label.
+ *  Strips everything that isn't a-z0-9, collapses repeats, trims length. */
+export function slugifyBusiness(name: string): string {
+  const slug = (name ?? "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")  // strip accents
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-")
+    .slice(0, 40);
+  return slug || "business";
+}
+
+/** Build a per-business FROM header, e.g.
+ *    "Crown Roofers <invoices@crownroofers.kireihq.com>"
+ *
+ *  Strategy is controlled by KIREI_FROM_STRATEGY env var:
+ *    - "subdomain" (default): invoices@<slug>.kireihq.com
+ *        Requires the wildcard `*.kireihq.com` to be verified in Resend.
+ *        Cleanest look for the customer.
+ *    - "local":             <slug>@kireihq.com
+ *        Only needs the root domain verified. Use this if subdomain
+ *        wildcard isn't set up yet.
+ *
+ *  Display name is the business name verbatim (sanitised — no quotes or
+ *  pipes — so it can't break the header).
+ */
+export function buildBusinessFrom(opts: {
+  /** Business name shown to the recipient. */
+  name: string;
+  /** Optional business slug if you already have one stored. Falls back to
+   *  slugifying the name. */
+  slug?: string | null;
+  /** Choose the local-part for the address. Default "invoices" reads
+   *  well across invoice / quote / team-invite contexts. */
+  localPart?: string;
+}): string {
+  const strategy = (process.env.KIREI_FROM_STRATEGY ?? "subdomain").toLowerCase();
+  const slug = (opts.slug && opts.slug.trim()) || slugifyBusiness(opts.name);
+  const local = opts.localPart ?? "invoices";
+  const displayName = (opts.name ?? "Kirei")
+    .replace(/[<>"\\]/g, "")
+    .trim() || "Kirei";
+
+  const address = strategy === "local"
+    ? `${slug}@${ROOT_DOMAIN}`
+    : `${local}@${slug}.${ROOT_DOMAIN}`;
+
+  return `${displayName} <${address}>`;
+}
 
 /** True when the configured FROM address is the dev fallback. In that case
  *  Resend rejects sends to anyone except the API key owner. Surfaced in error
  *  messages so the user knows to verify their domain. */
-function isDevFromAddress(): boolean {
-  return /onboarding@resend\.dev/i.test(FROM);
+function isDevFromAddress(from: string): boolean {
+  return /onboarding@resend\.dev/i.test(from);
 }
 
 export type EmailDocType = "invoice" | "quote" | "team_invite" | "lead" | "custom";
@@ -37,6 +93,8 @@ export async function sendEmail({
   html,
   attachments,
   tags,
+  from,
+  replyTo,
 }: {
   to: string | string[];
   subject: string;
@@ -46,7 +104,15 @@ export async function sendEmail({
    *  events back to the right invoice/quote. Falls back to a 'custom' row when
    *  business_id is provided without a doc. */
   tags?: EmailTags;
+  /** Override the From address — use `buildBusinessFrom({ name })` to get a
+   *  per-business sender (e.g. "Crown Roofers <invoices@crownroofers.kireihq.com>"). */
+  from?: string;
+  /** Set the Reply-To header — usually the business's own email so customer
+   *  replies go directly to them, not to our shared inbox. */
+  replyTo?: string | string[];
 }) {
+  const fromHeader = from ?? FALLBACK_FROM;
+
   // Resend headers can carry tags for our own webhook handler to read back.
   const headers: Record<string, string> = {};
   if (tags?.business_id) headers["X-Kirei-Business"] = tags.business_id;
@@ -57,11 +123,12 @@ export async function sendEmail({
   let sendError: string | null = null;
   try {
     const { data, error } = await getResend().emails.send({
-      from: FROM,
+      from: fromHeader,
       to,
       subject,
       html,
       attachments,
+      replyTo: replyTo,
       headers: Object.keys(headers).length ? headers : undefined,
     });
     if (error) throw new Error(error.message);
@@ -93,12 +160,15 @@ export async function sendEmail({
   }
 
   if (sendError) {
-    // Enrich the most common silent-failure mode: trying to send from the
-    // dev sandbox address. Resend's own error text doesn't always say this
-    // clearly, so the user just sees "failed" with no path forward.
-    const hint = isDevFromAddress()
-      ? " — RESEND_FROM_EMAIL isn't set or still uses the resend.dev sandbox, which only delivers to the API key owner's mailbox. Verify your domain in Resend, then set RESEND_FROM_EMAIL to a verified address."
-      : "";
+    let hint = "";
+    if (isDevFromAddress(fromHeader)) {
+      hint = " — Sender is still on the resend.dev sandbox, which only delivers to the API-key owner. Verify your domain in Resend.";
+    } else if (/domain.*not.*verified/i.test(sendError) || /not_found.*domain/i.test(sendError)) {
+      // Subdomain pattern failure — guide the user to the fix.
+      hint = ` — The sender (${fromHeader}) isn't a verified Resend domain. ` +
+        `Either verify the wildcard *.${ROOT_DOMAIN} in Resend (so each tenant gets its own subdomain), ` +
+        `or set KIREI_FROM_STRATEGY=local to send from <slug>@${ROOT_DOMAIN} instead.`;
+    }
     throw new Error(sendError + hint);
   }
   return { id: resendId };


### PR DESCRIPTION
Adds buildBusinessFrom() so every outbound email is branded with the business name and a per-tenant subdomain. Reply-To set to the business's own email. KIREI_FROM_STRATEGY=local toggles to <slug>@kireihq.com if wildcard isn't ready.