### PR TITLE
fix(invoices): paid deposit deducts from parent invoice

### DIFF
--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -86,13 +86,26 @@ export async function updateInvoice(id: string, payload: Partial<Invoice>): Prom
 
   const businessId = await getActiveBizId(supabase, user.id);
 
+  // Marking an invoice "paid" via the status dropdown should also settle the
+  // balance — otherwise amount_paid stays behind and (for deposit children)
+  // the parent-reconcile trigger has nothing to roll up. Only auto-fill when
+  // the caller didn't pass an explicit amount_paid.
+  const patch: Partial<Invoice> = { ...payload };
+  if (payload.status === "paid" && payload.amount_paid == null) {
+    const { data: cur } = await tbl(supabase, "invoices").select("total").eq("id", id).eq("business_id", businessId).single();
+    if (cur) patch.amount_paid = cur.total;
+  }
+
   const { data, error } = await tbl(supabase, "invoices")
-    .update(payload)
+    .update(patch)
     .eq("id", id)
     .eq("business_id", businessId)
     .select()
     .single();
   if (error) throw error;
+  // The parent (if any) is reconciled automatically by the DB trigger
+  // trg_reconcile_parent_invoice — revalidate it too so the UI reflects it.
+  if (data?.parent_invoice_id) revalidatePath(`/invoices/${data.parent_invoice_id}`);
   revalidatePath("/invoices");
   revalidatePath(`/invoices/${id}`);
   revalidatePath("/dashboard");

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -698,11 +698,17 @@ export function registerTools(server: McpServer): void {
       return text({ updated: true, invoice: data });
     });
 
-  tool("set_invoice_status", "Set an invoice's status.",
+  tool("set_invoice_status", "Set an invoice's status. Marking 'paid' also settles amount_paid, and (for deposit children) the parent invoice reconciles automatically.",
     { invoice_id: UUID, status: z.enum(["draft", "sent", "partial", "paid", "overdue", "cancelled"]) },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "invoices:write");
-      const { error } = await t(ctx, "invoices").update({ status: args.status }).eq("id", args.invoice_id).eq("business_id", ctx.businessId);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const patch: any = { status: args.status };
+      if (args.status === "paid") {
+        const { data: cur } = await t(ctx, "invoices").select("total").eq("id", args.invoice_id).eq("business_id", ctx.businessId).maybeSingle();
+        if (cur) patch.amount_paid = cur.total;  // DB trigger rolls this up to any parent
+      }
+      const { error } = await t(ctx, "invoices").update(patch).eq("id", args.invoice_id).eq("business_id", ctx.businessId);
       if (error) throw error;
       return text({ updated: true });
     });

--- a/supabase/migrations/20260522183034_deposit_parent_reconcile_trigger.sql
+++ b/supabase/migrations/20260522183034_deposit_parent_reconcile_trigger.sql
@@ -1,0 +1,84 @@
+-- Deposit / progress-invoice parent reconciliation trigger.
+--
+-- Problem: a deposit is a child invoice (parent_invoice_id set). The app-code
+-- rollup in addPayment() only fires when you *record a payment*. Marking the
+-- deposit "paid" via the status dropdown (updateInvoice), the MCP
+-- mark_invoice_paid / set_invoice_status, or any direct write bypassed it — so
+-- the parent never reflected the paid deposit (it wasn't "deducted").
+--
+-- Fix: a trigger that recomputes the PARENT's amount_paid + status whenever any
+-- child invoice changes. Parent.amount_paid = direct payments on the parent +
+-- sum of every child's amount_paid. This makes the parent correct no matter how
+-- the child's paid state was changed. (App code still sets the child's
+-- amount_paid = total when marking paid; this trigger propagates it up.)
+
+CREATE OR REPLACE FUNCTION public.reconcile_parent_invoice()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_parent    UUID;
+  v_total     NUMERIC;
+  v_status    TEXT;
+  v_collected NUMERIC;
+BEGIN
+  -- Which parent (if any) does the changed row belong to?
+  v_parent := COALESCE(NEW.parent_invoice_id, OLD.parent_invoice_id);
+  IF v_parent IS NULL THEN
+    RETURN NULL;  -- not a child invoice; nothing to roll up
+  END IF;
+
+  SELECT total, status INTO v_total, v_status FROM invoices WHERE id = v_parent;
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+
+  -- Everything collected toward the parent job: direct payments on the parent
+  -- plus what each child invoice has collected.
+  SELECT
+    COALESCE((SELECT SUM(amount)      FROM payments WHERE invoice_id = v_parent), 0)
+  + COALESCE((SELECT SUM(amount_paid) FROM invoices WHERE parent_invoice_id = v_parent), 0)
+  INTO v_collected;
+
+  UPDATE invoices
+     SET amount_paid = v_collected,
+         status = CASE
+                    WHEN status IN ('cancelled', 'draft') THEN status
+                    WHEN v_collected >= v_total - 0.01     THEN 'paid'
+                    WHEN v_collected > 0.01                THEN 'partial'
+                    ELSE status
+                  END
+   WHERE id = v_parent;
+  -- The UPDATE above re-fires this trigger on the parent row, but the parent has
+  -- no parent_invoice_id so it returns early — no recursion.
+
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_reconcile_parent_invoice ON public.invoices;
+CREATE TRIGGER trg_reconcile_parent_invoice
+AFTER INSERT OR UPDATE OR DELETE ON public.invoices
+FOR EACH ROW EXECUTE FUNCTION public.reconcile_parent_invoice();
+
+-- Backfill: reconcile every existing parent that has children.
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN SELECT DISTINCT parent_invoice_id AS id FROM invoices WHERE parent_invoice_id IS NOT NULL LOOP
+    UPDATE invoices p
+       SET amount_paid = COALESCE((SELECT SUM(amount) FROM payments WHERE invoice_id = r.id), 0)
+                       + COALESCE((SELECT SUM(amount_paid) FROM invoices WHERE parent_invoice_id = r.id), 0),
+           status = CASE
+                      WHEN p.status IN ('cancelled','draft') THEN p.status
+                      WHEN (COALESCE((SELECT SUM(amount) FROM payments WHERE invoice_id = r.id), 0)
+                          + COALESCE((SELECT SUM(amount_paid) FROM invoices WHERE parent_invoice_id = r.id), 0)) >= p.total - 0.01 THEN 'paid'
+                      WHEN (COALESCE((SELECT SUM(amount) FROM payments WHERE invoice_id = r.id), 0)
+                          + COALESCE((SELECT SUM(amount_paid) FROM invoices WHERE parent_invoice_id = r.id), 0)) > 0.01 THEN 'partial'
+                      ELSE p.status
+                    END
+     WHERE p.id = r.id;
+  END LOOP;
+END $$;


### PR DESCRIPTION
DB trigger reconciles a parent invoice whenever a deposit/child changes, + mark-paid now settles amount_paid. Fixes the deposit not being deducted.