### PR TITLE
chore(store): privacy/support pages + listing copy + v1.0.0

### DIFF
--- a/mobile/STORE_LISTING.md
+++ b/mobile/STORE_LISTING.md
@@ -1,0 +1,94 @@
+# Kirei — Store Listing Copy
+
+Paste-ready text for the App Store Connect + Google Play Console listings.
+URLs below are live on the web app.
+
+- **Privacy policy URL:** https://www.kireihq.com/privacy
+- **Support URL:** https://www.kireihq.com/support
+- **Marketing URL (optional):** https://www.kireihq.com
+
+---
+
+## App name
+Kirei — Trades Business Manager
+
+## Subtitle (App Store, 30 chars max)
+Quotes, invoices & jobs
+
+## Short description (Play, 80 chars max)
+Quotes, invoices, jobs and customers — run your trade business from your pocket.
+
+## Promotional text (App Store, 170 chars — updatable without review)
+Send quotes and invoices in seconds, schedule jobs, capture site photos, and keep every customer in one place. Built for tradies.
+
+## Full description (both stores)
+Kirei is the all-in-one business manager for trade and field-service businesses — roofers, plumbers, electricians, gardeners, cleaners, and every trade in between.
+
+Run the whole job from your phone:
+
+• QUOTES & INVOICES — Build a professional quote in seconds, send it as a PDF, and let customers accept or pay online. Convert accepted quotes to invoices with one tap. Take deposits and progress payments.
+
+• JOBS & SCHEDULING — Create work orders, assign your crew, schedule visits, and track each job from booked to complete. Workers see only the jobs assigned to them.
+
+• SITE PHOTOS — Capture before/during/after photos on site, attach them to the job, and share a clean record with your customer.
+
+• CUSTOMERS & LEADS — Keep every customer, contact, and property in one place. Track new leads through your pipeline so nothing slips.
+
+• GET PAID — Send payment reminders, record payments, and see exactly what's outstanding at a glance.
+
+• AI ASSISTANT — Ask it to draft a quote, find a customer, or tell you what needs your attention today.
+
+• WORKS FOR YOUR TEAM — Invite your crew with the right access level. Owners and admins manage everything; workers get a focused view of their jobs.
+
+Your data is private and isolated to your business. Kirei never sells your data.
+
+Start free and run your trade business the tidy way.
+
+## Keywords (App Store, 100 chars, comma-separated)
+quote,invoice,tradie,trades,job,scheduling,roofing,plumbing,electrician,invoicing,field service,crm
+
+## Category
+- Primary: Business
+- Secondary: Productivity
+
+---
+
+## Apple — App Privacy answers (App Store Connect → App Privacy)
+Data collected and **linked to the user**, used for **App Functionality** only (no tracking, no advertising):
+- Contact info: name, email address, phone number
+- User content: photos, customer records, financial info you enter (quotes/invoices)
+- Identifiers: user ID
+- Diagnostics: crash data, performance data
+
+Set **"Used for tracking": No** for all. No third-party advertising.
+
+---
+
+## Google Play — Data Safety form
+- **Data collected:** Name, Email, Phone (account + customer records you enter), Photos, App activity, Crash logs, Device identifiers.
+- **Encrypted in transit:** Yes
+- **Encrypted at rest:** Yes
+- **Data deletion:** Yes — users can request deletion at support@kireihq.com (and delete records in-app).
+- **Shared with third parties:** Only with processors that operate the service (hosting, database, email, AI) — not sold, not for ads.
+- **Purpose:** App functionality, account management.
+
+---
+
+## Screenshots needed (capture from a real device or simulator)
+**iOS** (App Store requires at least one set):
+- 6.7" iPhone (1290×2796) — required
+- 6.5" iPhone (1242×2688) — optional fallback
+- 12.9" iPad (2048×2732) — only if you mark the app iPad-compatible
+
+**Android** (Play):
+- Phone: 2–8 screenshots, min 1080px on the short side
+- (Optional) 7" + 10" tablet sets
+
+Suggested shots: Dashboard, a Quote, an Invoice with the pay button, the Jobs list, a Job with photos, the Schedule.
+
+---
+
+## Reviewer notes (App Store Connect → App Review Information)
+Provide a demo login so Apple can test:
+- Demo email + password for a seeded account with sample data.
+- Note: "This is a B2B field-service management tool. Sign in with the demo account to see quotes, invoices, jobs, and customers."

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Kirei",
     "slug": "kirei",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "orientation": "default",
     "scheme": "kirei",
     "userInterfaceStyle": "automatic",

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Kirei",
+  description: "How Kirei collects, uses, and protects your data.",
+};
+
+const UPDATED = "23 May 2026";
+const CONTACT = "support@kireihq.com";
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16 text-[15px] leading-relaxed text-zinc-800">
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-900">Privacy Policy</h1>
+      <p className="mt-2 text-sm text-zinc-500">Last updated: {UPDATED}</p>
+
+      <Section title="Who we are">
+        Kirei (“we”, “us”) is a field-services business management app — quotes, invoices,
+        jobs, customers, and scheduling for trade businesses. This policy explains what we
+        collect, why, and your choices. It applies to the Kirei mobile apps (iOS &amp; Android)
+        and the web app at kireihq.com.
+      </Section>
+
+      <Section title="Information we collect">
+        <ul className="list-disc space-y-1 pl-5">
+          <li><strong>Account data</strong> — your name, email, and password (passwords are stored hashed by our authentication provider, never in plain text).</li>
+          <li><strong>Business data you enter</strong> — customers, contacts, quotes, invoices, work orders, leads, tasks, products, photos, and related notes.</li>
+          <li><strong>Photos &amp; files</strong> — job photos and documents you upload, stored in secure cloud storage.</li>
+          <li><strong>Usage &amp; device data</strong> — basic technical information (device type, app version, error logs) used to operate and improve the app.</li>
+          <li><strong>Voice input</strong> — if you use voice features, audio is sent to a transcription service to convert it to text; it is not retained after transcription.</li>
+        </ul>
+      </Section>
+
+      <Section title="How we use it">
+        <ul className="list-disc space-y-1 pl-5">
+          <li>To provide the core features — creating and sending quotes/invoices, managing jobs and customers, scheduling, and reporting.</li>
+          <li>To send transactional emails on your behalf (e.g. a quote or invoice to your customer) and account emails to you.</li>
+          <li>To secure your account and isolate each business’s data from every other business.</li>
+          <li>To diagnose problems and improve reliability and performance.</li>
+        </ul>
+        <p className="mt-3">We do <strong>not</strong> sell your data or your customers’ data, and we do not use it for advertising.</p>
+      </Section>
+
+      <Section title="AI features">
+        Some features use AI (e.g. classifying inbound emails into leads/tasks, drafting quotes,
+        and the assistant). Relevant text is processed by our AI provider to generate the result.
+        We do not use your data to train third-party models, and providers we use operate under
+        zero-retention terms where available.
+      </Section>
+
+      <Section title="Sharing &amp; processors">
+        We share data only with the service providers that run the app on our behalf, under
+        contract and only as needed to provide the service:
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li><strong>Supabase</strong> — database, authentication, and file storage.</li>
+          <li><strong>Vercel</strong> — application hosting.</li>
+          <li><strong>Resend</strong> — sending the emails you trigger.</li>
+          <li><strong>Anthropic / OpenAI</strong> — AI text generation and voice transcription.</li>
+        </ul>
+        We may also disclose data if required by law.
+      </Section>
+
+      <Section title="Data retention">
+        We keep your data for as long as your account is active. When you delete a record it is
+        removed from the live database. If you close your account, contact us and we will delete
+        your business’s data within 30 days, except where we must retain it to meet legal or
+        tax obligations.
+      </Section>
+
+      <Section title="Security">
+        Data is encrypted in transit (HTTPS) and at rest. Every business’s data is isolated at
+        the database level so one business can never read another’s. Access is restricted to the
+        authenticated owner and the team members they invite.
+      </Section>
+
+      <Section title="Your rights">
+        You can access, correct, export, or delete your data at any time from within the app, or
+        by contacting us. Depending on your location you may have additional rights under laws
+        such as the Australian Privacy Act, GDPR, or CCPA — we honour these requests.
+      </Section>
+
+      <Section title="Children">
+        Kirei is a business tool and is not directed to anyone under 16. We do not knowingly
+        collect data from children.
+      </Section>
+
+      <Section title="Changes">
+        We may update this policy; we’ll change the “last updated” date above and, for material
+        changes, notify you in the app.
+      </Section>
+
+      <Section title="Contact">
+        Questions or data requests: <a className="text-teal-700 underline" href={`mailto:${CONTACT}`}>{CONTACT}</a>
+      </Section>
+    </main>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-lg font-semibold text-zinc-900">{title}</h2>
+      <div className="mt-2">{children}</div>
+    </section>
+  );
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Support — Kirei",
+  description: "Get help with the Kirei app.",
+};
+
+const CONTACT = "support@kireihq.com";
+
+export default function SupportPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16 text-[15px] leading-relaxed text-zinc-800">
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-900">Support</h1>
+      <p className="mt-3">
+        Need a hand with Kirei? We’re happy to help.
+      </p>
+
+      <section className="mt-8 rounded-xl border border-zinc-200 bg-zinc-50 p-6">
+        <h2 className="text-lg font-semibold text-zinc-900">Contact us</h2>
+        <p className="mt-2">
+          Email <a className="text-teal-700 underline" href={`mailto:${CONTACT}`}>{CONTACT}</a> and
+          we’ll get back to you, usually within one business day. Please include:
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>Your business name</li>
+          <li>What you were trying to do</li>
+          <li>What happened (a screenshot helps)</li>
+          <li>Your device + app version (Settings → About)</li>
+        </ul>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold text-zinc-900">Common questions</h2>
+        <Faq q="How do I send a quote or invoice to a customer?">
+          Open the quote or invoice, tap Send, and confirm the recipient. We email it as a PDF
+          with a link your customer can view (and pay/accept) online.
+        </Faq>
+        <Faq q="My customer didn’t receive the email.">
+          Check the Email delivery panel on the quote/invoice — it shows sent / delivered /
+          bounced. Ask the customer to check spam. If it shows bounced, verify the email address.
+        </Faq>
+        <Faq q="How do I add a team member?">
+          Go to Team → Add member, enter their email, and pick their access level. Workers only
+          see the jobs assigned to them.
+        </Faq>
+        <Faq q="How do I delete my account or data?">
+          Email us at {CONTACT} from your account address and we’ll permanently delete your
+          business’s data within 30 days.
+        </Faq>
+      </section>
+
+      <p className="mt-10 text-sm text-zinc-500">
+        See also our <a className="text-teal-700 underline" href="/privacy">Privacy Policy</a>.
+      </p>
+    </main>
+  );
+}
+
+function Faq({ q, children }: { q: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-4">
+      <p className="font-medium text-zinc-900">{q}</p>
+      <p className="mt-1 text-zinc-700">{children}</p>
+    </div>
+  );
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -45,6 +45,8 @@ export async function updateSession(request: NextRequest) {
     pathname === "/api/ai/transcribe";
 
   const isPublicRoute =
+    pathname === "/privacy" ||
+    pathname === "/support" ||
     pathname.startsWith("/invoice/") ||
     pathname.startsWith("/quote/") ||
     pathname.startsWith("/jobs/") ||


### PR DESCRIPTION
Removes the store blockers I can: public privacy + support pages (mandatory URLs), paste-ready App Store/Play listing copy with data-safety answers, and version bump to 1.0.0.