### PR TITLE
chore(mobile): align deps to SDK 54 + metro config

### DIFF
--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,23 @@
+// Metro config for the Kirei Expo app.
+//
+// This app lives inside the larger Invoicer repo (the Next.js web app), which
+// has its OWN node_modules containing a different React version. Without this,
+// Metro's hierarchical lookup can resolve the web app's React and crash the
+// bundle with a duplicate-React error. We extend Expo's default config and pin
+// module resolution to this folder's node_modules only.
+//
+// (EAS cloud builds install fresh from mobile/package.json in isolation, so
+// this mainly protects local `expo start`, but keeping it explicit avoids
+// surprises and satisfies expo-doctor's metro check.)
+
+const { getDefaultConfig } = require("expo/metro-config");
+const path = require("path");
+
+const config = getDefaultConfig(__dirname);
+
+// Prefer this folder's node_modules first (so the web app's React up the tree
+// is never resolved). We intentionally leave hierarchical lookup on its
+// default so expo-doctor stays happy; nodeModulesPaths priority is enough.
+config.resolver.nodeModulesPaths = [path.resolve(__dirname, "node_modules")];
+
+module.exports = config;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,13 +14,14 @@
         "@tanstack/react-query": "^5.62.0",
         "date-fns": "^4.1.0",
         "expo": "~54.0.0",
+        "expo-asset": "~12.0.13",
         "expo-audio": "~1.1.1",
         "expo-constants": "~18.0.13",
         "expo-device": "~8.0.10",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image-picker": "~17.0.11",
-        "expo-linear-gradient": "^55.0.13",
+        "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.12",
         "expo-notifications": "~0.32.17",
         "expo-router": "~6.0.0",
@@ -40,11 +41,11 @@
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
         "react-native-url-polyfill": "^2.0.0",
-        "react-native-worklets": "^0.8.1"
+        "react-native-worklets": "^0.5.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.0",
-        "@types/react": "~19.0.0",
+        "@types/react": "~19.1.10",
         "babel-plugin-module-resolver": "^5.0.0",
         "typescript": "^5.6.0"
       }
@@ -2485,12 +2486,12 @@
       "license": "MIT"
     },
     "node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
+      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.3"
+        "cross-spawn": "^7.0.6"
       },
       "engines": {
         "node": ">=12"
@@ -3967,9 +3968,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
-      "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
+      "version": "19.1.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
+      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5685,9 +5686,9 @@
       }
     },
     "node_modules/expo-linear-gradient": {
-      "version": "55.0.13",
-      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.13.tgz",
-      "integrity": "sha512-Qz2T4jpkA15RIk29DBqI1TwW+8O9AN8MyC4TJPbh/5UnihH0yNNz3waplUO8Szh5OZ3czTGvtPQU4ysF3RDxwQ==",
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -8887,34 +8888,33 @@
       }
     },
     "node_modules/react-native-worklets": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.1.tgz",
-      "integrity": "sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
+        "semver": "7.7.2"
       },
       "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
+        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "0.81 - 0.85"
+        "react-native": "*"
       }
     },
     "node_modules/react-native-worklets/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,13 +17,14 @@
     "@tanstack/react-query": "^5.62.0",
     "date-fns": "^4.1.0",
     "expo": "~54.0.0",
+    "expo-asset": "~12.0.13",
     "expo-audio": "~1.1.1",
     "expo-constants": "~18.0.13",
     "expo-device": "~8.0.10",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image-picker": "~17.0.11",
-    "expo-linear-gradient": "^55.0.13",
+    "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.12",
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.0",
@@ -43,11 +44,11 @@
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
     "react-native-url-polyfill": "^2.0.0",
-    "react-native-worklets": "^0.8.1"
+    "react-native-worklets": "^0.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",
-    "@types/react": "~19.0.0",
+    "@types/react": "~19.1.10",
     "babel-plugin-module-resolver": "^5.0.0",
     "typescript": "^5.6.0"
   },


### PR DESCRIPTION
Fixes expo-doctor version drift (expo-linear-gradient major mismatch etc.) that would break the first EAS store build, and pins module resolution for the nested monorepo.