### PR TITLE
chore(mobile): .npmrc legacy-peer-deps for EAS

### DIFF
--- a/mobile/.npmrc
+++ b/mobile/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
EAS Build npm install was ERESOLVE-failing the Android build in 16s. Add legacy-peer-deps .npmrc.