### PR TITLE
chore(mobile): iOS submit config

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -26,9 +26,11 @@
   "submit": {
     "production": {
       "ios": {
-        "appleId":         "REPLACE_WITH_YOUR_APPLE_ID_EMAIL",
-        "ascAppId":        "REPLACE_WITH_APP_STORE_CONNECT_APP_ID",
-        "appleTeamId":     "REPLACE_WITH_APPLE_TEAM_ID"
+        "ascAppId":              "6772754750",
+        "ascApiKeyPath":         "./asc-key.p8",
+        "ascApiKeyId":           "G7R8967FYN",
+        "ascApiKeyIssuerId":     "ac1d8617-9810-4aaa-a5c7-1455eca2d090",
+        "appleTeamId":           "474LBTA57F"
       },
       "android": {
         "serviceAccountKeyPath": "./play-service-account.json",


### PR DESCRIPTION
Saves ASC App ID + API key refs in eas.json for non-interactive submits. .p8 stays gitignored.