### PR TITLE
chore(mobile): rebrand app id to com.kireihq.app

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -18,7 +18,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.crownroofers.connectedhub",
+      "bundleIdentifier": "com.kireihq.app",
       "buildNumber": "1",
       "infoPlist": {
         "NSCameraUsageDescription": "Kirei needs camera access so you can attach photos to jobs and capture site shots for invoices.",
@@ -29,7 +29,7 @@
       }
     },
     "android": {
-      "package": "com.crownroofers.connectedhub",
+      "package": "com.kireihq.app",
       "versionCode": 1,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",


### PR DESCRIPTION
Bundle/package → com.kireihq.app. Android clean; iOS needs new ASC app.