### PR TITLE
chore(stripe): temp webhook diagnostic log

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -24,6 +24,12 @@ export async function POST(request: NextRequest) {
     event = stripe.webhooks.constructEvent(raw, sig, secret);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Invalid signature";
+    // TEMP diagnostic — safe: logs only the secret's prefix + length, never its value.
+    console.error(
+      "[stripe.webhook] verify failed:", msg,
+      "| secretPrefix:", secret.slice(0, 6), "secretLen:", secret.length,
+      "| sigPresent:", !!sig,
+    );
     return NextResponse.json({ error: msg }, { status: 400 });
   }
 


### PR DESCRIPTION
Temporary: logs why webhook signature verification fails (secret prefix + length, never the value) to debug the 400s. Revert after.