### PR TITLE
Stripe card-on-file + autopay (off-session recurring charges)

### DIFF
--- a/docs/MOBILE_PARITY_PLAN.md
+++ b/docs/MOBILE_PARITY_PLAN.md
@@ -138,6 +138,7 @@ Status legend: ✅ done · 🟡 partial · ❌ missing · 🚫 not applicable on
 | Stripe card payments | 🟡 | 3f | Web: Settings → Payment connects Stripe (Standard, account_links), "Pay with card" on portal invoice + in invoice emails, payment receipt email, quote-accept deposit. Mobile: deep-link `/settings/payments` to web for now; native onboarding requires WebView around accountLinks URL — follow-up. |
 | Pay link in invoice emails | 🟡 | 3f | Server-side — emails sent from mobile auto-include the card-pay button when Stripe is enabled |
 | Quote deposit by card | 🚫 | — | Customer-facing portal flow (accept quote → pay deposit); not the tradie's app |
+| Card on file / autopay | 🟡 | 3f | Customer saves a card (portal, SetupIntent) → invoices auto-charge off-session on send; "Charge saved card" on invoice detail (web). Mobile: surfaces autopay status; charge action could mirror later |
 | Team management | ✅ | 2g | List + add (email/role) + change role + remove; pending → active on first login |
 | API keys | 🟡 | 3f | /settings/advanced surfaces it with web deep-link (mint/revoke needs server endpoint) |
 | Webhooks | 🟡 | 3f | Same — /settings/advanced deep-links to web |

--- a/src/app/api/stripe/save-card/route.ts
+++ b/src/app/api/stripe/save-card/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getStripe } from "@/lib/stripe";
+import { customerAllowsCard } from "@/lib/payment-methods";
+
+/**
+ * Public, token-gated. Sends the customer to Stripe's hosted card-setup page to
+ * save a card on file for automatic payments. On completion the webhook
+ * (checkout.session.completed, mode=setup) stores the payment method + enables
+ * autopay. We create/reuse a Stripe Customer ON THE CONNECTED ACCOUNT, since
+ * that's where direct charges (and therefore the saved card) live.
+ */
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  const invoiceId = url.searchParams.get("invoice"); // optional, for return redirect
+  if (!token) return NextResponse.json({ error: "Missing token" }, { status: 400 });
+
+  const sb = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: link } = await (sb as any).from("customer_portal_tokens")
+    .select("business_id, customer_id, expires_at, revoked_at")
+    .eq("token", token)
+    .maybeSingle();
+  if (!link || link.revoked_at) return NextResponse.json({ error: "Invalid token" }, { status: 404 });
+  if (link.expires_at && new Date(link.expires_at) < new Date()) {
+    return NextResponse.json({ error: "Token expired" }, { status: 404 });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: business } = await (sb as any).from("businesses")
+    .select("name, stripe_account_id, stripe_charges_enabled")
+    .eq("id", link.business_id).single();
+  if (!business?.stripe_account_id || !business.stripe_charges_enabled) {
+    return NextResponse.json({ error: "Card payments aren't enabled for this business" }, { status: 400 });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: customer } = await (sb as any).from("customers")
+    .select("id, name, email, stripe_customer_id, allowed_payment_methods")
+    .eq("id", link.customer_id).maybeSingle();
+  if (!customer) return NextResponse.json({ error: "Customer not found" }, { status: 404 });
+  if (!customerAllowsCard(customer.allowed_payment_methods)) {
+    return NextResponse.json({ error: "Card payment is disabled for this account" }, { status: 403 });
+  }
+
+  const stripe = getStripe();
+  const acctOpts = { stripeAccount: business.stripe_account_id as string };
+
+  // Ensure a Stripe Customer exists on the connected account.
+  let stripeCustomerId = customer.stripe_customer_id as string | null;
+  if (!stripeCustomerId) {
+    const created = await stripe.customers.create(
+      {
+        name: customer.name || undefined,
+        email: customer.email || undefined,
+        metadata: { kirei_customer_id: customer.id, kirei_business_id: link.business_id },
+      },
+      acctOpts,
+    );
+    stripeCustomerId = created.id;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sb as any).from("customers").update({ stripe_customer_id: stripeCustomerId }).eq("id", customer.id);
+  }
+
+  const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || `${url.protocol}//${url.host}`;
+  const ret = invoiceId ? `/portal/${token}/invoice/${invoiceId}` : `/portal/${token}`;
+
+  const session = await stripe.checkout.sessions.create(
+    {
+      mode: "setup",
+      customer: stripeCustomerId,
+      payment_method_types: ["card"],
+      success_url: `${base}${ret}?card_saved=1`,
+      cancel_url: `${base}${ret}?card_cancelled=1`,
+      metadata: {
+        kirei_customer_id: customer.id,
+        kirei_business_id: link.business_id,
+      },
+    },
+    acctOpts,
+  );
+
+  if (!session.url) {
+    return NextResponse.json({ error: "Stripe didn't return a setup URL" }, { status: 500 });
+  }
+  return NextResponse.redirect(session.url, { status: 303 });
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import type Stripe from "stripe";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getStripe, fromStripeAmount } from "@/lib/stripe";
-import { dispatchWebhook } from "@/lib/webhooks";
+import { recordStripePayment } from "@/lib/stripe-payments";
 
 export const runtime = "nodejs";
 // Disable Next's default body parsing so we get the raw bytes for signature verification.
@@ -33,6 +33,9 @@ export async function POST(request: NextRequest) {
       case "checkout.session.async_payment_succeeded":
         await handleCheckoutCompleted(event);
         break;
+      case "payment_intent.succeeded":
+        await handlePaymentIntentSucceeded(event);
+        break;
       case "account.updated":
         await handleAccountUpdated(event);
         break;
@@ -62,6 +65,14 @@ async function handleAccountUpdated(event: Stripe.Event) {
 
 async function handleCheckoutCompleted(event: Stripe.Event) {
   const session = event.data.object as Stripe.Checkout.Session;
+  const connectedAcct = typeof event.account === "string" ? event.account : null;
+
+  // Setup mode = the customer saved a card on file (no payment taken).
+  if (session.mode === "setup") {
+    await handleCardSaved(session, connectedAcct);
+    return;
+  }
+
   if (session.payment_status !== "paid") return;
 
   const invoiceId = session.metadata?.kirei_invoice_id;
@@ -70,209 +81,77 @@ async function handleCheckoutCompleted(event: Stripe.Event) {
     console.warn("[stripe.webhook] session missing kirei_invoice_id/business_id", session.id);
     return;
   }
-
   const piId = typeof session.payment_intent === "string" ? session.payment_intent : session.payment_intent?.id;
   if (!piId) {
     console.warn("[stripe.webhook] session has no payment_intent", session.id);
     return;
   }
 
-  const sb = createAdminClient();
-  const stripe = getStripe();
-
-  // Fees live on the connected account's charge. Read them robustly:
-  //  - Stripe processing fee → the charge's balance_transaction.fee
-  //  - Platform fee → charge.application_fee_amount (a plain integer that's
-  //    always set when we charged a fee — far more reliable than expanding the
-  //    application_fee OBJECT, which is platform-owned and often returns null
-  //    when fetched through the connected account).
-  const connectedAcct = typeof event.account === "string" ? event.account : null;
-  let stripeFee = 0;
-  let applicationFee = 0;
-  try {
-    const pi = await stripe.paymentIntents.retrieve(
-      piId,
-      { expand: ["latest_charge.balance_transaction"] },
-      connectedAcct ? { stripeAccount: connectedAcct } : undefined,
-    );
-    const charge = pi.latest_charge && typeof pi.latest_charge === "object"
-      ? (pi.latest_charge as Stripe.Charge)
-      : null;
-    if (charge) {
-      // Platform fee — plain integer, always set when we charged a fee.
-      if (charge.application_fee_amount != null) {
-        applicationFee = fromStripeAmount(
-          charge.application_fee_amount,
-          (charge.currency || session.currency || "usd").toUpperCase(),
-        );
-      }
-      // Stripe processing fee — from the charge's balance transaction. It can
-      // arrive expanded, as a bare id, or not yet exist at webhook time; fetch
-      // it by id when we only got the id.
-      let bt = charge.balance_transaction && typeof charge.balance_transaction === "object"
-        ? (charge.balance_transaction as Stripe.BalanceTransaction)
-        : null;
-      if (!bt && typeof charge.balance_transaction === "string") {
-        bt = await stripe.balanceTransactions.retrieve(
-          charge.balance_transaction,
-          undefined,
-          connectedAcct ? { stripeAccount: connectedAcct } : undefined,
-        );
-      }
-      if (bt) stripeFee = fromStripeAmount(bt.fee, bt.currency.toUpperCase());
-    }
-  } catch (err) {
-    console.warn("[stripe.webhook] couldn't read fees", err);
-  }
-
   const currency = session.currency?.toUpperCase() ?? "USD";
   const amount = fromStripeAmount(session.amount_total ?? 0, currency);
 
-  // Idempotent insert — unique index on (business_id, provider_payment_id)
-  // means a redelivered event silently no-ops on conflict.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: existing } = await (sb as any).from("payments")
-    .select("id")
-    .eq("business_id", businessId)
-    .eq("provider_payment_id", piId)
-    .maybeSingle();
-  if (existing) return;
+  const sb = createAdminClient();
+  await recordStripePayment(sb, getStripe(), {
+    businessId, invoiceId, piId, sessionId: session.id, amount, currency,
+    connectedAcct, portalToken: session.metadata?.kirei_portal_token ?? null,
+  });
+}
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: invoice } = await (sb as any).from("invoices")
-    .select("id, total, amount_paid, parent_invoice_id, user_id, status, number, customer_id")
-    .eq("id", invoiceId)
-    .eq("business_id", businessId)
-    .single();
-  if (!invoice) {
-    console.warn("[stripe.webhook] invoice not found", invoiceId);
+/**
+ * Off-session autopay charges record themselves inline, but if a
+ * payment_intent.succeeded is also delivered here we record it too (idempotent).
+ * Only acts on PaymentIntents we tagged with kirei_invoice_id — hosted-Checkout
+ * PIs carry no such metadata and are handled via the session event above.
+ */
+async function handlePaymentIntentSucceeded(event: Stripe.Event) {
+  const pi = event.data.object as Stripe.PaymentIntent;
+  const invoiceId = pi.metadata?.kirei_invoice_id;
+  const businessId = pi.metadata?.kirei_business_id;
+  if (!invoiceId || !businessId) return;
+
+  const connectedAcct = typeof event.account === "string" ? event.account : null;
+  const currency = (pi.currency ?? "usd").toUpperCase();
+  const amount = fromStripeAmount(pi.amount_received ?? pi.amount ?? 0, currency);
+
+  const sb = createAdminClient();
+  await recordStripePayment(sb, getStripe(), {
+    businessId, invoiceId, piId: pi.id, amount, currency,
+    connectedAcct, portalToken: pi.metadata?.kirei_portal_token ?? null,
+  });
+}
+
+/** Persist a newly-saved card on file (from a setup-mode Checkout session). */
+async function handleCardSaved(session: Stripe.Checkout.Session, connectedAcct: string | null) {
+  const customerId = session.metadata?.kirei_customer_id;
+  const businessId = session.metadata?.kirei_business_id;
+  if (!customerId || !businessId) {
+    console.warn("[stripe.webhook] setup session missing kirei_customer_id/business_id", session.id);
     return;
   }
+  const setupIntentId = typeof session.setup_intent === "string" ? session.setup_intent : session.setup_intent?.id;
+  if (!setupIntentId) return;
 
+  const stripe = getStripe();
+  const opts = connectedAcct ? { stripeAccount: connectedAcct } : undefined;
+
+  const si = await stripe.setupIntents.retrieve(setupIntentId, { expand: ["payment_method"] }, opts);
+  const pm = si.payment_method && typeof si.payment_method === "object"
+    ? (si.payment_method as Stripe.PaymentMethod)
+    : null;
+  const pmId = pm?.id ?? (typeof si.payment_method === "string" ? si.payment_method : null);
+  if (!pmId) return;
+
+  const card = pm?.card ?? null;
+  const stripeCustomerId = typeof session.customer === "string" ? session.customer : session.customer?.id ?? null;
+
+  const sb = createAdminClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await (sb as any).from("payments").insert({
-    invoice_id: invoiceId,
-    business_id: businessId,
-    user_id: invoice.user_id,
-    amount,
-    date: new Date().toISOString().slice(0, 10),
-    method: "Stripe (card)",
-    reference: piId,
-    notes: null,
-    provider: "stripe",
-    provider_payment_id: piId,
-    provider_session_id: session.id,
-    provider_fee: stripeFee || null,
-    provider_platform_fee: applicationFee || null,
-  });
-
-  // Recompute amount_paid on this invoice from truth (direct payments + child
-  // collections). Mirrors src/lib/actions/invoices.ts addPayment() exactly so
-  // progress / deposit invoices reconcile the same way.
-  await recomputeInvoice(sb, businessId, invoiceId, invoice.total);
-
-  // Roll up to a parent invoice if this is a deposit/child. The DB trigger
-  // trg_reconcile_parent_invoice will also do this — calling it explicitly
-  // here keeps behavior identical to the cookie-bound addPayment().
-  if (invoice.parent_invoice_id) {
-    await recomputeParent(sb, businessId, invoice.parent_invoice_id);
-  }
-
-  // Notify any subscribed webhooks the merchant has configured.
-  try {
-    dispatchWebhook(businessId, "payment.received", {
-      invoice_id: invoiceId,
-      amount,
-      provider: "stripe",
-      stripe_payment_intent_id: piId,
-    });
-  } catch { /* never blocks */ }
-
-  // Email the customer a branded receipt — best-effort, never blocks the webhook.
-  try {
-    await sendPaymentReceipt(sb, {
-      businessId,
-      invoiceId,
-      amount,
-      portalToken: session.metadata?.kirei_portal_token ?? null,
-    });
-  } catch (err) {
-    console.warn("[stripe.webhook] receipt email failed", err);
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function sendPaymentReceipt(sb: any, opts: { businessId: string; invoiceId: string; amount: number; portalToken: string | null }) {
-  // Re-read the invoice AFTER recompute so the receipt shows the correct
-  // running total + remaining balance.
-  const { data: invoice } = await sb.from("invoices")
-    .select("id, number, total, amount_paid, customer_id")
-    .eq("id", opts.invoiceId).eq("business_id", opts.businessId).single();
-  if (!invoice) return;
-
-  const [{ data: business }, { data: customer }] = await Promise.all([
-    sb.from("businesses").select("name, email, phone, currency").eq("id", opts.businessId).single(),
-    invoice.customer_id
-      ? sb.from("customers").select("name, email").eq("id", invoice.customer_id).maybeSingle()
-      : Promise.resolve({ data: null }),
-  ]);
-  if (!customer?.email) return; // nowhere to send it
-
-  const { getResolvedEmailTemplate } = await import("@/lib/emails/templates");
-  const { paymentReceiptEmailHtml, paymentReceiptEmailSubject } = await import("@/lib/emails/payment-receipt");
-  const { sendEmail, buildBusinessFrom } = await import("@/lib/email");
-
-  const template = await getResolvedEmailTemplate(sb, opts.businessId, "payment_receipt");
-  const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "";
-  const portalUrl = opts.portalToken && base ? `${base}/portal/${opts.portalToken}/invoice/${invoice.id}` : null;
-  const args = {
-    invoice, customer, business,
-    amount: opts.amount,
-    paymentDate: new Date().toISOString(),
-    paymentMethod: "Stripe (card)",
-  };
-
-  await sendEmail({
-    to: customer.email,
-    subject: paymentReceiptEmailSubject(args, template),
-    html: paymentReceiptEmailHtml({ ...args, portalUrl, template }),
-    from: business?.name ? buildBusinessFrom({ name: business.name, localPart: "invoices" }) : undefined,
-    replyTo: business?.email || undefined,
-    tags: { business_id: opts.businessId, doc_type: "payment_receipt", doc_id: invoice.id },
-  });
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function recomputeInvoice(sb: any, businessId: string, invoiceId: string, invoiceTotal: number) {
-  const [{ data: directs }, { data: childCollections }] = await Promise.all([
-    sb.from("payments").select("amount").eq("invoice_id", invoiceId).eq("business_id", businessId),
-    sb.from("invoices").select("amount_paid").eq("parent_invoice_id", invoiceId).eq("business_id", businessId),
-  ]);
-  const direct = (directs ?? []).reduce((s: number, r: { amount: unknown }) => s + Number(r.amount ?? 0), 0);
-  const childSum = (childCollections ?? []).reduce((s: number, r: { amount_paid: unknown }) => s + Number(r.amount_paid ?? 0), 0);
-  const total = Number(invoiceTotal);
-  const newPaid = direct + childSum;
-  const newStatus = newPaid >= total - 0.01 ? "paid" : "partial";
-  await sb.from("invoices").update({ amount_paid: newPaid, status: newStatus }).eq("id", invoiceId);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function recomputeParent(sb: any, businessId: string, parentId: string) {
-  const [{ data: siblings }, { data: parentDirects }, { data: parentRow }] = await Promise.all([
-    sb.from("invoices").select("amount_paid").eq("parent_invoice_id", parentId).eq("business_id", businessId),
-    sb.from("payments").select("amount").eq("invoice_id", parentId).eq("business_id", businessId),
-    sb.from("invoices").select("total, status").eq("id", parentId).eq("business_id", businessId).maybeSingle(),
-  ]);
-  if (!parentRow) return;
-  const collectedChildren = (siblings ?? []).reduce((s: number, r: { amount_paid: unknown }) => s + Number(r.amount_paid ?? 0), 0);
-  const direct = (parentDirects ?? []).reduce((s: number, r: { amount: unknown }) => s + Number(r.amount ?? 0), 0);
-  const totalCollected = direct + collectedChildren;
-  const parentTotal = Number(parentRow.total ?? 0);
-  const fullyCovered = totalCollected >= parentTotal - 0.01;
-  let nextStatus = parentRow.status as string;
-  if (nextStatus !== "cancelled" && nextStatus !== "draft") {
-    if (fullyCovered)               nextStatus = "paid";
-    else if (totalCollected > 0.01) nextStatus = "partial";
-  }
-  await sb.from("invoices").update({ amount_paid: totalCollected, status: nextStatus }).eq("id", parentId);
+  await (sb as any).from("customers").update({
+    stripe_customer_id: stripeCustomerId,
+    stripe_payment_method_id: pmId,
+    stripe_pm_brand: card?.brand ?? null,
+    stripe_pm_last4: card?.last4 ?? null,
+    stripe_pm_exp: card ? `${String(card.exp_month).padStart(2, "0")}/${String(card.exp_year).slice(-2)}` : null,
+    autopay_enabled: true,
+  }).eq("id", customerId).eq("business_id", businessId);
 }

--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
       .eq("customer_id", link.customer_id)
       .maybeSingle(),
     tbl(sb, "businesses").select("name, logo_url, currency, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban, phone, email, stripe_charges_enabled").eq("id", link.business_id).maybeSingle(),
-    tbl(sb, "customers").select("name, company, email, phone, address, city, postcode, country, allowed_payment_methods").eq("id", link.customer_id).maybeSingle(),
+    tbl(sb, "customers").select("name, company, email, phone, address, city, postcode, country, allowed_payment_methods, autopay_enabled, stripe_payment_method_id, stripe_pm_brand, stripe_pm_last4").eq("id", link.customer_id).maybeSingle(),
     tbl(sb, "payments")
       .select("amount, date, method, reference")
       .eq("invoice_id", id)
@@ -244,6 +244,24 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
               <Download className="w-3.5 h-3.5" /> Download PDF
             </a>
           </div>
+
+          {/* Autopay / card on file */}
+          {offered.card && (
+            customer?.autopay_enabled && customer?.stripe_payment_method_id ? (
+              <p className="text-xs text-muted-foreground pt-1">
+                Autopay is on — future invoices are charged automatically to your {customer.stripe_pm_brand ?? "card"}
+                {customer.stripe_pm_last4 ? ` ending ${customer.stripe_pm_last4}` : ""}.{" "}
+                <a href={`/api/stripe/save-card?token=${token}&invoice=${invoice.id}`} className="underline hover:text-foreground">Update card</a>
+              </p>
+            ) : (
+              <a
+                href={`/api/stripe/save-card?token=${token}&invoice=${invoice.id}`}
+                className="inline-block text-xs text-primary underline hover:opacity-80 pt-1"
+              >
+                Save a card for automatic payments
+              </a>
+            )
+          )}
         </Card>
 
         <footer className="text-center text-xs text-muted-foreground py-6 border-t">

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Edit, Send, Copy, Trash2, CheckCircle, DollarSign, MoreHorizontal, FileStack, ArrowRight, Link2, FileText, Calendar } from "@/components/ui/icons";
+import { Edit, Send, Copy, Trash2, CheckCircle, DollarSign, MoreHorizontal, FileStack, ArrowRight, Link2, FileText, Calendar, CreditCard, Loader2 } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateInvoice, deleteInvoice, duplicateInvoice, addPayment, sendInvoiceEmail, sendInvoiceSms, createProgressInvoice } from "@/lib/actions/invoices";
+import { chargeSavedCardNow } from "@/lib/actions/stripe";
 import { SendDocumentModal } from "@/components/send/send-document-modal";
 import { InvoiceEditor } from "./invoice-editor";
 import { InvoicePDFDownload } from "./invoice-pdf";
@@ -65,6 +66,7 @@ export function InvoiceDetailClient({
   const [paymentMethod, setPaymentMethod] = useState("bank_transfer");
   const [paymentRef, setPaymentRef] = useState("");
   const [saving, setSaving] = useState(false);
+  const [charging, setCharging] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [progressOpen, setProgressOpen] = useState(false);
@@ -496,6 +498,26 @@ export function InvoiceDetailClient({
                   className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg border border-dashed border-border hover:border-primary/40 hover:bg-primary/5 text-sm font-medium text-primary cursor-pointer"
                 >
                   <DollarSign className="w-4 h-4" /> Record payment
+                </AnimatedPress>
+              )}
+              {invoice.status !== "paid" && invoice.status !== "cancelled" && customer?.stripe_payment_method_id && (
+                <AnimatedPress
+                  onClick={async () => {
+                    if (charging) return;
+                    if (!confirm(`Charge the saved card${customer.stripe_pm_last4 ? ` •••• ${customer.stripe_pm_last4}` : ""} for the outstanding balance?`)) return;
+                    setCharging(true);
+                    try {
+                      const res = await chargeSavedCardNow(invoice.id);
+                      if (res.ok) { toast.success(res.message); router.refresh(); }
+                      else toast.error(res.message);
+                    } catch (e) {
+                      toast.error(e instanceof Error ? e.message : "Charge failed");
+                    } finally { setCharging(false); }
+                  }}
+                  className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg bg-primary text-primary-foreground text-sm font-medium cursor-pointer disabled:opacity-60"
+                >
+                  {charging ? <Loader2 className="w-4 h-4 animate-spin" /> : <CreditCard className="w-4 h-4" />}
+                  Charge saved card{customer.stripe_pm_last4 ? ` •••• ${customer.stripe_pm_last4}` : ""}
                 </AnimatedPress>
               )}
             </div>

--- a/src/lib/actions/customers.ts
+++ b/src/lib/actions/customers.ts
@@ -45,7 +45,7 @@ export async function getCustomer(id: string): Promise<Customer> {
 }
 
 type CreateCustomerInput =
-  Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods">
+  Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods" | "stripe_customer_id" | "stripe_payment_method_id" | "stripe_pm_brand" | "stripe_pm_last4" | "stripe_pm_exp" | "autopay_enabled">
   & Partial<Pick<Customer, "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods">>;
 
 export async function createCustomer(payload: CreateCustomerInput): Promise<Customer> {
@@ -169,7 +169,7 @@ export async function getCustomerStats(): Promise<Record<string, {
 }
 
 export async function bulkImportCustomers(
-  rows: Array<Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "archived">>
+  rows: Array<Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "archived" | "allowed_payment_methods" | "stripe_customer_id" | "stripe_payment_method_id" | "stripe_pm_brand" | "stripe_pm_last4" | "stripe_pm_exp" | "autopay_enabled">>
 ): Promise<{ imported: number; errors: string[] }> {
   const supabase = await createClient();
   const user = await getUser();

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -505,6 +505,29 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
 
   const lineItems = (invoiceData.line_items ?? []) as LineItem[];
 
+  // Autopay — if the customer saved a card for automatic payments, charge it
+  // off-session now and skip the manual pay-request email (the charge path
+  // sends a receipt). Falls through to the normal email when the card needs
+  // authentication or is declined, so they can still pay via the link.
+  if (customer?.id && businessData?.stripe_charges_enabled) {
+    const { data: cust } = await tbl(supabase, "customers")
+      .select("autopay_enabled, stripe_payment_method_id").eq("id", customer.id).maybeSingle();
+    const balance = Number(invoiceData.total) - Number(invoiceData.amount_paid ?? 0);
+    if (cust?.autopay_enabled && cust?.stripe_payment_method_id && balance > 0.01) {
+      if (invoiceData.status === "draft") {
+        await tbl(supabase, "invoices").update({ status: "sent" }).eq("id", id);
+      }
+      const { createAdminClient } = await import("@/lib/supabase/admin");
+      const { chargeInvoiceToSavedCard } = await import("@/lib/stripe-charge");
+      const res = await chargeInvoiceToSavedCard(createAdminClient(), id, businessData.id);
+      if (res.ok) {
+        revalidatePath(`/invoices/${id}`); revalidatePath("/invoices");
+        return; // charged off-session; receipt already emailed by the charge path
+      }
+      // else: fall through and email the invoice + pay link for manual payment
+    }
+  }
+
   // Generate PDF buffer
   const { renderToStream } = await import("@react-pdf/renderer");
   const { InvoicePDFDocument } = await import("@/components/invoices/invoice-pdf-document");

--- a/src/lib/actions/stripe.ts
+++ b/src/lib/actions/stripe.ts
@@ -7,6 +7,9 @@ import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { canManageSettings, type Role } from "@/lib/permissions";
 import { getStripe, DEFAULT_DEPOSIT_PERCENT } from "@/lib/stripe";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { chargeInvoiceToSavedCard } from "@/lib/stripe-charge";
+import { randomBytes } from "crypto";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -206,4 +209,97 @@ export async function setDepositPercent(percent: number | null): Promise<void> {
 
   await tbl(supabase, "businesses").update({ deposit_percent: value }).eq("id", businessId);
   revalidatePath("/settings");
+}
+
+// ===========================================================================
+// Card on file / autopay
+// ===========================================================================
+
+/** Mint or reuse a 90-day portal token for a customer (admins only path). */
+async function getOrMintCustomerToken(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  businessId: string,
+  customerId: string,
+  userId: string,
+): Promise<string | null> {
+  const { data: existing } = await tbl(supabase, "customer_portal_tokens")
+    .select("token")
+    .eq("business_id", businessId)
+    .eq("customer_id", customerId)
+    .is("revoked_at", null)
+    .or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .limit(1)
+    .maybeSingle();
+  if (existing?.token) return existing.token;
+  const token = "cust_" + randomBytes(24).toString("hex");
+  const { error } = await tbl(supabase, "customer_portal_tokens").insert({
+    token, business_id: businessId, customer_id: customerId, created_by: userId,
+    expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+  });
+  if (error) return null;
+  return token;
+}
+
+/** A link the business can send so a customer can save a card for autopay. */
+export async function getSaveCardLink(customerId: string): Promise<{ url: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const token = await getOrMintCustomerToken(supabase, businessId, customerId, user.id);
+  if (!token) throw new Error("Couldn't create a secure link");
+  const base = (process.env.NEXT_PUBLIC_APP_URL ?? "https://www.kireihq.com").replace(/\/$/, "");
+  return { url: `${base}/api/stripe/save-card?token=${token}` };
+}
+
+/** Turn autopay on/off for a customer (off keeps the saved card, just stops auto-charging). */
+export async function setCustomerAutopay(customerId: string, enabled: boolean): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "customers")
+    .update({ autopay_enabled: enabled })
+    .eq("id", customerId).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath(`/customers/${customerId}`);
+}
+
+/** Remove the saved card + disable autopay. Detaches the PM at Stripe too. */
+export async function removeSavedCard(customerId: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: cust } = await tbl(supabase, "customers")
+    .select("stripe_payment_method_id").eq("id", customerId).eq("business_id", businessId).maybeSingle();
+  const { data: biz } = await tbl(supabase, "businesses")
+    .select("stripe_account_id").eq("id", businessId).single();
+
+  if (cust?.stripe_payment_method_id && biz?.stripe_account_id) {
+    try {
+      await getStripe().paymentMethods.detach(
+        cust.stripe_payment_method_id, undefined, { stripeAccount: biz.stripe_account_id },
+      );
+    } catch { /* already detached / not found — fine */ }
+  }
+
+  const { error } = await tbl(supabase, "customers").update({
+    stripe_payment_method_id: null, stripe_pm_brand: null, stripe_pm_last4: null,
+    stripe_pm_exp: null, autopay_enabled: false,
+  }).eq("id", customerId).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath(`/customers/${customerId}`);
+}
+
+/** Owner/admin: charge an invoice to the customer's saved card right now. */
+export async function chargeSavedCardNow(invoiceId: string): Promise<{ ok: boolean; message: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const role = await resolveRole(supabase, user.id, businessId);
+  if (!canManageSettings(role)) throw new Error("Only owners and admins can charge a saved card");
+
+  const res = await chargeInvoiceToSavedCard(createAdminClient(), invoiceId, businessId);
+  revalidatePath(`/invoices/${invoiceId}`);
+  if (res.ok) return { ok: true, message: "Card charged successfully" };
+  return { ok: false, message: res.message };
 }

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -910,6 +910,38 @@ export function registerTools(server: McpServer): void {
       return text({ payment_url: session.url, expires_at: session.expires_at, amount: requested });
     });
 
+  tool("get_save_card_link", "Get a secure link to send a customer so they can save a card on file for automatic payments (autopay). Requires the business to have connected Stripe.",
+    { customer_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "customers:write");
+      const { data: biz } = await t(ctx, "businesses").select("stripe_account_id, stripe_charges_enabled").eq("id", ctx.businessId).single();
+      if (!biz?.stripe_account_id || !biz.stripe_charges_enabled) return errorText("Stripe isn't connected / charges not enabled.");
+      const { data: cust } = await t(ctx, "customers").select("id").eq("id", args.customer_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!cust) return errorText("Customer not found");
+      const tok = await getOrMintPortalToken(ctx, args.customer_id);
+      return text({ save_card_url: `${appBase()}/api/stripe/save-card?token=${tok}` });
+    });
+
+  tool("set_customer_autopay", "Turn automatic card charging (autopay) on or off for a customer. Off keeps any saved card but stops auto-charging their invoices.",
+    { customer_id: UUID, enabled: z.boolean() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "customers:write");
+      const { error } = await t(ctx, "customers").update({ autopay_enabled: args.enabled }).eq("id", args.customer_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true, autopay_enabled: args.enabled });
+    });
+
+  tool("charge_saved_card", "Charge an invoice's outstanding balance to the customer's saved card right now (off-session). Fails cleanly if there's no saved card, the card needs authentication, or it's declined.",
+    { invoice_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "invoices:write");
+      const { chargeInvoiceToSavedCard } = await import("@/lib/stripe-charge");
+      const { createAdminClient } = await import("@/lib/supabase/admin");
+      const res = await chargeInvoiceToSavedCard(createAdminClient(), args.invoice_id, ctx.businessId);
+      if (res.ok) return text({ charged: true, amount: res.amount, payment_intent_id: res.paymentIntentId });
+      return errorText(`Couldn't charge saved card (${res.reason}): ${res.message}`);
+    });
+
   // ===== LEADS (get / update / delete / convert) =====
   tool("get_lead", "Get one lead with all its fields.",
     { lead_id: UUID },

--- a/src/lib/stripe-charge.ts
+++ b/src/lib/stripe-charge.ts
@@ -1,0 +1,113 @@
+/**
+ * Off-session autopay — charge a customer's saved card for an invoice without
+ * them present. Industry-standard Stripe pattern: a confirmed PaymentIntent
+ * with off_session:true on the connected account, taking the platform fee.
+ *
+ * On success it records the payment inline (via the shared recorder) so autopay
+ * works with the existing webhook subscription — no extra Stripe event needed.
+ * On SCA / decline it returns a typed failure so callers fall back to emailing
+ * the customer a manual pay link.
+ */
+
+import { getStripe, toStripeAmount, computeApplicationFeeAmount } from "@/lib/stripe";
+import { customerAllowsCard } from "@/lib/payment-methods";
+import { recordStripePayment } from "@/lib/stripe-payments";
+
+export type ChargeResult =
+  | { ok: true; paymentIntentId: string; amount: number }
+  | { ok: false; reason: "not_eligible" | "requires_action" | "card_declined" | "error"; message: string };
+
+/**
+ * Attempt to charge an invoice's balance to the customer's saved card.
+ * `sb` must be an admin (service-role) client — used from server actions, the
+ * portal, and cron.
+ */
+export async function chargeInvoiceToSavedCard(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  invoiceId: string,
+  businessId: string,
+): Promise<ChargeResult> {
+  const { data: invoice } = await sb.from("invoices")
+    .select("id, number, total, amount_paid, status, customer_id")
+    .eq("id", invoiceId).eq("business_id", businessId).maybeSingle();
+  if (!invoice) return { ok: false, reason: "not_eligible", message: "Invoice not found" };
+  if (invoice.status === "cancelled" || invoice.status === "draft") {
+    return { ok: false, reason: "not_eligible", message: `Invoice is ${invoice.status}` };
+  }
+
+  const balance = Math.max(0, Number(invoice.total) - Number(invoice.amount_paid ?? 0));
+  if (balance < 0.5) return { ok: false, reason: "not_eligible", message: "Nothing left to charge" };
+
+  const { data: biz } = await sb.from("businesses")
+    .select("stripe_account_id, stripe_charges_enabled, currency, platform_fee_percent")
+    .eq("id", businessId).single();
+  if (!biz?.stripe_account_id || !biz.stripe_charges_enabled) {
+    return { ok: false, reason: "not_eligible", message: "Card payments aren't enabled for this business" };
+  }
+
+  const { data: customer } = await sb.from("customers")
+    .select("stripe_customer_id, stripe_payment_method_id, autopay_enabled, allowed_payment_methods")
+    .eq("id", invoice.customer_id).maybeSingle();
+  if (!customer?.stripe_customer_id || !customer?.stripe_payment_method_id) {
+    return { ok: false, reason: "not_eligible", message: "Customer has no saved card" };
+  }
+  if (!customerAllowsCard(customer.allowed_payment_methods)) {
+    return { ok: false, reason: "not_eligible", message: "Card payment is disabled for this customer" };
+  }
+
+  const currency = (biz.currency || "GBP").toLowerCase();
+  const amountUnit = toStripeAmount(balance, currency);
+  const appFee = computeApplicationFeeAmount(
+    balance, currency, biz.platform_fee_percent != null ? Number(biz.platform_fee_percent) : null,
+  );
+
+  const stripe = getStripe();
+  try {
+    const pi = await stripe.paymentIntents.create(
+      {
+        amount: amountUnit,
+        currency,
+        customer: customer.stripe_customer_id,
+        payment_method: customer.stripe_payment_method_id,
+        off_session: true,
+        confirm: true,
+        application_fee_amount: appFee > 0 ? appFee : undefined,
+        metadata: {
+          kirei_invoice_id: invoice.id,
+          kirei_business_id: businessId,
+          kirei_source: "autopay",
+        },
+      },
+      { stripeAccount: biz.stripe_account_id },
+    );
+
+    if (pi.status === "succeeded") {
+      // Record inline so the invoice flips to paid + receipt sends immediately,
+      // independent of webhook delivery. Idempotent if the webhook also fires.
+      await recordStripePayment(sb, stripe, {
+        businessId,
+        invoiceId: invoice.id,
+        piId: pi.id,
+        amount: balance,
+        currency: currency.toUpperCase(),
+        connectedAcct: biz.stripe_account_id,
+        portalToken: null,
+      });
+      return { ok: true, paymentIntentId: pi.id, amount: balance };
+    }
+    // requires_action / processing — couldn't complete unattended.
+    return { ok: false, reason: "requires_action", message: `Payment ${pi.status}` };
+  } catch (err: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const e = err as any;
+    const code = e?.code ?? e?.raw?.code;
+    if (code === "authentication_required") {
+      return { ok: false, reason: "requires_action", message: "Card needs authentication" };
+    }
+    if (e?.type === "StripeCardError" || code === "card_declined") {
+      return { ok: false, reason: "card_declined", message: e?.message ?? "Card was declined" };
+    }
+    return { ok: false, reason: "error", message: e?.message ?? "Charge failed" };
+  }
+}

--- a/src/lib/stripe-payments.ts
+++ b/src/lib/stripe-payments.ts
@@ -1,0 +1,209 @@
+/**
+ * Shared Stripe payment recording — used by both the webhook (hosted Checkout)
+ * and the off-session autopay charge engine, so a payment is recorded exactly
+ * one way no matter how it was taken.
+ *
+ * Idempotent: keyed on (business_id, provider_payment_id) which has a unique
+ * index, so a redelivered webhook + an inline record of the same PaymentIntent
+ * can't double-insert.
+ */
+
+import type Stripe from "stripe";
+import { fromStripeAmount } from "@/lib/stripe";
+import { dispatchWebhook } from "@/lib/webhooks";
+
+interface RecordOpts {
+  businessId: string;
+  invoiceId: string;
+  piId: string;
+  /** Checkout session id, if the payment came via hosted Checkout. */
+  sessionId?: string | null;
+  amount: number;
+  currency: string;
+  /** Connected account the charge lives on (for fee lookup). */
+  connectedAcct?: string | null;
+  /** Portal token for the receipt's "view invoice" link, if available. */
+  portalToken?: string | null;
+}
+
+/** Pull the Stripe processing fee + platform application fee for a PaymentIntent. */
+async function lookupFees(
+  stripe: Stripe,
+  piId: string,
+  connectedAcct: string | null | undefined,
+  fallbackCurrency: string,
+): Promise<{ stripeFee: number; applicationFee: number }> {
+  let stripeFee = 0;
+  let applicationFee = 0;
+  try {
+    const pi = await stripe.paymentIntents.retrieve(
+      piId,
+      { expand: ["latest_charge.balance_transaction"] },
+      connectedAcct ? { stripeAccount: connectedAcct } : undefined,
+    );
+    const charge = pi.latest_charge && typeof pi.latest_charge === "object"
+      ? (pi.latest_charge as Stripe.Charge)
+      : null;
+    if (charge) {
+      if (charge.application_fee_amount != null) {
+        applicationFee = fromStripeAmount(charge.application_fee_amount, (charge.currency || fallbackCurrency).toUpperCase());
+      }
+      let bt = charge.balance_transaction && typeof charge.balance_transaction === "object"
+        ? (charge.balance_transaction as Stripe.BalanceTransaction)
+        : null;
+      if (!bt && typeof charge.balance_transaction === "string") {
+        bt = await stripe.balanceTransactions.retrieve(
+          charge.balance_transaction,
+          undefined,
+          connectedAcct ? { stripeAccount: connectedAcct } : undefined,
+        );
+      }
+      if (bt) stripeFee = fromStripeAmount(bt.fee, bt.currency.toUpperCase());
+    }
+  } catch (err) {
+    console.warn("[stripe] couldn't read fees", err);
+  }
+  return { stripeFee, applicationFee };
+}
+
+/**
+ * Record a successful Stripe payment against an invoice (idempotent), recompute
+ * the invoice + any parent rollup, fire the merchant webhook, and email the
+ * customer a receipt. Returns true if a new payment row was written.
+ */
+export async function recordStripePayment(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  stripe: Stripe,
+  opts: RecordOpts,
+): Promise<boolean> {
+  const { businessId, invoiceId, piId } = opts;
+
+  // Idempotency: bail if this PaymentIntent is already recorded.
+  const { data: existing } = await sb.from("payments")
+    .select("id").eq("business_id", businessId).eq("provider_payment_id", piId).maybeSingle();
+  if (existing) return false;
+
+  const { data: invoice } = await sb.from("invoices")
+    .select("id, total, amount_paid, parent_invoice_id, user_id, status, number, customer_id")
+    .eq("id", invoiceId).eq("business_id", businessId).single();
+  if (!invoice) {
+    console.warn("[stripe] invoice not found for payment", invoiceId);
+    return false;
+  }
+
+  const { stripeFee, applicationFee } = await lookupFees(stripe, piId, opts.connectedAcct, opts.currency);
+
+  const { error: insErr } = await sb.from("payments").insert({
+    invoice_id: invoiceId,
+    business_id: businessId,
+    user_id: invoice.user_id,
+    amount: opts.amount,
+    date: new Date().toISOString().slice(0, 10),
+    method: "Stripe (card)",
+    reference: piId,
+    notes: null,
+    provider: "stripe",
+    provider_payment_id: piId,
+    provider_session_id: opts.sessionId ?? null,
+    provider_fee: stripeFee || null,
+    provider_platform_fee: applicationFee || null,
+  });
+  // A concurrent insert (webhook + inline race) trips the unique index — treat
+  // the conflict as "already recorded" and stop.
+  if (insErr) {
+    if (insErr.code === "23505") return false;
+    throw insErr;
+  }
+
+  await recomputeInvoice(sb, businessId, invoiceId, invoice.total);
+  if (invoice.parent_invoice_id) await recomputeParent(sb, businessId, invoice.parent_invoice_id);
+
+  try {
+    dispatchWebhook(businessId, "payment.received", {
+      invoice_id: invoiceId, amount: opts.amount, provider: "stripe", stripe_payment_intent_id: piId,
+    });
+  } catch { /* never blocks */ }
+
+  try {
+    await sendPaymentReceipt(sb, { businessId, invoiceId, amount: opts.amount, portalToken: opts.portalToken ?? null });
+  } catch (err) {
+    console.warn("[stripe] receipt email failed", err);
+  }
+
+  return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function sendPaymentReceipt(sb: any, opts: { businessId: string; invoiceId: string; amount: number; portalToken: string | null }) {
+  const { data: invoice } = await sb.from("invoices")
+    .select("id, number, total, amount_paid, customer_id")
+    .eq("id", opts.invoiceId).eq("business_id", opts.businessId).single();
+  if (!invoice) return;
+
+  const [{ data: business }, { data: customer }] = await Promise.all([
+    sb.from("businesses").select("name, email, phone, currency").eq("id", opts.businessId).single(),
+    invoice.customer_id
+      ? sb.from("customers").select("name, email").eq("id", invoice.customer_id).maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
+  if (!customer?.email) return;
+
+  const { getResolvedEmailTemplate } = await import("@/lib/emails/templates");
+  const { paymentReceiptEmailHtml, paymentReceiptEmailSubject } = await import("@/lib/emails/payment-receipt");
+  const { sendEmail, buildBusinessFrom } = await import("@/lib/email");
+
+  const template = await getResolvedEmailTemplate(sb, opts.businessId, "payment_receipt");
+  const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "";
+  const portalUrl = opts.portalToken && base ? `${base}/portal/${opts.portalToken}/invoice/${invoice.id}` : null;
+  const args = {
+    invoice, customer, business,
+    amount: opts.amount,
+    paymentDate: new Date().toISOString(),
+    paymentMethod: "Stripe (card)",
+  };
+
+  await sendEmail({
+    to: customer.email,
+    subject: paymentReceiptEmailSubject(args, template),
+    html: paymentReceiptEmailHtml({ ...args, portalUrl, template }),
+    from: business?.name ? buildBusinessFrom({ name: business.name, localPart: "invoices" }) : undefined,
+    replyTo: business?.email || undefined,
+    tags: { business_id: opts.businessId, doc_type: "payment_receipt", doc_id: invoice.id },
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function recomputeInvoice(sb: any, businessId: string, invoiceId: string, invoiceTotal: number) {
+  const [{ data: directs }, { data: childCollections }] = await Promise.all([
+    sb.from("payments").select("amount").eq("invoice_id", invoiceId).eq("business_id", businessId),
+    sb.from("invoices").select("amount_paid").eq("parent_invoice_id", invoiceId).eq("business_id", businessId),
+  ]);
+  const direct = (directs ?? []).reduce((s: number, r: { amount: unknown }) => s + Number(r.amount ?? 0), 0);
+  const childSum = (childCollections ?? []).reduce((s: number, r: { amount_paid: unknown }) => s + Number(r.amount_paid ?? 0), 0);
+  const total = Number(invoiceTotal);
+  const newPaid = direct + childSum;
+  const newStatus = newPaid >= total - 0.01 ? "paid" : "partial";
+  await sb.from("invoices").update({ amount_paid: newPaid, status: newStatus }).eq("id", invoiceId);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function recomputeParent(sb: any, businessId: string, parentId: string) {
+  const [{ data: siblings }, { data: parentDirects }, { data: parentRow }] = await Promise.all([
+    sb.from("invoices").select("amount_paid").eq("parent_invoice_id", parentId).eq("business_id", businessId),
+    sb.from("payments").select("amount").eq("invoice_id", parentId).eq("business_id", businessId),
+    sb.from("invoices").select("total, status").eq("id", parentId).eq("business_id", businessId).maybeSingle(),
+  ]);
+  if (!parentRow) return;
+  const collectedChildren = (siblings ?? []).reduce((s: number, r: { amount_paid: unknown }) => s + Number(r.amount_paid ?? 0), 0);
+  const direct = (parentDirects ?? []).reduce((s: number, r: { amount: unknown }) => s + Number(r.amount ?? 0), 0);
+  const totalCollected = direct + collectedChildren;
+  const parentTotal = Number(parentRow.total ?? 0);
+  const fullyCovered = totalCollected >= parentTotal - 0.01;
+  let nextStatus = parentRow.status as string;
+  if (nextStatus !== "cancelled" && nextStatus !== "draft") {
+    if (fullyCovered)               nextStatus = "paid";
+    else if (totalCollected > 0.01) nextStatus = "partial";
+  }
+  await sb.from("invoices").update({ amount_paid: totalCollected, status: nextStatus }).eq("id", parentId);
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -72,6 +72,7 @@ export async function updateSession(request: NextRequest) {
     // Stripe webhook (signed, owns its auth) + token-gated public Checkout route.
     pathname === "/api/stripe/webhook" ||
     pathname === "/api/stripe/checkout" ||
+    pathname === "/api/stripe/save-card" ||
     (isBearerAuthRoute && hasBearer) ||
     (pathname.startsWith("/api/pdf/") && new URL(request.url).searchParams.get("token") !== null);
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -98,6 +98,13 @@ export interface Customer {
   preferred_contact: 'email' | 'phone' | 'sms' | 'any' | null;
   /** Payment methods this customer may use. NULL = all the business supports. */
   allowed_payment_methods: string[] | null;
+  /** Card-on-file / autopay (Stripe ids live on the business's connected account). */
+  stripe_customer_id: string | null;
+  stripe_payment_method_id: string | null;
+  stripe_pm_brand: string | null;
+  stripe_pm_last4: string | null;
+  stripe_pm_exp: string | null;
+  autopay_enabled: boolean;
   archived: boolean;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20260621100000_customer_card_on_file.sql
+++ b/supabase/migrations/20260621100000_customer_card_on_file.sql
@@ -1,0 +1,16 @@
+-- Card-on-file / autopay for customers (Stripe Connect, direct charges).
+-- The Stripe Customer + saved payment method live on the BUSINESS's connected
+-- account (that's where direct charges happen), so these ids are scoped to that
+-- account, not the platform.
+ALTER TABLE public.customers
+  ADD COLUMN IF NOT EXISTS stripe_customer_id       TEXT,   -- cus_… on the connected account
+  ADD COLUMN IF NOT EXISTS stripe_payment_method_id TEXT,   -- pm_… default saved card
+  ADD COLUMN IF NOT EXISTS stripe_pm_brand          TEXT,   -- e.g. "visa" (display only)
+  ADD COLUMN IF NOT EXISTS stripe_pm_last4          TEXT,   -- e.g. "4242" (display only)
+  ADD COLUMN IF NOT EXISTS stripe_pm_exp            TEXT,   -- e.g. "12/34" (display only)
+  -- Customer consented to automatic charging of their invoices to the card.
+  ADD COLUMN IF NOT EXISTS autopay_enabled          BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_customers_stripe_customer_id
+  ON public.customers (stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;


### PR DESCRIPTION
## Summary
Industry-standard saved-card autopay on top of Stripe Connect. A customer saves a card once (hosted SetupIntent Checkout on the connected account), and their invoices are charged automatically off-session — with SCA/decline fallback to the emailed pay link.

- **DB**: customers gain `stripe_customer_id`, `stripe_payment_method_id`, brand/last4/exp, `autopay_enabled` (migration applied + recorded).
- **Save card**: token-gated `/api/stripe/save-card` → hosted card setup; webhook (`checkout.session.completed` mode=setup) stores the PM + enables autopay. Surfaced on the portal invoice page.
- **Charge engine** (`src/lib/stripe-charge.ts`): off-session PaymentIntent + application fee; typed failures for SCA / decline. Records inline via shared `src/lib/stripe-payments.ts` (idempotent) → **no new webhook event required**.
- **Triggers**: `sendInvoiceEmail` auto-charges autopay customers; "Charge saved card" button on invoice detail; `chargeSavedCardNow` / `setCustomerAutopay` / `removeSavedCard` / `getSaveCardLink` server actions.
- **MCP**: `get_save_card_link`, `set_customer_autopay`, `charge_saved_card`.
- Webhook refactored to share the recorder + added idempotent `payment_intent.succeeded`.

## Notes
- Works with the existing webhook subscription (autopay records inline; card-save uses `checkout.session.completed`).
- Card data never touches our servers — Stripe-hosted setup + tokenized PM only.

tsc + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)