### PR TITLE
Automatic recurring invoices + auto-bill recurring jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,9 +310,53 @@ User's accumulated preferences:
 - **Never trust empty input** — coerce, validate, soft-fail
 - Current accent name: **teal**; sidebar: **light**; canvas: warm off-white. Don't revert to flux lime unless explicitly asked.
 
+## Session log (June 2026) — Stripe payments + email templates (MOST RECENT — pick up here)
+
+Big multi-day push: per-business email templates, then a full Stripe Connect payments stack. All shipped to `main` (production = kireihq.com) and DB migrations applied + recorded on remote.
+
+### Per-business email templates
+- `email_templates` table — one row per `(business_id, template_type)`, type ∈ `invoice | quote | team_invite | work_order_submitted | payment_receipt`. NULL field = use built-in default. Migrations `20260611000001` + `20260618120000` (adds payment_receipt to the CHECK).
+- Engine: `src/lib/emails/templates.ts` — `EMAIL_TEMPLATE_DEFAULTS/VARIABLES/LABELS`, `renderTemplateVars` ({{var}}), `resolveEmailTemplate` (row→defaults), `getResolvedEmailTemplate(sb, bizId, type)`. Each builder (`invoice.ts`, `quote.ts`, `team-invite.ts`, `work-order-submitted.ts`, `payment-receipt.ts`) exports `…EmailVars` + `…EmailSubject` + `…EmailHtml({…, template})`, supports `custom_html` full override + section toggles (show_line_items/payment_details/buttons).
+- Wired into EVERY send path: `sendInvoiceEmail`/`sendQuoteEmail` actions, scheduled-send cron, `/api/v1/agent`, MCP `send_invoice_email`/`send_quote_email`, team invites, work-order-submitted.
+- Editor at `/settings/email-templates` (linked from Settings → Email): per-type editor + live preview (`previewEmailTemplate`) + reset. Server actions in `src/lib/actions/email-templates.ts`.
+- MCP: `list_email_templates`, `update_email_template`, `reset_email_template`.
+
+### Stripe Connect Standard — payments (the main work)
+**Architecture:** Connect **Standard**, **direct charges** on each business's own connected account + `application_fee` to the platform. Platform account = "Kirei Business Manager" (`acct_1TjgR1DbruxScmob`). The app key, the connected account, AND the webhook must all be in the **same Stripe environment** (test/sandbox vs live) or webhook signatures fail — this caused a long debug; see traps below.
+- **Env vars (Vercel, prod):** `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PLATFORM_FEE_PERCENT` (default 2). Currently set to **test/sandbox** keys → production runs Stripe in test mode. Going live = repeat in Stripe **Live mode** (live key + live webhook) and swap the two Vercel vars.
+- **Webhook:** ONE endpoint at `https://www.kireihq.com/api/stripe/webhook`, scope **Connected accounts** (critical — charges fire on connected accounts), events `checkout.session.completed`, `checkout.session.async_payment_succeeded`, `account.updated`. `/api/stripe/{webhook,checkout,save-card}` are whitelisted in `src/lib/supabase/middleware.ts`.
+- **Files:** `src/lib/stripe.ts` (client + amount helpers + `DEFAULT_DEPOSIT_PERCENT` + `defaultPlatformFeePercent`), `src/lib/actions/stripe.ts` (onboarding/status/disconnect/fee/deposit + autopay actions), `src/app/api/stripe/{connect/return,connect/refresh,checkout,webhook,save-card}`.
+- **Migrations:** `20260618090626` (businesses stripe_* cols + payments provider_* cols + idempotency index), `20260618130000` (businesses.deposit_percent), `20260618140000` (customers.allowed_payment_methods), `20260621100000` (customers card-on-file cols).
+
+**Features built on top:**
+- **Pay-with-card in invoice emails** — `invoiceEmailHtml` gains `payUrl`; gated on stripe_charges_enabled + balance + customer allows card.
+- **Payment receipt email** — webhook → branded receipt (template type `payment_receipt`).
+- **Quote deposit by card** — `businesses.deposit_percent` (default 50); portal "Accept & pay deposit" → `/api/portal/[token]/quote/[id]/accept-with-deposit` converts quote→invoice + mints a deposit child invoice → reuses checkout; `trg_reconcile_parent_invoice` rolls up.
+- **Per-customer payment methods** — `customers.allowed_payment_methods` (NULL=all; explicit list=only those; 'cash' opt-in). `src/lib/payment-methods.ts` (`resolveOfferedMethods`, `customerAllowsCard`). Enforced on portal, email pay-link, checkout route (403), quote deposit.
+- **Card on file + autopay (recurring)** — `customers.stripe_customer_id/stripe_payment_method_id/stripe_pm_brand/last4/exp/autopay_enabled`. Save-card = `/api/stripe/save-card` (hosted SetupIntent Checkout on connected acct) → webhook `checkout.session.completed` mode=setup stores PM + enables autopay. **Off-session charge engine** `src/lib/stripe-charge.ts` (`chargeInvoiceToSavedCard`) — confirmed PaymentIntent off_session + application_fee; SCA/decline → typed failure → fall back to emailed pay link. **Shared recorder** `src/lib/stripe-payments.ts` (`recordStripePayment`, idempotent on `(business_id, provider_payment_id)`) used by BOTH the webhook and the inline autopay record — so autopay needs no extra webhook event. `sendInvoiceEmail` auto-charges autopay customers (skips dunning email on success). "Charge saved card" button on invoice detail. Actions: `chargeSavedCardNow`, `setCustomerAutopay`, `removeSavedCard` (detaches PM), `getSaveCardLink`. MCP: `get_save_card_link`, `set_customer_autopay`, `charge_saved_card`, `get_stripe_status`, `create_stripe_payment_link`.
+
+**Stripe MCP:** a Stripe MCP connector is available in-session (tools `mcp__…__stripe_api_*`, `get_stripe_account_info`) but it authed to a DIFFERENT environment than the app's keys (couldn't see the connected account / GetAccounts empty), so it can't inspect the app's sandbox. Verify payments via the **Supabase DB** (`payments` where `provider='stripe'`) and **Vercel runtime logs** (`/api/stripe/webhook` status) instead.
+
+**Verified working (test mode):** Connect onboarding, one-off card payment (invoice→paid), receipt email, platform fee capture (`provider_platform_fee`). `provider_fee` (Stripe processing fee, the connected account's cost) can be null at webhook time — best-effort. Autopay built + shipped, not yet user-tested end-to-end.
+
+### Not yet done / parked
+- **App Store submission** (iOS): mid-flight on App Store Connect for "Kirei Business Manager" (ASC App ID `6773209964`, bundle `com.kireihq.app`, build 5). Metadata/build/age-rating(4+)/pricing(free, 175 territories)/privacy-policy-URL filled; **demo account created** (`apple.review@kireihq.com` / `AppleReview2026!`, biz "Kirei Demo Services" seeded via SQL). STILL NEEDS: screenshots (1290×2796), App Privacy data-collection answers, accept Developer Program License Agreement, then "Add for Review". The browser tools BLOCK the Stripe dashboard (financial site) but App Store Connect was driveable via Chrome MCP. **Do NOT click "Add for Review" without explicit per-action user confirmation.**
+- **Recurring auto-INVOICING:** Kirei "Recurring" (`recurring_jobs` + `/api/cron/recurring-jobs`) generates **work orders, not invoices** — so autopay charges invoices you send, but nothing yet auto-generates a monthly invoice. Follow-up: add optional billing (line items + auto-bill flag) to recurring_jobs so the cron generates an invoice and auto-charges via the existing engine.
+- **Go live on Stripe:** swap test→live keys + live webhook when ready for real money.
+
+### Traps learned this session
+- **Stripe env consistency** — app `STRIPE_SECRET_KEY`, the connected account, and the webhook endpoint must all be in the SAME Stripe environment (sandbox vs test vs live). A duplicate/idle webhook endpoint (0 deliveries) whose secret was copied caused persistent webhook 400s ("No signatures found matching"). Fix: ONE endpoint, copy ITS signing secret, same env as the keys.
+- **Vercel env changes need a redeploy** to take effect; updating a var alone does nothing to the running deployment.
+- **`"use server"` files may only export async functions** — a `export const` in `src/lib/actions/stripe.ts` broke ALL its exports at build (moved the const to `src/lib/stripe.ts`).
+- **Vercel `invoicer` project = kireihq.com** (the Vercel project is named "invoicer", branded Kirei). Env vars go on that project.
+- **Browser tools block the Stripe dashboard** (financial site) — can't automate it; guide the user click-by-click.
+- **Stripe webhook signature** needs the raw body — handled by `await request.text()` in the route handler (don't add body parsing/middleware that consumes it).
+
+---
+
 ## Session log (late May 2026) — store launch, MCP, email agent, design system
 
-Most recent push. Pick up from here.
+(Superseded by the June 2026 log above — kept for history.)
 
 ### Mobile published to the stores (EAS)
 - **EAS project linked:** `@tim90six/kirei`, `projectId` in `mobile/app.json`. Expo account `tim90six` (m.altamimi96@outlook.com). Drive EAS non-interactively with `EXPO_TOKEN` (create at expo.dev/settings/access-tokens) — `eas login` itself can't be automated.

--- a/src/app/(dashboard)/recurring-invoices/page.tsx
+++ b/src/app/(dashboard)/recurring-invoices/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { canEdit, type Role } from "@/lib/permissions";
+import { getRecurringInvoices } from "@/lib/actions/recurring-invoices";
+import { getCustomers } from "@/lib/actions/customers";
+import { getProducts } from "@/lib/actions/products";
+import { RecurringInvoicesClient } from "@/components/recurring/recurring-invoices-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function RecurringInvoicesPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const businessId = await getActiveBizId(supabase as any, user.id);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: biz } = await (supabase as any).from("businesses")
+    .select("user_id, currency, stripe_charges_enabled").eq("id", businessId).single();
+
+  let role: Role = "owner";
+  if (biz?.user_id !== user.id) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: m } = await (supabase as any).from("business_members")
+      .select("role").eq("business_id", businessId).eq("user_id", user.id).eq("status", "active").maybeSingle();
+    role = (m?.role ?? "viewer") as Role;
+  }
+  if (!canEdit(role)) redirect("/dashboard");
+
+  const [schedules, customers, products] = await Promise.all([
+    getRecurringInvoices(),
+    getCustomers(),
+    getProducts(),
+  ]);
+
+  return (
+    <RecurringInvoicesClient
+      initial={schedules}
+      customers={customers}
+      products={products}
+      currency={biz?.currency ?? "GBP"}
+      stripeEnabled={!!biz?.stripe_charges_enabled}
+    />
+  );
+}

--- a/src/app/(dashboard)/recurring/page.tsx
+++ b/src/app/(dashboard)/recurring/page.tsx
@@ -1,13 +1,40 @@
 import { getRecurringJobs } from "@/lib/actions/recurring-jobs";
 import { getCustomers } from "@/lib/actions/customers";
 import { getMemberProfiles } from "@/lib/actions/member-profiles";
+import { getProducts } from "@/lib/actions/products";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
 import { RecurringJobsClient } from "@/components/recurring/recurring-jobs-client";
 
 export default async function RecurringPage() {
-  const [schedules, customers, profiles] = await Promise.all([
+  const [schedules, customers, profiles, products] = await Promise.all([
     getRecurringJobs(),
     getCustomers(),
     getMemberProfiles(),
+    getProducts(),
   ]);
-  return <RecurringJobsClient initialSchedules={schedules} customers={customers} profiles={profiles} />;
+
+  // Business currency for the line-items editor.
+  let currency = "GBP";
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const businessId = await getActiveBizId(supabase as any, user.id);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: biz } = await (supabase as any).from("businesses").select("currency").eq("id", businessId).single();
+      currency = biz?.currency ?? "GBP";
+    }
+  } catch { /* default currency */ }
+
+  return (
+    <RecurringJobsClient
+      initialSchedules={schedules}
+      customers={customers}
+      profiles={profiles}
+      products={products}
+      currency={currency}
+    />
+  );
 }

--- a/src/app/api/cron/recurring-invoices/route.ts
+++ b/src/app/api/cron/recurring-invoices/route.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /api/cron/recurring-invoices
+ *
+ * Runs daily. For each active recurring-invoice schedule whose next_run_on has
+ * arrived (catching up any missed days), generates an invoice from the saved
+ * line items and either auto-charges the customer's saved card or emails it with
+ * a pay link. Advances next_run_on by the cadence; deactivates past ends_on.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { advanceOccurrence } from "@/lib/recurring/cadence";
+import { generateRecurringInvoice } from "@/lib/recurring/generate-invoice";
+import type { RecurringInvoice, LineItem } from "@/types/database";
+
+function todayISO(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const sb = createAdminClient();
+  const today = todayISO();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: schedules } = await (sb as any)
+    .from("recurring_invoices")
+    .select("*")
+    .eq("active", true)
+    .lte("next_run_on", today);
+
+  const items = (schedules ?? []) as RecurringInvoice[];
+  const results: Array<{ id: string; generated: number; next: string | null; charged: number; stopped?: boolean }> = [];
+
+  for (const r of items) {
+    let runOn = r.next_run_on;
+    let generated = 0;
+    let charged = 0;
+    let stopped = false;
+
+    // Catch up any missed cycles (cap to avoid runaway).
+    while (generated < 6 && runOn <= today) {
+      if (r.ends_on && runOn > r.ends_on) { stopped = true; break; }
+      try {
+        const res = await generateRecurringInvoice(sb, {
+          businessId: r.business_id,
+          userId: r.user_id,
+          customerId: r.customer_id,
+          lineItems: (r.line_items ?? []) as LineItem[],
+          subtotal: Number(r.subtotal), taxTotal: Number(r.tax_total), total: Number(r.total),
+          dueDays: r.due_days ?? 14,
+          notes: r.notes, terms: r.terms,
+          autoCharge: r.auto_charge, sendEmail: r.send_email,
+        });
+        generated++;
+        if (res.charged) charged++;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (sb as any).from("recurring_invoices").update({ last_invoice_id: res.invoiceId }).eq("id", r.id);
+      } catch (err) {
+        console.error("[cron.recurring-invoices] generate failed", r.id, err);
+        break; // leave next_run_on as-is so it retries next run
+      }
+      runOn = advanceOccurrence(runOn, r.cadence);
+      if (r.ends_on && runOn > r.ends_on) { stopped = true; break; }
+    }
+
+    if (generated > 0 || stopped) {
+      const update: Record<string, unknown> = { next_run_on: runOn, last_run_at: new Date().toISOString() };
+      if (stopped) update.active = false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any).from("recurring_invoices").update(update).eq("id", r.id);
+    }
+
+    results.push({ id: r.id, generated, charged, next: runOn, ...(stopped ? { stopped: true } : {}) });
+  }
+
+  return NextResponse.json({ ok: true, today, processed: results.length, results });
+}

--- a/src/app/api/cron/recurring-jobs/route.ts
+++ b/src/app/api/cron/recurring-jobs/route.ts
@@ -10,7 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { advanceOccurrence } from "@/lib/recurring/cadence";
-import type { RecurringJob } from "@/types/database";
+import type { RecurringJob, LineItem } from "@/types/database";
 
 function todayISO(): string {
   return new Date().toISOString().split("T")[0];
@@ -99,6 +99,31 @@ export async function GET(req: NextRequest) {
             assigned_by: r.user_id,
           }))
         );
+      }
+
+      // Auto-bill: generate (and optionally auto-charge) an invoice for this job.
+      if (wo && r.auto_invoice && r.customer_id && (r.invoice_line_items?.length ?? 0) > 0) {
+        try {
+          const { generateRecurringInvoice } = await import("@/lib/recurring/generate-invoice");
+          const { totalsFromLineItems } = await import("@/lib/recurring/totals");
+          const items = r.invoice_line_items as LineItem[];
+          const totals = totalsFromLineItems(items);
+          await generateRecurringInvoice(sb, {
+            businessId: r.business_id,
+            userId: r.user_id,
+            customerId: r.customer_id,
+            lineItems: items,
+            subtotal: totals.subtotal, taxTotal: totals.tax_total, total: totals.total,
+            dueDays: 14,
+            notes: r.title ? `For ${r.title} (${number})` : null,
+            terms: null,
+            autoCharge: r.auto_charge,
+            sendEmail: true,
+            workOrderId: wo.id,
+          });
+        } catch (err) {
+          console.error("[cron.recurring-jobs] auto-bill failed", r.id, err);
+        }
       }
 
       generated++;

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -39,6 +39,7 @@ const navSections: NavSection[] = [
     { label: "Invoices",      href: "/invoices",      icon: FileText                                       },
     { label: "Site Reports",  href: "/reports",       icon: ClipboardList                                  },
     { label: "Recurring",     href: "/recurring",     icon: Repeat                                         },
+    { label: "Recurring billing", href: "/recurring-invoices", icon: Repeat                                 },
   ]},
   { section: "Service", items: [
     { label: "Work Orders",    href: "/work-orders",     icon: Wrench,        worker: true },

--- a/src/components/recurring/recurring-invoices-client.tsx
+++ b/src/components/recurring/recurring-invoices-client.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Repeat, Pause, Play, Trash2, Edit2, CreditCard, Zap } from "@/components/ui/icons";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/layout/page-header";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SearchableSelect } from "@/components/ui/searchable-select";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { LineItemsEditor } from "@/components/invoices/line-items-editor";
+import { formatCurrency } from "@/lib/utils";
+import {
+  createRecurringInvoice, updateRecurringInvoice, setRecurringInvoiceActive,
+  deleteRecurringInvoice, runRecurringInvoiceNow,
+} from "@/lib/actions/recurring-invoices";
+import type { RecurringInvoice, RecurringJobCadence, Customer, Product, LineItem } from "@/types/database";
+
+const CADENCES: { value: RecurringJobCadence; label: string }[] = [
+  { value: "weekly", label: "Weekly" },
+  { value: "fortnightly", label: "Fortnightly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "quarterly", label: "Quarterly" },
+];
+
+interface Props {
+  initial: RecurringInvoice[];
+  customers: Customer[];
+  products: Product[];
+  currency: string;
+  stripeEnabled: boolean;
+}
+
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
+function emptyForm() {
+  return {
+    id: undefined as string | undefined,
+    name: "",
+    customer_id: "",
+    line_items: [] as LineItem[],
+    cadence: "monthly" as RecurringJobCadence,
+    next_run_on: todayISO(),
+    due_days: 14,
+    auto_charge: true,
+    send_email: true,
+    ends_on: "",
+    notes: "",
+    terms: "",
+  };
+}
+
+export function RecurringInvoicesClient({ initial, customers, products, currency, stripeEnabled }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [form, setForm] = useState(emptyForm());
+
+  const customerName = (id: string) => customers.find((c) => c.id === id)?.name ?? "—";
+  const cardOnFile = (id: string) => !!customers.find((c) => c.id === id)?.stripe_payment_method_id;
+
+  const openNew = () => { setForm(emptyForm()); setOpen(true); };
+  const openEdit = (r: RecurringInvoice) => {
+    setForm({
+      id: r.id, name: r.name, customer_id: r.customer_id, line_items: r.line_items ?? [],
+      cadence: r.cadence, next_run_on: r.next_run_on, due_days: r.due_days,
+      auto_charge: r.auto_charge, send_email: r.send_email, ends_on: r.ends_on ?? "",
+      notes: r.notes ?? "", terms: r.terms ?? "",
+    });
+    setOpen(true);
+  };
+
+  const save = async () => {
+    if (!form.name.trim()) return toast.error("Give the schedule a name");
+    if (!form.customer_id) return toast.error("Pick a customer");
+    if (!form.line_items.length) return toast.error("Add at least one line item");
+    setSaving(true);
+    try {
+      const payload = {
+        name: form.name, customer_id: form.customer_id, line_items: form.line_items,
+        cadence: form.cadence, next_run_on: form.next_run_on, due_days: Number(form.due_days) || 14,
+        auto_charge: form.auto_charge, send_email: form.send_email,
+        ends_on: form.ends_on || null, notes: form.notes || null, terms: form.terms || null,
+      };
+      if (form.id) await updateRecurringInvoice(form.id, payload);
+      else await createRecurringInvoice(payload);
+      toast.success(form.id ? "Schedule updated" : "Recurring invoice created");
+      setOpen(false);
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't save");
+    } finally { setSaving(false); }
+  };
+
+  const toggleActive = async (r: RecurringInvoice) => {
+    setBusyId(r.id);
+    try { await setRecurringInvoiceActive(r.id, !r.active); router.refresh(); }
+    catch { toast.error("Couldn't update"); }
+    finally { setBusyId(null); }
+  };
+
+  const runNow = async (r: RecurringInvoice) => {
+    if (!confirm(`Generate ${r.name} now${r.auto_charge ? " and charge the saved card" : ""}?`)) return;
+    setBusyId(r.id);
+    try {
+      const res = await runRecurringInvoiceNow(r.id);
+      toast.success(`${res.number} created${res.charged ? " + charged" : res.emailed ? " + emailed" : ""}`);
+      router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't run"); }
+    finally { setBusyId(null); }
+  };
+
+  const total = form.line_items.reduce((s, li) => s + Number(li.total ?? 0), 0);
+
+  return (
+    <div>
+      <PageHeader
+        title="Recurring invoices"
+        subtitle="Auto-generate and auto-charge invoices on a schedule"
+        accent="linear-gradient(180deg, #34d399 0%, #059669 100%)"
+        actions={<Button onClick={openNew}><Plus className="w-4 h-4 mr-1.5" /> New schedule</Button>}
+      />
+
+      {!stripeEnabled && (
+        <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+          Connect Stripe (Settings → Payment) so recurring invoices can auto-charge saved cards. Until then they&apos;ll be emailed with a pay link.
+        </div>
+      )}
+
+      {initial.length === 0 ? (
+        <Card><CardContent className="py-12 text-center text-muted-foreground">
+          <Repeat className="w-8 h-8 mx-auto mb-3 opacity-40" />
+          <p className="font-medium">No recurring invoices yet</p>
+          <p className="text-sm mt-1">Create one to bill a customer automatically every cycle.</p>
+        </CardContent></Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {initial.map((r) => (
+            <Card key={r.id} className={r.active ? "" : "opacity-60"}>
+              <CardContent className="p-4 space-y-2">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="font-semibold break-words">{r.name}</p>
+                    <p className="text-sm text-muted-foreground break-words">{customerName(r.customer_id)}</p>
+                  </div>
+                  <Badge variant="secondary" className={r.active ? "bg-emerald-500/15 text-emerald-600" : ""}>{r.active ? "Active" : "Paused"}</Badge>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                  <span className="font-semibold tabular-nums">{formatCurrency(r.total, currency)}</span>
+                  <span className="text-muted-foreground capitalize">{r.cadence}</span>
+                  <span className="text-muted-foreground">Next: {r.next_run_on}</span>
+                </div>
+                <div className="flex items-center gap-2 text-xs">
+                  {r.auto_charge ? (
+                    <span className={`inline-flex items-center gap-1 ${cardOnFile(r.customer_id) ? "text-emerald-600" : "text-amber-600"}`}>
+                      <CreditCard className="w-3 h-3" /> {cardOnFile(r.customer_id) ? "Auto-charges saved card" : "Autopay on — no card saved yet"}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">Emails invoice</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5 pt-1">
+                  <Button size="sm" variant="outline" onClick={() => runNow(r)} disabled={busyId === r.id}>
+                    <Zap className="w-3.5 h-3.5 mr-1" /> Run now
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => toggleActive(r)} disabled={busyId === r.id}>
+                    {r.active ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => openEdit(r)}><Edit2 className="w-3.5 h-3.5" /></Button>
+                  <Button size="sm" variant="ghost" className="text-destructive" onClick={() => setDeleteId(r.id)}><Trash2 className="w-3.5 h-3.5" /></Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Create / edit dialog */}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader><DialogTitle>{form.id ? "Edit recurring invoice" : "New recurring invoice"}</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label>Schedule name</Label>
+              <Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="e.g. Monthly maintenance — Acme" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Customer</Label>
+              <SearchableSelect
+                value={form.customer_id}
+                onValueChange={(v) => setForm({ ...form, customer_id: v })}
+                items={customers.map((c) => ({ value: c.id, label: c.name, sublabel: c.email ?? undefined }))}
+                placeholder="Select customer"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Line items</Label>
+              <LineItemsEditor items={form.line_items} products={products} currency={currency} onChange={(items) => setForm({ ...form, line_items: items })} />
+              <p className="text-right text-sm font-semibold">Total per invoice: {formatCurrency(total, currency)}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Frequency</Label>
+                <Select value={form.cadence} onValueChange={(v) => setForm({ ...form, cadence: v as RecurringJobCadence })}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>{CADENCES.map((c) => <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>)}</SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Payment terms (days)</Label>
+                <Input type="number" min="0" value={form.due_days} onChange={(e) => setForm({ ...form, due_days: Number(e.target.value) })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>First invoice date</Label>
+                <Input type="date" value={form.next_run_on} onChange={(e) => setForm({ ...form, next_run_on: e.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Ends on (optional)</Label>
+                <Input type="date" value={form.ends_on} onChange={(e) => setForm({ ...form, ends_on: e.target.value })} />
+              </div>
+            </div>
+            <div className="space-y-3 rounded-lg border border-border p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-normal">Auto-charge saved card</Label>
+                  <p className="text-xs text-muted-foreground">Charge the customer&apos;s card on file automatically each cycle.</p>
+                </div>
+                <Switch checked={form.auto_charge} onCheckedChange={(v) => setForm({ ...form, auto_charge: v })} />
+              </div>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="font-normal">Email the invoice</Label>
+                  <p className="text-xs text-muted-foreground">Send the invoice (with a pay link) when auto-charge isn&apos;t possible.</p>
+                </div>
+                <Switch checked={form.send_email} onCheckedChange={(v) => setForm({ ...form, send_email: v })} />
+              </div>
+              {form.auto_charge && form.customer_id && !cardOnFile(form.customer_id) && (
+                <p className="text-xs text-amber-600">This customer has no saved card yet — they&apos;ll be emailed a link to save one / pay until they do.</p>
+              )}
+            </div>
+            <div className="space-y-1.5">
+              <Label>Notes (optional)</Label>
+              <Textarea rows={2} value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={save} disabled={saving}>{saving ? "Saving…" : form.id ? "Save changes" : "Create schedule"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this recurring invoice?</AlertDialogTitle>
+            <AlertDialogDescription>This stops future automatic invoices. Invoices already created are unaffected.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => { if (deleteId) { try { await deleteRecurringInvoice(deleteId); toast.success("Deleted"); router.refresh(); } catch { toast.error("Couldn't delete"); } setDeleteId(null); } }}
+            >Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/recurring/recurring-jobs-client.tsx
+++ b/src/components/recurring/recurring-jobs-client.tsx
@@ -12,13 +12,15 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { SearchableSelect } from "@/components/ui/searchable-select";
+import { Switch } from "@/components/ui/switch";
+import { LineItemsEditor } from "@/components/invoices/line-items-editor";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import {
   createRecurringJob, updateRecurringJob, deleteRecurringJob, setRecurringJobActive,
   type RecurringJobInput,
 } from "@/lib/actions/recurring-jobs";
-import type { RecurringJob, RecurringJobCadence, Customer, MemberProfile } from "@/types/database";
+import type { RecurringJob, RecurringJobCadence, Customer, MemberProfile, Product } from "@/types/database";
 
 const CADENCE_LABEL: Record<RecurringJobCadence, string> = {
   weekly: "Every week",
@@ -49,6 +51,9 @@ function emptyForm(): RecurringJobInput {
     next_occurrence_at: today,
     ends_on: null,
     active: true,
+    auto_invoice: false,
+    invoice_line_items: [],
+    auto_charge: false,
   };
 }
 
@@ -56,9 +61,11 @@ interface Props {
   initialSchedules: RecurringJob[];
   customers: Customer[];
   profiles: MemberProfile[];
+  products: Product[];
+  currency: string;
 }
 
-export function RecurringJobsClient({ initialSchedules, customers, profiles }: Props) {
+export function RecurringJobsClient({ initialSchedules, customers, profiles, products, currency }: Props) {
   const [schedules, setSchedules] = useState(initialSchedules);
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<RecurringJob | null>(null);
@@ -92,6 +99,9 @@ export function RecurringJobsClient({ initialSchedules, customers, profiles }: P
       next_occurrence_at: s.next_occurrence_at,
       ends_on: s.ends_on,
       active: s.active,
+      auto_invoice: s.auto_invoice ?? false,
+      invoice_line_items: s.invoice_line_items ?? [],
+      auto_charge: s.auto_charge ?? false,
     });
     setOpen(true);
   }
@@ -332,6 +342,38 @@ export function RecurringJobsClient({ initialSchedules, customers, profiles }: P
               <Label className="text-xs">Ends on (optional)</Label>
               <Input type="date" value={form.ends_on ?? ""} onChange={(e) => setForm({ ...form, ends_on: e.target.value || null })} />
             </div>
+          </div>
+
+          {/* Billing — optionally invoice + auto-charge each generated job */}
+          <div className="space-y-3 rounded-lg border border-border p-3 mt-1">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="font-normal">Auto-create an invoice each time</Label>
+                <p className="text-xs text-muted-foreground">When this job is generated, also raise an invoice for the customer.</p>
+              </div>
+              <Switch checked={!!form.auto_invoice} onCheckedChange={(v) => setForm({ ...form, auto_invoice: v })} />
+            </div>
+            {form.auto_invoice && (
+              <>
+                {!form.customer_id && <p className="text-xs text-amber-600">Pick a customer above so the invoice has someone to bill.</p>}
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Invoice line items</Label>
+                  <LineItemsEditor
+                    items={form.invoice_line_items ?? []}
+                    products={products}
+                    currency={currency}
+                    onChange={(items) => setForm({ ...form, invoice_line_items: items })}
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="font-normal">Auto-charge saved card</Label>
+                    <p className="text-xs text-muted-foreground">Charge the customer&apos;s card on file automatically (else the invoice is emailed).</p>
+                  </div>
+                  <Switch checked={!!form.auto_charge} onCheckedChange={(v) => setForm({ ...form, auto_charge: v })} />
+                </div>
+              </>
+            )}
           </div>
 
           <DialogFooter>

--- a/src/lib/actions/recurring-invoices.ts
+++ b/src/lib/actions/recurring-invoices.ts
@@ -1,0 +1,141 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { LineItem, RecurringInvoice, RecurringJobCadence } from "@/types/database";
+import { totalsFromLineItems } from "@/lib/recurring/totals";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+export interface RecurringInvoiceInput {
+  name: string;
+  customer_id: string;
+  line_items: LineItem[];
+  notes?: string | null;
+  terms?: string | null;
+  cadence: RecurringJobCadence;
+  preferred_day_of_month?: number | null;
+  due_days?: number;
+  next_run_on: string;          // ISO date
+  ends_on?: string | null;
+  auto_charge?: boolean;
+  send_email?: boolean;
+  active?: boolean;
+}
+
+export async function getRecurringInvoices(): Promise<RecurringInvoice[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data, error } = await tbl(supabase, "recurring_invoices")
+    .select("*").eq("business_id", businessId).order("next_run_on");
+  if (error) throw error;
+  return (data ?? []) as RecurringInvoice[];
+}
+
+export async function createRecurringInvoice(input: RecurringInvoiceInput): Promise<RecurringInvoice> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!input.name?.trim()) throw new Error("A schedule name is required");
+  if (!input.customer_id) throw new Error("A customer is required");
+  if (!input.line_items?.length) throw new Error("Add at least one line item");
+
+  const totals = totalsFromLineItems(input.line_items);
+  const { data, error } = await tbl(supabase, "recurring_invoices").insert({
+    business_id: businessId,
+    user_id: user.id,
+    name: input.name.trim(),
+    customer_id: input.customer_id,
+    line_items: input.line_items,
+    subtotal: totals.subtotal,
+    tax_total: totals.tax_total,
+    total: totals.total,
+    notes: input.notes ?? null,
+    terms: input.terms ?? null,
+    cadence: input.cadence,
+    preferred_day_of_month: input.preferred_day_of_month ?? null,
+    due_days: input.due_days ?? 14,
+    next_run_on: input.next_run_on,
+    ends_on: input.ends_on ?? null,
+    auto_charge: input.auto_charge ?? true,
+    send_email: input.send_email ?? true,
+    active: input.active ?? true,
+  }).select().single();
+  if (error) throw error;
+  revalidatePath("/recurring-invoices");
+  return data as RecurringInvoice;
+}
+
+export async function updateRecurringInvoice(id: string, updates: Partial<RecurringInvoiceInput>): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const patch: Record<string, any> = { ...updates };
+  if (updates.line_items) {
+    const t = totalsFromLineItems(updates.line_items);
+    patch.subtotal = t.subtotal; patch.tax_total = t.tax_total; patch.total = t.total;
+  }
+  const { error } = await tbl(supabase, "recurring_invoices")
+    .update(patch).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/recurring-invoices");
+}
+
+export async function setRecurringInvoiceActive(id: string, active: boolean): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "recurring_invoices")
+    .update({ active }).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/recurring-invoices");
+}
+
+export async function deleteRecurringInvoice(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "recurring_invoices")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/recurring-invoices");
+}
+
+/**
+ * Generate this schedule's invoice immediately (and auto-charge / email per its
+ * settings) without waiting for the daily cron. Does NOT advance next_run_on —
+ * it's a manual "bill now". Returns what happened.
+ */
+export async function runRecurringInvoiceNow(id: string): Promise<{ number: string; charged: boolean; emailed: boolean }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: r } = await tbl(supabase, "recurring_invoices")
+    .select("*").eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (!r) throw new Error("Recurring invoice not found");
+
+  const { createAdminClient } = await import("@/lib/supabase/admin");
+  const { generateRecurringInvoice } = await import("@/lib/recurring/generate-invoice");
+  const out = await generateRecurringInvoice(createAdminClient(), {
+    businessId,
+    userId: r.user_id,
+    customerId: r.customer_id,
+    lineItems: r.line_items ?? [],
+    subtotal: Number(r.subtotal), taxTotal: Number(r.tax_total), total: Number(r.total),
+    dueDays: r.due_days ?? 14,
+    notes: r.notes, terms: r.terms,
+    autoCharge: r.auto_charge, sendEmail: r.send_email,
+  });
+  await tbl(supabase, "recurring_invoices").update({ last_invoice_id: out.invoiceId, last_run_at: new Date().toISOString() }).eq("id", id);
+  revalidatePath("/recurring-invoices");
+  revalidatePath("/invoices");
+  return { number: out.number, charged: out.charged, emailed: out.emailed };
+}

--- a/src/lib/actions/recurring-jobs.ts
+++ b/src/lib/actions/recurring-jobs.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
-import type { RecurringJob, RecurringJobCadence } from "@/types/database";
+import type { RecurringJob, RecurringJobCadence, LineItem } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,6 +27,10 @@ export type RecurringJobInput = {
   next_occurrence_at: string;
   ends_on?: string | null;
   active?: boolean;
+  /** Billing: also generate (and optionally auto-charge) an invoice each occurrence. */
+  auto_invoice?: boolean;
+  invoice_line_items?: LineItem[];
+  auto_charge?: boolean;
 };
 
 export async function getRecurringJobs(): Promise<RecurringJob[]> {
@@ -67,6 +71,9 @@ export async function createRecurringJob(input: RecurringJobInput): Promise<Recu
     next_occurrence_at: input.next_occurrence_at,
     ends_on: input.ends_on ?? null,
     active: input.active ?? true,
+    auto_invoice: input.auto_invoice ?? false,
+    invoice_line_items: input.invoice_line_items ?? [],
+    auto_charge: input.auto_charge ?? false,
   }).select().single();
 
   if (error) throw error;

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1199,6 +1199,81 @@ export function registerTools(server: McpServer): void {
       return text({ updated: true });
     });
 
+  // ===== RECURRING INVOICES (subscriptions / automatic billing) =====
+  tool("list_recurring_invoices", "List recurring invoice schedules (subscriptions that auto-generate + auto-charge an invoice each cycle).",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "invoices:read");
+      const { data, error } = await t(ctx, "recurring_invoices")
+        .select("id, name, customer_id, total, cadence, next_run_on, auto_charge, active, last_run_at")
+        .eq("business_id", ctx.businessId).order("next_run_on");
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_recurring_invoice", "Create a recurring invoice schedule. Each cycle it auto-generates an invoice from these line items and (if auto_charge) charges the customer's saved card off-session, else emails it with a pay link. next_run_on is the first billing date (YYYY-MM-DD).",
+    {
+      customer_id: UUID,
+      name: z.string().min(1),
+      line_items: z.array(z.object({
+        name: z.string(), description: z.string().optional(), quantity: z.number().optional(),
+        unit_price: z.number(), tax_rate: z.number().optional(), discount_percent: z.number().optional(),
+      })).min(1),
+      cadence: z.enum(["weekly", "fortnightly", "monthly", "quarterly"]),
+      next_run_on: z.string(),
+      due_days: z.number().int().optional(),
+      auto_charge: z.boolean().optional(),
+      send_email: z.boolean().optional(),
+      ends_on: z.string().optional(),
+      notes: z.string().optional(),
+      terms: z.string().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "invoices:write");
+      const { items, subtotal, tax_total, total } = buildLineItems(args.line_items);
+      const { data, error } = await t(ctx, "recurring_invoices").insert({
+        business_id: ctx.businessId, user_id: ctx.userId,
+        name: args.name, customer_id: args.customer_id,
+        line_items: items, subtotal, tax_total, total,
+        cadence: args.cadence, next_run_on: args.next_run_on,
+        due_days: args.due_days ?? 14,
+        auto_charge: args.auto_charge ?? true,
+        send_email: args.send_email ?? true,
+        ends_on: args.ends_on ?? null,
+        notes: args.notes ?? null, terms: args.terms ?? null,
+        active: true,
+      }).select().single();
+      if (error) throw error;
+      return text({ created: true, recurring_invoice: data });
+    });
+
+  tool("set_recurring_invoice_active", "Pause or resume a recurring invoice schedule.",
+    { recurring_invoice_id: UUID, active: z.boolean() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "invoices:write");
+      const { error } = await t(ctx, "recurring_invoices").update({ active: args.active }).eq("id", args.recurring_invoice_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("run_recurring_invoice_now", "Generate this schedule's invoice immediately (auto-charge / email per its settings) without waiting for the daily cron. Does not change the schedule's next run date.",
+    { recurring_invoice_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "invoices:write");
+      const { data: r } = await t(ctx, "recurring_invoices").select("*").eq("id", args.recurring_invoice_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!r) return errorText("Recurring invoice not found");
+      const { generateRecurringInvoice } = await import("@/lib/recurring/generate-invoice");
+      const { createAdminClient } = await import("@/lib/supabase/admin");
+      const out = await generateRecurringInvoice(createAdminClient(), {
+        businessId: ctx.businessId, userId: r.user_id, customerId: r.customer_id,
+        lineItems: r.line_items ?? [], subtotal: Number(r.subtotal), taxTotal: Number(r.tax_total), total: Number(r.total),
+        dueDays: r.due_days ?? 14, notes: r.notes, terms: r.terms,
+        autoCharge: r.auto_charge, sendEmail: r.send_email,
+      });
+      await t(ctx, "recurring_invoices").update({ last_invoice_id: out.invoiceId, last_run_at: new Date().toISOString() }).eq("id", args.recurring_invoice_id);
+      return text({ generated: true, invoice_number: out.number, charged: out.charged, emailed: out.emailed });
+    });
+
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",
     { date: z.string().optional() },

--- a/src/lib/recurring/generate-invoice.ts
+++ b/src/lib/recurring/generate-invoice.ts
@@ -1,0 +1,144 @@
+/**
+ * Generate an invoice from a recurring schedule (admin/cron context) and either
+ * auto-charge the customer's saved card or email it with a pay link. Used by
+ * both the recurring-invoices cron and the auto-bill path of the recurring-jobs
+ * cron. Invoice numbers are minted MANUALLY (the next_invoice_number RPC checks
+ * auth.uid(), which is null for the service-role client).
+ */
+
+import { randomBytes } from "node:crypto";
+import { appUrl } from "@/lib/app-url";
+import { dispatchWebhook } from "@/lib/webhooks";
+import { chargeInvoiceToSavedCard } from "@/lib/stripe-charge";
+import { customerAllowsCard } from "@/lib/payment-methods";
+import type { LineItem } from "@/types/database";
+
+export interface GenerateInvoiceOpts {
+  businessId: string;
+  userId: string;
+  customerId: string;
+  lineItems: LineItem[];
+  subtotal: number;
+  taxTotal: number;
+  total: number;
+  dueDays: number;
+  notes?: string | null;
+  terms?: string | null;
+  autoCharge: boolean;
+  sendEmail: boolean;
+  workOrderId?: string | null;
+}
+
+export interface GenerateInvoiceResult {
+  invoiceId: string;
+  number: string;
+  charged: boolean;
+  emailed: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function generateRecurringInvoice(sb: any, opts: GenerateInvoiceOpts): Promise<GenerateInvoiceResult> {
+  // Mint the invoice number manually (read-bump the business counter).
+  const { data: biz } = await sb.from("businesses")
+    .select("invoice_prefix, invoice_next_number, name, email, phone, currency, stripe_charges_enabled, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban")
+    .eq("id", opts.businessId).single();
+  const next = biz?.invoice_next_number ?? 1;
+  await sb.from("businesses").update({ invoice_next_number: next + 1 }).eq("id", opts.businessId);
+  const number = `${biz?.invoice_prefix ?? "INV"}-${String(next).padStart(4, "0")}`;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const due = new Date(Date.now() + (opts.dueDays ?? 14) * 86_400_000).toISOString().slice(0, 10);
+
+  const { data: invoice, error } = await sb.from("invoices").insert({
+    business_id: opts.businessId,
+    user_id: opts.userId,
+    number,
+    status: "sent",
+    customer_id: opts.customerId,
+    issue_date: today,
+    due_date: due,
+    line_items: opts.lineItems,
+    subtotal: opts.subtotal,
+    discount_type: null,
+    discount_value: 0,
+    discount_amount: 0,
+    tax_total: opts.taxTotal,
+    total: opts.total,
+    amount_paid: 0,
+    notes: opts.notes ?? null,
+    terms: opts.terms ?? null,
+    work_order_id: opts.workOrderId ?? null,
+  }).select("id, number").single();
+  if (error || !invoice) throw error ?? new Error("Recurring invoice insert failed");
+
+  try { dispatchWebhook(opts.businessId, "invoice.created", { id: invoice.id, number, recurring: true }); } catch { /* never blocks */ }
+
+  let charged = false;
+  if (opts.autoCharge && biz?.stripe_charges_enabled) {
+    const res = await chargeInvoiceToSavedCard(sb, invoice.id, opts.businessId);
+    charged = res.ok;
+  }
+
+  let emailed = false;
+  if (!charged && opts.sendEmail) {
+    try {
+      emailed = await emailInvoice(sb, opts.businessId, invoice.id, opts.customerId, biz);
+    } catch (err) {
+      console.warn("[recurring] invoice email failed", err);
+    }
+  }
+
+  return { invoiceId: invoice.id, number, charged, emailed };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function emailInvoice(sb: any, businessId: string, invoiceId: string, customerId: string, biz: any): Promise<boolean> {
+  const { data: customer } = await sb.from("customers")
+    .select("name, email, allowed_payment_methods").eq("id", customerId).maybeSingle();
+  if (!customer?.email) return false;
+
+  const { data: invoice } = await sb.from("invoices").select("*").eq("id", invoiceId).single();
+  if (!invoice) return false;
+
+  const token = await getOrMintToken(sb, businessId, customerId);
+  const base = appUrl();
+  const portalUrl = base && token ? `${base}/portal/${token}/invoice/${invoiceId}` : null;
+  const pdfUrl = base && token ? `${base}/api/pdf/invoice/${invoiceId}?token=${token}` : null;
+  const balance = Number(invoice.total) - Number(invoice.amount_paid ?? 0);
+  const payUrl = base && token && biz?.stripe_charges_enabled && balance > 0.01 && customerAllowsCard(customer.allowed_payment_methods)
+    ? `${base}/api/stripe/checkout?invoice=${invoiceId}&token=${token}`
+    : null;
+
+  const { invoiceEmailHtml, invoiceEmailSubject } = await import("@/lib/emails/invoice");
+  const { getResolvedEmailTemplate } = await import("@/lib/emails/templates");
+  const { sendEmail, buildBusinessFrom } = await import("@/lib/email");
+
+  const tpl = await getResolvedEmailTemplate(sb, businessId, "invoice");
+  const lineItems = (invoice.line_items ?? []) as LineItem[];
+
+  await sendEmail({
+    to: customer.email,
+    subject: invoiceEmailSubject({ invoice, customer, business: biz }, tpl),
+    html: invoiceEmailHtml({ invoice, customer, business: biz, lineItems, portalUrl, pdfUrl, payUrl, template: tpl }),
+    from: biz?.name ? buildBusinessFrom({ name: biz.name, localPart: "invoices" }) : undefined,
+    replyTo: biz?.email || undefined,
+    tags: { business_id: businessId, doc_type: "invoice", doc_id: invoiceId },
+  });
+  return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getOrMintToken(sb: any, businessId: string, customerId: string): Promise<string | null> {
+  const { data: existing } = await sb.from("customer_portal_tokens")
+    .select("token").eq("business_id", businessId).eq("customer_id", customerId)
+    .is("revoked_at", null)
+    .or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .limit(1).maybeSingle();
+  if (existing?.token) return existing.token;
+  const token = "cust_" + randomBytes(24).toString("hex");
+  const { error } = await sb.from("customer_portal_tokens").insert({
+    token, business_id: businessId, customer_id: customerId,
+    expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+  });
+  return error ? null : token;
+}

--- a/src/lib/recurring/totals.ts
+++ b/src/lib/recurring/totals.ts
@@ -1,0 +1,24 @@
+import type { LineItem } from "@/types/database";
+
+const num = (v: unknown) => {
+  const n = typeof v === "number" ? v : parseFloat(String(v ?? 0));
+  return Number.isFinite(n) ? n : 0;
+};
+
+/** Sum a line-item array into {subtotal, tax_total, total}. */
+export function totalsFromLineItems(items: LineItem[]): { subtotal: number; tax_total: number; total: number } {
+  const r = (items ?? []).reduce(
+    (acc, li) => {
+      acc.subtotal += num(li.subtotal);
+      acc.tax_total += num(li.tax_amount);
+      acc.total += num(li.total);
+      return acc;
+    },
+    { subtotal: 0, tax_total: 0, total: 0 },
+  );
+  return {
+    subtotal: Math.round(r.subtotal * 100) / 100,
+    tax_total: Math.round(r.tax_total * 100) / 100,
+    total: Math.round(r.total * 100) / 100,
+  };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -356,6 +356,37 @@ export interface RecurringJob {
   last_generated_at: string | null;
   active: boolean;
   ends_on: string | null;
+  /** Billing: generate + (optionally) auto-charge an invoice each occurrence. */
+  auto_invoice: boolean;
+  invoice_line_items: LineItem[];
+  auto_charge: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Subscription-style schedule: auto-generate + auto-charge an invoice each cycle. */
+export interface RecurringInvoice {
+  id: string;
+  business_id: string;
+  user_id: string;
+  name: string;
+  customer_id: string;
+  line_items: LineItem[];
+  subtotal: number;
+  tax_total: number;
+  total: number;
+  notes: string | null;
+  terms: string | null;
+  cadence: RecurringJobCadence;
+  preferred_day_of_month: number | null;
+  due_days: number;
+  next_run_on: string;
+  ends_on: string | null;
+  auto_charge: boolean;
+  send_email: boolean;
+  active: boolean;
+  last_invoice_id: string | null;
+  last_run_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20260621160000_recurring_billing.sql
+++ b/supabase/migrations/20260621160000_recurring_billing.sql
@@ -1,0 +1,80 @@
+-- Automatic recurring billing.
+--  (A) recurring_invoices: subscription-style schedules that auto-generate an
+--      invoice each cycle and (optionally) auto-charge the customer's saved card.
+--  (B) billing fields on recurring_jobs so a generated job can also auto-invoice
+--      + auto-charge.
+
+-- ---------------------------------------------------------------------------
+-- (A) recurring_invoices
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.recurring_invoices (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id     UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  customer_id     UUID NOT NULL REFERENCES public.customers(id) ON DELETE CASCADE,
+  line_items      JSONB NOT NULL DEFAULT '[]'::jsonb,
+  subtotal        NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tax_total       NUMERIC(12,2) NOT NULL DEFAULT 0,
+  total           NUMERIC(12,2) NOT NULL DEFAULT 0,
+  notes           TEXT,
+  terms           TEXT,
+  cadence         TEXT NOT NULL CHECK (cadence IN ('weekly','fortnightly','monthly','quarterly')),
+  preferred_day_of_month INT CHECK (preferred_day_of_month BETWEEN 1 AND 28),
+  due_days        INT NOT NULL DEFAULT 14,
+  next_run_on     DATE NOT NULL,
+  ends_on         DATE,
+  -- Charge the customer's saved card off-session when the invoice is generated.
+  auto_charge     BOOLEAN NOT NULL DEFAULT TRUE,
+  -- Email the invoice (with a pay link) when it's generated / when auto-charge
+  -- isn't possible.
+  send_email      BOOLEAN NOT NULL DEFAULT TRUE,
+  active          BOOLEAN NOT NULL DEFAULT TRUE,
+  last_invoice_id UUID,
+  last_run_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS recurring_invoices_business_idx ON public.recurring_invoices (business_id);
+CREATE INDEX IF NOT EXISTS recurring_invoices_next_idx ON public.recurring_invoices (next_run_on) WHERE active = true;
+
+ALTER TABLE public.recurring_invoices ENABLE ROW LEVEL SECURITY;
+
+-- Read: any active member, but not workers (billing is hidden from workers).
+DROP POLICY IF EXISTS recurring_invoices_read ON public.recurring_invoices;
+CREATE POLICY recurring_invoices_read ON public.recurring_invoices FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+     WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+
+-- Write: owner / admin / editor.
+DROP POLICY IF EXISTS recurring_invoices_write ON public.recurring_invoices;
+CREATE POLICY recurring_invoices_write ON public.recurring_invoices FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+     WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+     WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+);
+
+DROP TRIGGER IF EXISTS recurring_invoices_updated_at ON public.recurring_invoices;
+CREATE TRIGGER recurring_invoices_updated_at BEFORE UPDATE ON public.recurring_invoices
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- (B) recurring_jobs billing
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.recurring_jobs
+  ADD COLUMN IF NOT EXISTS auto_invoice       BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS invoice_line_items JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS auto_charge        BOOLEAN NOT NULL DEFAULT FALSE;

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,10 @@
       "schedule": "30 19 * * *"
     },
     {
+      "path": "/api/cron/recurring-invoices",
+      "schedule": "0 6 * * *"
+    },
+    {
       "path": "/api/cron/process-scheduled-sends",
       "schedule": "0 8 * * *"
     },


### PR DESCRIPTION
## Summary
Fully-automatic recurring payments on top of the card-on-file autopay engine.

**Recurring invoices (subscriptions):** set customer + line items + frequency → a daily cron generates an invoice each cycle and auto-charges the saved card off-session (or emails a pay link). New `recurring_invoices` table + RLS, actions, `/api/cron/recurring-invoices` (added to vercel.json), UI at `/recurring-invoices` ("Recurring billing" in sidebar) with create/edit/pause/delete/Run-now, and MCP (`list_recurring_invoices`, `create_recurring_invoice`, `set_recurring_invoice_active`, `run_recurring_invoice_now`).

**Auto-bill recurring jobs:** `recurring_jobs` gains `auto_invoice` + `invoice_line_items` + `auto_charge`; the recurring-jobs cron generates + auto-charges an invoice when a job is materialised. Form gets a billing section.

Shared generator (`src/lib/recurring/generate-invoice.ts`) mints invoice numbers manually (the RPC needs `auth.uid()`, null for the service role), auto-charges via the autopay engine, else emails with a pay link.

Migration `20260621160000` applied + recorded. tsc + production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)