### PR TITLE
feat(stripe): optional card surcharge to customer

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { getStripe, toStripeAmount, computeApplicationFeeAmount } from "@/lib/stripe";
+import { getStripe, toStripeAmount, computeApplicationFeeAmount, computeSurcharge } from "@/lib/stripe";
 import { customerAllowsCard } from "@/lib/payment-methods";
 
 /**
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: business } = await (sb as any).from("businesses")
-    .select("name, currency, stripe_account_id, stripe_charges_enabled, platform_fee_percent")
+    .select("name, currency, stripe_account_id, stripe_charges_enabled, platform_fee_percent, card_surcharge_enabled, card_surcharge_percent, card_surcharge_fixed")
     .eq("id", link.business_id)
     .single();
   if (!business?.stripe_account_id || !business.stripe_charges_enabled) {
@@ -69,21 +69,32 @@ export async function GET(request: NextRequest) {
   const amountUnit = toStripeAmount(balance, currency);
   const applicationFee = computeApplicationFeeAmount(balance, currency, business.platform_fee_percent != null ? Number(business.platform_fee_percent) : null);
 
+  // Optional card surcharge passed to the customer (added on top of the balance).
+  const surcharge = computeSurcharge(balance, {
+    enabled: business.card_surcharge_enabled,
+    percent: business.card_surcharge_percent,
+    fixed: business.card_surcharge_fixed,
+  });
+
   const stripe = getStripe();
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || `${url.protocol}//${url.host}`;
+
+  const lineItems: Array<{ price_data: { currency: string; product_data: { name: string }; unit_amount: number }; quantity: number }> = [{
+    price_data: { currency, product_data: { name: `Invoice ${invoice.number}` }, unit_amount: amountUnit },
+    quantity: 1,
+  }];
+  if (surcharge > 0) {
+    lineItems.push({
+      price_data: { currency, product_data: { name: "Card processing fee" }, unit_amount: toStripeAmount(surcharge, currency) },
+      quantity: 1,
+    });
+  }
 
   // Direct charge on the connected account — the merchant owns the payment,
   // Kirei takes application_fee. This is the standard Connect Standard flow.
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
-    line_items: [{
-      price_data: {
-        currency,
-        product_data: { name: `Invoice ${invoice.number}` },
-        unit_amount: amountUnit,
-      },
-      quantity: 1,
-    }],
+    line_items: lineItems,
     payment_intent_data: applicationFee > 0 ? { application_fee_amount: applicationFee } : undefined,
     customer_email: customer?.email || undefined,
     success_url: `${baseUrl}/portal/${token}/invoice/${invoice.id}?paid=1`,
@@ -93,6 +104,9 @@ export async function GET(request: NextRequest) {
       kirei_business_id: invoice.business_id,
       kirei_portal_token: token,
       kirei_balance: String(balance),
+      // Amount to credit the invoice (excludes the surcharge, which just covers fees).
+      kirei_amount: String(balance),
+      kirei_surcharge: String(surcharge),
     },
   }, {
     stripeAccount: business.stripe_account_id,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -88,11 +88,15 @@ async function handleCheckoutCompleted(event: Stripe.Event) {
   }
 
   const currency = session.currency?.toUpperCase() ?? "USD";
-  const amount = fromStripeAmount(session.amount_total ?? 0, currency);
+  // Credit the invoice with the face amount; a card surcharge (kirei_amount <
+  // amount_total) just covers processing fees and isn't part of the invoice.
+  const faceAmount = session.metadata?.kirei_amount != null
+    ? Number(session.metadata.kirei_amount)
+    : fromStripeAmount(session.amount_total ?? 0, currency);
 
   const sb = createAdminClient();
   await recordStripePayment(sb, getStripe(), {
-    businessId, invoiceId, piId, sessionId: session.id, amount, currency,
+    businessId, invoiceId, piId, sessionId: session.id, amount: faceAmount, currency,
     connectedAcct, portalToken: session.metadata?.kirei_portal_token ?? null,
   });
 }
@@ -111,11 +115,13 @@ async function handlePaymentIntentSucceeded(event: Stripe.Event) {
 
   const connectedAcct = typeof event.account === "string" ? event.account : null;
   const currency = (pi.currency ?? "usd").toUpperCase();
-  const amount = fromStripeAmount(pi.amount_received ?? pi.amount ?? 0, currency);
+  const faceAmount = pi.metadata?.kirei_amount != null
+    ? Number(pi.metadata.kirei_amount)
+    : fromStripeAmount(pi.amount_received ?? pi.amount ?? 0, currency);
 
   const sb = createAdminClient();
   await recordStripePayment(sb, getStripe(), {
-    businessId, invoiceId, piId: pi.id, amount, currency,
+    businessId, invoiceId, piId: pi.id, amount: faceAmount, currency,
     connectedAcct, portalToken: pi.metadata?.kirei_portal_token ?? null,
   });
 }

--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import { ArrowLeft, FileText, Download, CreditCard } from "@/components/ui/icons";
 import { resolveOfferedMethods } from "@/lib/payment-methods";
+import { computeSurcharge, surchargeNote } from "@/lib/stripe";
 import type { LineItem } from "@/types/database";
 
 export const dynamic = "force-dynamic";
@@ -32,7 +33,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
       .eq("business_id", link.business_id)
       .eq("customer_id", link.customer_id)
       .maybeSingle(),
-    tbl(sb, "businesses").select("name, logo_url, currency, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban, phone, email, stripe_charges_enabled").eq("id", link.business_id).maybeSingle(),
+    tbl(sb, "businesses").select("name, logo_url, currency, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban, phone, email, stripe_charges_enabled, card_surcharge_enabled, card_surcharge_percent, card_surcharge_fixed, card_surcharge_note").eq("id", link.business_id).maybeSingle(),
     tbl(sb, "customers").select("name, company, email, phone, address, city, postcode, country, allowed_payment_methods, autopay_enabled, stripe_payment_method_id, stripe_pm_brand, stripe_pm_last4").eq("id", link.customer_id).maybeSingle(),
     tbl(sb, "payments")
       .select("amount, date, method, reference")
@@ -53,6 +54,19 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
     allowed: customer?.allowed_payment_methods,
     stripeEnabled: !!business?.stripe_charges_enabled,
     hasBankDetails,
+  });
+
+  // Optional card surcharge passed to the customer.
+  const surcharge = computeSurcharge(balance, {
+    enabled: business?.card_surcharge_enabled,
+    percent: business?.card_surcharge_percent,
+    fixed: business?.card_surcharge_fixed,
+  });
+  const cardNote = surchargeNote({
+    enabled: business?.card_surcharge_enabled,
+    percent: business?.card_surcharge_percent,
+    fixed: business?.card_surcharge_fixed,
+    note: business?.card_surcharge_note,
   });
 
   return (
@@ -226,13 +240,19 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
               This invoice is payable by cash / in person. Please contact us to arrange payment.
             </p>
           )}
+          {!isPaid && balance > 0 && offered.card && cardNote && (
+            <p className="text-xs text-muted-foreground">{cardNote}</p>
+          )}
           <div className="flex items-center justify-center gap-2 flex-wrap">
             {!isPaid && balance > 0 && offered.card && (
               <a
                 href={`/api/stripe/checkout?invoice=${invoice.id}&token=${token}`}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity shadow-sm"
               >
-                <CreditCard className="w-4 h-4" /> Pay {formatCurrency(balance, currency)} with card
+                <CreditCard className="w-4 h-4" />
+                {surcharge > 0
+                  ? `Pay ${formatCurrency(balance + surcharge, currency)} with card (incl. ${formatCurrency(surcharge, currency)} fee)`
+                  : `Pay ${formatCurrency(balance, currency)} with card`}
               </a>
             )}
             <a

--- a/src/components/settings/stripe-settings.tsx
+++ b/src/components/settings/stripe-settings.tsx
@@ -15,9 +15,12 @@ import {
   disconnectStripe,
   setPlatformFeePercent,
   setDepositPercent,
+  setCardSurcharge,
   syncStripeAccountStatus,
   type StripeAccountStatus,
 } from "@/lib/actions/stripe";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 
 interface Props { initial: StripeAccountStatus }
 
@@ -102,6 +105,27 @@ export function StripeSettings({ initial }: Props) {
     } finally {
       setSavingDeposit(false);
     }
+  };
+
+  const [surEnabled, setSurEnabled] = useState(status.surchargeEnabled);
+  const [surPct, setSurPct] = useState<string>(String(status.surchargePercent ?? 0));
+  const [surFixed, setSurFixed] = useState<string>(String(status.surchargeFixed ?? 0));
+  const [surNote, setSurNote] = useState<string>(status.surchargeNote ?? "");
+  const [savingSur, setSavingSur] = useState(false);
+
+  const handleSaveSurcharge = async () => {
+    setSavingSur(true);
+    try {
+      const percent = Number(surPct) || 0;
+      const fixed = Number(surFixed) || 0;
+      if (percent < 0 || percent > 30) throw new Error("Surcharge % must be 0–30");
+      if (fixed < 0) throw new Error("Fixed fee can't be negative");
+      await setCardSurcharge({ enabled: surEnabled, percent, fixed, note: surNote.trim() || null });
+      setStatus({ ...status, surchargeEnabled: surEnabled, surchargePercent: percent, surchargeFixed: fixed, surchargeNote: surNote.trim() || null });
+      toast.success("Card surcharge saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't save surcharge");
+    } finally { setSavingSur(false); }
   };
 
   const liveFee = status.platformFeePercent ?? status.defaultFeePercent;
@@ -202,6 +226,44 @@ export function StripeSettings({ initial }: Props) {
               <p className="text-xs text-muted-foreground">
                 When customers accept a quote online they can pay this deposit by card. Currently <strong>{liveDeposit}%</strong>. Set to <strong>0</strong> to hide the deposit option (full payment only). Blank = default ({status.defaultDepositPercent}%).
               </p>
+            </div>
+
+            <Separator />
+
+            {/* Card surcharge — pass the processing fee to the customer */}
+            <div className="space-y-3 max-w-md">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>Pass card fee to customer</Label>
+                  <p className="text-xs text-muted-foreground">Add a card processing fee on top when customers pay by card.</p>
+                </div>
+                <Switch checked={surEnabled} onCheckedChange={setSurEnabled} />
+              </div>
+              {surEnabled && (
+                <>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1">
+                      <Label className="text-xs">Percent (%)</Label>
+                      <Input type="number" min="0" max="30" step="0.01" value={surPct} onChange={(e) => setSurPct(e.target.value)} placeholder="1.75" />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs">Fixed fee</Label>
+                      <Input type="number" min="0" step="0.01" value={surFixed} onChange={(e) => setSurFixed(e.target.value)} placeholder="0.30" />
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Note shown to the customer (optional)</Label>
+                    <Textarea rows={2} value={surNote} onChange={(e) => setSurNote(e.target.value)} placeholder="Auto-generated from the rate if left blank, e.g. “A card processing fee of 1.75% + 0.30 applies when paying by card.”" />
+                  </div>
+                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                    ⚠️ Card surcharging is regulated — banned on consumer cards in the UK/EU and capped/regulated in AU &amp; parts of the US. Keep the rate at or below your actual cost of acceptance and follow your local rules.
+                  </p>
+                </>
+              )}
+              <Button type="button" onClick={handleSaveSurcharge} disabled={savingSur}>
+                {savingSur && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                Save surcharge
+              </Button>
             </div>
           </>
         )}

--- a/src/lib/actions/stripe.ts
+++ b/src/lib/actions/stripe.ts
@@ -46,6 +46,11 @@ export interface StripeAccountStatus {
   /** Up-front deposit % offered on quote accept. NULL = app default (50). */
   depositPercent: number | null;
   defaultDepositPercent: number;
+  /** Card surcharge passed to the customer. */
+  surchargeEnabled: boolean;
+  surchargePercent: number;
+  surchargeFixed: number;
+  surchargeNote: string | null;
 }
 
 /** Read the current Stripe connection state for the active business. */
@@ -55,7 +60,7 @@ export async function getStripeAccountStatus(): Promise<StripeAccountStatus> {
   const businessId = await getActiveBizId(supabase, user.id);
 
   const { data: biz } = await tbl(supabase, "businesses")
-    .select("stripe_account_id, stripe_charges_enabled, stripe_payouts_enabled, stripe_details_submitted, stripe_country, platform_fee_percent, deposit_percent")
+    .select("stripe_account_id, stripe_charges_enabled, stripe_payouts_enabled, stripe_details_submitted, stripe_country, platform_fee_percent, deposit_percent, card_surcharge_enabled, card_surcharge_percent, card_surcharge_fixed, card_surcharge_note")
     .eq("id", businessId)
     .single();
 
@@ -71,7 +76,33 @@ export async function getStripeAccountStatus(): Promise<StripeAccountStatus> {
     defaultFeePercent: defaultPlatformFeePercent(),
     depositPercent: biz?.deposit_percent != null ? Number(biz.deposit_percent) : null,
     defaultDepositPercent: DEFAULT_DEPOSIT_PERCENT,
+    surchargeEnabled: !!biz?.card_surcharge_enabled,
+    surchargePercent: biz?.card_surcharge_percent != null ? Number(biz.card_surcharge_percent) : 0,
+    surchargeFixed: biz?.card_surcharge_fixed != null ? Number(biz.card_surcharge_fixed) : 0,
+    surchargeNote: biz?.card_surcharge_note ?? null,
   };
+}
+
+/** Configure the optional card surcharge passed to customers. */
+export async function setCardSurcharge(input: { enabled: boolean; percent: number; fixed: number; note: string | null }): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const role = await resolveRole(supabase, user.id, businessId);
+  if (!canManageSettings(role)) throw new Error("Only owners and admins can change the card surcharge");
+
+  const percent = Number(input.percent);
+  const fixed = Number(input.fixed);
+  if (!Number.isFinite(percent) || percent < 0 || percent > 30) throw new Error("Surcharge % must be between 0 and 30");
+  if (!Number.isFinite(fixed) || fixed < 0) throw new Error("Fixed surcharge can't be negative");
+
+  await tbl(supabase, "businesses").update({
+    card_surcharge_enabled: !!input.enabled,
+    card_surcharge_percent: Math.round(percent * 100) / 100,
+    card_surcharge_fixed: Math.round(fixed * 100) / 100,
+    card_surcharge_note: input.note?.trim() ? input.note.trim() : null,
+  }).eq("id", businessId);
+  revalidatePath("/settings");
 }
 
 /**

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -588,6 +588,11 @@ export function registerTools(server: McpServer): void {
       // Stripe / payments: platform fee % and the quote-accept deposit %.
       platform_fee_percent: z.number().min(0).max(30).nullable().optional(),
       deposit_percent: z.number().min(0).max(100).nullable().optional(),
+      // Card surcharge passed to the customer (regulated — keep compliant).
+      card_surcharge_enabled: z.boolean().optional(),
+      card_surcharge_percent: z.number().min(0).max(30).optional(),
+      card_surcharge_fixed: z.number().min(0).optional(),
+      card_surcharge_note: z.string().nullable().optional(),
     },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");

--- a/src/lib/stripe-charge.ts
+++ b/src/lib/stripe-charge.ts
@@ -9,7 +9,7 @@
  * the customer a manual pay link.
  */
 
-import { getStripe, toStripeAmount, computeApplicationFeeAmount } from "@/lib/stripe";
+import { getStripe, toStripeAmount, computeApplicationFeeAmount, computeSurcharge } from "@/lib/stripe";
 import { customerAllowsCard } from "@/lib/payment-methods";
 import { recordStripePayment } from "@/lib/stripe-payments";
 
@@ -40,7 +40,7 @@ export async function chargeInvoiceToSavedCard(
   if (balance < 0.5) return { ok: false, reason: "not_eligible", message: "Nothing left to charge" };
 
   const { data: biz } = await sb.from("businesses")
-    .select("stripe_account_id, stripe_charges_enabled, currency, platform_fee_percent")
+    .select("stripe_account_id, stripe_charges_enabled, currency, platform_fee_percent, card_surcharge_enabled, card_surcharge_percent, card_surcharge_fixed")
     .eq("id", businessId).single();
   if (!biz?.stripe_account_id || !biz.stripe_charges_enabled) {
     return { ok: false, reason: "not_eligible", message: "Card payments aren't enabled for this business" };
@@ -57,7 +57,13 @@ export async function chargeInvoiceToSavedCard(
   }
 
   const currency = (biz.currency || "GBP").toLowerCase();
-  const amountUnit = toStripeAmount(balance, currency);
+  const surcharge = computeSurcharge(balance, {
+    enabled: biz.card_surcharge_enabled,
+    percent: biz.card_surcharge_percent,
+    fixed: biz.card_surcharge_fixed,
+  });
+  const chargeTotal = balance + surcharge;
+  const amountUnit = toStripeAmount(chargeTotal, currency);
   const appFee = computeApplicationFeeAmount(
     balance, currency, biz.platform_fee_percent != null ? Number(biz.platform_fee_percent) : null,
   );
@@ -77,6 +83,9 @@ export async function chargeInvoiceToSavedCard(
           kirei_invoice_id: invoice.id,
           kirei_business_id: businessId,
           kirei_source: "autopay",
+          // Credit the invoice with the face amount; surcharge just covers fees.
+          kirei_amount: String(balance),
+          kirei_surcharge: String(surcharge),
         },
       },
       { stripeAccount: biz.stripe_account_id },

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -50,6 +50,36 @@ export function fromStripeAmount(amount: number, currency: string): number {
 /** Deposit % to use when a business hasn't set one (quote-accept deposits). */
 export const DEFAULT_DEPOSIT_PERCENT = 50;
 
+export interface SurchargeConfig {
+  enabled?: boolean | null;
+  percent?: number | null;
+  fixed?: number | null;
+}
+
+/** Card surcharge (processing fee passed to the customer) in major units. 0 when off. */
+export function computeSurcharge(amount: number, cfg: SurchargeConfig): number {
+  if (!cfg?.enabled) return 0;
+  const pct = Number(cfg.percent ?? 0);
+  const fixed = Number(cfg.fixed ?? 0);
+  const s = (amount * pct) / 100 + fixed;
+  return s > 0 ? Math.round(s * 100) / 100 : 0;
+}
+
+/** Customer-facing note describing the card fee (custom overrides the auto text). */
+export function surchargeNote(cfg: SurchargeConfig & { note?: string | null; currencySymbol?: string }): string | null {
+  if (!cfg?.enabled) return null;
+  if (cfg.note && cfg.note.trim()) return cfg.note.trim();
+  const pct = Number(cfg.percent ?? 0);
+  const fixed = Number(cfg.fixed ?? 0);
+  const bits: string[] = [];
+  if (pct > 0) bits.push(`${pct}%`);
+  if (fixed > 0) bits.push(`${cfg.currencySymbol ?? ""}${fixed.toFixed(2)}`);
+  const amt = bits.join(" + ");
+  return amt
+    ? `A card processing fee of ${amt} applies when paying by card.`
+    : "A card processing fee applies when paying by card.";
+}
+
 /** Default platform fee percent. NULL on a business row → use this. */
 export function defaultPlatformFeePercent(): number {
   const raw = process.env.STRIPE_PLATFORM_FEE_PERCENT;

--- a/supabase/migrations/20260622100000_card_surcharge.sql
+++ b/supabase/migrations/20260622100000_card_surcharge.sql
@@ -1,0 +1,8 @@
+-- Optional card surcharge — pass the card processing fee to the customer.
+-- Business is responsible for keeping the rate compliant (surcharging is
+-- regulated/banned in some regions). Off by default.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS card_surcharge_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS card_surcharge_percent NUMERIC(5,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS card_surcharge_fixed   NUMERIC(10,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS card_surcharge_note    TEXT;


### PR DESCRIPTION
Opt-in, configurable card surcharge (Settings → Payment) passed to the customer at checkout + on autopay, with a customer-facing note and a compliance warning. Invoice credited the face amount (surcharge only covers fees). MCP update_settings extended. tsc + build green; migration applied.