### PR TITLE
feat: business-switch loader (Kirei logo) + MCP portal links

### DIFF
--- a/src/components/layout/app-loading.tsx
+++ b/src/components/layout/app-loading.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
-import { Loader2 } from "@/components/ui/icons";
+import Image from "next/image";
 
 interface AppLoadingValue {
-  /** Show a full-screen scrim with a spinner + label (e.g. while switching business). */
+  /** Show a full-screen takeover with the Kirei logo + spinner and a label
+   *  (e.g. while switching business). Pass null to dismiss. */
   setBusy: (label: string | null) => void;
   busy: string | null;
 }
@@ -24,14 +25,23 @@ export function AppLoadingProvider({ children }: { children: ReactNode }) {
       {children}
       {busy && (
         <div
-          className="fixed inset-0 z-[90] flex items-center justify-center bg-background/70 backdrop-blur-[1px]"
+          className="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-6 bg-background"
           role="status"
           aria-live="polite"
         >
-          <div className="flex items-center gap-3 px-5 py-3 rounded-xl bg-card border border-border shadow-lg">
-            <Loader2 className="w-4 h-4 animate-spin text-primary" />
-            <span className="text-sm font-medium">{busy}</span>
+          {/* Kirei logo inside a spinning accent ring */}
+          <div className="relative flex items-center justify-center w-24 h-24">
+            <span className="absolute inset-0 rounded-full border-[3px] border-primary/15 border-t-primary animate-spin" />
+            <Image
+              src="/kirei-logo.png"
+              alt="Kirei"
+              width={56}
+              height={56}
+              priority
+              className="object-contain"
+            />
           </div>
+          {busy && <span className="text-sm font-medium text-muted-foreground">{busy}</span>}
         </div>
       )}
     </AppLoadingCtx.Provider>

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1389,6 +1389,32 @@ export function registerTools(server: McpServer): void {
       return text({ deleted: true });
     });
 
+  // ===== CUSTOMER PORTAL LINKS =====
+  tool("get_portal_links",
+    "Get shareable customer-portal (hub) links for a customer, plus optional deep links to a specific invoice / quote / report. The customer opens these without logging in. Pass a customer_id, or an invoice_id / quote_id / report_id to resolve the customer automatically.",
+    { customer_id: UUID.optional(), invoice_id: UUID.optional(), quote_id: UUID.optional(), report_id: UUID.optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "customers:read");
+      let customerId = args.customer_id ?? null;
+      const resolve = async (table: string, id?: string) => {
+        if (!id || customerId) return;
+        const { data } = await t(ctx, table).select("customer_id").eq("id", id).eq("business_id", ctx.businessId).maybeSingle();
+        if (data?.customer_id) customerId = data.customer_id as string;
+      };
+      await resolve("invoices", args.invoice_id);
+      await resolve("quotes", args.quote_id);
+      await resolve("reports", args.report_id);
+      if (!customerId) return errorText("Provide a customer_id, or an invoice/quote/report id that belongs to a customer.");
+
+      const token = await getOrMintPortalToken(ctx, customerId);
+      const base = appBase();
+      const out: Record<string, string> = { customer_id: customerId, hub_url: `${base}/portal/${token}` };
+      if (args.invoice_id) out.invoice_url = `${base}/portal/${token}/invoice/${args.invoice_id}`;
+      if (args.quote_id) out.quote_url = `${base}/portal/${token}/quote/${args.quote_id}`;
+      if (args.report_id) out.report_url = `${base}/portal/${token}/report/${args.report_id}`;
+      return text(out);
+    });
+
   // ===== CONTRACTS =====
   tool("list_contracts", "List customer contracts (status: draft/sent/viewed/signed/declined/voided).",
     { status: z.string().optional() },


### PR DESCRIPTION
## What
1. **Full-screen business-switch loader** — switching business now shows an opaque takeover that hides the whole app: the **Kirei logo inside a spinning accent ring** + the "Switching to …" label. (Previously a small scrim + pill.) Driven by the existing `setBusy()` the `BusinessSwitcher` already calls.
2. **MCP `get_portal_links`** — returns the customer's **portal hub URL** plus optional deep links to a specific **invoice / quote / report**. Pass a `customer_id`, or an `invoice_id` / `quote_id` / `report_id` and it resolves the customer automatically. Mints/reuses the customer portal token. Scope: `customers:read`.

## Test plan
- [x] `tsc` / `vitest` / `build` green locally + CI
- [ ] Switch business → confirm full-screen Kirei spinner hides everything
- [ ] MCP: `get_portal_links { invoice_id }` → returns hub_url + invoice_url that opens the portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)