### PR TITLE
fix(mobile): invoice/quote list cards no longer clip

### DIFF
--- a/mobile/app/invoices/index.tsx
+++ b/mobile/app/invoices/index.tsx
@@ -117,10 +117,10 @@ export default function InvoicesList() {
         />
       ) : (
         <FlatList
+          style={{ flex: 1 }}
           initialNumToRender={12}
           maxToRenderPerBatch={12}
           windowSize={7}
-          removeClippedSubviews
           data={filtered!}
           keyExtractor={(item) => item.id}
           contentContainerStyle={{ paddingHorizontal: space.lg, paddingBottom: space.xxl }}
@@ -145,12 +145,12 @@ export default function InvoicesList() {
                     <Text style={{ fontFamily: "monospace", fontSize: 12, color: colors.muted }}>{item.number}</Text>
                     <StatusPill tone={tone} />
                   </View>
-                  <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{item.customers?.name ?? "No customer"}</Text>
-                  <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
-                    <Text style={{ fontSize: 11, color: colors.muted }}>
+                  <Text numberOfLines={1} style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{item.customers?.name ?? "No customer"}</Text>
+                  <View style={{ flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between", gap: 8 }}>
+                    <Text numberOfLines={1} style={{ flex: 1, fontSize: 11, color: colors.muted }}>
                       {item.issue_date ?? "—"}{item.due_date ? ` · due ${item.due_date}` : ""}
                     </Text>
-                    <View style={{ alignItems: "flex-end" }}>
+                    <View style={{ alignItems: "flex-end", flexShrink: 0 }}>
                       <Text style={{ fontSize: 16, fontWeight: "800", color: colors.text, letterSpacing: -0.4 }}>{fmtMoney(num(item.total), currency)}</Text>
                       {balance > 0 && balance < num(item.total) && (
                         <Text style={{ fontSize: 11, color: "#dc2626", fontWeight: "700" }}>{fmtMoney(balance, currency)} due</Text>

--- a/mobile/app/quotes/index.tsx
+++ b/mobile/app/quotes/index.tsx
@@ -110,10 +110,10 @@ export default function QuotesList() {
         />
       ) : (
         <FlatList
+          style={{ flex: 1 }}
           initialNumToRender={12}
           maxToRenderPerBatch={12}
           windowSize={7}
-          removeClippedSubviews
           data={filtered!}
           keyExtractor={(item) => item.id}
           contentContainerStyle={{ paddingHorizontal: space.lg, paddingBottom: space.xxl }}
@@ -134,12 +134,12 @@ export default function QuotesList() {
                     <Text style={{ fontFamily: "monospace", fontSize: 12, color: colors.muted }}>{item.number}</Text>
                     <StatusPill tone={item.status} />
                   </View>
-                  <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{item.customers?.name ?? "No customer"}</Text>
-                  <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
-                    <Text style={{ fontSize: 11, color: colors.muted }}>
+                  <Text numberOfLines={1} style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{item.customers?.name ?? "No customer"}</Text>
+                  <View style={{ flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between", gap: 8 }}>
+                    <Text numberOfLines={1} style={{ flex: 1, fontSize: 11, color: colors.muted }}>
                       {item.issue_date ?? "Draft"}{item.expiry_date ? ` · expires ${item.expiry_date}` : ""}
                     </Text>
-                    <Text style={{ fontSize: 16, fontWeight: "800", color: colors.text, letterSpacing: -0.4 }}>{fmtMoney(num(item.total), currency)}</Text>
+                    <Text style={{ fontSize: 16, fontWeight: "800", color: colors.text, letterSpacing: -0.4, flexShrink: 0 }}>{fmtMoney(num(item.total), currency)}</Text>
                   </View>
                 </Pressable>
               </FadeIn>


### PR DESCRIPTION
## Problem
On the phone, invoice and quote list cards were cutting off — the date + amount row collided on narrow screens and rows could clip.

## Fix (both invoices & quotes lists)
- `FlatList` gets `style={{ flex: 1 }}` so it sizes/scrolls correctly.
- Meta row: date `Text` is `flex:1` + `numberOfLines={1}` (ellipsis), amount is `flexShrink:0` so it's always fully visible and never pushed off.
- Customer name `numberOfLines={1}` (ellipsized) — consistent card height.
- Removed `removeClippedSubviews` (known to blank/clip rows).

## Notes
- Mobile `tsc --noEmit` clean.
- Mobile isn't built by web CI; needs an **EAS rebuild + TestFlight/Play resubmit** to reach devices (no OTA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)