### PR TITLE
fix(business-switch): hold loader until new dashboard is fully loaded

### DIFF
--- a/src/components/business/business-switcher.tsx
+++ b/src/components/business/business-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronsUpDown, Check, Plus, Building2 } from "@/components/ui/icons";
 import {
@@ -28,22 +28,34 @@ export function BusinessSwitcher({ business, businesses, onClose }: BusinessSwit
   const [isPending, startTransition] = useTransition();
   const [addOpen, setAddOpen] = useState(false);
   const { setBusy } = useAppLoading();
+  const pendingSwitch = useRef(false);
 
   const handleSwitch = (biz: Business) => {
     if (biz.id === business.id) return;
     setBusy(`Switching to ${biz.name}…`);
+    pendingSwitch.current = true;
+    onClose?.();
+    // setActiveBusiness flips the cookie, then router.refresh() refetches the
+    // whole tree for the new business. Both run inside the transition, so
+    // `isPending` stays true until the refreshed dashboard has committed.
     startTransition(async () => {
-      try {
-        await setActiveBusiness(biz.id);
-        router.refresh();
-        onClose?.();
-      } finally {
-        // Clear the overlay shortly after refresh kicks off so the new
-        // route's RSC payload arrives behind the spinner without flashing.
-        setTimeout(() => setBusy(null), 350);
-      }
+      await setActiveBusiness(biz.id);
+      router.refresh();
     });
+    // Safety net: never let the overlay get stuck if the refresh stalls.
+    window.setTimeout(() => {
+      if (pendingSwitch.current) { pendingSwitch.current = false; setBusy(null); }
+    }, 15000);
   };
+
+  // Hold the full-screen loader until the switch transition fully resolves
+  // (new dashboard data fetched + committed), then clear it.
+  useEffect(() => {
+    if (!isPending && pendingSwitch.current) {
+      pendingSwitch.current = false;
+      setBusy(null);
+    }
+  }, [isPending, setBusy]);
 
   return (
     <>


### PR DESCRIPTION
## What
The full-screen Kirei loader cleared on a fixed **350ms timer**, so it disappeared before the new business's dashboard finished loading. Now it stays up until the refreshed dashboard actually commits.

## How
- The `BusinessSwitcher` lives **outside** the `key={business.id}` remount, so it persists across the switch.
- `setActiveBusiness()` (cookie flip) + `router.refresh()` both run inside the same `startTransition`, so **`isPending` stays true until the refreshed RSC tree (with its data) commits**.
- A `useEffect` clears the loader when `isPending` flips false. A 15s safety timeout prevents a stuck overlay if the refresh ever stalls.

## Test plan
- [x] tsc / build green (booking DB test is flaky locally only; auto-skips in CI)
- [ ] Switch business → Kirei spinner stays until the new dashboard is visible, then clears (no early flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)