### PR TITLE
feat(onboarding): foundation — schema, secure fields, actions, MCP (1/3)

### DIFF
--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -1,0 +1,292 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { randomBytes } from "node:crypto";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { appUrl } from "@/lib/app-url";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { redactSecureAnswers } from "@/lib/onboarding/answers";
+import { decryptSecret, isEncryptedAnswer, secureFieldsAvailable } from "@/lib/onboarding/crypto";
+import type {
+  OnboardingForm, OnboardingField, OnboardingRequest, OnboardingResponse,
+} from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+// ── Feature flag (plugin enable/disable, mirrors quoting agent) ─────────────
+
+export interface OnboardingSettings { business_id: string; enabled: boolean }
+
+export async function getOnboardingSettings(): Promise<OnboardingSettings> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "onboarding_settings")
+    .select("business_id, enabled").eq("business_id", businessId).maybeSingle();
+  if (data) return data as OnboardingSettings;
+  const { data: created, error } = await tbl(supabase, "onboarding_settings")
+    .insert({ business_id: businessId, enabled: false })
+    .select("business_id, enabled").single();
+  if (error) throw error;
+  return created as OnboardingSettings;
+}
+
+export async function setOnboardingEnabled(enabled: boolean): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "onboarding_settings")
+    .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  if (error) throw error;
+  revalidatePath("/onboarding");
+  revalidatePath("/", "layout"); // sidebar flag
+}
+
+/** Whether the secure-credential field type can be offered (env key present). */
+export async function getSecureFieldsAvailable(): Promise<boolean> {
+  return secureFieldsAvailable();
+}
+
+// ── Forms CRUD ──────────────────────────────────────────────────────────────
+
+export async function getOnboardingForms(): Promise<(OnboardingForm & { request_count: number; completed_count: number })[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const [{ data: forms, error }, { data: reqs }] = await Promise.all([
+    tbl(supabase, "onboarding_forms").select("*").eq("business_id", businessId).order("created_at", { ascending: false }),
+    tbl(supabase, "onboarding_requests").select("form_id, status").eq("business_id", businessId),
+  ]);
+  if (error) throw error;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const counts = new Map<string, { total: number; done: number }>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (reqs ?? []).forEach((r: any) => {
+    const c = counts.get(r.form_id) ?? { total: 0, done: 0 };
+    c.total++; if (r.status === "completed") c.done++;
+    counts.set(r.form_id, c);
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (forms ?? []).map((f: any) => ({
+    ...f,
+    request_count: counts.get(f.id)?.total ?? 0,
+    completed_count: counts.get(f.id)?.done ?? 0,
+  }));
+}
+
+export async function getOnboardingForm(id: string): Promise<OnboardingForm> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data, error } = await tbl(supabase, "onboarding_forms")
+    .select("*").eq("id", id).eq("business_id", businessId).single();
+  if (error) throw error;
+  return data as OnboardingForm;
+}
+
+export async function createOnboardingForm(input: {
+  name: string; description?: string | null; schema?: OnboardingField[];
+}): Promise<OnboardingForm> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!input.name?.trim()) throw new Error("Form name is required");
+  const { data, error } = await tbl(supabase, "onboarding_forms").insert({
+    business_id: businessId, name: input.name.trim(),
+    description: input.description?.trim() || null,
+    schema: input.schema ?? [], status: "draft",
+  }).select().single();
+  if (error) throw error;
+  revalidatePath("/onboarding");
+  return data as OnboardingForm;
+}
+
+export async function updateOnboardingForm(id: string, updates: {
+  name?: string; description?: string | null; status?: "draft" | "active" | "archived";
+  schema?: OnboardingField[];
+  settings?: { thank_you_message?: string; allow_edit_after_submit?: boolean };
+}): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const clean = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
+  if (Object.keys(clean).length === 0) return;
+  const { error } = await tbl(supabase, "onboarding_forms")
+    .update(clean).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/onboarding");
+  revalidatePath(`/onboarding/${id}`);
+}
+
+export async function deleteOnboardingForm(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "onboarding_forms")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/onboarding");
+}
+
+// ── Requests (send a form to a customer via the portal) ─────────────────────
+
+async function mintPortalToken(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  businessId: string, customerId: string, userId: string,
+): Promise<string> {
+  const { data: existing } = await tbl(supabase, "customer_portal_tokens")
+    .select("token").eq("business_id", businessId).eq("customer_id", customerId)
+    .is("revoked_at", null)
+    .or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .order("created_at", { ascending: false }).limit(1).maybeSingle();
+  if (existing?.token) return existing.token as string;
+  const token = "cust_" + randomBytes(24).toString("hex");
+  const { error } = await tbl(supabase, "customer_portal_tokens").insert({
+    token, business_id: businessId, customer_id: customerId, created_by: userId,
+    expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+  });
+  if (error) throw error;
+  return token;
+}
+
+/** Send an onboarding form to a customer: creates the request, mints/reuses a
+ *  portal token, and emails the fill link. Returns the link either way. */
+export async function sendOnboardingRequest(formId: string, customerId: string, opts: { email?: boolean } = {}): Promise<{ request_id: string; url: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const [{ data: form }, { data: customer }, { data: biz }] = await Promise.all([
+    tbl(supabase, "onboarding_forms").select("id, name, status, schema").eq("id", formId).eq("business_id", businessId).maybeSingle(),
+    tbl(supabase, "customers").select("id, name, email").eq("id", customerId).eq("business_id", businessId).maybeSingle(),
+    tbl(supabase, "businesses").select("name, slug, email").eq("id", businessId).single(),
+  ]);
+  if (!form) throw new Error("Form not found");
+  if (!customer) throw new Error("Customer not found");
+  if ((form.schema ?? []).length === 0) throw new Error("Add at least one field before sending");
+
+  // Reuse an open request for the same form+customer instead of duplicating.
+  const { data: openReq } = await tbl(supabase, "onboarding_requests")
+    .select("id").eq("business_id", businessId).eq("form_id", formId)
+    .eq("customer_id", customerId).neq("status", "completed")
+    .order("created_at", { ascending: false }).limit(1).maybeSingle();
+
+  let requestId: string = openReq?.id ?? "";
+  if (!requestId) {
+    const { data: created, error } = await tbl(supabase, "onboarding_requests").insert({
+      business_id: businessId, form_id: formId, customer_id: customerId,
+    }).select("id").single();
+    if (error) throw error;
+    requestId = created.id;
+  }
+
+  const token = await mintPortalToken(supabase, businessId, customerId, user.id);
+  const url = `${appUrl()}/portal/${token}/onboarding/${requestId}`;
+
+  const shouldEmail = opts.email !== false;
+  if (shouldEmail) {
+    if (!customer.email) throw new Error("This customer has no email address — use Copy link instead");
+    const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px;color:#111">
+      <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:28px">
+        <p style="font-size:13px;color:#666;margin:0 0 4px">${biz?.name ?? "Your provider"}</p>
+        <h1 style="font-size:20px;margin:0 0 12px">${form.name}</h1>
+        <p style="font-size:14px;line-height:1.6;color:#333">Hi ${customer.name ?? "there"}, please fill in a few details so we can get you set up. Your progress saves automatically.</p>
+        <p style="margin:24px 0"><a href="${url}" style="background:#2f6f73;color:#fff;text-decoration:none;padding:12px 22px;border-radius:8px;font-size:14px;font-weight:600">Open the form</a></p>
+        <p style="font-size:12px;color:#888">Or paste this link into your browser:<br>${url}</p>
+      </div></body></html>`;
+    await sendEmail({
+      to: customer.email,
+      subject: `${biz?.name ?? "Onboarding"}: ${form.name}`,
+      html,
+      from: buildBusinessFrom({ name: biz?.name ?? "Kirei", slug: biz?.slug, localPart: "onboarding" }),
+      replyTo: biz?.email ?? undefined,
+      tags: { business_id: businessId, doc_type: "custom", doc_id: requestId },
+    });
+  }
+
+  revalidatePath("/onboarding");
+  revalidatePath(`/customers/${customerId}`);
+  return { request_id: requestId, url };
+}
+
+export interface OnboardingRequestRow extends OnboardingRequest {
+  customers?: { name: string; email: string | null } | null;
+  onboarding_forms?: { name: string } | null;
+}
+
+export async function getOnboardingRequests(filter: { form_id?: string; customer_id?: string } = {}): Promise<OnboardingRequestRow[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  let q = tbl(supabase, "onboarding_requests")
+    .select("*, customers(name, email), onboarding_forms(name)")
+    .eq("business_id", businessId).order("created_at", { ascending: false }).limit(200);
+  if (filter.form_id) q = q.eq("form_id", filter.form_id);
+  if (filter.customer_id) q = q.eq("customer_id", filter.customer_id);
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data ?? []) as OnboardingRequestRow[];
+}
+
+export async function deleteOnboardingRequest(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "onboarding_requests")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/onboarding");
+}
+
+// ── Responses ───────────────────────────────────────────────────────────────
+
+/** Response with secure answers REDACTED (safe default for all UI lists). */
+export async function getOnboardingResponse(requestId: string): Promise<(OnboardingResponse & { redacted: true }) | null> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "onboarding_responses")
+    .select("*").eq("request_id", requestId).eq("business_id", businessId).maybeSingle();
+  if (!data) return null;
+  const schema = (data.schema_snapshot ?? []) as OnboardingField[];
+  return { ...data, answers: redactSecureAnswers(schema, data.answers ?? {}), redacted: true };
+}
+
+/** Explicit owner/admin-only reveal of ONE secure answer. */
+export async function revealSecureAnswer(responseId: string, fieldId: string): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // Owner or admin only — editors/viewers can see the form but not credentials.
+  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
+  if (biz?.user_id !== user.id) {
+    const { data: m } = await tbl(supabase, "business_members")
+      .select("role").eq("business_id", businessId).eq("user_id", user.id).eq("status", "active").maybeSingle();
+    if (m?.role !== "admin") throw new Error("Only the owner or an admin can reveal credentials");
+  }
+
+  const { data: resp } = await tbl(supabase, "onboarding_responses")
+    .select("answers").eq("id", responseId).eq("business_id", businessId).single();
+  const value = resp?.answers?.[fieldId];
+  if (!isEncryptedAnswer(value)) throw new Error("No secure value stored for this field");
+  return decryptSecret(value.enc);
+}
+
+/** Signed URL for a customer-uploaded file/image answer. */
+export async function getOnboardingUploadUrl(path: string): Promise<string | null> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  // Paths are namespaced by business id — refuse anything outside our own.
+  if (!path.startsWith(`${businessId}/`)) throw new Error("Not found");
+  const { createAdminClient } = await import("@/lib/supabase/admin");
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any).storage.from("onboarding-uploads").createSignedUrl(path, 3600);
+  if (error) throw error;
+  return data?.signedUrl ?? null;
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1415,6 +1415,142 @@ export function registerTools(server: McpServer): void {
       return text(out);
     });
 
+  // ===== CLIENT ONBOARDING (feature-flagged form builder) =====
+  const ONBOARDING_FIELD = z.object({
+    id: z.string().min(1),
+    type: z.enum([
+      "short_text", "long_text", "instructions", "email", "phone", "url", "address",
+      "abn", "company", "dropdown", "multi_select", "radio", "checkboxes", "yes_no",
+      "number", "currency", "date", "time", "opening_hours", "file", "image",
+      "rating", "secure", "consent", "heading", "divider",
+    ]),
+    label: z.string(),
+    help_text: z.string().optional(),
+    placeholder: z.string().optional(),
+    required: z.boolean().optional(),
+    options: z.array(z.string()).optional(),
+    show_if: z.object({ field_id: z.string(), equals: z.string() }).nullable().optional(),
+  });
+
+  tool("set_onboarding_enabled", "Enable or disable the Client Onboarding plugin for this business.",
+    { enabled: z.boolean() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
+      const { error } = await t(ctx, "onboarding_settings")
+        .upsert({ business_id: ctx.businessId, enabled: args.enabled }, { onConflict: "business_id" });
+      if (error) throw error;
+      return text({ enabled: args.enabled });
+    });
+
+  tool("list_onboarding_forms", "List this business's client-onboarding forms.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:read");
+      const { data, error } = await t(ctx, "onboarding_forms")
+        .select("id, name, description, status, created_at")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_onboarding_form",
+    "Create a client-onboarding form. fields is an ordered array; each field needs a unique id, a type (short_text/long_text/email/phone/url/address/abn/company/dropdown/multi_select/radio/checkboxes/yes_no/number/currency/date/time/opening_hours/file/image/rating/secure/consent/heading/divider/instructions) and a label. Use type 'secure' for credentials — those answers are encrypted and never readable via the API.",
+    { name: z.string().min(1), description: z.string().optional(), fields: z.array(ONBOARDING_FIELD), activate: z.boolean().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
+      const { data, error } = await t(ctx, "onboarding_forms").insert({
+        business_id: ctx.businessId, name: args.name, description: args.description ?? null,
+        schema: args.fields, status: args.activate ? "active" : "draft",
+      }).select("id, name, status").single();
+      if (error) throw error;
+      return text({ created: true, form: data });
+    });
+
+  tool("update_onboarding_form", "Update an onboarding form's name/description/status/fields.",
+    {
+      form_id: UUID, name: z.string().optional(), description: z.string().optional(),
+      status: z.enum(["draft", "active", "archived"]).optional(),
+      fields: z.array(ONBOARDING_FIELD).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
+      const { form_id, fields, ...rest } = args;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clean: Record<string, any> = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (fields !== undefined) clean.schema = fields;
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "onboarding_forms").update(clean).eq("id", form_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("send_onboarding_form", "Send an onboarding form to a customer — emails them a portal link and returns it.",
+    { form_id: UUID, customer_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
+      const [{ data: form }, { data: customer }, { data: biz }] = await Promise.all([
+        t(ctx, "onboarding_forms").select("id, name, schema").eq("id", args.form_id).eq("business_id", ctx.businessId).maybeSingle(),
+        t(ctx, "customers").select("id, name, email").eq("id", args.customer_id).eq("business_id", ctx.businessId).maybeSingle(),
+        t(ctx, "businesses").select("name, slug, email").eq("id", ctx.businessId).single(),
+      ]);
+      if (!form) return errorText("Form not found");
+      if (!customer) return errorText("Customer not found");
+      if (!customer.email) return errorText("Customer has no email address");
+      if ((form.schema ?? []).length === 0) return errorText("Form has no fields yet");
+
+      const { data: openReq } = await t(ctx, "onboarding_requests")
+        .select("id").eq("business_id", ctx.businessId).eq("form_id", args.form_id)
+        .eq("customer_id", args.customer_id).neq("status", "completed")
+        .order("created_at", { ascending: false }).limit(1).maybeSingle();
+      let requestId: string = openReq?.id ?? "";
+      if (!requestId) {
+        const { data: created, error } = await t(ctx, "onboarding_requests").insert({
+          business_id: ctx.businessId, form_id: args.form_id, customer_id: args.customer_id,
+        }).select("id").single();
+        if (error) throw error;
+        requestId = created.id;
+      }
+      const token = await getOrMintPortalToken(ctx, args.customer_id);
+      const url = `${appBase()}/portal/${token}/onboarding/${requestId}`;
+      const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px;color:#111"><div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:28px"><p style="font-size:13px;color:#666;margin:0 0 4px">${biz?.name ?? "Your provider"}</p><h1 style="font-size:20px;margin:0 0 12px">${form.name}</h1><p style="font-size:14px;line-height:1.6;color:#333">Hi ${customer.name ?? "there"}, please fill in a few details so we can get you set up.</p><p style="margin:24px 0"><a href="${url}" style="background:#2f6f73;color:#fff;text-decoration:none;padding:12px 22px;border-radius:8px;font-size:14px;font-weight:600">Open the form</a></p><p style="font-size:12px;color:#888">${url}</p></div></body></html>`;
+      await sendEmail({
+        to: customer.email, subject: `${biz?.name ?? "Onboarding"}: ${form.name}`, html,
+        from: buildBusinessFrom({ name: biz?.name ?? "Kirei", slug: biz?.slug, localPart: "onboarding" }),
+        replyTo: biz?.email ?? undefined,
+        tags: { business_id: ctx.businessId, doc_type: "custom", doc_id: requestId },
+      });
+      return text({ sent: true, request_id: requestId, url });
+    });
+
+  tool("list_onboarding_requests", "List onboarding requests (optionally by form or customer) with status.",
+    { form_id: UUID.optional(), customer_id: UUID.optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:read");
+      let q = t(ctx, "onboarding_requests")
+        .select("id, form_id, customer_id, status, sent_at, completed_at, customers(name), onboarding_forms(name)")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false }).limit(100);
+      if (args.form_id) q = q.eq("form_id", args.form_id);
+      if (args.customer_id) q = q.eq("customer_id", args.customer_id);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("get_onboarding_response",
+    "Get a customer's submitted onboarding answers. Secure (credential) fields are ALWAYS redacted here — they can only be revealed by an owner/admin in the web app.",
+    { request_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:read");
+      const { data } = await t(ctx, "onboarding_responses")
+        .select("*").eq("request_id", args.request_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!data) return errorText("No response yet for this request");
+      const { redactSecureAnswers } = await import("@/lib/onboarding/answers");
+      return text({
+        ...data,
+        answers: redactSecureAnswers(data.schema_snapshot ?? [], data.answers ?? {}),
+      });
+    });
+
   // ===== CONTRACTS =====
   tool("list_contracts", "List customer contracts (status: draft/sent/viewed/signed/declined/voided).",
     { status: z.string().optional() },

--- a/src/lib/onboarding/answers.ts
+++ b/src/lib/onboarding/answers.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared answer-processing helpers (plain module — used by server actions AND
+ * the token-gated portal submit route; keep free of "use server").
+ */
+import type { OnboardingField, OnboardingAnswers } from "@/types/database";
+import { encryptSecret, isEncryptedAnswer } from "./crypto";
+
+/** Field types that never hold an answer. */
+export const DISPLAY_ONLY_TYPES = new Set(["instructions", "heading", "divider"]);
+
+/** Encrypt secure-field values before storage; pass everything else through.
+ *  Already-encrypted values (autosave round-trips) are left as-is. */
+export function processAnswersForStorage(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers
+): OnboardingAnswers {
+  const secureIds = new Set(schema.filter((f) => f.type === "secure").map((f) => f.id));
+  const out: OnboardingAnswers = {};
+  for (const [id, value] of Object.entries(answers ?? {})) {
+    if (secureIds.has(id) && value != null && value !== "") {
+      out[id] = isEncryptedAnswer(value) ? value : { enc: encryptSecret(String(value)) };
+    } else {
+      out[id] = value;
+    }
+  }
+  return out;
+}
+
+/** Replace secure-field answers with a redaction marker (for lists, MCP, agents). */
+export function redactSecureAnswers(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers
+): OnboardingAnswers {
+  const secureIds = new Set(schema.filter((f) => f.type === "secure").map((f) => f.id));
+  const out: OnboardingAnswers = {};
+  for (const [id, value] of Object.entries(answers ?? {})) {
+    out[id] = secureIds.has(id) && value != null && value !== ""
+      ? { secure: true, redacted: "••••••••" }
+      : value;
+  }
+  return out;
+}
+
+/** Validate required fields (honouring simple show_if visibility). Returns
+ *  the ids of missing required fields — empty array = valid. */
+export function missingRequiredFields(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers
+): string[] {
+  const visible = (f: OnboardingField): boolean => {
+    if (!f.show_if?.field_id) return true;
+    return String(answers?.[f.show_if.field_id] ?? "") === f.show_if.equals;
+  };
+  return schema
+    .filter((f) => f.required && !DISPLAY_ONLY_TYPES.has(f.type) && visible(f))
+    .filter((f) => {
+      const v = answers?.[f.id];
+      if (v == null || v === "") return true;
+      if (Array.isArray(v) && v.length === 0) return true;
+      return false;
+    })
+    .map((f) => f.id);
+}

--- a/src/lib/onboarding/crypto.ts
+++ b/src/lib/onboarding/crypto.ts
@@ -1,0 +1,52 @@
+/**
+ * AES-256-GCM encryption for onboarding "secure" fields (client credentials
+ * like Instagram passwords). Plaintext never touches the database — answers
+ * store `{ enc: "<v1.iv.tag.ciphertext>" }` and are decrypted server-side only
+ * on an explicit owner/admin reveal. MCP/agent reads always redact these.
+ *
+ * Key: ONBOARDING_SECRET_KEY env var — 64 hex chars (32 bytes). Generate with:
+ *   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ * Rotating the key makes previously-stored secrets unreadable — treat it like
+ * a database credential.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const VERSION = "v1";
+
+function key(): Buffer {
+  const hex = process.env.ONBOARDING_SECRET_KEY?.trim();
+  if (!hex || !/^[0-9a-f]{64}$/i.test(hex)) {
+    throw new Error(
+      "Secure fields need ONBOARDING_SECRET_KEY (64 hex chars) set in the environment."
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/** True when the encryption key is configured (secure fields usable). */
+export function secureFieldsAvailable(): boolean {
+  const hex = process.env.ONBOARDING_SECRET_KEY?.trim();
+  return Boolean(hex && /^[0-9a-f]{64}$/i.test(hex));
+}
+
+export function encryptSecret(plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key(), iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [VERSION, iv.toString("base64"), tag.toString("base64"), ct.toString("base64")].join(".");
+}
+
+export function decryptSecret(payload: string): string {
+  const [version, ivB64, tagB64, ctB64] = payload.split(".");
+  if (version !== VERSION || !ivB64 || !tagB64 || !ctB64) throw new Error("Malformed secure payload");
+  const decipher = createDecipheriv("aes-256-gcm", key(), Buffer.from(ivB64, "base64"));
+  decipher.setAuthTag(Buffer.from(tagB64, "base64"));
+  return Buffer.concat([decipher.update(Buffer.from(ctB64, "base64")), decipher.final()]).toString("utf8");
+}
+
+/** Shape stored in answers JSONB for secure fields. */
+export interface EncryptedAnswer { enc: string }
+export function isEncryptedAnswer(v: unknown): v is EncryptedAnswer {
+  return typeof v === "object" && v !== null && typeof (v as EncryptedAnswer).enc === "string";
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -426,6 +426,79 @@ export interface Contract {
   updated_at: string;
 }
 
+// ── Client onboarding (per-business form builder, feature-flagged) ──────────
+
+export type OnboardingFieldType =
+  | 'short_text' | 'long_text' | 'instructions'
+  | 'email' | 'phone' | 'url' | 'address'
+  | 'abn' | 'company'
+  | 'dropdown' | 'multi_select' | 'radio' | 'checkboxes' | 'yes_no'
+  | 'number' | 'currency' | 'date' | 'time' | 'opening_hours'
+  | 'file' | 'image'
+  | 'rating' | 'secure' | 'consent'
+  | 'heading' | 'divider';
+
+export interface OnboardingField {
+  id: string;                       // stable key answers are stored under
+  type: OnboardingFieldType;
+  label: string;
+  help_text?: string;
+  placeholder?: string;
+  required?: boolean;
+  options?: string[];               // dropdown / multi_select / radio / checkboxes
+  /** Simple conditional visibility: show when another field equals a value. */
+  show_if?: { field_id: string; equals: string } | null;
+}
+
+export type OnboardingFormStatus = 'draft' | 'active' | 'archived';
+
+export interface OnboardingForm {
+  id: string;
+  business_id: string;
+  name: string;
+  description: string | null;
+  status: OnboardingFormStatus;
+  schema: OnboardingField[];
+  settings: { thank_you_message?: string; allow_edit_after_submit?: boolean };
+  created_at: string;
+  updated_at: string;
+}
+
+export type OnboardingRequestStatus = 'pending' | 'viewed' | 'completed';
+
+export interface OnboardingRequest {
+  id: string;
+  business_id: string;
+  form_id: string;
+  customer_id: string;
+  status: OnboardingRequestStatus;
+  sent_at: string;
+  viewed_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Secure ("secure" type) answers are stored as { enc: string } — AES-256-GCM,
+ *  decrypted only server-side on explicit reveal. Files/images store the
+ *  storage path; everything else stores the raw value. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OnboardingAnswers = Record<string, any>;
+
+export interface OnboardingResponse {
+  id: string;
+  business_id: string;
+  request_id: string;
+  form_id: string;
+  customer_id: string;
+  answers: OnboardingAnswers;
+  schema_snapshot: OnboardingField[];
+  draft: boolean;
+  submitted_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface CustomerPortalToken {
   token: string;
   business_id: string;
@@ -971,6 +1044,8 @@ export type ApiScope =
   | 'bookings:write'
   | 'contracts:read'
   | 'contracts:write'
+  | 'onboarding:read'
+  | 'onboarding:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -997,6 +1072,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'bookings:write',   label: 'Manage bookings & config', group: 'Bookings' },
   { value: 'contracts:read',   label: 'Read contracts',    group: 'Contracts' },
   { value: 'contracts:write',  label: 'Create / send contracts', group: 'Contracts' },
+  { value: 'onboarding:read',  label: 'Read onboarding forms & responses (secure fields redacted)', group: 'Onboarding' },
+  { value: 'onboarding:write', label: 'Create / send onboarding forms', group: 'Onboarding' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260624100000_client_onboarding.sql
+++ b/supabase/migrations/20260624100000_client_onboarding.sql
@@ -1,0 +1,116 @@
+-- Client onboarding forms — a per-business form builder ("plugin", enable/disable
+-- like the quoting agent). Businesses design custom intake forms (ABN, socials,
+-- opening hours, images, secure credentials…), send them to customers through the
+-- existing customer-portal token system, and responses are stored per customer.
+--
+-- Secure fields ("secure" type — e.g. Instagram passwords) are AES-256-GCM
+-- encrypted app-side before they land in answers JSONB; the DB never sees
+-- plaintext credentials.
+
+-- Feature flag (mirrors quoting_agent_settings)
+CREATE TABLE IF NOT EXISTS public.onboarding_settings (
+  business_id UUID PRIMARY KEY REFERENCES public.businesses(id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Form definitions (a business can have several)
+CREATE TABLE IF NOT EXISTS public.onboarding_forms (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  description TEXT,
+  status      TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','active','archived')),
+  schema      JSONB NOT NULL DEFAULT '[]'::jsonb,   -- ordered field list
+  settings    JSONB NOT NULL DEFAULT '{}'::jsonb,   -- thank_you_message, allow_edit_after_submit…
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_forms_business ON public.onboarding_forms (business_id, created_at DESC);
+
+-- A form sent to a specific customer (delivered via customer_portal_tokens)
+CREATE TABLE IF NOT EXISTS public.onboarding_requests (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  form_id      UUID NOT NULL REFERENCES public.onboarding_forms(id) ON DELETE CASCADE,
+  customer_id  UUID NOT NULL REFERENCES public.customers(id) ON DELETE CASCADE,
+  status       TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','viewed','completed')),
+  sent_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  viewed_at    TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_requests_business ON public.onboarding_requests (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_onboarding_requests_customer ON public.onboarding_requests (customer_id);
+CREATE INDEX IF NOT EXISTS idx_onboarding_requests_form     ON public.onboarding_requests (form_id);
+
+-- Submitted (or draft/autosaved) answers
+CREATE TABLE IF NOT EXISTS public.onboarding_responses (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id     UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  request_id      UUID NOT NULL UNIQUE REFERENCES public.onboarding_requests(id) ON DELETE CASCADE,
+  form_id         UUID NOT NULL REFERENCES public.onboarding_forms(id) ON DELETE CASCADE,
+  customer_id     UUID NOT NULL REFERENCES public.customers(id) ON DELETE CASCADE,
+  answers         JSONB NOT NULL DEFAULT '{}'::jsonb,   -- keyed by field id; secure fields hold {"enc": "..."}
+  schema_snapshot JSONB NOT NULL DEFAULT '[]'::jsonb,   -- fields as asked, so edits to the form don't orphan answers
+  draft           BOOLEAN NOT NULL DEFAULT TRUE,        -- autosave until final submit
+  submitted_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_responses_business ON public.onboarding_responses (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_onboarding_responses_customer ON public.onboarding_responses (customer_id);
+
+ALTER TABLE public.onboarding_settings  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.onboarding_forms     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.onboarding_requests  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.onboarding_responses ENABLE ROW LEVEL SECURITY;
+
+-- Read: any active member except workers. Write: owner / admin / editor.
+-- (Portal submit path uses the service-role client gated by the portal token,
+--  so no anon policies are needed.)
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['onboarding_settings','onboarding_forms','onboarding_requests','onboarding_responses'] LOOP
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, t);
+  END LOOP;
+END $$;
+
+-- updated_at triggers
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['onboarding_settings','onboarding_forms','onboarding_requests','onboarding_responses'] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %1$s_updated_at ON public.%1$s;
+      CREATE TRIGGER %1$s_updated_at BEFORE UPDATE ON public.%1$s
+      FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();', t);
+  END LOOP;
+END $$;
+
+-- Private bucket for customer file/image uploads (served via signed URLs;
+-- portal uploads go through a token-gated API route using the admin client).
+INSERT INTO storage.buckets (id, name, public) VALUES ('onboarding-uploads', 'onboarding-uploads', false)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## What
Phase 1 of the **client-onboarding form builder** — the data layer, server actions, and MCP surface. No UI yet (builder = PR 2, portal fill page = PR 3), so nothing user-visible changes.

### Plugin model
Feature-flagged per business exactly like the quoting agent: `onboarding_settings.enabled` (default **off**). Crown Roofers can ignore it; Connected Studio can turn it on.

### Data model
- `onboarding_forms` — per-business form definitions (`schema` JSONB = ordered field list, status draft/active/archived)
- `onboarding_requests` — a form sent to a customer (pending/viewed/completed), delivered via the existing portal-token system
- `onboarding_responses` — answers keyed by field id + a **schema snapshot** (form edits never orphan old answers), `draft` flag for autosave
- Private `onboarding-uploads` bucket for customer file/image uploads
- Standard RLS (members-non-worker read; owner/admin/editor write)

### Field model (25 types)
Text/long text/instructions, email/phone/url/address, **ABN**/company, dropdown/multi-select/radio/checkboxes/yes-no, number/currency/date/time/**opening-hours grid**, **file/image upload**, rating, consent, heading/divider, simple conditional visibility (`show_if`), and:

### 🔐 Secure credential fields
`secure` type for things like Instagram passwords:
- **AES-256-GCM encrypted app-side** (`ONBOARDING_SECRET_KEY` env — 64 hex chars); DB only ever stores ciphertext
- Decrypt only via `revealSecureAnswer` — **owner/admin only**, one field at a time
- **Always redacted** in list views and every MCP/agent read

### MCP (new scopes `onboarding:read/write`)
`set_onboarding_enabled`, `list/create/update_onboarding_form` (AI can draft a whole form from a description), `send_onboarding_form` (emails the portal link), `list_onboarding_requests`, `get_onboarding_response` (redacted).

## DB
Migration `20260624100000_client_onboarding.sql` — **applied + recorded on remote** (additive only).

## Action needed after merge
Set `ONBOARDING_SECRET_KEY` on Vercel (Production + Preview): 64-hex-char key, generate locally with
`node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` — without it, everything works except secure fields (they're cleanly unavailable).

## Test plan
- [x] tsc / vitest / build green locally
- [ ] CI green
- [ ] PR 2 (builder UI) exercises the actions end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)