### PR TITLE
feat(onboarding): preset fields + validation, share link, customer-profile tab

### DIFF
--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -7,12 +7,37 @@ import { getWorkOrders } from "@/lib/actions/work-orders";
 import { getReports } from "@/lib/actions/reports";
 import { getCustomerProperties, getCustomerContacts, getCustomerNotes } from "@/lib/actions/customer-hub";
 import { getBillingProfilesForAccount } from "@/lib/actions/billing-profiles";
-import { CustomerDetailClient } from "@/components/customers/customer-detail-client";
+import {
+  getOnboardingSettings, getOnboardingRequests, getOnboardingResponsesForCustomer, getOnboardingForms,
+} from "@/lib/actions/onboarding";
+import { CustomerDetailClient, type CustomerOnboardingData } from "@/components/customers/customer-detail-client";
+
+/** Onboarding tab data — only when the plugin is enabled; never break the page. */
+async function loadOnboarding(customerId: string): Promise<CustomerOnboardingData | null> {
+  try {
+    const settings = await getOnboardingSettings();
+    if (!settings.enabled) return null;
+    const [requests, responses, forms] = await Promise.all([
+      getOnboardingRequests({ customer_id: customerId }),
+      getOnboardingResponsesForCustomer(customerId),
+      getOnboardingForms(),
+    ]);
+    return {
+      requests,
+      responses,
+      activeForms: forms
+        .filter((f) => f.status !== "archived" && f.schema.length > 0)
+        .map((f) => ({ id: f.id, name: f.name })),
+    };
+  } catch {
+    return null;
+  }
+}
 
 export default async function CustomerDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
-    const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles] = await Promise.all([
+    const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles, onboarding] = await Promise.all([
       getCustomer(id),
       getInvoices({ customer_id: id }),
       getQuotes({ customer_id: id }),
@@ -23,6 +48,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
       getCustomerContacts(id).catch(() => []),
       getCustomerNotes(id).catch(() => []),
       getBillingProfilesForAccount(id).catch(() => []),
+      loadOnboarding(id),
     ]);
     return (
       <CustomerDetailClient
@@ -37,6 +63,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
         billingProfiles={billingProfiles}
         currency={business.currency}
         businessCountry={business.country ?? null}
+        onboarding={onboarding}
       />
     );
   } catch {

--- a/src/app/api/portal/[token]/onboarding/[id]/save/route.ts
+++ b/src/app/api/portal/[token]/onboarding/[id]/save/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { processAnswersForStorage, missingRequiredFields } from "@/lib/onboarding/answers";
+import { processAnswersForStorage, missingRequiredFields, invalidAnswerFields } from "@/lib/onboarding/answers";
 import type { OnboardingField } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,8 +41,12 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tok
 
   if (body.submit) {
     const missing = missingRequiredFields(schema, merged);
-    if (missing.length > 0) {
-      return NextResponse.json({ error: "Please fill in all required fields", missing }, { status: 422 });
+    const invalid = invalidAnswerFields(schema, merged);
+    if (missing.length > 0 || invalid.length > 0) {
+      return NextResponse.json({
+        error: missing.length > 0 ? "Please fill in all required fields" : "Please fix the highlighted fields",
+        missing, invalid,
+      }, { status: 422 });
     }
   }
 

--- a/src/components/customer-portal/onboarding-fill.tsx
+++ b/src/components/customer-portal/onboarding-fill.tsx
@@ -38,7 +38,7 @@ export function OnboardingFill({ token, requestId, fields, initialAnswers, alrea
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(alreadySubmitted);
   const [error, setError] = useState<string | null>(null);
-  const [missing, setMissing] = useState<Set<string>>(new Set());
+  const [problems, setProblems] = useState<Record<string, string>>({});
   const [savedTick, setSavedTick] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dirtyRef = useRef<OnboardingAnswers>({});
@@ -58,7 +58,10 @@ export function OnboardingFill({ token, requestId, fields, initialAnswers, alrea
 
   const setAnswer = (id: string, value: unknown) => {
     setAnswers((prev) => ({ ...prev, [id]: value }));
-    setMissing((prev) => { if (!prev.has(id)) return prev; const n = new Set(prev); n.delete(id); return n; });
+    setProblems((prev) => {
+      if (!(id in prev)) return prev;
+      const n = { ...prev }; delete n[id]; return n;
+    });
     dirtyRef.current[id] = value;
     // Debounced autosave of just the changed keys.
     if (saveTimer.current) clearTimeout(saveTimer.current);
@@ -89,7 +92,10 @@ export function OnboardingFill({ token, requestId, fields, initialAnswers, alrea
       });
       const j = await res.json().catch(() => ({}));
       if (!res.ok) {
-        if (Array.isArray(j.missing)) setMissing(new Set(j.missing));
+        const next: Record<string, string> = {};
+        if (Array.isArray(j.missing)) for (const id of j.missing) next[id] = "This field is required";
+        if (Array.isArray(j.invalid)) for (const e of j.invalid) if (e?.field_id) next[e.field_id] = e.message || "Doesn't match the expected format";
+        if (Object.keys(next).length > 0) setProblems(next);
         setError(j.error || "Couldn't submit — please try again.");
         return;
       }
@@ -128,7 +134,7 @@ export function OnboardingFill({ token, requestId, fields, initialAnswers, alrea
 
       <Card className="p-6 space-y-5">
         {visible.map((f) => (
-          <FillField key={f.id} field={f} value={answers[f.id]} invalid={missing.has(f.id)}
+          <FillField key={f.id} field={f} value={answers[f.id]} problem={problems[f.id]}
             endpoint={endpoint} onChange={(v) => setAnswer(f.id, v)} />
         ))}
       </Card>
@@ -145,10 +151,10 @@ export function OnboardingFill({ token, requestId, fields, initialAnswers, alrea
 
 // ── Individual field controls ────────────────────────────────────────────────
 
-function FillField({ field: f, value, invalid, endpoint, onChange }: {
+function FillField({ field: f, value, problem, endpoint, onChange }: {
   field: OnboardingField;
   value: unknown;
-  invalid: boolean;
+  problem?: string;
   endpoint: string;
   onChange: (v: unknown) => void;
 }) {
@@ -157,7 +163,7 @@ function FillField({ field: f, value, invalid, endpoint, onChange }: {
   if (f.type === "instructions") return <p className="text-sm text-muted-foreground bg-muted/40 rounded-md p-3 whitespace-pre-wrap">{f.label}</p>;
 
   return (
-    <div className={`space-y-1.5 ${invalid ? "rounded-lg ring-1 ring-rose-400 p-2 -m-2" : ""}`}>
+    <div className={`space-y-1.5 ${problem ? "rounded-lg ring-1 ring-rose-400 p-2 -m-2" : ""}`}>
       {f.type !== "consent" && (
         <Label className="text-sm">
           {f.label}{f.required && <span className="text-rose-500 ml-0.5">*</span>}
@@ -165,7 +171,7 @@ function FillField({ field: f, value, invalid, endpoint, onChange }: {
       )}
       {f.help_text && <p className="text-xs text-muted-foreground">{f.help_text}</p>}
       <FieldControl field={f} value={value} endpoint={endpoint} onChange={onChange} />
-      {invalid && <p className="text-xs text-rose-600">This field is required</p>}
+      {problem && <p className="text-xs text-rose-600">{problem}</p>}
     </div>
   );
 }

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -42,11 +42,21 @@ import {
   createBillingProfile, updateBillingProfile, archiveBillingProfile,
   type BillingProfilePayload,
 } from "@/lib/actions/billing-profiles";
+import { CustomerOnboardingCard } from "@/components/onboarding/customer-onboarding-card";
+import type { OnboardingRequestRow } from "@/lib/actions/onboarding";
 import type {
   Customer, InvoiceWithCustomer, QuoteWithCustomer,
   WorkOrderWithCustomer, ReportWithCustomer,
   CustomerProperty, CustomerContact, CustomerNote, BillingProfile,
+  OnboardingForm, OnboardingResponse,
 } from "@/types/database";
+
+/** Onboarding tab payload — null hides the tab (plugin disabled). */
+export interface CustomerOnboardingData {
+  requests: OnboardingRequestRow[];
+  responses: OnboardingResponse[];
+  activeForms: Pick<OnboardingForm, "id" | "name">[];
+}
 
 interface Props {
   customer: Customer;
@@ -61,6 +71,8 @@ interface Props {
   currency?: string;
   /** Country of the active business — drives address-field layout. */
   businessCountry?: string | null;
+  /** Client-onboarding tab data; null/undefined when the plugin is disabled. */
+  onboarding?: CustomerOnboardingData | null;
 }
 
 // ── Property Modal ─────────────────────────────────────────────────────────────
@@ -459,6 +471,7 @@ export function CustomerDetailClient({
   billingProfiles: initialBillingProfiles,
   currency = "AUD",
   businessCountry = null,
+  onboarding = null,
 }: Props) {
   const [customer, setCustomer] = useState(initial);
   const [editing, setEditing] = useState(false);
@@ -675,7 +688,24 @@ export function CustomerDetailClient({
                 <TabsTrigger value="notes" className="gap-1.5">
                   <StickyNote className="w-3.5 h-3.5" />Notes ({notes.length})
                 </TabsTrigger>
+                {onboarding && (
+                  <TabsTrigger value="onboarding" className="gap-1.5">
+                    <ClipboardList className="w-3.5 h-3.5" />Onboarding ({onboarding.requests.length})
+                  </TabsTrigger>
+                )}
               </TabsList>
+
+              {/* ── Onboarding ── */}
+              {onboarding && (
+                <TabsContent value="onboarding" className="mt-3">
+                  <CustomerOnboardingCard
+                    customerId={customer.id}
+                    requests={onboarding.requests}
+                    responses={onboarding.responses}
+                    activeForms={onboarding.activeForms}
+                  />
+                </TabsContent>
+              )}
 
               {/* ── Properties ── */}
               <TabsContent value="properties" className="mt-3 space-y-3">

--- a/src/components/onboarding/customer-onboarding-card.tsx
+++ b/src/components/onboarding/customer-onboarding-card.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * Onboarding tab on the customer profile — every form sent to this customer,
+ * its status, share/copy-link, a send-form picker, and (for completed ones)
+ * the answers inline. Secure answers stay redacted here; full viewer +
+ * reveal lives at /onboarding-forms/[id]?response=….
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { toast } from "sonner";
+import { ClipboardList, Send, Copy, Loader2, Lock, Check, ChevronDown } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { sendOnboardingRequest, type OnboardingRequestRow } from "@/lib/actions/onboarding";
+import { formatDate } from "@/lib/utils";
+import type { OnboardingForm, OnboardingResponse, OnboardingField } from "@/types/database";
+
+const STATUS_TONES: Record<string, string> = {
+  pending: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+  viewed: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  completed: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+};
+
+interface Props {
+  customerId: string;
+  requests: OnboardingRequestRow[];
+  responses: OnboardingResponse[];
+  activeForms: Pick<OnboardingForm, "id" | "name">[];
+}
+
+export function CustomerOnboardingCard({ customerId, requests, responses, activeForms }: Props) {
+  const router = useRouter();
+  const [pickedForm, setPickedForm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const responseByRequest = new Map(responses.map((r) => [r.request_id, r]));
+
+  const act = async (formId: string, email: boolean) => {
+    setBusy(true);
+    try {
+      const { url } = await sendOnboardingRequest(formId, customerId, { email });
+      await navigator.clipboard.writeText(url).catch(() => {});
+      toast.success(email ? "Sent — link also copied" : "Share link copied");
+      setPickedForm("");
+      router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Failed"); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Send picker */}
+      {activeForms.length > 0 && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <Select value={pickedForm} onValueChange={setPickedForm}>
+            <SelectTrigger className="h-9 w-[240px]"><SelectValue placeholder="Choose a form to send…" /></SelectTrigger>
+            <SelectContent>
+              {activeForms.map((f) => <SelectItem key={f.id} value={f.id}>{f.name}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Button size="sm" disabled={!pickedForm || busy} onClick={() => act(pickedForm, true)}>
+            {busy ? <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" /> : <Send className="w-3.5 h-3.5 mr-1.5" />} Send email
+          </Button>
+          <Button size="sm" variant="outline" disabled={!pickedForm || busy} onClick={() => act(pickedForm, false)}>
+            <Copy className="w-3.5 h-3.5 mr-1.5" /> Copy link
+          </Button>
+        </div>
+      )}
+
+      {requests.length === 0 ? (
+        <Card><CardContent className="py-10 text-center text-muted-foreground text-sm">
+          <ClipboardList className="w-7 h-7 mx-auto mb-2 opacity-40" />
+          No onboarding forms sent to this customer yet.
+        </CardContent></Card>
+      ) : (
+        requests.map((req) => {
+          const resp = responseByRequest.get(req.id);
+          return (
+            <Card key={req.id}>
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-center justify-between gap-2 flex-wrap">
+                  <div className="min-w-0">
+                    <p className="font-medium break-words">{req.onboarding_forms?.name ?? "Form"}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Sent {formatDate(req.sent_at)}
+                      {req.completed_at ? ` · completed ${formatDate(req.completed_at)}` : ""}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className={STATUS_TONES[req.status] ?? ""}>{req.status}</Badge>
+                    {req.status !== "completed" && (
+                      <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={() => act(req.form_id, false)} disabled={busy}>
+                        <Copy className="w-3 h-3 mr-1" /> Copy link
+                      </Button>
+                    )}
+                    {resp && (
+                      <Button size="sm" variant="outline" className="h-7 text-xs" asChild>
+                        <Link href={`/onboarding-forms/${req.form_id}?response=${req.id}`}>Full view</Link>
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                {resp && <InlineAnswers response={resp} />}
+              </CardContent>
+            </Card>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function InlineAnswers({ response }: { response: OnboardingResponse }) {
+  const [open, setOpen] = useState(true);
+  const fields = (response.schema_snapshot ?? []).filter(
+    (f) => !["instructions", "heading", "divider"].includes(f.type)
+  );
+  if (fields.length === 0) return null;
+
+  return (
+    <div className="border-t border-border/60 pt-3">
+      <button onClick={() => setOpen((v) => !v)} className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+        <ChevronDown className={`w-3.5 h-3.5 transition-transform ${open ? "" : "-rotate-90"}`} />
+        Answers{response.draft ? " (draft — not submitted)" : ""}
+      </button>
+      {open && (
+        <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {fields.map((f) => (
+            <div key={f.id} className="min-w-0">
+              <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{f.label}</dt>
+              <dd className="text-sm break-words"><CompactValue field={f} value={response.answers?.[f.id]} /></dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}
+
+function CompactValue({ field: f, value }: { field: OnboardingField; value: unknown }) {
+  if (value == null || value === "" || (Array.isArray(value) && value.length === 0)) {
+    return <span className="text-muted-foreground italic">—</span>;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const v = value as any;
+  if (f.type === "secure" || v?.secure) return <span className="inline-flex items-center gap-1 text-muted-foreground"><Lock className="w-3 h-3" /> hidden</span>;
+  if (f.type === "file" || f.type === "image") return <span>📎 {v?.name ?? "Uploaded"}</span>;
+  if (f.type === "consent") return v === true ? <span className="inline-flex items-center gap-1 text-emerald-600"><Check className="w-3.5 h-3.5" /> Agreed</span> : <span>No</span>;
+  if (f.type === "rating") return <span>{"★".repeat(Number(v) || 0)} ({String(v)}/5)</span>;
+  if (Array.isArray(v)) return <span>{v.join(", ")}</span>;
+  if (f.type === "opening_hours" && typeof v === "object") {
+    const parts = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+      .filter((d) => v[d])
+      .map((d) => `${d[0].toUpperCase()}${d.slice(1, 3)} ${v[d].closed ? "closed" : `${v[d].open ?? "?"}–${v[d].close ?? "?"}`}`);
+    return <span>{parts.join(" · ") || "—"}</span>;
+  }
+  return <span>{String(v)}</span>;
+}

--- a/src/components/onboarding/form-builder-client.tsx
+++ b/src/components/onboarding/form-builder-client.tsx
@@ -25,6 +25,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { updateOnboardingForm } from "@/lib/actions/onboarding";
+import { PRESET_LIBRARY, PRESET_GROUPS, fieldFromPreset } from "@/lib/onboarding/presets";
 import type { OnboardingForm, OnboardingField, OnboardingFieldType } from "@/types/database";
 
 // ── Field palette definition ─────────────────────────────────────────────────
@@ -196,6 +197,36 @@ export function FormBuilderClient({ form, secureAvailable }: Props) {
           {/* Palette */}
           <Card className="h-fit lg:sticky lg:top-4">
             <CardContent className="p-3 space-y-3 max-h-[75vh] overflow-y-auto">
+              {/* Quick-add presets — ready-made fields with validation baked in */}
+              <div>
+                <p className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground px-1 mb-1">Ready-made</p>
+                <Select value="" onValueChange={(key) => {
+                  const p = PRESET_LIBRARY.find((x) => x.key === key);
+                  if (!p) return;
+                  if (p.type === "secure" && !secureAvailable) {
+                    toast.error("Secure fields need ONBOARDING_SECRET_KEY set on the server first.");
+                    return;
+                  }
+                  const f = fieldFromPreset(p, newId());
+                  setFields((prev) => [...prev, f]);
+                  setSelectedId(f.id);
+                  setPreview(false);
+                }}>
+                  <SelectTrigger className="h-8 text-xs"><SelectValue placeholder="Add a preset field…" /></SelectTrigger>
+                  <SelectContent className="max-h-[320px]">
+                    {PRESET_GROUPS.map((g) => (
+                      <div key={g}>
+                        <p className="px-2 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{g}</p>
+                        {PRESET_LIBRARY.filter((p) => p.group === g).map((p) => (
+                          <SelectItem key={p.key} value={p.key} className="text-xs">{p.label}</SelectItem>
+                        ))}
+                      </div>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-[10px] text-muted-foreground px-1 mt-1">Presets include the right format checks (ABN checksum, handle rules…)</p>
+              </div>
+
               {PALETTE.map((group) => (
                 <div key={group.group}>
                   <p className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground px-1 mb-1">{group.group}</p>

--- a/src/components/onboarding/onboarding-forms-client.tsx
+++ b/src/components/onboarding/onboarding-forms-client.tsx
@@ -288,10 +288,27 @@ export function OnboardingFormsClient({ enabled, forms, requests, customers }: P
               They&apos;ll get an email with a secure portal link — no login needed. The link is also copied to your clipboard.
             </p>
           </div>
-          <DialogFooter>
+          <DialogFooter className="gap-2">
             <Button variant="outline" onClick={() => setSendForm(null)}>Cancel</Button>
+            <Button
+              variant="outline" disabled={busy || !sendCustomer}
+              onClick={async () => {
+                if (!sendForm || !sendCustomer) return;
+                setBusy(true);
+                try {
+                  const { url } = await sendOnboardingRequest(sendForm.id, sendCustomer, { email: false });
+                  await navigator.clipboard.writeText(url);
+                  toast.success("Share link copied — send it however you like");
+                  setSendForm(null); setSendCustomer("");
+                  router.refresh();
+                } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't create link"); }
+                finally { setBusy(false); }
+              }}
+            >
+              <Copy className="w-4 h-4 mr-1.5" /> Copy link
+            </Button>
             <Button onClick={send} disabled={busy || !sendCustomer}>
-              {busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : <Send className="w-4 h-4 mr-1.5" />} Send
+              {busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : <Send className="w-4 h-4 mr-1.5" />} Send email
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/onboarding/response-viewer-client.tsx
+++ b/src/components/onboarding/response-viewer-client.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
 import { revealSecureAnswer, getOnboardingUploadUrl } from "@/lib/actions/onboarding";
+import { socialProfileUrl } from "@/lib/onboarding/presets";
 import { formatDate } from "@/lib/utils";
 import type { OnboardingResponse, OnboardingField } from "@/types/database";
 
@@ -119,8 +120,18 @@ function AnswerValue({ field: f, value, responseId }: { field: OnboardingField; 
       return <a href={href} target="_blank" rel="noopener noreferrer" className="text-sm text-primary underline break-all">{String(value)}</a>;
     }
 
-    default:
+    default: {
+      // Social-handle presets (instagram / tiktok / x) become profile links.
+      const social = typeof value === "string" ? socialProfileUrl(f.preset, value) : null;
+      if (social) {
+        return (
+          <a href={social} target="_blank" rel="noopener noreferrer" className="text-sm text-primary underline break-all">
+            {String(value)}
+          </a>
+        );
+      }
       return <p className="text-sm whitespace-pre-wrap break-words">{String(value)}</p>;
+    }
   }
 }
 

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -266,6 +266,21 @@ export async function getOnboardingResponse(requestId: string): Promise<(Onboard
   return { ...data, answers: redactSecureAnswers(schema, data.answers ?? {}), redacted: true };
 }
 
+/** All of a customer's responses (secure answers redacted) — for the profile tab. */
+export async function getOnboardingResponsesForCustomer(customerId: string): Promise<OnboardingResponse[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "onboarding_responses")
+    .select("*").eq("customer_id", customerId).eq("business_id", businessId)
+    .order("created_at", { ascending: false });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((data ?? []) as any[]).map((r) => ({
+    ...r,
+    answers: redactSecureAnswers((r.schema_snapshot ?? []) as OnboardingField[], r.answers ?? {}),
+  })) as OnboardingResponse[];
+}
+
 /** Explicit owner/admin-only reveal of ONE secure answer. */
 export async function revealSecureAnswer(responseId: string, fieldId: string): Promise<string> {
   const supabase = await createClient();

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1430,6 +1430,8 @@ export function registerTools(server: McpServer): void {
     required: z.boolean().optional(),
     options: z.array(z.string()).optional(),
     show_if: z.object({ field_id: z.string(), equals: z.string() }).nullable().optional(),
+    preset: z.string().optional().describe("Preset key enabling smart validation/links: instagram, tiktok, x_handle, abn, acn, website, facebook, linkedin, youtube, google_business, logo…"),
+    validation: z.object({ pattern: z.string(), message: z.string() }).optional().describe("Custom regex validation applied on submit"),
   });
 
   tool("set_onboarding_enabled", "Enable or disable the Client Onboarding plugin for this business.",

--- a/src/lib/onboarding/answers.ts
+++ b/src/lib/onboarding/answers.ts
@@ -41,6 +41,89 @@ export function redactSecureAnswers(
   return out;
 }
 
+// ── Format validation ────────────────────────────────────────────────────────
+
+/** ABN checksum (ATO algorithm): subtract 1 from the first digit, apply
+ *  weights, total must be divisible by 89. */
+export function isValidAbn(raw: string): boolean {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length !== 11) return false;
+  const weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+  const sum = weights.reduce((acc, w, i) => acc + w * (Number(digits[i]) - (i === 0 ? 1 : 0)), 0);
+  return sum % 89 === 0;
+}
+
+/** ACN checksum (ASIC algorithm): weights 8..1 over the first 8 digits,
+ *  complement of the remainder is the 9th digit. */
+export function isValidAcn(raw: string): boolean {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length !== 9) return false;
+  const sum = [8, 7, 6, 5, 4, 3, 2, 1].reduce((acc, w, i) => acc + w * Number(digits[i]), 0);
+  return (10 - (sum % 10)) % 10 === Number(digits[8]);
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+const URL_RE = /^(https?:\/\/)?[\w-]+(\.[\w-]+)+([/?#].*)?$/i;
+const PHONE_RE = /^\+?[0-9 ()\-]{6,20}$/;
+
+export interface AnswerError { field_id: string; message: string }
+
+/** Validate answer FORMATS for non-empty, visible answers. Runs on final
+ *  submit alongside missingRequiredFields. Custom `validation.pattern` on a
+ *  field (e.g. social-handle presets) is checked after the type-level rules. */
+export function invalidAnswerFields(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers
+): AnswerError[] {
+  const visible = (f: OnboardingField): boolean => {
+    if (!f.show_if?.field_id) return true;
+    return String(answers?.[f.show_if.field_id] ?? "") === f.show_if.equals;
+  };
+  const errors: AnswerError[] = [];
+
+  for (const f of schema) {
+    if (DISPLAY_ONLY_TYPES.has(f.type) || !visible(f)) continue;
+    const v = answers?.[f.id];
+    if (v == null || v === "" || typeof v !== "string") continue; // formats apply to string answers only
+    const s = v.trim();
+    if (!s) continue;
+
+    // ACN preset rides on short_text — checksum it before the generic pattern.
+    if (f.preset === "acn") {
+      if (!isValidAcn(s)) errors.push({ field_id: f.id, message: "That doesn't look like a valid ACN (9 digits)" });
+      continue;
+    }
+
+    switch (f.type) {
+      case "email":
+        if (!EMAIL_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid email address" });
+        continue;
+      case "url":
+        if (!URL_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid link (e.g. https://example.com)" });
+        continue;
+      case "phone":
+        if (!PHONE_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid phone number" });
+        continue;
+      case "abn":
+        if (!isValidAbn(s)) errors.push({ field_id: f.id, message: "That doesn't look like a valid ABN (11 digits, checksum failed)" });
+        continue;
+      case "number":
+      case "currency":
+        if (Number.isNaN(Number(s.replace(/[, ]/g, "")))) errors.push({ field_id: f.id, message: "Enter a number" });
+        continue;
+    }
+
+    if (f.validation?.pattern) {
+      try {
+        if (!new RegExp(f.validation.pattern).test(s)) {
+          errors.push({ field_id: f.id, message: f.validation.message || "Doesn't match the expected format" });
+        }
+      } catch { /* bad pattern authored on the form — never block the customer */ }
+    }
+  }
+  return errors;
+}
+
 /** Validate required fields (honouring simple show_if visibility). Returns
  *  the ids of missing required fields — empty array = valid. */
 export function missingRequiredFields(

--- a/src/lib/onboarding/presets.ts
+++ b/src/lib/onboarding/presets.ts
@@ -1,0 +1,137 @@
+/**
+ * Preset field library for the onboarding form builder — one-click fields with
+ * correct labels, placeholders, and format validation baked in. Plain module
+ * (used by the builder UI and the response viewer).
+ */
+import type { OnboardingField, OnboardingFieldType } from "@/types/database";
+
+export interface PresetDef {
+  key: string;                 // stable preset id stored on the field
+  group: string;
+  type: OnboardingFieldType;
+  label: string;
+  placeholder?: string;
+  help_text?: string;
+  options?: string[];
+  validation?: { pattern: string; message: string };
+}
+
+export const PRESET_LIBRARY: PresetDef[] = [
+  // ── Business details ────────────────────────────────────────────────────
+  { key: "company", group: "Business", type: "company", label: "Business / trading name", placeholder: "Acme Pty Ltd" },
+  {
+    key: "abn", group: "Business", type: "abn", label: "ABN",
+    placeholder: "51 824 753 556",
+    help_text: "11-digit Australian Business Number",
+  },
+  {
+    key: "acn", group: "Business", type: "short_text", label: "ACN",
+    placeholder: "123 456 789",
+    help_text: "9-digit Australian Company Number",
+    validation: { pattern: "^\\s*\\d[\\d ]{7,12}\\d\\s*$", message: "Enter a 9-digit ACN" },
+  },
+  { key: "gst_registered", group: "Business", type: "yes_no", label: "Registered for GST?" },
+  { key: "industry", group: "Business", type: "short_text", label: "Industry / what you do", placeholder: "e.g. Cafe, hair salon, roofing" },
+  { key: "business_address", group: "Business", type: "address", label: "Business address", placeholder: "Street, suburb, state, postcode" },
+  { key: "postal_address", group: "Business", type: "address", label: "Postal address (if different)" },
+  { key: "opening_hours", group: "Business", type: "opening_hours", label: "Opening hours" },
+  {
+    key: "website", group: "Business", type: "url", label: "Website",
+    placeholder: "https://yourbusiness.com.au",
+  },
+
+  // ── Social media ────────────────────────────────────────────────────────
+  {
+    key: "instagram", group: "Socials", type: "short_text", label: "Instagram handle",
+    placeholder: "@yourbusiness",
+    validation: { pattern: "^@?[A-Za-z0-9._]{1,30}$", message: "Handles are letters, numbers, dots and underscores (no spaces)" },
+  },
+  {
+    key: "tiktok", group: "Socials", type: "short_text", label: "TikTok handle",
+    placeholder: "@yourbusiness",
+    validation: { pattern: "^@?[A-Za-z0-9._]{1,24}$", message: "Handles are letters, numbers, dots and underscores (no spaces)" },
+  },
+  {
+    key: "x_handle", group: "Socials", type: "short_text", label: "X (Twitter) handle",
+    placeholder: "@yourbusiness",
+    validation: { pattern: "^@?[A-Za-z0-9_]{1,15}$", message: "Handles are letters, numbers and underscores, up to 15 characters" },
+  },
+  { key: "facebook", group: "Socials", type: "url", label: "Facebook page", placeholder: "https://facebook.com/yourbusiness" },
+  { key: "linkedin", group: "Socials", type: "url", label: "LinkedIn", placeholder: "https://linkedin.com/company/yourbusiness" },
+  { key: "youtube", group: "Socials", type: "url", label: "YouTube channel", placeholder: "https://youtube.com/@yourbusiness" },
+  { key: "google_business", group: "Socials", type: "url", label: "Google Business Profile link", placeholder: "https://g.page/yourbusiness" },
+
+  // ── Contact ─────────────────────────────────────────────────────────────
+  { key: "contact_name", group: "Contact", type: "short_text", label: "Main contact name", placeholder: "Full name" },
+  { key: "contact_email", group: "Contact", type: "email", label: "Best email", placeholder: "you@example.com" },
+  { key: "contact_phone", group: "Contact", type: "phone", label: "Best phone number", placeholder: "0400 000 000" },
+  {
+    key: "preferred_contact", group: "Contact", type: "dropdown", label: "Preferred contact method",
+    options: ["Email", "Phone call", "SMS", "WhatsApp"],
+  },
+  {
+    key: "best_time", group: "Contact", type: "dropdown", label: "Best time to reach you",
+    options: ["Morning", "Afternoon", "Evening", "Any time"],
+  },
+  { key: "emergency_name", group: "Contact", type: "short_text", label: "Emergency / after-hours contact name" },
+  { key: "emergency_phone", group: "Contact", type: "phone", label: "Emergency / after-hours phone" },
+
+  // ── Branding & assets ───────────────────────────────────────────────────
+  { key: "logo", group: "Branding", type: "image", label: "Logo upload", help_text: "PNG with transparent background works best" },
+  { key: "brand_images", group: "Branding", type: "image", label: "Brand photo / hero image" },
+  { key: "brand_colors", group: "Branding", type: "short_text", label: "Brand colours", placeholder: "#0e7490, #2dd4bf …", help_text: "Hex codes or a description" },
+  { key: "brand_guidelines", group: "Branding", type: "file", label: "Brand guidelines / style guide (PDF)" },
+  { key: "tagline", group: "Branding", type: "short_text", label: "Tagline / slogan" },
+  { key: "about_business", group: "Branding", type: "long_text", label: "About your business", placeholder: "A short paragraph about who you are and what you do" },
+
+  // ── Engagement / operations ─────────────────────────────────────────────
+  {
+    key: "services_needed", group: "Engagement", type: "multi_select", label: "What do you need from us?",
+    options: ["Social media management", "Content creation", "Website", "Advertising", "Photography", "Other"],
+    help_text: "Edit these options to match your services",
+  },
+  { key: "goals", group: "Engagement", type: "long_text", label: "Goals — what does success look like?" },
+  { key: "budget", group: "Engagement", type: "currency", label: "Monthly budget" },
+  { key: "start_date", group: "Engagement", type: "date", label: "Ideal start date" },
+  {
+    key: "referral_source", group: "Engagement", type: "dropdown", label: "How did you hear about us?",
+    options: ["Google", "Instagram", "Facebook", "Word of mouth", "Existing client", "Other"],
+  },
+  { key: "target_audience", group: "Engagement", type: "long_text", label: "Who are your customers / target audience?" },
+  { key: "competitors", group: "Engagement", type: "long_text", label: "Main competitors (names or links)" },
+  { key: "extra_notes", group: "Engagement", type: "long_text", label: "Anything else we should know?" },
+  { key: "terms_consent", group: "Engagement", type: "consent", label: "I agree to the terms of service" },
+
+  // ── Secure credentials ──────────────────────────────────────────────────
+  { key: "account_password", group: "Secure", type: "secure", label: "Account password", help_text: "Stored encrypted — only the business owner can view it" },
+  { key: "account_username", group: "Secure", type: "short_text", label: "Account username / login email" },
+];
+
+export const PRESET_GROUPS = [...new Set(PRESET_LIBRARY.map((p) => p.group))];
+
+export function presetByKey(key: string | undefined): PresetDef | undefined {
+  return key ? PRESET_LIBRARY.find((p) => p.key === key) : undefined;
+}
+
+/** Build a ready-to-insert field from a preset (id supplied by the caller). */
+export function fieldFromPreset(p: PresetDef, id: string): OnboardingField {
+  return {
+    id, type: p.type, label: p.label, preset: p.key,
+    ...(p.placeholder ? { placeholder: p.placeholder } : {}),
+    ...(p.help_text ? { help_text: p.help_text } : {}),
+    ...(p.options ? { options: [...p.options] } : {}),
+    ...(p.validation ? { validation: { ...p.validation } } : {}),
+  };
+}
+
+/** Social presets the response viewer can turn into profile links. */
+export function socialProfileUrl(preset: string | undefined, raw: string): string | null {
+  if (!preset) return null;
+  const handle = raw.trim().replace(/^@/, "");
+  switch (preset) {
+    case "instagram": return `https://instagram.com/${handle}`;
+    case "tiktok": return `https://tiktok.com/@${handle}`;
+    case "x_handle": return `https://x.com/${handle}`;
+    default: return null;
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -448,6 +448,11 @@ export interface OnboardingField {
   options?: string[];               // dropdown / multi_select / radio / checkboxes
   /** Simple conditional visibility: show when another field equals a value. */
   show_if?: { field_id: string; equals: string } | null;
+  /** Preset key (e.g. "instagram", "abn") — drives format validation and
+   *  smart rendering (handle → profile link) in the response viewer. */
+  preset?: string;
+  /** Custom regex validation applied on submit (in addition to type/preset checks). */
+  validation?: { pattern?: string; message?: string };
 }
 
 export type OnboardingFormStatus = 'draft' | 'active' | 'archived';


### PR DESCRIPTION
## What
Rounds out the onboarding builder with the three requested upgrades.

### 1. Preset field library (~35 ready-made fields, validated)
New **"Ready-made"** dropdown at the top of the builder palette — one click inserts a field with the right label, placeholder, help text and **format validation**:

- **Business**: trading name, **ABN (real ATO checksum)**, **ACN (ASIC checksum)**, GST registered, industry, business + postal address, opening hours, website
- **Socials**: **Instagram / TikTok / X handles** (proper handle rules, no spaces, length caps), Facebook / LinkedIn / YouTube / Google Business Profile links
- **Contact**: contact name, best email/phone, preferred contact method, best time to call, emergency contact
- **Branding**: logo upload, brand photo, brand colours, brand-guidelines PDF, tagline, about-your-business
- **Engagement**: services needed (editable multi-select), goals, monthly budget, start date, referral source, target audience, competitors, extra notes, terms consent
- **Secure**: account username + encrypted password

### 2. Real validation on submit
Server-side (`invalidAnswerFields`) + per-field messages in the portal: ABN/ACN checksums, email/URL/phone/number formats, plus custom regex per field (`validation.pattern/message`). Invalid fields highlight with the exact reason. MCP field schema accepts `preset` + `validation` so the AI builds validated forms too.

### 3. Share button
Send dialog now has **Copy link** alongside Send email — creates the request and puts the portal link on your clipboard to share however you like (SMS, WhatsApp…).

### 4. Customer profile tab
New **Onboarding** tab on `/customers/[id]` (only when the plugin is enabled):
- Every form sent to that customer with status, sent/completed dates, copy-link, full-view
- **Inline answers** for completed (and draft) responses — socials, hours, uploads, ratings all formatted; secure values stay 🔒 hidden (reveal lives in the full viewer)
- Send-form picker right on the profile (Send email / Copy link)

Bonus: social-handle answers (Instagram/TikTok/X) render as **clickable profile links** in the response viewer.

## Test plan
- [x] tsc / vitest / build green
- [ ] Preview: add presets (check ABN validation rejects bad checksums), share link, fill + submit with a bad handle → message, check customer profile tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)