### PR TITLE
feat(onboarding): image previews on portal, viewer & customer profile

### DIFF
--- a/src/app/api/portal/[token]/onboarding/[id]/file/route.ts
+++ b/src/app/api/portal/[token]/onboarding/[id]/file/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Serve a customer's own onboarding upload back to them (token-gated) —
+ *  used for image previews on the portal fill page. Only paths inside this
+ *  request's namespace are reachable. */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ token: string; id: string }> }) {
+  const { token, id } = await params;
+  const path = req.nextUrl.searchParams.get("path") ?? "";
+  if (!path) return NextResponse.json({ error: "path required" }, { status: 400 });
+
+  const sb = createAdminClient();
+  const { data: link } = await tbl(sb, "customer_portal_tokens")
+    .select("business_id, customer_id, expires_at, revoked_at").eq("token", token).maybeSingle();
+  if (!link || link.revoked_at) return NextResponse.json({ error: "Invalid link" }, { status: 404 });
+  if (link.expires_at && new Date(link.expires_at) < new Date()) return NextResponse.json({ error: "Link expired" }, { status: 410 });
+
+  const { data: request } = await tbl(sb, "onboarding_requests")
+    .select("id").eq("id", id)
+    .eq("business_id", link.business_id).eq("customer_id", link.customer_id).maybeSingle();
+  if (!request) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Uploads are namespaced businessId/requestId/… — refuse anything else.
+  if (!path.startsWith(`${link.business_id}/${id}/`)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { data: blob, error } = await sb.storage.from("onboarding-uploads").download(path);
+  if (error || !blob) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const buf = Buffer.from(await blob.arrayBuffer());
+  return new NextResponse(buf, {
+    headers: {
+      "Content-Type": blob.type || "application/octet-stream",
+      "Cache-Control": "private, max-age=300",
+    },
+  });
+}

--- a/src/components/customer-portal/onboarding-fill.tsx
+++ b/src/components/customer-portal/onboarding-fill.tsx
@@ -343,6 +343,22 @@ function UploadControl({ field: f, value, endpoint, onChange }: {
   };
 
   if (meta?.path) {
+    if (f.type === "image") {
+      // Serve the customer's own upload back through the token-gated file route.
+      const src = `${endpoint}/file?path=${encodeURIComponent(meta.path)}`;
+      return (
+        <div className="relative inline-block">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={src} alt={meta.name ?? "Uploaded image"}
+            className="max-h-48 max-w-full rounded-lg border border-border object-contain bg-muted/30" />
+          <button type="button" onClick={() => onChange(null)} aria-label="Remove image"
+            className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-destructive">
+            <X className="w-3.5 h-3.5" />
+          </button>
+          {meta.name && <p className="text-[11px] text-muted-foreground mt-1 truncate max-w-[240px]">{meta.name}</p>}
+        </div>
+      );
+    }
     return (
       <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm">
         <span className="truncate">📎 {meta.name ?? "Uploaded"}{meta.size ? ` · ${(meta.size / 1024 / 1024).toFixed(1)} MB` : ""}</span>

--- a/src/components/onboarding/answer-image-thumb.tsx
+++ b/src/components/onboarding/answer-image-thumb.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * Inline preview for an image answer on the business side. Resolves a
+ * short-lived signed URL for the private onboarding-uploads bucket on mount;
+ * click opens the full-size image in a new tab.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, ImageIcon } from "@/components/ui/icons";
+import { getOnboardingUploadUrl } from "@/lib/actions/onboarding";
+
+export function AnswerImageThumb({ path, name, size = "md" }: {
+  path: string;
+  name?: string | null;
+  /** md = viewer (larger), sm = compact profile card */
+  size?: "sm" | "md";
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getOnboardingUploadUrl(path)
+      .then((u) => { if (alive) { if (u) setUrl(u); else setFailed(true); } })
+      .catch(() => { if (alive) setFailed(true); });
+    return () => { alive = false; };
+  }, [path]);
+
+  const box = size === "sm" ? "h-16 w-16" : "h-32 w-32";
+
+  if (failed) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+        <ImageIcon className="w-4 h-4" /> {name ?? "Image unavailable"}
+      </span>
+    );
+  }
+  if (!url) {
+    return (
+      <span className={`${box} rounded-lg border border-border bg-muted/40 inline-flex items-center justify-center`}>
+        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+      </span>
+    );
+  }
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" title={name ?? "Open full size"} className="inline-block">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url}
+        alt={name ?? "Uploaded image"}
+        className={`${box} rounded-lg border border-border object-cover hover:opacity-90 transition-opacity`}
+      />
+    </a>
+  );
+}

--- a/src/components/onboarding/customer-onboarding-card.tsx
+++ b/src/components/onboarding/customer-onboarding-card.tsx
@@ -19,6 +19,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { sendOnboardingRequest, type OnboardingRequestRow } from "@/lib/actions/onboarding";
+import { AnswerImageThumb } from "@/components/onboarding/answer-image-thumb";
 import { formatDate } from "@/lib/utils";
 import type { OnboardingForm, OnboardingResponse, OnboardingField } from "@/types/database";
 
@@ -151,6 +152,7 @@ function CompactValue({ field: f, value }: { field: OnboardingField; value: unkn
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const v = value as any;
   if (f.type === "secure" || v?.secure) return <span className="inline-flex items-center gap-1 text-muted-foreground"><Lock className="w-3 h-3" /> hidden</span>;
+  if (f.type === "image" && v?.path) return <AnswerImageThumb path={v.path} name={v.name} size="sm" />;
   if (f.type === "file" || f.type === "image") return <span>📎 {v?.name ?? "Uploaded"}</span>;
   if (f.type === "consent") return v === true ? <span className="inline-flex items-center gap-1 text-emerald-600"><Check className="w-3.5 h-3.5" /> Agreed</span> : <span>No</span>;
   if (f.type === "rating") return <span>{"★".repeat(Number(v) || 0)} ({String(v)}/5)</span>;

--- a/src/components/onboarding/response-viewer-client.tsx
+++ b/src/components/onboarding/response-viewer-client.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
 import { revealSecureAnswer, getOnboardingUploadUrl } from "@/lib/actions/onboarding";
 import { socialProfileUrl } from "@/lib/onboarding/presets";
+import { AnswerImageThumb } from "@/components/onboarding/answer-image-thumb";
 import { formatDate } from "@/lib/utils";
 import type { OnboardingResponse, OnboardingField } from "@/types/database";
 
@@ -80,8 +81,12 @@ function AnswerValue({ field: f, value, responseId }: { field: OnboardingField; 
     case "secure":
       return <SecureAnswer responseId={responseId} fieldId={f.id} />;
 
+    case "image": {
+      const meta = value as { path?: string; name?: string };
+      if (!meta?.path) return <p className="text-sm text-muted-foreground italic">Not answered</p>;
+      return <AnswerImageThumb path={meta.path} name={meta.name} size="md" />;
+    }
     case "file":
-    case "image":
       return <UploadAnswer value={value} />;
 
     case "multi_select":


### PR DESCRIPTION
## What
Image answers now render as actual previews instead of a filename row:

- **Customer portal (fill page)** — after uploading, the image shows inline (max-h 48, object-contain) with an ✕ remove button and the filename. Served via a new **token-gated** `GET /api/portal/[token]/onboarding/[id]/file?path=…` route that only exposes paths inside that request's own namespace (`businessId/requestId/…`).
- **Response viewer** — large clickable thumbnail (opens full size in a new tab) via a short-lived signed URL for the private bucket.
- **Customer profile → Onboarding tab** — compact 64px thumbnail in the inline answers grid.

Shared `AnswerImageThumb` component handles signed-URL resolution + loading/failure states. Non-image files keep the existing download row/button.

## Test plan
- [x] tsc / vitest / build green (file route present)
- [ ] Preview: upload an image on the portal → see preview, remove, re-upload; check viewer + profile thumbnails open full-size

🤖 Generated with [Claude Code](https://claude.com/claude-code)