### PR TITLE
feat(onboarding): View form (read-only preview)

### DIFF
--- a/src/app/(dashboard)/onboarding-forms/[id]/page.tsx
+++ b/src/app/(dashboard)/onboarding-forms/[id]/page.tsx
@@ -9,10 +9,10 @@ export const dynamic = "force-dynamic";
 
 export default async function OnboardingFormBuilderPage({ params, searchParams }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ response?: string }>;
+  searchParams: Promise<{ response?: string; view?: string }>;
 }) {
   const { id } = await params;
-  const { response: responseRequestId } = await searchParams;
+  const { response: responseRequestId, view } = await searchParams;
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/auth/login");
@@ -45,5 +45,5 @@ export default async function OnboardingFormBuilderPage({ params, searchParams }
   }
 
   const secureAvailable = await getSecureFieldsAvailable();
-  return <FormBuilderClient form={form} secureAvailable={secureAvailable} />;
+  return <FormBuilderClient form={form} secureAvailable={secureAvailable} startInPreview={view === "1"} />;
 }

--- a/src/components/onboarding/form-builder-client.tsx
+++ b/src/components/onboarding/form-builder-client.tsx
@@ -94,16 +94,16 @@ function newId() { return "f_" + Math.random().toString(36).slice(2, 10); }
 
 // ── Main builder ─────────────────────────────────────────────────────────────
 
-interface Props { form: OnboardingForm; secureAvailable: boolean }
+interface Props { form: OnboardingForm; secureAvailable: boolean; startInPreview?: boolean }
 
-export function FormBuilderClient({ form, secureAvailable }: Props) {
+export function FormBuilderClient({ form, secureAvailable, startInPreview = false }: Props) {
   const router = useRouter();
   const [name, setName] = useState(form.name);
   const [description, setDescription] = useState(form.description ?? "");
   const [status, setStatus] = useState(form.status);
   const [fields, setFields] = useState<OnboardingField[]>(form.schema ?? []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [preview, setPreview] = useState(false);
+  const [preview, setPreview] = useState(startInPreview);
   const [saving, setSaving] = useState(false);
 
   const selected = fields.find((f) => f.id === selectedId) ?? null;

--- a/src/components/onboarding/onboarding-forms-client.tsx
+++ b/src/components/onboarding/onboarding-forms-client.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
-import { Plus, ClipboardList, Send, Trash2, Copy, Loader2 } from "@/components/ui/icons";
+import { Plus, ClipboardList, Send, Trash2, Copy, Loader2, Eye } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -175,6 +175,9 @@ export function OnboardingFormsClient({ enabled, forms, requests, customers }: P
                     {f.schema.length} field{f.schema.length === 1 ? "" : "s"} · {f.completed_count}/{f.request_count} completed
                   </p>
                   <div className="flex items-center gap-2 pt-1">
+                    <Button size="sm" variant="outline" className="h-8" disabled={f.schema.length === 0} asChild>
+                      <Link href={`/onboarding-forms/${f.id}?view=1`}><Eye className="w-3.5 h-3.5 mr-1" /> View</Link>
+                    </Button>
                     <Button size="sm" variant="outline" className="h-8" asChild>
                       <Link href={`/onboarding-forms/${f.id}`}>Edit</Link>
                     </Button>


### PR DESCRIPTION
Adds a **View** button to each onboarding form card → opens the form in customer-facing Preview mode (`?view=1`), so you can see exactly what the customer gets without entering edit mode or sending it. Edit stays one click away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)