### PR TITLE
feat(forms): public form builder foundation (1/3)

### DIFF
--- a/src/lib/actions/forms.ts
+++ b/src/lib/actions/forms.ts
@@ -1,0 +1,183 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { slugifyFormName } from "@/lib/forms/slug";
+import type { PublicForm, PublicFormSubmission, OnboardingField } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+// ── Feature flag (plugin) ────────────────────────────────────────────────────
+
+export interface FormBuilderSettings { business_id: string; enabled: boolean }
+
+export async function getFormBuilderSettings(): Promise<FormBuilderSettings> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "form_builder_settings")
+    .select("business_id, enabled").eq("business_id", businessId).maybeSingle();
+  if (data) return data as FormBuilderSettings;
+  const { data: created, error } = await tbl(supabase, "form_builder_settings")
+    .insert({ business_id: businessId, enabled: false })
+    .select("business_id, enabled").single();
+  if (error) throw error;
+  return created as FormBuilderSettings;
+}
+
+export async function setFormBuilderEnabled(enabled: boolean): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "form_builder_settings")
+    .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  if (error) throw error;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (createAdminClient() as any).from("business_agent_installs").upsert(
+      { business_id: businessId, agent_id: "form-builder", enabled, updated_at: new Date().toISOString() },
+      { onConflict: "business_id,agent_id" },
+    );
+  } catch { /* non-fatal */ }
+  revalidatePath("/forms");
+  revalidatePath("/agents");
+  revalidatePath("/", "layout");
+}
+
+// ── Slug uniqueness ──────────────────────────────────────────────────────────
+
+/** Globally-unique slug — appends -2, -3… on collision. Uses the admin client
+ *  since slugs are unique across businesses. */
+async function uniqueSlug(base: string, excludeId?: string): Promise<string> {
+  const admin = createAdminClient();
+  const root = slugifyFormName(base);
+  for (let i = 0; i < 200; i++) {
+    const candidate = i === 0 ? root : `${root}-${i + 1}`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await (admin as any).from("public_forms").select("id").eq("slug", candidate).maybeSingle();
+    if (!data || data.id === excludeId) return candidate;
+  }
+  return `${root}-${Date.now().toString(36)}`;
+}
+
+// ── Forms CRUD ───────────────────────────────────────────────────────────────
+
+export async function getPublicForms(): Promise<(PublicForm & { submission_count: number })[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const [{ data: forms, error }, { data: subs }] = await Promise.all([
+    tbl(supabase, "public_forms").select("*").eq("business_id", businessId).order("created_at", { ascending: false }),
+    tbl(supabase, "public_form_submissions").select("form_id").eq("business_id", businessId),
+  ]);
+  if (error) throw error;
+  const counts = new Map<string, number>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (subs ?? []).forEach((s: any) => counts.set(s.form_id, (counts.get(s.form_id) ?? 0) + 1));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (forms ?? []).map((f: any) => ({ ...f, submission_count: counts.get(f.id) ?? 0 }));
+}
+
+export async function getPublicForm(id: string): Promise<PublicForm> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data, error } = await tbl(supabase, "public_forms")
+    .select("*").eq("id", id).eq("business_id", businessId).single();
+  if (error) throw error;
+  return data as PublicForm;
+}
+
+export async function createPublicForm(input: { name: string; description?: string | null }): Promise<PublicForm> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!input.name?.trim()) throw new Error("Form name is required");
+  const slug = await uniqueSlug(input.name);
+  const { data, error } = await tbl(supabase, "public_forms").insert({
+    business_id: businessId, name: input.name.trim(), description: input.description?.trim() || null,
+    slug, schema: [], status: "draft",
+    settings: { submit_text: "Submit", create_lead: true },
+    theme: { show_branding: true },
+  }).select().single();
+  if (error) throw error;
+  revalidatePath("/forms");
+  return data as PublicForm;
+}
+
+export async function updatePublicForm(id: string, updates: {
+  name?: string; description?: string | null; status?: "draft" | "published" | "archived";
+  slug?: string;
+  schema?: OnboardingField[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  settings?: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  theme?: Record<string, any>;
+}): Promise<{ slug?: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const clean: Record<string, any> = Object.fromEntries(Object.entries(updates).filter(([, v]) => v !== undefined));
+  if (clean.slug !== undefined) clean.slug = await uniqueSlug(clean.slug || updates.name || "form", id);
+  if (Object.keys(clean).length === 0) return {};
+
+  const { error } = await tbl(supabase, "public_forms").update(clean).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/forms");
+  revalidatePath(`/forms/${id}`);
+  return { slug: clean.slug };
+}
+
+export async function deletePublicForm(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "public_forms").delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/forms");
+}
+
+// ── Submissions ──────────────────────────────────────────────────────────────
+
+export interface SubmissionRow extends PublicFormSubmission {
+  leads?: { id: string; name: string } | null;
+}
+
+export async function getFormSubmissions(formId: string): Promise<SubmissionRow[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data, error } = await tbl(supabase, "public_form_submissions")
+    .select("*, leads(id, name)")
+    .eq("business_id", businessId).eq("form_id", formId)
+    .order("created_at", { ascending: false }).limit(500);
+  if (error) throw error;
+  return (data ?? []) as SubmissionRow[];
+}
+
+export async function deleteFormSubmission(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "public_form_submissions").delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+}
+
+/** Signed URL for a submission's uploaded file/image (private bucket). */
+export async function getFormUploadUrl(path: string): Promise<string | null> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!path.startsWith(`${businessId}/`)) throw new Error("Not found");
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any).storage.from("public-form-uploads").createSignedUrl(path, 3600);
+  if (error) throw error;
+  return data?.signedUrl ?? null;
+}

--- a/src/lib/forms/slug.ts
+++ b/src/lib/forms/slug.ts
@@ -1,0 +1,10 @@
+/** Slugify a form name for its public URL (/f/<slug>). Plain module. */
+export function slugifyFormName(name: string): string {
+  const base = (name || "form")
+    .toLowerCase()
+    .normalize("NFKD").replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return base || "form";
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1415,6 +1415,116 @@ export function registerTools(server: McpServer): void {
       return text(out);
     });
 
+  // ===== PUBLIC FORM BUILDER (feature-flagged, lead-capture / embeddable) =====
+  const FORM_FIELD = z.object({
+    id: z.string().min(1),
+    type: z.enum([
+      "short_text", "long_text", "instructions", "email", "phone", "url", "address",
+      "abn", "company", "dropdown", "multi_select", "radio", "checkboxes", "yes_no",
+      "number", "currency", "date", "time", "opening_hours", "file", "image",
+      "rating", "consent", "heading", "divider",
+    ]),
+    label: z.string(),
+    help_text: z.string().optional(),
+    placeholder: z.string().optional(),
+    required: z.boolean().optional(),
+    options: z.array(z.string()).optional(),
+    preset: z.string().optional(),
+    validation: z.object({ pattern: z.string(), message: z.string() }).optional(),
+    show_if: z.object({ field_id: z.string(), equals: z.string() }).nullable().optional(),
+  });
+
+  tool("set_form_builder_enabled", "Enable or disable the Public Form Builder plugin for this business.",
+    { enabled: z.boolean() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:write");
+      const { error } = await t(ctx, "form_builder_settings")
+        .upsert({ business_id: ctx.businessId, enabled: args.enabled }, { onConflict: "business_id" });
+      if (error) throw error;
+      return text({ enabled: args.enabled });
+    });
+
+  tool("list_public_forms", "List public/embeddable forms with their status and public URL slug.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:read");
+      const { data, error } = await t(ctx, "public_forms")
+        .select("id, name, slug, status, created_at").eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return text((data ?? []).map((f: any) => ({ ...f, public_url: `${appBase()}/f/${f.slug}`, embed_url: `${appBase()}/embed/${f.slug}` })));
+    });
+
+  tool("get_public_form", "Get one public form including its full field schema and settings.",
+    { form_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:read");
+      const { data } = await t(ctx, "public_forms").select("*").eq("id", args.form_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!data) return errorText("Form not found");
+      return text({ ...data, public_url: `${appBase()}/f/${data.slug}`, embed_url: `${appBase()}/embed/${data.slug}` });
+    });
+
+  tool("create_public_form",
+    "Create a public/embeddable form (draft). fields is an ordered array (same field model as onboarding, minus secure). Set activate:true to publish immediately. create_lead (default true) makes each submission a lead in the sales pipeline.",
+    { name: z.string().min(1), description: z.string().optional(), fields: z.array(FORM_FIELD).optional(), activate: z.boolean().optional(), create_lead: z.boolean().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:write");
+      const base = args.name.toLowerCase().normalize("NFKD").replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 48) || "form";
+      let slug = base;
+      for (let i = 1; i < 200; i++) {
+        const { data: hit } = await t(ctx, "public_forms").select("id").eq("slug", slug).maybeSingle();
+        if (!hit) break;
+        slug = `${base}-${i + 1}`;
+      }
+      const { data, error } = await t(ctx, "public_forms").insert({
+        business_id: ctx.businessId, name: args.name, description: args.description ?? null, slug,
+        schema: args.fields ?? [], status: args.activate ? "published" : "draft",
+        settings: { submit_text: "Submit", create_lead: args.create_lead ?? true },
+        theme: { show_branding: true },
+      }).select("id, name, slug, status").single();
+      if (error) throw error;
+      return text({ created: true, form: data, public_url: `${appBase()}/f/${slug}`, embed_url: `${appBase()}/embed/${slug}` });
+    });
+
+  tool("update_public_form", "Update a public form's name/description/status/fields.",
+    {
+      form_id: UUID, name: z.string().optional(), description: z.string().optional(),
+      status: z.enum(["draft", "published", "archived"]).optional(),
+      fields: z.array(FORM_FIELD).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:write");
+      const { form_id, fields, ...rest } = args;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clean: Record<string, any> = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (fields !== undefined) clean.schema = fields;
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "public_forms").update(clean).eq("id", form_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("delete_public_form", "Delete a public form and all its submissions.",
+    { form_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:write");
+      const { error } = await t(ctx, "public_forms").delete().eq("id", args.form_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("list_form_submissions", "List submissions to a public form (newest first).",
+    { form_id: UUID, limit: z.number().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "forms:read");
+      const { data, error } = await t(ctx, "public_form_submissions")
+        .select("id, answers, lead_id, created_at, leads(name)")
+        .eq("business_id", ctx.businessId).eq("form_id", args.form_id)
+        .order("created_at", { ascending: false }).limit(args.limit ?? 100);
+      if (error) throw error;
+      return text(data);
+    });
+
   // ===== CLIENT ONBOARDING (feature-flagged form builder) =====
   const ONBOARDING_FIELD = z.object({
     id: z.string().min(1),

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -504,6 +504,51 @@ export interface OnboardingResponse {
   updated_at: string;
 }
 
+// ── Public form builder (lead-capture / embeddable forms, feature-flagged) ──
+
+export type PublicFormStatus = 'draft' | 'published' | 'archived';
+
+export interface PublicFormSettings {
+  submit_text?: string;
+  thank_you_message?: string;
+  redirect_url?: string | null;
+  /** Create a lead in the sales pipeline on submit. */
+  create_lead?: boolean;
+  /** Which field ids map onto lead name / email / phone. */
+  lead_map?: { name?: string; email?: string; phone?: string };
+  /** Email addresses notified on each submission. */
+  notify_emails?: string[];
+}
+
+export interface PublicFormTheme {
+  accent?: string;          // hex
+  show_branding?: boolean;  // "Powered by Kirei"
+}
+
+export interface PublicForm {
+  id: string;
+  business_id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  status: PublicFormStatus;
+  schema: OnboardingField[];   // reuses the onboarding field model
+  settings: PublicFormSettings;
+  theme: PublicFormTheme;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PublicFormSubmission {
+  id: string;
+  business_id: string;
+  form_id: string;
+  answers: OnboardingAnswers;
+  lead_id: string | null;
+  meta: { ip?: string | null; user_agent?: string | null; referrer?: string | null };
+  created_at: string;
+}
+
 export interface CustomerPortalToken {
   token: string;
   business_id: string;
@@ -1051,6 +1096,8 @@ export type ApiScope =
   | 'contracts:write'
   | 'onboarding:read'
   | 'onboarding:write'
+  | 'forms:read'
+  | 'forms:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1079,6 +1126,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'contracts:write',  label: 'Create / send contracts', group: 'Contracts' },
   { value: 'onboarding:read',  label: 'Read onboarding forms & responses (secure fields redacted)', group: 'Onboarding' },
   { value: 'onboarding:write', label: 'Create / send onboarding forms', group: 'Onboarding' },
+  { value: 'forms:read',       label: 'Read public forms & submissions', group: 'Forms' },
+  { value: 'forms:write',      label: 'Create / publish public forms', group: 'Forms' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260624140000_form_builder.sql
+++ b/supabase/migrations/20260624140000_form_builder.sql
@@ -1,0 +1,94 @@
+-- Public Form Builder — a per-business "plugin" (enable/disable like onboarding).
+-- Businesses design public/embeddable forms (lead capture, contact, surveys),
+-- share them via a public URL (/f/[slug]) or an iframe embed (/embed/[slug]),
+-- and each submission can optionally create a lead in the sales pipeline.
+--
+-- Reuses the onboarding field model (OnboardingField[] in the schema JSONB).
+-- No secure/credential fields on public forms (excluded in the builder).
+
+CREATE TABLE IF NOT EXISTS public.form_builder_settings (
+  business_id UUID PRIMARY KEY REFERENCES public.businesses(id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.public_forms (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  slug        TEXT NOT NULL UNIQUE,              -- public URL key (globally unique)
+  description TEXT,
+  status      TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','published','archived')),
+  schema      JSONB NOT NULL DEFAULT '[]'::jsonb,   -- ordered field list (OnboardingField[])
+  -- settings: submit_text, thank_you_message, redirect_url, create_lead (bool),
+  --           lead_map {name,email,phone -> field id}, notify_emails []
+  settings    JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- theme: accent (hex), show_branding (bool)
+  theme       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_public_forms_business ON public.public_forms (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_public_forms_slug ON public.public_forms (slug);
+
+CREATE TABLE IF NOT EXISTS public.public_form_submissions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  form_id     UUID NOT NULL REFERENCES public.public_forms(id) ON DELETE CASCADE,
+  answers     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  lead_id     UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  meta        JSONB NOT NULL DEFAULT '{}'::jsonb,   -- ip, user_agent, referrer
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_public_form_submissions_business ON public.public_form_submissions (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_public_form_submissions_form ON public.public_form_submissions (form_id, created_at DESC);
+
+ALTER TABLE public.form_builder_settings     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.public_forms              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.public_form_submissions   ENABLE ROW LEVEL SECURITY;
+
+-- Read: members except workers. Write: owner / admin / editor.
+-- Public render + submit go through the service-role client (slug-gated), so
+-- there are no anon policies here.
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['form_builder_settings','public_forms','public_form_submissions'] LOOP
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, t);
+  END LOOP;
+END $$;
+
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['form_builder_settings','public_forms'] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %1$s_updated_at ON public.%1$s;
+      CREATE TRIGGER %1$s_updated_at BEFORE UPDATE ON public.%1$s
+      FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();', t);
+  END LOOP;
+END $$;
+
+-- Private bucket for public-form file/image uploads (served via signed URLs).
+INSERT INTO storage.buckets (id, name, public) VALUES ('public-form-uploads', 'public-form-uploads', false)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## What
Phase 1 of the **Public Form Builder** plugin — data layer, server actions, MCP. No UI yet (builder = PR2, public pages + submit + lead creation = PR3).

Public/embeddable lead-capture forms (Typeform / GoHighLevel style), **reusing the onboarding field engine** (25 types, presets, validation) minus secure fields.

### Model
- `form_builder_settings` — per-business enable flag (plugin)
- `public_forms` — name, **globally-unique slug** (public URL), status, schema, `settings` (submit text, thank-you, redirect, **create_lead** default on, lead field-mapping, notify emails), theme
- `public_form_submissions` — answers, optional `lead_id`, meta (ip/ua/referrer)
- private `public-form-uploads` bucket; standard RLS

### MCP (scopes `forms:read`/`forms:write`)
`set_form_builder_enabled`, `list/get/create/update/delete_public_form`, `list_form_submissions` — list/get return `public_url` (`/f/slug`) + `embed_url` (`/embed/slug`). AI can build a whole lead form from a prompt.

## DB
Migration `20260624140000_form_builder.sql` applied + recorded on remote (additive).

## Next
PR2 builder UI + settings + submissions + embed/share panel + agents-store plugin; PR3 public `/f/[slug]` + `/embed/[slug]` + submit API + lead creation + notifications.

## Test plan
- [x] tsc / vitest / build green
🤖 Generated with [Claude Code](https://claude.com/claude-code)