### PR TITLE
feat(forms): builder UI + plugin + submissions + embed (2/3)

### DIFF
--- a/src/app/(dashboard)/forms/[id]/page.tsx
+++ b/src/app/(dashboard)/forms/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getPublicForm, getFormSubmissions } from "@/lib/actions/forms";
+import { appUrl } from "@/lib/app-url";
+import { FormsBuilderClient } from "@/components/forms/forms-builder-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function FormBuilderPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  let form;
+  try { form = await getPublicForm(id); } catch { notFound(); }
+  if (!form) notFound();
+  const submissions = await getFormSubmissions(id).catch(() => []);
+
+  return <FormsBuilderClient form={form} submissions={submissions} baseUrl={appUrl()} />;
+}

--- a/src/app/(dashboard)/forms/page.tsx
+++ b/src/app/(dashboard)/forms/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getFormBuilderSettings, getPublicForms } from "@/lib/actions/forms";
+import { appUrl } from "@/lib/app-url";
+import { FormsListClient } from "@/components/forms/forms-list-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function FormsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const settings = await getFormBuilderSettings();
+  if (!settings.enabled) {
+    return <FormsListClient enabled={false} forms={[]} baseUrl={appUrl()} />;
+  }
+  const forms = await getPublicForms();
+  return <FormsListClient enabled forms={forms} baseUrl={appUrl()} />;
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -61,13 +61,15 @@ export default async function DashboardLayout({ children }: { children: React.Re
   }
 
   // Feature flags — kept cheap (parallel single lookups). Used to gate sidebar items.
-  const [{ data: quotingSettings }, { data: onboardingSettings }] = await Promise.all([
+  const [{ data: quotingSettings }, { data: onboardingSettings }, { data: formBuilderSettings }] = await Promise.all([
     sb.from("quoting_agent_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
     sb.from("onboarding_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
+    sb.from("form_builder_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
   ]);
   const features = {
     quotingAgent: !!quotingSettings?.enabled,
     onboarding: !!onboardingSettings?.enabled,
+    formBuilder: !!formBuilderSettings?.enabled,
   };
 
   return (

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import {
   Bot, MailSearch, PlugZap, BellRing, Send,
   Settings, Trash2, Plus,
-  Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList,
+  Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -52,6 +52,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   "check-circle": CheckCircle,
   star: Star,
   "clipboard-list": ClipboardList,
+  "list-checks": ListChecks,
 };
 
 function AgentIcon({ name, className }: { name: string; className?: string }) {

--- a/src/components/forms/form-field-preview.tsx
+++ b/src/components/forms/form-field-preview.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { OnboardingField } from "@/types/database";
+
+/** Non-interactive render of a field for builder preview (public form + reuse). */
+export function FormFieldPreview({ field: f }: { field: OnboardingField }) {
+  if (f.type === "divider") return <hr className="border-border" />;
+  if (f.type === "heading") return <h3 className="text-base font-semibold pt-2">{f.label}</h3>;
+  if (f.type === "instructions") return <p className="text-sm text-muted-foreground bg-muted/40 rounded-md p-3">{f.label}</p>;
+
+  const label = f.type !== "consent" && (
+    <Label className="text-sm">{f.label}{f.required && <span className="text-rose-500 ml-0.5">*</span>}</Label>
+  );
+  const help = f.help_text && <p className="text-xs text-muted-foreground">{f.help_text}</p>;
+
+  const control = (() => {
+    switch (f.type) {
+      case "long_text": case "address": return <Textarea rows={3} disabled placeholder={f.placeholder} />;
+      case "dropdown": case "radio":
+        return <Select disabled><SelectTrigger><SelectValue placeholder={f.options?.[0] ?? "Choose…"} /></SelectTrigger><SelectContent /></Select>;
+      case "multi_select": case "checkboxes":
+        return <div className="space-y-1.5">{(f.options ?? []).map((o) => <label key={o} className="flex items-center gap-2 text-sm text-muted-foreground"><input type="checkbox" disabled /> {o}</label>)}</div>;
+      case "yes_no": return <div className="flex gap-2"><Button size="sm" variant="outline" disabled>Yes</Button><Button size="sm" variant="outline" disabled>No</Button></div>;
+      case "image": case "file": return <div className="text-xs text-muted-foreground border border-dashed border-border rounded-md p-6 text-center">{f.type === "image" ? "Image upload" : "File upload"}</div>;
+      case "rating": return <div className="text-lg tracking-widest text-muted-foreground">☆ ☆ ☆ ☆ ☆</div>;
+      case "consent": return <label className="flex items-start gap-2 text-sm text-muted-foreground"><input type="checkbox" disabled className="mt-0.5" /> {f.label}</label>;
+      case "date": return <Input type="date" disabled />;
+      case "time": return <Input type="time" disabled />;
+      case "number": case "currency": return <Input type="number" disabled placeholder={f.placeholder ?? (f.type === "currency" ? "0.00" : "")} />;
+      default: return <Input disabled placeholder={f.placeholder} />;
+    }
+  })();
+
+  return <div className="space-y-1.5">{label}{help}{control}</div>;
+}

--- a/src/components/forms/forms-builder-client.tsx
+++ b/src/components/forms/forms-builder-client.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+/**
+ * Public form builder — Build / Settings / Submissions tabs. Reuses the
+ * onboarding field model + presets (minus secure fields). Publishes a public
+ * page at /f/[slug] and an iframe embed at /embed/[slug].
+ */
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Reorder } from "framer-motion";
+import { toast } from "sonner";
+import {
+  ArrowLeft, Plus, Trash2, Save, Loader2, Eye, Pencil, GripVertical, Copy, ExternalLink, CodeIcon,
+} from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { updatePublicForm, deleteFormSubmission, type SubmissionRow } from "@/lib/actions/forms";
+import { PRESET_LIBRARY, PRESET_GROUPS, fieldFromPreset } from "@/lib/onboarding/presets";
+import { embedSnippet } from "@/lib/forms/embed";
+import { FormFieldPreview } from "@/components/forms/form-field-preview";
+import { formatDate } from "@/lib/utils";
+import type { PublicForm, OnboardingField, OnboardingFieldType, PublicFormSettings } from "@/types/database";
+
+// Field palette — same model as onboarding, minus secure (public form).
+const PALETTE: { group: string; fields: { type: OnboardingFieldType; label: string; hasOptions?: boolean; hasPlaceholder?: boolean; displayOnly?: boolean; defaultLabel: string }[] }[] = [
+  { group: "Text", fields: [
+    { type: "short_text", label: "Short text", defaultLabel: "Short answer", hasPlaceholder: true },
+    { type: "long_text", label: "Long text", defaultLabel: "Message", hasPlaceholder: true },
+    { type: "instructions", label: "Instructions", defaultLabel: "Read this", displayOnly: true },
+  ]},
+  { group: "Contact", fields: [
+    { type: "email", label: "Email", defaultLabel: "Email", hasPlaceholder: true },
+    { type: "phone", label: "Phone", defaultLabel: "Phone", hasPlaceholder: true },
+    { type: "url", label: "Website", defaultLabel: "Website", hasPlaceholder: true },
+    { type: "address", label: "Address", defaultLabel: "Address", hasPlaceholder: true },
+  ]},
+  { group: "Choices", fields: [
+    { type: "dropdown", label: "Dropdown", defaultLabel: "Pick one", hasOptions: true },
+    { type: "radio", label: "Radio", defaultLabel: "Pick one", hasOptions: true },
+    { type: "multi_select", label: "Multi-select", defaultLabel: "Pick any", hasOptions: true },
+    { type: "checkboxes", label: "Checkboxes", defaultLabel: "Pick any", hasOptions: true },
+    { type: "yes_no", label: "Yes / No", defaultLabel: "Yes or no?" },
+  ]},
+  { group: "Numbers & dates", fields: [
+    { type: "number", label: "Number", defaultLabel: "Number" },
+    { type: "currency", label: "Currency", defaultLabel: "Amount" },
+    { type: "date", label: "Date", defaultLabel: "Date" },
+    { type: "time", label: "Time", defaultLabel: "Time" },
+  ]},
+  { group: "Uploads", fields: [
+    { type: "image", label: "Image upload", defaultLabel: "Upload an image" },
+    { type: "file", label: "File upload", defaultLabel: "Upload a file" },
+  ]},
+  { group: "Extras", fields: [
+    { type: "rating", label: "Rating", defaultLabel: "Rate us" },
+    { type: "consent", label: "Consent tick", defaultLabel: "I agree" },
+    { type: "heading", label: "Heading", defaultLabel: "Section", displayOnly: true },
+    { type: "divider", label: "Divider", defaultLabel: "", displayOnly: true },
+  ]},
+];
+const DEF_BY_TYPE = Object.fromEntries(PALETTE.flatMap((g) => g.fields).map((f) => [f.type, f]));
+const newId = () => "f_" + Math.random().toString(36).slice(2, 10);
+const CHOICE_TYPES = new Set(["dropdown", "radio", "multi_select", "checkboxes", "yes_no"]);
+// Presets safe for public forms (drop secure ones).
+const PUBLIC_PRESETS = PRESET_LIBRARY.filter((p) => p.type !== "secure");
+const PUBLIC_PRESET_GROUPS = PRESET_GROUPS.filter((g) => PUBLIC_PRESETS.some((p) => p.group === g));
+
+interface Props { form: PublicForm; submissions: SubmissionRow[]; baseUrl: string }
+
+export function FormsBuilderClient({ form, submissions, baseUrl }: Props) {
+  const router = useRouter();
+  const [name, setName] = useState(form.name);
+  const [description, setDescription] = useState(form.description ?? "");
+  const [status, setStatus] = useState(form.status);
+  const [fields, setFields] = useState<OnboardingField[]>(form.schema ?? []);
+  const [settings, setSettings] = useState<PublicFormSettings>(form.settings ?? {});
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [preview, setPreview] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const selected = fields.find((f) => f.id === selectedId) ?? null;
+  const publicUrl = `${baseUrl}/f/${form.slug}`;
+  const dirty = useMemo(() =>
+    name !== form.name || description !== (form.description ?? "") || status !== form.status ||
+    JSON.stringify(fields) !== JSON.stringify(form.schema ?? []) ||
+    JSON.stringify(settings) !== JSON.stringify(form.settings ?? {}),
+  [name, description, status, fields, settings, form]);
+
+  const addField = (def: { type: OnboardingFieldType; defaultLabel: string; hasOptions?: boolean }) => {
+    const f: OnboardingField = { id: newId(), type: def.type, label: def.defaultLabel, ...(def.hasOptions ? { options: ["Option 1", "Option 2"] } : {}) };
+    setFields((p) => [...p, f]); setSelectedId(f.id); setPreview(false);
+  };
+  const addPreset = (key: string) => {
+    const p = PUBLIC_PRESETS.find((x) => x.key === key); if (!p) return;
+    const f = fieldFromPreset(p, newId());
+    setFields((prev) => [...prev, f]); setSelectedId(f.id); setPreview(false);
+  };
+  const patchField = (id: string, patch: Partial<OnboardingField>) => setFields((p) => p.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+  const removeField = (id: string) => {
+    setFields((p) => p.filter((f) => f.id !== id).map((f) => (f.show_if?.field_id === id ? { ...f, show_if: null } : f)));
+    if (selectedId === id) setSelectedId(null);
+  };
+  const setSetting = (patch: Partial<PublicFormSettings>) => setSettings((s) => ({ ...s, ...patch }));
+
+  const save = async () => {
+    if (!name.trim()) return toast.error("The form needs a name");
+    setSaving(true);
+    try {
+      await updatePublicForm(form.id, { name: name.trim(), description: description.trim() || null, status, schema: fields, settings });
+      toast.success("Saved"); router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't save"); }
+    finally { setSaving(false); }
+  };
+
+  const copy = (t: string, m: string) => navigator.clipboard.writeText(t).then(() => toast.success(m), () => toast.error("Copy failed"));
+  const conditionSources = (target: OnboardingField) => {
+    const idx = fields.findIndex((f) => f.id === target.id);
+    return fields.slice(0, idx).filter((f) => CHOICE_TYPES.has(f.type));
+  };
+  // Fields eligible for lead mapping (email/phone/text-ish).
+  const mappable = fields.filter((f) => !["heading", "divider", "instructions"].includes(f.type));
+
+  return (
+    <div>
+      <Link href="/forms" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-4">
+        <ArrowLeft className="w-4 h-4" /> Forms
+      </Link>
+
+      <div className="flex items-end justify-between gap-3 flex-wrap mb-4">
+        <div className="min-w-0 flex-1 max-w-lg space-y-1">
+          <Input value={name} onChange={(e) => setName(e.target.value)} className="text-lg font-semibold h-10" placeholder="Form name" />
+          <Input value={description} onChange={(e) => setDescription(e.target.value)} className="h-8 text-sm" placeholder="Description (optional)" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={status} onValueChange={(v) => setStatus(v as typeof status)}>
+            <SelectTrigger className="w-[130px] h-9"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="draft">Draft</SelectItem>
+              <SelectItem value="published">Published</SelectItem>
+              <SelectItem value="archived">Archived</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button onClick={save} disabled={saving || !dirty}>
+            {saving ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : <Save className="w-4 h-4 mr-1.5" />} Save
+          </Button>
+        </div>
+      </div>
+
+      {/* Share bar (published only) */}
+      {status === "published" && (
+        <Card className="mb-4"><CardContent className="p-3 flex items-center gap-2 flex-wrap text-sm">
+          <code className="text-xs bg-muted px-2 py-1 rounded truncate max-w-[280px]">{publicUrl}</code>
+          <Button size="sm" variant="outline" className="h-8" onClick={() => copy(publicUrl, "Public link copied")}><Copy className="w-3.5 h-3.5 mr-1" /> Copy link</Button>
+          <Button size="sm" variant="outline" className="h-8" onClick={() => copy(embedSnippet(baseUrl, form.slug), "Embed code copied")}><CodeIcon className="w-3.5 h-3.5 mr-1" /> Copy embed</Button>
+          <a href={publicUrl} target="_blank" rel="noopener noreferrer" className="ml-auto text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"><ExternalLink className="w-3.5 h-3.5" /> Open</a>
+        </CardContent></Card>
+      )}
+
+      <Tabs defaultValue="build">
+        <TabsList>
+          <TabsTrigger value="build">Build</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+          <TabsTrigger value="submissions">Submissions ({submissions.length})</TabsTrigger>
+        </TabsList>
+
+        {/* ── BUILD ── */}
+        <TabsContent value="build" className="mt-4">
+          <div className="flex justify-end mb-3">
+            <Button variant="outline" size="sm" onClick={() => setPreview((v) => !v)}>
+              {preview ? <Pencil className="w-4 h-4 mr-1.5" /> : <Eye className="w-4 h-4 mr-1.5" />}{preview ? "Edit" : "Preview"}
+            </Button>
+          </div>
+          {preview ? (
+            <div className="max-w-xl mx-auto">
+              <Card><CardContent className="p-6 space-y-5">
+                <div><h2 className="text-xl font-bold">{name}</h2>{description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}</div>
+                {fields.map((f) => <FormFieldPreview key={f.id} field={f} />)}
+                <Button disabled className="w-full">{settings.submit_text || "Submit"}</Button>
+              </CardContent></Card>
+            </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-[220px_1fr_300px]">
+              {/* Palette */}
+              <Card className="h-fit lg:sticky lg:top-4"><CardContent className="p-3 space-y-3 max-h-[75vh] overflow-y-auto">
+                <div>
+                  <p className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground px-1 mb-1">Ready-made</p>
+                  <Select value="" onValueChange={addPreset}>
+                    <SelectTrigger className="h-8 text-xs"><SelectValue placeholder="Add a preset…" /></SelectTrigger>
+                    <SelectContent className="max-h-[320px]">
+                      {PUBLIC_PRESET_GROUPS.map((g) => (
+                        <div key={g}>
+                          <p className="px-2 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{g}</p>
+                          {PUBLIC_PRESETS.filter((p) => p.group === g).map((p) => <SelectItem key={p.key} value={p.key} className="text-xs">{p.label}</SelectItem>)}
+                        </div>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {PALETTE.map((group) => (
+                  <div key={group.group}>
+                    <p className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground px-1 mb-1">{group.group}</p>
+                    <div className="grid gap-1">
+                      {group.fields.map((def) => (
+                        <button key={def.type} onClick={() => addField(def)}
+                          className="flex items-center gap-1.5 text-left text-xs px-2 py-1.5 rounded-md border border-border hover:border-primary/50 hover:bg-muted/50 transition-colors">
+                          <Plus className="w-3 h-3 text-muted-foreground shrink-0" /><span className="flex-1">{def.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </CardContent></Card>
+
+              {/* Canvas */}
+              <div>
+                {fields.length === 0 ? (
+                  <Card><CardContent className="py-16 text-center text-muted-foreground text-sm">Add fields from the palette — drag to reorder, click to edit.</CardContent></Card>
+                ) : (
+                  <Reorder.Group axis="y" values={fields} onReorder={setFields} className="space-y-2">
+                    {fields.map((f) => (
+                      <Reorder.Item key={f.id} value={f}>
+                        <div onClick={() => setSelectedId(f.id)}
+                          className={`flex items-center gap-2 rounded-lg border bg-card px-3 py-2.5 cursor-pointer transition-colors ${selectedId === f.id ? "border-primary ring-1 ring-primary/30" : "border-border hover:border-primary/40"}`}>
+                          <GripVertical className="w-4 h-4 text-muted-foreground/50 cursor-grab shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium break-words">
+                              {f.type === "divider" ? <span className="text-muted-foreground">— divider —</span> : f.label || <span className="text-muted-foreground italic">Untitled</span>}
+                              {f.required && <span className="text-rose-500 ml-0.5">*</span>}
+                            </p>
+                            {f.show_if?.field_id && <p className="text-[11px] text-muted-foreground">conditional</p>}
+                          </div>
+                          <Badge variant="outline" className="text-[10px] shrink-0">{DEF_BY_TYPE[f.type]?.label ?? f.type}</Badge>
+                          <button onClick={(e) => { e.stopPropagation(); removeField(f.id); }} className="text-muted-foreground hover:text-destructive shrink-0"><Trash2 className="w-3.5 h-3.5" /></button>
+                        </div>
+                      </Reorder.Item>
+                    ))}
+                  </Reorder.Group>
+                )}
+              </div>
+
+              {/* Field settings */}
+              <Card className="h-fit lg:sticky lg:top-4"><CardContent className="p-4 space-y-3">
+                {!selected ? <p className="text-sm text-muted-foreground py-6 text-center">Select a field to edit</p> : (
+                  <>
+                    <Badge variant="outline" className="text-[10px]">{DEF_BY_TYPE[selected.type]?.label ?? selected.type}</Badge>
+                    {selected.type !== "divider" && (
+                      <div className="space-y-1"><Label className="text-xs">Label</Label>
+                        <Input value={selected.label} onChange={(e) => patchField(selected.id, { label: e.target.value })} /></div>
+                    )}
+                    {!DEF_BY_TYPE[selected.type]?.displayOnly && (
+                      <>
+                        <div className="space-y-1"><Label className="text-xs">Help text</Label>
+                          <Input value={selected.help_text ?? ""} onChange={(e) => patchField(selected.id, { help_text: e.target.value || undefined })} /></div>
+                        {DEF_BY_TYPE[selected.type]?.hasPlaceholder && (
+                          <div className="space-y-1"><Label className="text-xs">Placeholder</Label>
+                            <Input value={selected.placeholder ?? ""} onChange={(e) => patchField(selected.id, { placeholder: e.target.value || undefined })} /></div>
+                        )}
+                        {DEF_BY_TYPE[selected.type]?.hasOptions && (
+                          <div className="space-y-1"><Label className="text-xs">Options (one per line)</Label>
+                            <Textarea rows={4} value={(selected.options ?? []).join("\n")} onChange={(e) => patchField(selected.id, { options: e.target.value.split("\n").map((s) => s.trim()).filter(Boolean) })} /></div>
+                        )}
+                        <div className="flex items-center justify-between pt-1"><Label className="text-xs">Required</Label>
+                          <Switch checked={!!selected.required} onCheckedChange={(v) => patchField(selected.id, { required: v })} /></div>
+                        {conditionSources(selected).length > 0 && (
+                          <div className="space-y-2 border-t pt-3">
+                            <Label className="text-xs">Show only when…</Label>
+                            <Select value={selected.show_if?.field_id ?? "__always__"}
+                              onValueChange={(v) => patchField(selected.id, { show_if: v === "__always__" ? null : { field_id: v, equals: selected.show_if?.equals ?? "" } })}>
+                              <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="__always__">Always shown</SelectItem>
+                                {conditionSources(selected).map((s) => <SelectItem key={s.id} value={s.id}>{s.label || s.id}</SelectItem>)}
+                              </SelectContent>
+                            </Select>
+                            {selected.show_if?.field_id && (() => {
+                              const src = fields.find((f) => f.id === selected.show_if!.field_id);
+                              const opts = src?.type === "yes_no" ? ["Yes", "No"] : (src?.options ?? []);
+                              return (
+                                <Select value={selected.show_if.equals || "__pick__"} onValueChange={(v) => patchField(selected.id, { show_if: { field_id: selected.show_if!.field_id, equals: v } })}>
+                                  <SelectTrigger className="h-8 text-xs"><SelectValue placeholder="equals…" /></SelectTrigger>
+                                  <SelectContent>{opts.map((o) => <SelectItem key={o} value={o}>= {o}</SelectItem>)}</SelectContent>
+                                </Select>
+                              );
+                            })()}
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </>
+                )}
+              </CardContent></Card>
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── SETTINGS ── */}
+        <TabsContent value="settings" className="mt-4">
+          <div className="max-w-xl space-y-4">
+            <Card><CardContent className="p-5 space-y-4">
+              <p className="font-semibold text-sm">After submit</p>
+              <div className="space-y-1"><Label className="text-xs">Submit button text</Label>
+                <Input value={settings.submit_text ?? ""} placeholder="Submit" onChange={(e) => setSetting({ submit_text: e.target.value })} /></div>
+              <div className="space-y-1"><Label className="text-xs">Thank-you message</Label>
+                <Textarea rows={2} value={settings.thank_you_message ?? ""} placeholder="Thanks — we'll be in touch shortly." onChange={(e) => setSetting({ thank_you_message: e.target.value })} /></div>
+              <div className="space-y-1"><Label className="text-xs">Or redirect to a URL (optional)</Label>
+                <Input value={settings.redirect_url ?? ""} placeholder="https://yoursite.com/thank-you" onChange={(e) => setSetting({ redirect_url: e.target.value || null })} /></div>
+            </CardContent></Card>
+
+            <Card><CardContent className="p-5 space-y-4">
+              <div className="flex items-center justify-between">
+                <div><p className="font-semibold text-sm">Create a lead on submit</p>
+                  <p className="text-xs text-muted-foreground">Pushes each submission into your sales pipeline.</p></div>
+                <Switch checked={settings.create_lead ?? true} onCheckedChange={(v) => setSetting({ create_lead: v })} />
+              </div>
+              {(settings.create_lead ?? true) && (
+                <div className="grid gap-2 sm:grid-cols-3">
+                  {(["name", "email", "phone"] as const).map((slot) => (
+                    <div key={slot} className="space-y-1">
+                      <Label className="text-xs capitalize">{slot} field</Label>
+                      <Select value={settings.lead_map?.[slot] ?? "__none__"}
+                        onValueChange={(v) => setSetting({ lead_map: { ...settings.lead_map, [slot]: v === "__none__" ? undefined : v } })}>
+                        <SelectTrigger className="h-8 text-xs"><SelectValue placeholder="—" /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__none__">—</SelectItem>
+                          {mappable.map((f) => <SelectItem key={f.id} value={f.id}>{f.label || f.id}</SelectItem>)}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <p className="text-[11px] text-muted-foreground">Map which fields become the lead&apos;s name / email / phone. We also auto-detect email &amp; phone fields if unset.</p>
+            </CardContent></Card>
+
+            <Card><CardContent className="p-5 space-y-3">
+              <p className="font-semibold text-sm">Notifications</p>
+              <div className="space-y-1"><Label className="text-xs">Email these addresses on each submission (comma-separated)</Label>
+                <Input value={(settings.notify_emails ?? []).join(", ")} placeholder="you@business.com"
+                  onChange={(e) => setSetting({ notify_emails: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })} /></div>
+            </CardContent></Card>
+            <p className="text-xs text-muted-foreground">Remember to <strong>Save</strong> after changing settings.</p>
+          </div>
+        </TabsContent>
+
+        {/* ── SUBMISSIONS ── */}
+        <TabsContent value="submissions" className="mt-4">
+          {submissions.length === 0 ? (
+            <Card><CardContent className="py-12 text-center text-muted-foreground text-sm">No submissions yet.</CardContent></Card>
+          ) : (
+            <div className="space-y-2">
+              {submissions.map((s) => (
+                <Card key={s.id}><CardContent className="p-4 space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-xs text-muted-foreground">{formatDate(s.created_at)}
+                      {s.leads?.name ? <> · lead: <Link href={`/leads/${s.lead_id}`} className="underline hover:text-foreground">{s.leads.name}</Link></> : ""}</p>
+                    <button className="text-muted-foreground hover:text-destructive"
+                      onClick={async () => { if (!confirm("Delete this submission?")) return; try { await deleteFormSubmission(s.id); router.refresh(); } catch { toast.error("Delete failed"); } }}>
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                  <dl className="grid gap-x-6 gap-y-1 sm:grid-cols-2">
+                    {(form.schema ?? []).filter((f) => !["heading", "divider", "instructions"].includes(f.type)).map((f) => (
+                      <div key={f.id} className="min-w-0">
+                        <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{f.label}</dt>
+                        <dd className="text-sm break-words">{fmtAnswer(s.answers?.[f.id])}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </CardContent></Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function fmtAnswer(v: unknown): string {
+  if (v == null || v === "") return "—";
+  if (Array.isArray(v)) return v.join(", ");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof v === "object" && (v as any).name) return `📎 ${(v as any).name}`;
+  if (v === true) return "Yes";
+  if (v === false) return "No";
+  return String(v);
+}

--- a/src/components/forms/forms-list-client.tsx
+++ b/src/components/forms/forms-list-client.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { toast } from "sonner";
+import { Plus, ListChecks, Trash2, Copy, Loader2, Eye, ExternalLink, CodeIcon } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/layout/page-header";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import { setFormBuilderEnabled, createPublicForm, deletePublicForm } from "@/lib/actions/forms";
+import { formatDate } from "@/lib/utils";
+import { embedSnippet } from "@/lib/forms/embed";
+import type { PublicForm } from "@/types/database";
+
+const STATUS_TONES: Record<string, string> = {
+  draft: "bg-muted text-muted-foreground",
+  published: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  archived: "bg-muted text-muted-foreground line-through",
+};
+
+interface Props {
+  enabled: boolean;
+  forms: (PublicForm & { submission_count: number })[];
+  baseUrl: string;
+}
+
+export function FormsListClient({ enabled, forms, baseUrl }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [newOpen, setNewOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [embedFor, setEmbedFor] = useState<PublicForm | null>(null);
+
+  if (!enabled) {
+    return (
+      <div className="max-w-xl mx-auto py-12">
+        <Card>
+          <CardContent className="p-8 text-center space-y-4">
+            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-indigo-500 via-violet-500 to-fuchsia-500 flex items-center justify-center text-white mx-auto">
+              <ListChecks className="w-8 h-8" />
+            </div>
+            <div>
+              <h1 className="text-xl font-bold">Form Builder</h1>
+              <p className="text-sm text-muted-foreground mt-2 max-w-sm mx-auto">
+                Build public lead-capture forms, share them with a link or embed them on your
+                website. Every submission is captured and can auto-create a lead in your pipeline.
+              </p>
+            </div>
+            <Button className="mt-2" disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                try { await setFormBuilderEnabled(true); toast.success("Form Builder enabled"); router.refresh(); }
+                catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't enable"); }
+                finally { setBusy(false); }
+              }}>
+              {busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : null} Enable Form Builder
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const create = async () => {
+    if (!name.trim()) return toast.error("Give the form a name");
+    setBusy(true);
+    try {
+      const form = await createPublicForm({ name: name.trim(), description: description.trim() || null });
+      toast.success("Form created — now add your fields");
+      setNewOpen(false); setName(""); setDescription("");
+      router.push(`/forms/${form.id}`);
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't create"); }
+    finally { setBusy(false); }
+  };
+
+  const publicUrl = (slug: string) => `${baseUrl}/f/${slug}`;
+  const copy = (text: string, msg: string) => navigator.clipboard.writeText(text).then(() => toast.success(msg), () => toast.error("Copy failed"));
+
+  return (
+    <div>
+      <PageHeader
+        title="Forms"
+        subtitle="Public lead-capture forms you can share or embed"
+        accent="linear-gradient(180deg, #818cf8 0%, #7c3aed 100%)"
+        actions={
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Switch checked onCheckedChange={async (v) => {
+                if (v) return;
+                try { await setFormBuilderEnabled(false); toast.success("Form Builder disabled"); router.refresh(); }
+                catch { toast.error("Couldn't disable"); }
+              }} />
+              Enabled
+            </div>
+            <Button onClick={() => setNewOpen(true)}><Plus className="w-4 h-4 mr-1.5" /> New form</Button>
+          </div>
+        }
+      />
+
+      {forms.length === 0 ? (
+        <Card><CardContent className="py-12 text-center text-muted-foreground">
+          <ListChecks className="w-8 h-8 mx-auto mb-3 opacity-40" />
+          <p className="font-medium">No forms yet</p>
+          <p className="text-sm mt-1">Create a lead-capture form, then share the link or embed it on your site.</p>
+        </CardContent></Card>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {forms.map((f) => (
+            <Card key={f.id} className="hover:border-primary/40 transition-colors">
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <Link href={`/forms/${f.id}`} className="font-semibold hover:underline break-words">{f.name}</Link>
+                  <Badge variant="secondary" className={STATUS_TONES[f.status] ?? ""}>{f.status}</Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {f.schema.length} field{f.schema.length === 1 ? "" : "s"} · {f.submission_count} submission{f.submission_count === 1 ? "" : "s"}
+                </p>
+                <code className="block text-[11px] text-muted-foreground truncate">/f/{f.slug}</code>
+                <div className="flex items-center gap-1.5 pt-1 flex-wrap">
+                  <Button size="sm" variant="outline" className="h-8" asChild>
+                    <Link href={`/forms/${f.id}`}>Edit</Link>
+                  </Button>
+                  <Button size="sm" variant="ghost" className="h-8" onClick={() => copy(publicUrl(f.slug), "Public link copied")} disabled={f.status !== "published"}>
+                    <Copy className="w-3.5 h-3.5 mr-1" /> Link
+                  </Button>
+                  <Button size="sm" variant="ghost" className="h-8" onClick={() => setEmbedFor(f)} disabled={f.status !== "published"}>
+                    <CodeIcon className="w-3.5 h-3.5 mr-1" /> Embed
+                  </Button>
+                  <a href={publicUrl(f.slug)} target="_blank" rel="noopener noreferrer" className="ml-auto text-muted-foreground hover:text-foreground p-1.5" title="Open public form">
+                    <ExternalLink className="w-3.5 h-3.5" />
+                  </a>
+                  <button className="text-muted-foreground hover:text-destructive p-1.5"
+                    onClick={async () => {
+                      if (!confirm(`Delete "${f.name}" and all its submissions?`)) return;
+                      try { await deletePublicForm(f.id); toast.success("Deleted"); router.refresh(); }
+                      catch { toast.error("Delete failed"); }
+                    }}>
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+                {f.status !== "published" && <p className="text-[11px] text-amber-600">Publish the form (in its editor) to share or embed it.</p>}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* New form dialog */}
+      <Dialog open={newOpen} onOpenChange={setNewOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle>New form</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label>Name</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Contact us / Get a quote" />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Description (optional)</Label>
+              <Textarea rows={2} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Shown at the top of the form" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setNewOpen(false)}>Cancel</Button>
+            <Button onClick={create} disabled={busy}>{busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : null} Create & build</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Embed dialog */}
+      <Dialog open={!!embedFor} onOpenChange={(v) => !v && setEmbedFor(null)}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader><DialogTitle>Embed “{embedFor?.name}”</DialogTitle></DialogHeader>
+          {embedFor && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Public link</Label>
+                <div className="flex gap-1.5">
+                  <Input readOnly value={publicUrl(embedFor.slug)} className="text-xs" onClick={(e) => (e.target as HTMLInputElement).select()} />
+                  <Button size="icon" variant="outline" className="shrink-0" onClick={() => copy(publicUrl(embedFor.slug), "Link copied")}><Copy className="w-4 h-4" /></Button>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Embed code — paste into your website&apos;s HTML</Label>
+                <Textarea readOnly rows={4} className="font-mono text-[11px]" value={embedSnippet(baseUrl, embedFor.slug)} onClick={(e) => (e.target as HTMLTextAreaElement).select()} />
+                <Button size="sm" variant="outline" onClick={() => copy(embedSnippet(baseUrl, embedFor.slug), "Embed code copied")}>
+                  <Copy className="w-3.5 h-3.5 mr-1.5" /> Copy embed code
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -14,7 +14,7 @@ import { canManageSettings, isWorker, ROLE_LABELS } from "@/lib/permissions";
 import Image from "next/image";
 import { BusinessSwitcher } from "@/components/business/business-switcher";
 
-type FeatureFlag = "quotingAgent" | "onboarding";
+type FeatureFlag = "quotingAgent" | "onboarding" | "formBuilder";
 type NavItem = {
   label: string;
   href: string;
@@ -34,6 +34,7 @@ const navSections: NavSection[] = [
   ]},
   { section: "Sales", items: [
     { label: "Leads",         href: "/leads",         icon: UserPlus                                       },
+    { label: "Forms",         href: "/forms",         icon: ListChecks,  feature: "formBuilder"           },
     { label: "Quoting Agent", href: "/quoting-agent", icon: Sparkles,    feature: "quotingAgent"          },
     { label: "Quotes",        href: "/quotes",        icon: FileCheck                                      },
     { label: "Invoices",      href: "/invoices",      icon: FileText                                       },
@@ -73,7 +74,7 @@ interface AppSidebarProps {
   businesses: Business[];
   userRole: Role;
   /** Server-fetched flags driving conditional nav items. */
-  features?: { quotingAgent?: boolean; onboarding?: boolean };
+  features?: { quotingAgent?: boolean; onboarding?: boolean; formBuilder?: boolean };
   open: boolean;
   onClose: () => void;
 }

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -18,7 +18,7 @@ interface DashboardShellProps {
   userRole: Role;
   /** Feature flags fetched on the server. Drives conditional sidebar items
    *  (e.g. the Quoting Agent tab only shows when enabled). */
-  features?: { quotingAgent?: boolean; onboarding?: boolean };
+  features?: { quotingAgent?: boolean; onboarding?: boolean; formBuilder?: boolean };
   children: React.ReactNode;
 }
 

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -119,6 +119,8 @@ export {
   ArrowsOutCardinal as Move,
   ArrowsOut as Maximize2,
   DotsSixVertical as GripVertical,
+  ListChecks,
+  Code as CodeIcon,
   NavigationArrow as Navigation,
   XCircle as OctagonX,
   Sidebar as PanelLeft,

--- a/src/lib/actions/agents.ts
+++ b/src/lib/actions/agents.ts
@@ -128,4 +128,9 @@ async function syncSideEffects(sb: any, businessId: string, agentId: string, ena
       .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
     revalidatePath("/", "layout"); // sidebar tab appears/disappears
   }
+  if (agentId === "form-builder") {
+    await tbl(sb, "form_builder_settings")
+      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+    revalidatePath("/", "layout");
+  }
 }

--- a/src/lib/agents-catalog.ts
+++ b/src/lib/agents-catalog.ts
@@ -50,6 +50,18 @@ export const AGENT_CATALOG: AgentDefinition[] = [
     badge: "new",
   },
   {
+    id: "form-builder",
+    name: "Form Builder",
+    description: "Build public lead-capture forms to share or embed on your website.",
+    longDescription:
+      "Design public forms with the drag-and-drop builder and share them via a link or embed them on any website with an iframe snippet. Every submission is captured, and can automatically create a lead in your sales pipeline. Enabling adds a Forms tab under Sales.",
+    icon: "list-checks",
+    category: "leads",
+    configType: "inline",
+    configPath: "/forms",
+    badge: "new",
+  },
+  {
     id: "daily-digest",
     name: "Daily Business Digest",
     description: "Receive a morning email summary of revenue, leads, overdue invoices, and today's jobs.",

--- a/src/lib/forms/embed.ts
+++ b/src/lib/forms/embed.ts
@@ -1,0 +1,5 @@
+/** Iframe embed snippet for a published public form. Plain module. */
+export function embedSnippet(baseUrl: string, slug: string): string {
+  const src = `${baseUrl}/embed/${slug}`;
+  return `<iframe src="${src}" title="Form" width="100%" height="700" style="border:0;max-width:640px" loading="lazy"></iframe>`;
+}


### PR DESCRIPTION
## What
Phase 2 — the **Form Builder UI** and plugin wiring.

### Plugin
"Form Builder" card in the **Agents store** (install/toggle flips `form_builder_settings.enabled`); conditional **Forms** item under Sales, enable card on `/forms` when off. Same pattern as onboarding/quoting.

### `/forms` list
Grid with status, field + submission counts, **Copy link** (`/f/slug`), **Copy embed** code, open, delete; create dialog.

### `/forms/[id]` builder — 3 tabs
- **Build** — palette (25 field types minus secure) + **ready-made presets**, drag-reorder, per-field settings, conditional visibility, preview.
- **Settings** — submit button text, thank-you message OR redirect URL, **Create-a-lead toggle (default on) + name/email/phone field mapping**, notification emails.
- **Submissions** — every submission's answers, linked to the created lead.
- **Share bar** (published forms): copy public link + copy embed snippet + open.

## Next (PR3)
Public `/f/[slug]` + `/embed/[slug]` pages, the public submit API (spam protection), lead creation + notifications.

## Test plan
- [x] tsc / vitest / build green (/forms, /forms/[id] present)
🤖 Generated with [Claude Code](https://claude.com/claude-code)