### PR TITLE
feat(forms): public pages + submit + lead creation (3/3)

### DIFF
--- a/src/app/api/f/[slug]/file/route.ts
+++ b/src/app/api/f/[slug]/file/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Serve a just-uploaded public-form image back for inline preview (slug-gated
+ *  to the form's own namespace). */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const path = req.nextUrl.searchParams.get("path") ?? "";
+  if (!path) return NextResponse.json({ error: "path required" }, { status: 400 });
+
+  const sb = createAdminClient();
+  const { data: form } = await tbl(sb, "public_forms").select("id, business_id, status").eq("slug", slug).maybeSingle();
+  if (!form || form.status !== "published") return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!path.startsWith(`${form.business_id}/${form.id}/`)) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data: blob, error } = await sb.storage.from("public-form-uploads").download(path);
+  if (error || !blob) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const buf = Buffer.from(await blob.arrayBuffer());
+  return new NextResponse(buf, { headers: { "Content-Type": blob.type || "application/octet-stream", "Cache-Control": "private, max-age=300" } });
+}

--- a/src/app/api/f/[slug]/submit/route.ts
+++ b/src/app/api/f/[slug]/submit/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { processAnswersForStorage, missingRequiredFields, invalidAnswerFields } from "@/lib/onboarding/answers";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { rateLimit, clientIp } from "@/lib/booking/public";
+import type { OnboardingField, PublicFormSettings } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Public submit for a published form. No auth — slug-gated + spam-guarded. */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let body: { answers?: Record<string, any>; _hp?: string };
+  try { body = await req.json(); } catch { return NextResponse.json({ error: "Bad request" }, { status: 400 }); }
+
+  // Honeypot — bots fill the hidden field. Pretend success, do nothing.
+  if (body._hp) return NextResponse.json({ ok: true });
+
+  const ip = clientIp(req);
+  if (!rateLimit(`form:${slug}:${ip}`, 8, 60_000)) {
+    return NextResponse.json({ error: "Too many submissions — please wait a minute." }, { status: 429 });
+  }
+
+  const sb = createAdminClient();
+  const { data: form } = await tbl(sb, "public_forms")
+    .select("id, business_id, name, status, schema, settings").eq("slug", slug).maybeSingle();
+  if (!form || form.status !== "published") return NextResponse.json({ error: "Form not found" }, { status: 404 });
+
+  const schema = (form.schema ?? []) as OnboardingField[];
+  const settings = (form.settings ?? {}) as PublicFormSettings;
+  const answers = body.answers ?? {};
+
+  const missing = missingRequiredFields(schema, answers);
+  const invalid = invalidAnswerFields(schema, answers);
+  if (missing.length > 0 || invalid.length > 0) {
+    return NextResponse.json({
+      error: missing.length > 0 ? "Please fill in all required fields" : "Please fix the highlighted fields",
+      missing, invalid,
+    }, { status: 422 });
+  }
+
+  const stored = processAnswersForStorage(schema, answers); // no secure fields on public forms → passthrough
+  const meta = {
+    ip,
+    user_agent: req.headers.get("user-agent")?.slice(0, 300) ?? null,
+    referrer: req.headers.get("referer") ?? null,
+  };
+
+  // Optionally create a lead.
+  let leadId: string | null = null;
+  if (settings.create_lead ?? true) {
+    const val = (fieldId?: string) => (fieldId ? String(answers[fieldId] ?? "").trim() : "");
+    const firstOfType = (types: string[]) => schema.find((f) => types.includes(f.type))?.id;
+    const nameFieldId  = settings.lead_map?.name  ?? schema.find((f) => /name/i.test(f.label) && ["short_text", "company"].includes(f.type))?.id;
+    const emailFieldId = settings.lead_map?.email ?? firstOfType(["email"]);
+    const phoneFieldId = settings.lead_map?.phone ?? firstOfType(["phone"]);
+    const name  = val(nameFieldId);
+    const email = val(emailFieldId);
+    const phone = val(phoneFieldId);
+
+    if (name || email || phone) {
+      const { data: biz } = await tbl(sb, "businesses").select("user_id, name, slug, email").eq("id", form.business_id).single();
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: created } = await (sb as any).rpc("upsert_lead", {
+          p_business_id: form.business_id,
+          p_user_id: biz?.user_id ?? null,
+          p_name: name || email || phone || "Website enquiry",
+          p_email: email || null,
+          p_phone: phone || null,
+          p_notes: `Submitted via form "${form.name}"`,
+          p_source: "form",
+          p_source_ref: slug,
+        }).single();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        leadId = (created as any)?.id ?? null;
+      } catch { /* lead creation best-effort — never block the submission */ }
+    }
+  }
+
+  const { error } = await tbl(sb, "public_form_submissions").insert({
+    business_id: form.business_id, form_id: form.id, answers: stored, lead_id: leadId, meta,
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Notify (best-effort).
+  const notify = settings.notify_emails ?? [];
+  if (notify.length > 0) {
+    try {
+      const { data: biz } = await tbl(sb, "businesses").select("name, slug, email").eq("id", form.business_id).single();
+      const rows = schema.filter((f) => !["heading", "divider", "instructions"].includes(f.type))
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map((f) => `<tr><td style="padding:4px 10px;color:#666">${f.label}</td><td style="padding:4px 10px"><strong>${fmt((answers as any)[f.id])}</strong></td></tr>`).join("");
+      const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px"><div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:24px"><h1 style="font-size:18px;margin:0 0 12px">New submission: ${form.name}</h1><table style="width:100%;border-collapse:collapse;font-size:14px">${rows}</table>${leadId ? '<p style="font-size:12px;color:#2f6f73;margin-top:12px">✓ A lead was created in your pipeline.</p>' : ""}</div></body></html>`;
+      await sendEmail({
+        to: notify, subject: `New form submission — ${form.name}`, html,
+        from: buildBusinessFrom({ name: biz?.name ?? "Kirei", slug: biz?.slug, localPart: "forms" }),
+        replyTo: biz?.email ?? undefined,
+        tags: { business_id: form.business_id, doc_type: "custom", doc_id: form.id },
+      });
+    } catch { /* non-fatal */ }
+  }
+
+  return NextResponse.json({ ok: true, redirect_url: settings.redirect_url || null });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fmt(v: any): string {
+  if (v == null || v === "") return "—";
+  if (Array.isArray(v)) return v.join(", ");
+  if (typeof v === "object" && v.name) return `📎 ${v.name}`;
+  if (v === true) return "Yes"; if (v === false) return "No";
+  return String(v);
+}

--- a/src/app/api/f/[slug]/upload/route.ts
+++ b/src/app/api/f/[slug]/upload/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { randomBytes } from "node:crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { rateLimit, clientIp } from "@/lib/booking/public";
+import type { OnboardingField } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+const MAX_BYTES = 10 * 1024 * 1024;
+const IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|heic|heif)$/i;
+
+/** Public file/image upload for a form field (slug-gated, rate-limited). */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const ip = clientIp(req);
+  if (!rateLimit(`formup:${slug}:${ip}`, 20, 60_000)) {
+    return NextResponse.json({ error: "Too many uploads — please wait." }, { status: 429 });
+  }
+
+  const sb = createAdminClient();
+  const { data: form } = await tbl(sb, "public_forms")
+    .select("id, business_id, status, schema").eq("slug", slug).maybeSingle();
+  if (!form || form.status !== "published") return NextResponse.json({ error: "Form not found" }, { status: 404 });
+
+  let fd: FormData;
+  try { fd = await req.formData(); } catch { return NextResponse.json({ error: "Bad request" }, { status: 400 }); }
+  const file = fd.get("file");
+  const fieldId = String(fd.get("field_id") ?? "");
+  if (!(file instanceof File) || !fieldId) return NextResponse.json({ error: "file and field_id required" }, { status: 400 });
+  if (file.size > MAX_BYTES) return NextResponse.json({ error: "File must be under 10 MB" }, { status: 413 });
+
+  const field = ((form.schema ?? []) as OnboardingField[]).find((x) => x.id === fieldId);
+  if (!field || (field.type !== "file" && field.type !== "image")) return NextResponse.json({ error: "Unknown upload field" }, { status: 400 });
+  if (field.type === "image" && !IMAGE_TYPES.test(file.type)) return NextResponse.json({ error: "Please upload an image" }, { status: 415 });
+
+  const ext = (file.name.split(".").pop() ?? "bin").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 8) || "bin";
+  const path = `${form.business_id}/${form.id}/${fieldId}-${randomBytes(6).toString("hex")}.${ext}`;
+  const bytes = Buffer.from(await file.arrayBuffer());
+  const { error } = await sb.storage.from("public-form-uploads").upload(path, bytes, { contentType: file.type || "application/octet-stream", upsert: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ path, name: file.name, size: file.size, type: file.type || null });
+}

--- a/src/app/embed/[slug]/page.tsx
+++ b/src/app/embed/[slug]/page.tsx
@@ -1,0 +1,9 @@
+import { PublicFormShell } from "@/components/forms/public-form-shell";
+
+export const dynamic = "force-dynamic";
+
+// Bare page meant to load inside an <iframe> on a third-party site.
+export default async function EmbedFormPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <PublicFormShell slug={slug} embed />;
+}

--- a/src/app/f/[slug]/page.tsx
+++ b/src/app/f/[slug]/page.tsx
@@ -1,0 +1,8 @@
+import { PublicFormShell } from "@/components/forms/public-form-shell";
+
+export const dynamic = "force-dynamic";
+
+export default async function PublicFormPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <PublicFormShell slug={slug} />;
+}

--- a/src/components/forms/public-form-fill.tsx
+++ b/src/components/forms/public-form-fill.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+/**
+ * Public one-shot form fill (hosted /f/[slug] and embedded /embed/[slug]).
+ * No auth, no autosave — validates + submits once. Honeypot for spam.
+ */
+
+import { useMemo, useRef, useState } from "react";
+import { Check, Loader2, Upload, X, Star } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DISPLAY_ONLY_TYPES } from "@/lib/onboarding/answers";
+import type { OnboardingField, OnboardingAnswers } from "@/types/database";
+
+const DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+const DAY_LABEL: Record<string, string> = { mon: "Mon", tue: "Tue", wed: "Wed", thu: "Thu", fri: "Fri", sat: "Sat", sun: "Sun" };
+
+interface Props {
+  slug: string;
+  fields: OnboardingField[];
+  submitText: string;
+  thankYouMessage: string | null;
+  accent?: string;
+}
+
+export function PublicFormFill({ slug, fields, submitText, thankYouMessage, accent }: Props) {
+  const [answers, setAnswers] = useState<OnboardingAnswers>({});
+  const [problems, setProblems] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hp = useRef("");
+
+  const endpoint = `/api/f/${slug}`;
+  const visible = useMemo(() => fields.filter((f) => {
+    if (!f.show_if?.field_id) return true;
+    return String(answers[f.show_if.field_id] ?? "") === f.show_if.equals;
+  }), [fields, answers]);
+
+  const setAnswer = (id: string, v: unknown) => {
+    setAnswers((prev) => ({ ...prev, [id]: v }));
+    setProblems((prev) => { if (!(id in prev)) return prev; const n = { ...prev }; delete n[id]; return n; });
+  };
+
+  const submit = async () => {
+    setError(null); setSubmitting(true);
+    try {
+      const res = await fetch(`${endpoint}/submit`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers, _hp: hp.current }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const next: Record<string, string> = {};
+        if (Array.isArray(j.missing)) for (const id of j.missing) next[id] = "This field is required";
+        if (Array.isArray(j.invalid)) for (const e of j.invalid) if (e?.field_id) next[e.field_id] = e.message || "Invalid";
+        if (Object.keys(next).length) setProblems(next);
+        setError(j.error || "Couldn't submit — please try again.");
+        return;
+      }
+      if (j.redirect_url) { window.location.href = j.redirect_url; return; }
+      setDone(true);
+    } catch { setError("Couldn't submit — check your connection."); }
+    finally { setSubmitting(false); }
+  };
+
+  if (done) {
+    return (
+      <Card className="p-8 text-center space-y-3 border-emerald-500/30 bg-emerald-500/5">
+        <div className="w-12 h-12 rounded-full bg-emerald-500 text-white flex items-center justify-center mx-auto"><Check className="w-6 h-6" /></div>
+        <p className="font-semibold text-lg">Thank you!</p>
+        <p className="text-sm text-muted-foreground">{thankYouMessage || "Your submission has been received. We'll be in touch shortly."}</p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="p-6 space-y-5">
+        {/* Honeypot — visually hidden, off-screen. Bots fill it. */}
+        <input type="text" tabIndex={-1} autoComplete="off" aria-hidden="true"
+          onChange={(e) => { hp.current = e.target.value; }}
+          style={{ position: "absolute", left: "-9999px", width: 1, height: 1, opacity: 0 }} />
+
+        {visible.map((f) => (
+          <FillField key={f.id} field={f} value={answers[f.id]} problem={problems[f.id]} endpoint={endpoint} onChange={(v) => setAnswer(f.id, v)} />
+        ))}
+      </Card>
+
+      {error && <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>}
+      <Button onClick={submit} disabled={submitting} size="lg" className="w-full"
+        style={accent ? { backgroundColor: accent } : undefined}>
+        {submitting ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Check className="w-4 h-4 mr-2" />}
+        {submitText || "Submit"}
+      </Button>
+    </div>
+  );
+}
+
+function FillField({ field: f, value, problem, endpoint, onChange }: {
+  field: OnboardingField; value: unknown; problem?: string; endpoint: string; onChange: (v: unknown) => void;
+}) {
+  if (f.type === "divider") return <hr className="border-border" />;
+  if (f.type === "heading") return <h3 className="text-base font-semibold pt-1">{f.label}</h3>;
+  if (f.type === "instructions") return <p className="text-sm text-muted-foreground bg-muted/40 rounded-md p-3 whitespace-pre-wrap">{f.label}</p>;
+  if (DISPLAY_ONLY_TYPES.has(f.type)) return null;
+
+  return (
+    <div className={`space-y-1.5 ${problem ? "rounded-lg ring-1 ring-rose-400 p-2 -m-2" : ""}`}>
+      {f.type !== "consent" && <Label className="text-sm">{f.label}{f.required && <span className="text-rose-500 ml-0.5">*</span>}</Label>}
+      {f.help_text && <p className="text-xs text-muted-foreground">{f.help_text}</p>}
+      <Control field={f} value={value} endpoint={endpoint} onChange={onChange} />
+      {problem && <p className="text-xs text-rose-600">{problem}</p>}
+    </div>
+  );
+}
+
+function Control({ field: f, value, endpoint, onChange }: { field: OnboardingField; value: unknown; endpoint: string; onChange: (v: unknown) => void }) {
+  switch (f.type) {
+    case "long_text": case "address": return <Textarea rows={f.type === "address" ? 2 : 4} value={(value as string) ?? ""} placeholder={f.placeholder} onChange={(e) => onChange(e.target.value)} />;
+    case "dropdown": case "radio":
+      if (f.type === "radio" && (f.options ?? []).length <= 5) {
+        return <div className="space-y-1.5">{(f.options ?? []).map((o) => <label key={o} className="flex items-center gap-2 text-sm cursor-pointer"><input type="radio" checked={value === o} onChange={() => onChange(o)} /> {o}</label>)}</div>;
+      }
+      return <Select value={(value as string) ?? ""} onValueChange={onChange}><SelectTrigger><SelectValue placeholder="Choose…" /></SelectTrigger><SelectContent>{(f.options ?? []).map((o) => <SelectItem key={o} value={o}>{o}</SelectItem>)}</SelectContent></Select>;
+    case "multi_select": case "checkboxes": {
+      const arr = Array.isArray(value) ? (value as string[]) : [];
+      return <div className="space-y-1.5">{(f.options ?? []).map((o) => <label key={o} className="flex items-center gap-2 text-sm cursor-pointer"><input type="checkbox" checked={arr.includes(o)} onChange={(e) => onChange(e.target.checked ? [...arr, o] : arr.filter((x) => x !== o))} /> {o}</label>)}</div>;
+    }
+    case "yes_no": return <div className="flex gap-2">{["Yes", "No"].map((o) => <Button key={o} type="button" size="sm" variant={value === o ? "default" : "outline"} onClick={() => onChange(o)}>{o}</Button>)}</div>;
+    case "opening_hours": {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const hours = (value ?? {}) as Record<string, any>;
+      const patch = (d: string, p: object) => onChange({ ...hours, [d]: { ...(hours[d] ?? {}), ...p } });
+      return <div className="space-y-1.5">{DAYS.map((d) => { const r = hours[d] ?? {}; return (
+        <div key={d} className="flex items-center gap-2 text-sm">
+          <span className="w-10 text-muted-foreground">{DAY_LABEL[d]}</span>
+          <label className="flex items-center gap-1 text-xs text-muted-foreground"><input type="checkbox" checked={!!r.closed} onChange={(e) => patch(d, { closed: e.target.checked })} /> closed</label>
+          {!r.closed && <><Input type="time" className="h-8 w-[110px]" value={r.open ?? ""} onChange={(e) => patch(d, { open: e.target.value })} /><span className="text-muted-foreground">–</span><Input type="time" className="h-8 w-[110px]" value={r.close ?? ""} onChange={(e) => patch(d, { close: e.target.value })} /></>}
+        </div>); })}</div>;
+    }
+    case "image": case "file": return <UploadControl field={f} value={value} endpoint={endpoint} onChange={onChange} />;
+    case "rating": { const n = typeof value === "number" ? value : 0; return <div className="flex gap-1">{[1, 2, 3, 4, 5].map((i) => <button key={i} type="button" onClick={() => onChange(i)}><Star className={`w-6 h-6 ${i <= n ? "text-amber-400 fill-amber-400" : "text-muted-foreground/40"}`} /></button>)}</div>; }
+    case "consent": return <label className="flex items-start gap-2 text-sm cursor-pointer"><input type="checkbox" checked={value === true} onChange={(e) => onChange(e.target.checked)} className="mt-0.5" /><span>{f.label}{f.required && <span className="text-rose-500 ml-0.5">*</span>}</span></label>;
+    case "date": return <Input type="date" value={(value as string) ?? ""} onChange={(e) => onChange(e.target.value)} />;
+    case "time": return <Input type="time" value={(value as string) ?? ""} onChange={(e) => onChange(e.target.value)} />;
+    case "number": case "currency": return <Input type="number" step={f.type === "currency" ? "0.01" : undefined} value={(value as string) ?? ""} placeholder={f.placeholder ?? (f.type === "currency" ? "0.00" : "")} onChange={(e) => onChange(e.target.value)} />;
+    case "email": return <Input type="email" value={(value as string) ?? ""} placeholder={f.placeholder} onChange={(e) => onChange(e.target.value)} />;
+    case "phone": return <Input type="tel" value={(value as string) ?? ""} placeholder={f.placeholder} onChange={(e) => onChange(e.target.value)} />;
+    case "url": return <Input type="url" value={(value as string) ?? ""} placeholder={f.placeholder ?? "https://"} onChange={(e) => onChange(e.target.value)} />;
+    default: return <Input value={(value as string) ?? ""} placeholder={f.placeholder} onChange={(e) => onChange(e.target.value)} />;
+  }
+}
+
+function UploadControl({ field: f, value, endpoint, onChange }: { field: OnboardingField; value: unknown; endpoint: string; onChange: (v: unknown) => void }) {
+  const [uploading, setUploading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const ref = useRef<HTMLInputElement>(null);
+  const meta = (typeof value === "object" && value !== null ? value : null) as { path?: string; name?: string } | null;
+
+  const upload = async (file?: File) => {
+    if (!file) return; setErr(null); setUploading(true);
+    try {
+      const fd = new FormData(); fd.append("file", file); fd.append("field_id", f.id);
+      const res = await fetch(`${endpoint}/upload`, { method: "POST", body: fd });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) { setErr(j.error || "Upload failed"); return; }
+      onChange(j);
+    } catch { setErr("Upload failed"); } finally { setUploading(false); if (ref.current) ref.current.value = ""; }
+  };
+
+  if (meta?.path) {
+    if (f.type === "image") {
+      const src = `${endpoint}/file?path=${encodeURIComponent(meta.path)}`;
+      return (
+        <div className="relative inline-block">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={src} alt={meta.name ?? ""} className="max-h-40 max-w-full rounded-lg border border-border object-contain bg-muted/30" />
+          <button type="button" onClick={() => onChange(null)} className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-destructive"><X className="w-3.5 h-3.5" /></button>
+        </div>
+      );
+    }
+    return <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm"><span className="truncate">📎 {meta.name}</span><button type="button" onClick={() => onChange(null)} className="text-muted-foreground hover:text-destructive shrink-0"><X className="w-4 h-4" /></button></div>;
+  }
+
+  return (
+    <div>
+      <input ref={ref} type="file" className="hidden" accept={f.type === "image" ? "image/*" : undefined} onChange={(e) => upload(e.target.files?.[0])} />
+      <button type="button" onClick={() => ref.current?.click()} disabled={uploading} className="w-full border border-dashed border-border rounded-lg p-5 text-sm text-muted-foreground hover:border-primary/50 hover:text-foreground transition-colors flex items-center justify-center gap-2">
+        {uploading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Upload className="w-4 h-4" />}{uploading ? "Uploading…" : f.type === "image" ? "Choose an image" : "Choose a file"}
+      </button>
+      {err && <p className="text-xs text-rose-600 mt-1">{err}</p>}
+    </div>
+  );
+}

--- a/src/components/forms/public-form-shell.tsx
+++ b/src/components/forms/public-form-shell.tsx
@@ -1,0 +1,55 @@
+import { notFound } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { PublicFormFill } from "@/components/forms/public-form-fill";
+import type { OnboardingField, PublicFormSettings, PublicFormTheme } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Shared render for the hosted (/f) and embedded (/embed) public form pages. */
+export async function PublicFormShell({ slug, embed }: { slug: string; embed?: boolean }) {
+  const sb = createAdminClient();
+  const { data: form } = await tbl(sb, "public_forms")
+    .select("id, business_id, name, description, status, schema, settings, theme").eq("slug", slug).maybeSingle();
+  if (!form || form.status !== "published") notFound();
+
+  const { data: business } = await tbl(sb, "businesses").select("name, logo_url").eq("id", form.business_id).maybeSingle();
+
+  const schema = (form.schema ?? []) as OnboardingField[];
+  const settings = (form.settings ?? {}) as PublicFormSettings;
+  const theme = (form.theme ?? {}) as PublicFormTheme;
+  const showBranding = theme.show_branding !== false;
+
+  const body = (
+    <div className={embed ? "px-4 py-6" : "max-w-2xl mx-auto px-6 py-10"}>
+      {!embed && (business?.logo_url || business?.name) && (
+        <div className="flex items-center gap-3 mb-6">
+          {business?.logo_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={business.logo_url} alt={business.name} className="w-11 h-11 rounded-lg object-contain bg-white border border-border p-1" />
+          ) : null}
+          <span className="font-semibold">{business?.name}</span>
+        </div>
+      )}
+      <h1 className="text-2xl font-bold">{form.name}</h1>
+      {form.description && <p className="text-sm text-muted-foreground mt-1 mb-5">{form.description}</p>}
+      <div className={form.description ? "" : "mt-5"}>
+        <PublicFormFill
+          slug={slug}
+          fields={schema}
+          submitText={settings.submit_text || "Submit"}
+          thankYouMessage={settings.thank_you_message ?? null}
+          accent={theme.accent}
+        />
+      </div>
+      {showBranding && (
+        <p className="text-center text-xs text-muted-foreground mt-6">
+          Powered by <a href="https://kireihq.com" target="_blank" rel="noopener noreferrer" className="hover:underline">Kirei</a>
+        </p>
+      )}
+    </div>
+  );
+
+  if (embed) return <div className="min-h-screen bg-background">{body}</div>;
+  return <div className="min-h-screen bg-gradient-to-b from-background to-muted/30">{body}</div>;
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -56,6 +56,10 @@ export async function updateSession(request: NextRequest) {
     // These own their tenant resolution (by slug) and bot protection.
     pathname.startsWith("/book/") ||
     pathname.startsWith("/booking/") ||
+    // Public form builder: hosted form, iframe embed, and public submit/upload.
+    pathname.startsWith("/f/") ||
+    pathname.startsWith("/embed/") ||
+    pathname.startsWith("/api/f/") ||
     pathname.startsWith("/api/public/") ||
     pathname === "/api/auth/signup" ||
     pathname.startsWith("/api/v1/") ||


### PR DESCRIPTION
## What
Final phase — the forms go **live and public**.

### Public pages
- **`/f/[slug]`** — hosted public form (business logo + name, powered-by-Kirei).
- **`/embed/[slug]`** — bare page for the iframe embed (no frame headers set, so it embeds on any site).
- Both render published forms only, via the admin client (no auth).

### Filling
`PublicFormFill` — interactive controls for every field type (uploads with inline image preview, opening-hours, rating, conditionals), a **honeypot** hidden field, client + server validation, then a thank-you screen or redirect to the configured URL.

### Public APIs (slug-gated, unauthenticated)
- **`POST /api/f/[slug]/submit`** — honeypot + in-memory **rate limit** (8/min/IP) + server-side validation (ABN/email/etc). Stores the submission with meta (ip/ua/referrer). If `create_lead` is on, creates/updates a **lead** via `upsert_lead` using the settings field-map (or auto-detected email/phone), source `form`. Emails `notify_emails`. Returns `{ ok, redirect_url }`.
- **`POST …/upload`** — 10 MB cap, image-type guard, namespaced storage path.
- **`GET …/file?path=`** — inline image preview, scoped to the form's own namespace.

Middleware whitelists `/f/`, `/embed/`, `/api/f/`.

## The complete feature
Enable via Agents → build a form (fields/presets/validation) → publish → **share the `/f/` link or paste the embed snippet** → submissions land in the Submissions tab and (optionally) as leads in the pipeline, with email notifications.

## Test plan
- [x] tsc / vitest / build green (all public routes present)
- [ ] Preview: publish a form, open `/f/slug`, submit (check validation + honeypot), verify submission + lead created + notification; test the embed iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)