### PR TITLE
fix: drop non-existent businesses.slug from selects (broke form-submit lead creation)

### DIFF
--- a/src/app/api/f/[slug]/submit/route.ts
+++ b/src/app/api/f/[slug]/submit/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
     const phone = val(phoneFieldId);
 
     if (name || email || phone) {
-      const { data: biz } = await tbl(sb, "businesses").select("user_id, name, slug, email").eq("id", form.business_id).single();
+      const { data: biz } = await tbl(sb, "businesses").select("user_id, name, email").eq("id", form.business_id).single();
       const leadName = name || email || phone || "Website enquiry";
       // leads.user_id is NOT NULL — always have a valid owner id.
       const ownerId: string | null = biz?.user_id ?? null;
@@ -113,7 +113,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
   const notify = settings.notify_emails ?? [];
   if (notify.length > 0) {
     try {
-      const { data: biz } = await tbl(sb, "businesses").select("name, slug, email").eq("id", form.business_id).single();
+      const { data: biz } = await tbl(sb, "businesses").select("name, email").eq("id", form.business_id).single();
       const rows = schema.filter((f) => !["heading", "divider", "instructions"].includes(f.type))
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .map((f) => `<tr><td style="padding:4px 10px;color:#666">${f.label}</td><td style="padding:4px 10px"><strong>${fmt((answers as any)[f.id])}</strong></td></tr>`).join("");

--- a/src/lib/actions/contracts.ts
+++ b/src/lib/actions/contracts.ts
@@ -235,7 +235,7 @@ export async function sendContractForSignature(contractId: string): Promise<{ ok
   const signerName = (c.customers?.name as string | undefined) ?? "Customer";
   if (!signerEmail) throw new Error("This customer has no email address");
 
-  const { data: biz } = await tbl(supabase, "businesses").select("name, slug, email").eq("id", businessId).single();
+  const { data: biz } = await tbl(supabase, "businesses").select("name, email").eq("id", businessId).single();
   const { url } = await contractSignUrl(supabase, businessId, c.customer_id, user.id, contractId);
 
   const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px;color:#111">

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -173,7 +173,7 @@ export async function sendOnboardingRequest(formId: string, customerId: string, 
   const [{ data: form }, { data: customer }, { data: biz }] = await Promise.all([
     tbl(supabase, "onboarding_forms").select("id, name, status, schema").eq("id", formId).eq("business_id", businessId).maybeSingle(),
     tbl(supabase, "customers").select("id, name, email").eq("id", customerId).eq("business_id", businessId).maybeSingle(),
-    tbl(supabase, "businesses").select("name, slug, email").eq("id", businessId).single(),
+    tbl(supabase, "businesses").select("name, email").eq("id", businessId).single(),
   ]);
   if (!form) throw new Error("Form not found");
   if (!customer) throw new Error("Customer not found");

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1623,7 +1623,7 @@ export function registerTools(server: McpServer): void {
       const [{ data: form }, { data: customer }, { data: biz }] = await Promise.all([
         t(ctx, "onboarding_forms").select("id, name, schema").eq("id", args.form_id).eq("business_id", ctx.businessId).maybeSingle(),
         t(ctx, "customers").select("id, name, email").eq("id", args.customer_id).eq("business_id", ctx.businessId).maybeSingle(),
-        t(ctx, "businesses").select("name, slug, email").eq("id", ctx.businessId).single(),
+        t(ctx, "businesses").select("name, email").eq("id", ctx.businessId).single(),
       ]);
       if (!form) return errorText("Form not found");
       if (!customer) return errorText("Customer not found");
@@ -1776,7 +1776,7 @@ export function registerTools(server: McpServer): void {
 
       const token = await getOrMintPortalToken(ctx, c.customer_id);
       const url = `${appBase()}/portal/${token}/contract/${c.id}`;
-      const { data: biz } = await t(ctx, "businesses").select("name, slug, email").eq("id", ctx.businessId).single();
+      const { data: biz } = await t(ctx, "businesses").select("name, email").eq("id", ctx.businessId).single();
       const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px;color:#111"><div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:28px"><p style="font-size:13px;color:#666;margin:0 0 4px">${biz?.name ?? "Your provider"}</p><h1 style="font-size:20px;margin:0 0 12px">Please sign: ${c.title}</h1><p style="font-size:14px;line-height:1.6;color:#333">Hi ${signer}, you have a contract ready to sign.</p><p style="margin:24px 0"><a href="${url}" style="background:#2f6f73;color:#fff;text-decoration:none;padding:12px 22px;border-radius:8px;font-size:14px;font-weight:600">Review &amp; sign</a></p><p style="font-size:12px;color:#888">${url}</p></div></body></html>`;
       await sendEmail({
         to: email, subject: `${biz?.name ?? "Contract"}: please sign “${c.title}”`, html,


### PR DESCRIPTION
## Root cause (found by live prod test + logs)
`businesses` has **no `slug` column**, but several paths did `businesses.select("...slug...")`. PostgREST errors the whole query → returns `null`. In the public-form submit route that made `biz.user_id` null → `upsert_lead` violated the `leads.user_id` NOT-NULL constraint → **no lead was created** (submissions saved with `lead_id` null). In onboarding/contract sends it silently degraded the email sender to generic "Kirei".

## Fix
Drop `slug` from every `businesses` select (submit route ×2, onboarding send, contract send, MCP send_onboarding_form + send_contract). `buildBusinessFrom` already slugifies the business name when no slug is passed, so per-business email senders are restored too. (`public_forms.slug` selects are untouched — that column exists.)

## Verification
Traced end-to-end on production: submitted the live `/f/cs-test-enquiry` form → runtime log showed `null value in column "user_id"` → confirmed `businesses` lacks `slug`. Will re-test post-deploy to confirm the lead now lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)