### PR TITLE
feat(plugins): registry + resolver + route gating + MCP (P0-A)

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getUserOrNull } from "@/lib/auth";
 import { DashboardShell } from "@/components/layout/dashboard-shell";
 import { isWorker, isPathAllowedForWorker, type Role } from "@/lib/permissions";
+import { resolveEnabledPlugins, ROUTE_GATES } from "@/lib/plugins/registry";
 import type { Business } from "@/types/database";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -60,20 +61,34 @@ export default async function DashboardLayout({ children }: { children: React.Re
     }
   }
 
-  // Feature flags — kept cheap (parallel single lookups). Used to gate sidebar items.
-  const [{ data: quotingSettings }, { data: onboardingSettings }, { data: formBuilderSettings }] = await Promise.all([
+  // Plugin system (docs/SEO_AGENCY_PLAN.md P0) — resolve which modules this
+  // business has enabled. No install row = the plugin's default (legacy
+  // modules default ON), so existing businesses see zero change until they
+  // explicitly toggle something. Legacy settings tables stay authoritative
+  // for the three original feature-flagged verticals.
+  const [{ data: installRows }, { data: quotingSettings }, { data: onboardingSettings }, { data: formBuilderSettings }] = await Promise.all([
+    sb.from("business_agent_installs").select("agent_id, enabled").eq("business_id", business.id),
     sb.from("quoting_agent_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
     sb.from("onboarding_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
     sb.from("form_builder_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
   ]);
-  const features = {
-    quotingAgent: !!quotingSettings?.enabled,
-    onboarding: !!onboardingSettings?.enabled,
-    formBuilder: !!formBuilderSettings?.enabled,
-  };
+  const plugins = resolveEnabledPlugins(installRows ?? [], {
+    quoting_agent_settings: quotingSettings ? !!quotingSettings.enabled : null,
+    onboarding_settings: onboardingSettings ? !!onboardingSettings.enabled : null,
+    form_builder_settings: formBuilderSettings ? !!formBuilderSettings.enabled : null,
+  });
+
+  // Route-level gating: visiting a disabled plugin's URL redirects home
+  // (hiding nav alone would leave features reachable by direct link).
+  {
+    const h = await headers();
+    const path = h.get("x-pathname") ?? "";
+    const gate = ROUTE_GATES.find((g) => path === g.prefix || path.startsWith(g.prefix + "/"));
+    if (gate && !plugins[gate.pluginId]) redirect("/dashboard");
+  }
 
   return (
-    <DashboardShell business={business} businesses={allBusinesses} user={user} userRole={userRole} features={features}>
+    <DashboardShell business={business} businesses={allBusinesses} user={user} userRole={userRole} features={plugins}>
       {children}
     </DashboardShell>
   );

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -14,14 +14,13 @@ import { canManageSettings, isWorker, ROLE_LABELS } from "@/lib/permissions";
 import Image from "next/image";
 import { BusinessSwitcher } from "@/components/business/business-switcher";
 
-type FeatureFlag = "quotingAgent" | "onboarding" | "formBuilder";
 type NavItem = {
   label: string;
   href: string;
   icon: typeof LayoutDashboard;
   worker?: boolean;
-  /** Only show when this feature is enabled for the business. */
-  feature?: FeatureFlag;
+  /** Owning plugin id (src/lib/plugins/registry.ts). Untagged = core, always shown. */
+  plugin?: string;
 };
 type NavSection = { section: string; items: NavItem[] };
 
@@ -29,40 +28,40 @@ const navSections: NavSection[] = [
   { section: "Workspace", items: [
     { label: "Dashboard",  href: "/dashboard",  icon: LayoutDashboard, worker: true },
     { label: "Assistant",  href: "/assistant",  icon: Sparkles                      },
-    { label: "Messages",   href: "/messages",   icon: MessageSquare                 },
+    { label: "Messages",   href: "/messages",   icon: MessageSquare,   plugin: "messages" },
     { label: "Tasks",      href: "/tasks",      icon: Columns3                      },
   ]},
   { section: "Sales", items: [
-    { label: "Leads",         href: "/leads",         icon: UserPlus                                       },
-    { label: "Forms",         href: "/forms",         icon: ListChecks,  feature: "formBuilder"           },
-    { label: "Quoting Agent", href: "/quoting-agent", icon: Sparkles,    feature: "quotingAgent"          },
-    { label: "Quotes",        href: "/quotes",        icon: FileCheck                                      },
-    { label: "Invoices",      href: "/invoices",      icon: FileText                                       },
-    { label: "Contracts",     href: "/contracts",     icon: FileStack                                      },
-    { label: "Site Reports",  href: "/reports",       icon: ClipboardList                                  },
-    { label: "Recurring",     href: "/recurring",     icon: Repeat                                         },
-    { label: "Recurring billing", href: "/recurring-invoices", icon: Repeat                                 },
+    { label: "Leads",         href: "/leads",         icon: UserPlus,     plugin: "leads"             },
+    { label: "Forms",         href: "/forms",         icon: ListChecks,   plugin: "form-builder"      },
+    { label: "Quoting Agent", href: "/quoting-agent", icon: Sparkles,     plugin: "quoting-agent"     },
+    { label: "Quotes",        href: "/quotes",        icon: FileCheck,    plugin: "quotes"            },
+    { label: "Invoices",      href: "/invoices",      icon: FileText,     plugin: "invoicing"         },
+    { label: "Contracts",     href: "/contracts",     icon: FileStack,    plugin: "contracts"         },
+    { label: "Site Reports",  href: "/reports",       icon: ClipboardList, plugin: "site-reports"     },
+    { label: "Recurring",     href: "/recurring",     icon: Repeat,       plugin: "recurring-jobs"    },
+    { label: "Recurring billing", href: "/recurring-invoices", icon: Repeat, plugin: "recurring-billing" },
   ]},
   { section: "Service", items: [
-    { label: "Work Orders",    href: "/work-orders",     icon: Wrench,        worker: true },
-    { label: "Schedule",       href: "/schedule",        icon: CalendarDays,  worker: true },
-    { label: "Bookings",       href: "/bookings",        icon: CalendarDays                 },
-    { label: "Online Booking", href: "/settings/booking", icon: CalendarDays                 },
+    { label: "Work Orders",    href: "/work-orders",     icon: Wrench,        worker: true, plugin: "jobs" },
+    { label: "Schedule",       href: "/schedule",        icon: CalendarDays,  worker: true, plugin: "scheduling" },
+    { label: "Bookings",       href: "/bookings",        icon: CalendarDays,  plugin: "booking" },
+    { label: "Online Booking", href: "/settings/booking", icon: CalendarDays,  plugin: "booking" },
   ]},
   { section: "Contacts", items: [
     { label: "Customers",  href: "/customers",  icon: Users                         },
     { label: "Contacts",   href: "/contacts",   icon: Users2                        },
-    { label: "Onboarding", href: "/onboarding-forms", icon: ClipboardList, feature: "onboarding" },
+    { label: "Onboarding", href: "/onboarding-forms", icon: ClipboardList, plugin: "client-onboarding" },
   ]},
   { section: "Catalog", items: [
-    { label: "Products",   href: "/products",   icon: Package                       },
+    { label: "Products",   href: "/products",   icon: Package,       plugin: "products" },
   ]},
   { section: "Workforce", items: [
     { label: "Team",       href: "/team",       icon: Users2                        },
     { label: "Agents",     href: "/agents",     icon: Bot                           },
   ]},
   { section: "Insights", items: [
-    { label: "Analytics",  href: "/analytics",  icon: TrendingUp                    },
+    { label: "Analytics",  href: "/analytics",  icon: TrendingUp,    plugin: "analytics" },
   ]},
   { section: "Account", items: [
     { label: "Help",       href: "/help",       icon: HelpCircle,    worker: true   },
@@ -73,8 +72,8 @@ interface AppSidebarProps {
   business: Business;
   businesses: Business[];
   userRole: Role;
-  /** Server-fetched flags driving conditional nav items. */
-  features?: { quotingAgent?: boolean; onboarding?: boolean; formBuilder?: boolean };
+  /** Enabled-plugin map from the layout resolver (plugin id → enabled). */
+  features?: Record<string, boolean>;
   open: boolean;
   onClose: () => void;
 }
@@ -87,7 +86,7 @@ export function AppSidebar({ business, businesses, userRole, features, open, onC
       ...s,
       items: s.items.filter((i) => {
         if (workerView && !i.worker) return false;
-        if (i.feature && !features?.[i.feature]) return false;
+        if (i.plugin && !features?.[i.plugin]) return false;
         return true;
       }),
     }))

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -18,7 +18,7 @@ interface DashboardShellProps {
   userRole: Role;
   /** Feature flags fetched on the server. Drives conditional sidebar items
    *  (e.g. the Quoting Agent tab only shows when enabled). */
-  features?: { quotingAgent?: boolean; onboarding?: boolean; formBuilder?: boolean };
+  features?: Record<string, boolean>;
   children: React.ReactNode;
 }
 

--- a/src/lib/actions/agents.ts
+++ b/src/lib/actions/agents.ts
@@ -112,25 +112,12 @@ export async function toggleAgent(agentId: string, enabled: boolean): Promise<vo
 }
 
 /**
- * Keep downstream tables in sync when agent state changes.
- * email-lead-scanner ↔ business_email_config.enabled
- * client-onboarding ↔ onboarding_settings.enabled (drives the sidebar tab)
+ * Keep downstream tables in sync when agent/plugin state changes. Shared
+ * logic lives in src/lib/plugins/sync.ts (plain module) so MCP reuses it.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function syncSideEffects(sb: any, businessId: string, agentId: string, enabled: boolean) {
-  if (agentId === "email-lead-scanner") {
-    await tbl(sb, "business_email_config")
-      .update({ enabled })
-      .eq("business_id", businessId);
-  }
-  if (agentId === "client-onboarding") {
-    await tbl(sb, "onboarding_settings")
-      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
-    revalidatePath("/", "layout"); // sidebar tab appears/disappears
-  }
-  if (agentId === "form-builder") {
-    await tbl(sb, "form_builder_settings")
-      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
-    revalidatePath("/", "layout");
-  }
+  const { syncPluginSideEffects } = await import("@/lib/plugins/sync");
+  await syncPluginSideEffects(sb, businessId, agentId, enabled);
+  revalidatePath("/", "layout"); // sidebar items appear/disappear with plugin state
 }

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1415,6 +1415,69 @@ export function registerTools(server: McpServer): void {
       return text(out);
     });
 
+  // ===== PLUGINS (module system — docs/SEO_AGENCY_PLAN.md P0) =====
+  tool("list_plugins",
+    "List Kirei's plugins (modules) and whether each is enabled for this business. Core plugins are always on. Disabling a plugin only hides it — no data is ever deleted.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:read");
+      const { PLUGIN_REGISTRY, resolveEnabledPlugins } = await import("@/lib/plugins/registry");
+      const [{ data: rows }, { data: qa }, { data: ob }, { data: fb }] = await Promise.all([
+        t(ctx, "business_agent_installs").select("agent_id, enabled").eq("business_id", ctx.businessId),
+        t(ctx, "quoting_agent_settings").select("enabled").eq("business_id", ctx.businessId).maybeSingle(),
+        t(ctx, "onboarding_settings").select("enabled").eq("business_id", ctx.businessId).maybeSingle(),
+        t(ctx, "form_builder_settings").select("enabled").eq("business_id", ctx.businessId).maybeSingle(),
+      ]);
+      const enabled = resolveEnabledPlugins(rows ?? [], {
+        quoting_agent_settings: qa ? !!qa.enabled : null,
+        onboarding_settings: ob ? !!ob.enabled : null,
+        form_builder_settings: fb ? !!fb.enabled : null,
+      });
+      return text(PLUGIN_REGISTRY.filter((p) => p.kind === "module").map((p) => ({
+        id: p.id, name: p.name, category: p.category, core: !!p.core,
+        enabled: enabled[p.id], dependencies: p.dependencies ?? [],
+      })));
+    });
+
+  tool("set_plugin_enabled",
+    "Enable or disable a plugin (module) for this business. Core plugins can't be disabled; plugins that other enabled plugins depend on are blocked. Disabling hides the module — data is preserved and re-enabling restores it.",
+    { plugin_id: z.string().min(1), enabled: z.boolean() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const { PLUGINS_BY_ID, resolveEnabledPlugins, dependentsOf } = await import("@/lib/plugins/registry");
+      const plugin = PLUGINS_BY_ID[args.plugin_id];
+      if (!plugin) return errorText(`Unknown plugin "${args.plugin_id}"`);
+      if (plugin.core) return errorText(`"${plugin.name}" is a core module and can't be disabled`);
+
+      if (!args.enabled) {
+        // Block disabling something an enabled plugin depends on.
+        const [{ data: rows }, { data: qa }, { data: ob }, { data: fb }] = await Promise.all([
+          t(ctx, "business_agent_installs").select("agent_id, enabled").eq("business_id", ctx.businessId),
+          t(ctx, "quoting_agent_settings").select("enabled").eq("business_id", ctx.businessId).maybeSingle(),
+          t(ctx, "onboarding_settings").select("enabled").eq("business_id", ctx.businessId).maybeSingle(),
+          t(ctx, "form_builder_settings").select("enabled").eq("business_id", ctx.businessId).maybeSingle(),
+        ]);
+        const enabled = resolveEnabledPlugins(rows ?? [], {
+          quoting_agent_settings: qa ? !!qa.enabled : null,
+          onboarding_settings: ob ? !!ob.enabled : null,
+          form_builder_settings: fb ? !!fb.enabled : null,
+        });
+        const deps = dependentsOf(plugin.id, enabled);
+        if (deps.length > 0) {
+          return errorText(`Disable ${deps.map((d) => `"${d.name}"`).join(", ")} first — ${deps.length > 1 ? "they depend" : "it depends"} on "${plugin.name}".`);
+        }
+      }
+
+      const { error } = await t(ctx, "business_agent_installs").upsert(
+        { business_id: ctx.businessId, agent_id: plugin.id, enabled: args.enabled, updated_at: new Date().toISOString() },
+        { onConflict: "business_id,agent_id" },
+      );
+      if (error) throw error;
+      const { syncPluginSideEffects } = await import("@/lib/plugins/sync");
+      await syncPluginSideEffects(ctx.sb, ctx.businessId, plugin.id, args.enabled);
+      return text({ plugin: plugin.id, enabled: args.enabled });
+    });
+
   // ===== PUBLIC FORM BUILDER (feature-flagged, lead-capture / embeddable) =====
   const FORM_FIELD = z.object({
     id: z.string().min(1),

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -1,0 +1,116 @@
+/**
+ * Plugin registry — Kirei's module system (docs/SEO_AGENCY_PLAN.md, Phase 0).
+ *
+ * Every major module is a plugin a business can enable/disable. State lives in
+ * `business_agent_installs` (one row per (business_id, plugin_id)) — the same
+ * table the /agents store has always used, so nothing migrates.
+ *
+ * DATA-SAFETY SEMANTICS (the important part):
+ *   enabled(plugin) = settingsTable.enabled   — when the plugin has a legacy
+ *                                               settings table (authoritative)
+ *                   ?? installRow.enabled     — explicit user choice
+ *                   ?? defaultEnabled         — NO ROW = TODAY'S BEHAVIOR
+ *
+ * Legacy modules default to enabled, so existing businesses see zero change
+ * until they (or a preset) explicitly toggle something. Disabling only hides
+ * nav + gates routes — it NEVER deletes data; re-enabling restores everything.
+ *
+ * Plain module — safe to import from server components, actions, and MCP.
+ */
+
+export type PluginKind = "module" | "agent";
+export type PluginCategory =
+  | "core" | "sales" | "service" | "contacts" | "catalog"
+  | "communication" | "insights" | "automation" | "seo";
+
+export interface PluginDefinition {
+  id: string;
+  name: string;
+  description: string;
+  kind: PluginKind;
+  category: PluginCategory;
+  /** Core plugins are always on and cannot be disabled. */
+  core?: boolean;
+  /** Behavior when a business has no install row (legacy = true). */
+  defaultEnabled: boolean;
+  /** Plugins that must be enabled for this one to work. */
+  dependencies?: string[];
+  /** Dashboard route prefixes owned by this plugin (route-level gating). */
+  routePrefixes?: string[];
+  /** Legacy per-feature settings table that stays authoritative for enabled. */
+  settingsTable?: "quoting_agent_settings" | "onboarding_settings" | "form_builder_settings";
+}
+
+export const PLUGIN_REGISTRY: PluginDefinition[] = [
+  // ── Core (always on) ───────────────────────────────────────────────────────
+  { id: "dashboard",  name: "Dashboard",     description: "Business overview, KPIs and activity.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/dashboard"] },
+  { id: "assistant",  name: "AI Assistant",  description: "Run the business by chat or voice.",     kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/assistant"] },
+  { id: "customers",  name: "Customers & Contacts", description: "Client records, sites, notes and portal links.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/customers", "/contacts", "/sites"] },
+  { id: "tasks",      name: "Tasks",         description: "Kanban board for the team's work.",      kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/tasks"] },
+  { id: "team",       name: "Team",          description: "Members, roles and workforce profiles.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/team"] },
+  { id: "settings",   name: "Settings",      description: "Business profile, appearance, API keys.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/settings", "/agents"] },
+
+  // ── Sales ──────────────────────────────────────────────────────────────────
+  { id: "leads",      name: "Leads",         description: "Capture and work the sales pipeline.",   kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/leads"] },
+  { id: "quotes",     name: "Quotes",        description: "Build and send quotes customers accept online.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/quotes"] },
+  { id: "invoicing",  name: "Invoices",      description: "Invoice, take payments, track balances.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/invoices"] },
+  { id: "recurring-billing", name: "Recurring billing", description: "Subscription invoices that bill (and auto-charge) on a schedule.", kind: "module", category: "sales", defaultEnabled: true, dependencies: ["invoicing"], routePrefixes: ["/recurring-invoices"] },
+  { id: "contracts",  name: "Contracts",     description: "Contracts with free in-app e-signature.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/contracts"] },
+  { id: "site-reports", name: "Site Reports", description: "Client-facing inspection / scope-of-work PDFs.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/reports"] },
+
+  // ── Service / field ops ────────────────────────────────────────────────────
+  { id: "jobs",       name: "Work Orders",   description: "Jobs with photos, time, materials and timelines.", kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/work-orders"] },
+  { id: "scheduling", name: "Schedule",      description: "Calendar and dispatch board for the crew.", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/schedule"] },
+  { id: "recurring-jobs", name: "Recurring jobs", description: "Repeating jobs that generate work orders (and optionally invoices).", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/recurring"] },
+  { id: "booking",    name: "Online booking", description: "Public booking pages with reminders.",   kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/bookings"] },
+
+  // ── Catalog / comms / insights ────────────────────────────────────────────
+  { id: "products",   name: "Products",      description: "Price list used across quotes and invoices.", kind: "module", category: "catalog", defaultEnabled: true, routePrefixes: ["/products"] },
+  { id: "messages",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "communication", defaultEnabled: true, routePrefixes: ["/messages"] },
+  { id: "analytics",  name: "Analytics",     description: "Revenue and pipeline insight.",          kind: "module", category: "insights", defaultEnabled: true, routePrefixes: ["/analytics"] },
+
+  // ── Feature-flagged verticals (existing plugins; settings table authoritative) ─
+  { id: "quoting-agent",     name: "Quoting Agent",     description: "AI that learns your pricing and writes quotes.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "quoting_agent_settings", routePrefixes: ["/quoting-agent"] },
+  { id: "client-onboarding", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
+  { id: "form-builder",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "sales", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
+];
+
+export const PLUGINS_BY_ID: Record<string, PluginDefinition> =
+  Object.fromEntries(PLUGIN_REGISTRY.map((p) => [p.id, p]));
+
+/** Optional (non-core) plugins — the toggleable surface. */
+export const OPTIONAL_PLUGINS = PLUGIN_REGISTRY.filter((p) => !p.core);
+
+/** Route-prefix → plugin id, for route-level gating (optional plugins only). */
+export const ROUTE_GATES: Array<{ prefix: string; pluginId: string }> =
+  OPTIONAL_PLUGINS.flatMap((p) => (p.routePrefixes ?? []).map((prefix) => ({ prefix, pluginId: p.id })));
+
+/** Enabled plugins that list `pluginId` as a dependency (blocks disabling it). */
+export function dependentsOf(pluginId: string, enabled: Record<string, boolean>): PluginDefinition[] {
+  return PLUGIN_REGISTRY.filter(
+    (p) => p.dependencies?.includes(pluginId) && (enabled[p.id] ?? p.defaultEnabled)
+  );
+}
+
+/**
+ * Resolve the enabled map for a business from its install rows + legacy
+ * settings flags. `installRows` = business_agent_installs; `settingsFlags` =
+ * { quoting_agent_settings: bool|null, ... } (null = no row).
+ */
+export function resolveEnabledPlugins(
+  installRows: Array<{ agent_id: string; enabled: boolean }>,
+  settingsFlags: Partial<Record<NonNullable<PluginDefinition["settingsTable"]>, boolean | null>>
+): Record<string, boolean> {
+  const byId = new Map(installRows.map((r) => [r.agent_id, r.enabled]));
+  const out: Record<string, boolean> = {};
+  for (const p of PLUGIN_REGISTRY) {
+    if (p.core) { out[p.id] = true; continue; }
+    if (p.settingsTable) {
+      const flag = settingsFlags[p.settingsTable];
+      out[p.id] = flag ?? byId.get(p.id) ?? p.defaultEnabled;
+      continue;
+    }
+    out[p.id] = byId.get(p.id) ?? p.defaultEnabled;
+  }
+  return out;
+}

--- a/src/lib/plugins/sync.ts
+++ b/src/lib/plugins/sync.ts
@@ -1,0 +1,31 @@
+/**
+ * Plugin/agent side-effect sync — keeps downstream settings tables in step
+ * with business_agent_installs toggles. Plain module (no "use server") shared
+ * by the agents-store actions and the MCP set_plugin_enabled tool.
+ *
+ *   email-lead-scanner ↔ business_email_config.enabled
+ *   client-onboarding  ↔ onboarding_settings.enabled
+ *   form-builder       ↔ form_builder_settings.enabled
+ *   quoting-agent      ↔ quoting_agent_settings.enabled
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function syncPluginSideEffects(sb: any, businessId: string, pluginId: string, enabled: boolean): Promise<void> {
+  if (pluginId === "email-lead-scanner") {
+    await tbl(sb, "business_email_config").update({ enabled }).eq("business_id", businessId);
+  }
+  if (pluginId === "client-onboarding") {
+    await tbl(sb, "onboarding_settings")
+      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  }
+  if (pluginId === "form-builder") {
+    await tbl(sb, "form_builder_settings")
+      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  }
+  if (pluginId === "quoting-agent") {
+    await tbl(sb, "quoting_agent_settings")
+      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  }
+}


### PR DESCRIPTION
## What
Phase 0-A of `docs/SEO_AGENCY_PLAN.md` — the plugin **infrastructure**. Deliberately zero visible change; the user-facing store/presets land in P0-B.

### Data-safety design (the user's hard requirement)
- **No migration, no backfill** — state stays in `business_agent_installs`.
- Resolution: `settingsTable ?? installRow ?? defaultEnabled`, with every legacy module `defaultEnabled: true` → **a business with no rows sees exactly today's app**. Existing agent rows (`ai-chat`, `email-lead-scanner`…) don't collide with module ids.
- Disabling **hides** (nav + route redirect). Nothing is deleted; re-enable restores instantly.
- The three existing verticals (quoting-agent / client-onboarding / form-builder) keep their settings tables **authoritative** — behavior identical.

### Pieces
- `src/lib/plugins/registry.ts` — 20 modules as `PluginDefinition` (core: dashboard, assistant, customers/contacts, tasks, team, settings), `dependencies` (e.g. scheduling→jobs, recurring-billing→invoicing), `routePrefixes`.
- **Layout resolver** — one `business_agent_installs` query + the 3 legacy flags → `plugins` map; passed to the sidebar.
- **Route gating** — `x-pathname` (already forwarded by proxy) checked against disabled plugins' prefixes → `redirect("/dashboard")`. Closes the reachable-by-URL hole.
- **Sidebar** — `feature?:` flags generalized to `plugin?:` tags on every optional item.
- **MCP** — `list_plugins`, `set_plugin_enabled` (core + dependency guards). Sync logic shared via `src/lib/plugins/sync.ts`.

### Next (P0-B)
Industry presets + signup step, `/agents` → **Plugins** store with module toggles (toggle-only for modules — uninstall stays agent-only), minimal vocab layer.

## Test plan
- [x] tsc / vitest / build green
- [ ] Preview: existing business → sidebar unchanged; MCP `set_plugin_enabled {"plugin_id":"booking","enabled":false}` → Bookings vanishes + `/bookings` redirects; re-enable restores; `set_plugin_enabled jobs false` blocked (scheduling depends on it); core blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)