### PR TITLE
feat(plugins): apply industry preset from the Plugins page (P1)

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -16,7 +16,7 @@ export default async function AgentsPage() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: biz } = await (supabase as any)
     .from("businesses")
-    .select("user_id")
+    .select("user_id, industry_preset")
     .eq("id", businessId)
     .single();
 
@@ -42,7 +42,11 @@ export default async function AgentsPage() {
 
   return (
     <div className="">
-      <AgentsStore installs={installs} pluginEnabled={pluginEnabled} />
+      <AgentsStore
+        installs={installs}
+        pluginEnabled={pluginEnabled}
+        activePreset={(biz?.industry_preset as string | null) ?? null}
+      />
     </div>
   );
 }

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -38,8 +38,9 @@ import {
   toggleAgent,
   type AgentInstall,
 } from "@/lib/actions/agents";
-import { setPluginEnabled } from "@/lib/actions/plugins";
-import { PLUGIN_REGISTRY, type PluginDefinition } from "@/lib/plugins/registry";
+import { setPluginEnabled, applyPresetToActiveBusiness } from "@/lib/actions/plugins";
+import { PLUGIN_REGISTRY, PLUGINS_BY_ID, OPTIONAL_PLUGINS, type PluginDefinition } from "@/lib/plugins/registry";
+import { INDUSTRY_PRESETS, type IndustryPreset } from "@/lib/plugins/presets";
 
 // ── Icon map ──────────────────────────────────────────────────────────────────
 
@@ -105,15 +106,36 @@ interface AgentsStoreProps {
   installs: AgentInstall[];
   /** Resolved plugin-enabled map (plugin id → enabled) from the server. */
   pluginEnabled: Record<string, boolean>;
+  /** businesses.industry_preset — the preset currently applied, if any. */
+  activePreset: string | null;
 }
 
-export function AgentsStore({ installs: initialInstalls, pluginEnabled }: AgentsStoreProps) {
+export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePreset }: AgentsStoreProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [installs, setInstalls] = useState<AgentInstall[]>(initialInstalls);
   const [activeCategory, setActiveCategory] = useState<AgentCategory | "all">("all");
   const [uninstallTarget, setUninstallTarget] = useState<AgentDefinition | null>(null);
   const [modules, setModules] = useState<Record<string, boolean>>(pluginEnabled);
+  const [presetTarget, setPresetTarget] = useState<IndustryPreset | null>(null);
+
+  function handleApplyPreset(preset: IndustryPreset) {
+    startTransition(async () => {
+      try {
+        await applyPresetToActiveBusiness(preset.id);
+        // Reflect the new enabled set locally so the Modules toggles update at once.
+        const next: Record<string, boolean> = { ...modules };
+        for (const p of OPTIONAL_PLUGINS) next[p.id] = preset.plugins.includes(p.id);
+        setModules(next);
+        toast.success(`${preset.label} preset applied`);
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't apply preset");
+      } finally {
+        setPresetTarget(null);
+      }
+    });
+  }
 
   function handleModuleToggle(plugin: PluginDefinition, enabled: boolean) {
     setModules((prev) => ({ ...prev, [plugin.id]: enabled }));
@@ -250,6 +272,47 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled }: Agents
         </div>
       </div>
 
+      {/* Industry presets — one click to shape the whole app for a business type */}
+      <div className="mb-10">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Industry preset</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {INDUSTRY_PRESETS.map((preset) => {
+            const isActive = activePreset === preset.id;
+            return (
+              <div
+                key={preset.id}
+                className={cn(
+                  "rounded-xl border bg-card p-4 flex items-start gap-3",
+                  isActive ? "border-primary/40 shadow-sm" : "border-border"
+                )}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm font-semibold break-words">{preset.label}</p>
+                    {isActive && (
+                      <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Active</Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{preset.description}</p>
+                </div>
+                <Button
+                  size="sm"
+                  variant={isActive ? "ghost" : "outline"}
+                  className="h-7 px-3 text-xs shrink-0"
+                  onClick={() => setPresetTarget(preset)}
+                  disabled={isPending}
+                >
+                  {isActive ? "Re-apply" : "Apply"}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+        <p className="text-[11px] text-muted-foreground mt-2">
+          A preset turns a bundle of modules on and hides the rest. Nothing is deleted — you can fine-tune individual modules below.
+        </p>
+      </div>
+
       {/* Modules — the app's building blocks */}
       <div className="mb-10">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Modules</h2>
@@ -314,6 +377,47 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled }: Agents
           );
         })}
       </div>
+
+      {/* Apply-preset confirm dialog */}
+      <AlertDialog
+        open={!!presetTarget}
+        onOpenChange={(open) => !open && setPresetTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Apply the {presetTarget?.label} preset?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3 text-sm">
+                <p>This sets which modules are on for this business. Hidden modules keep all their data — re-enable any of them anytime.</p>
+                {presetTarget && (() => {
+                  const on = OPTIONAL_PLUGINS.filter((p) => presetTarget.plugins.includes(p.id));
+                  const off = OPTIONAL_PLUGINS.filter((p) => !presetTarget.plugins.includes(p.id));
+                  return (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-emerald-600 mb-1">Turned on</p>
+                        <p className="text-xs text-muted-foreground">{on.map((p) => PLUGINS_BY_ID[p.id].name).join(", ") || "—"}</p>
+                      </div>
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">Hidden</p>
+                        <p className="text-xs text-muted-foreground">{off.map((p) => PLUGINS_BY_ID[p.id].name).join(", ") || "—"}</p>
+                      </div>
+                    </div>
+                  );
+                })()}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => presetTarget && handleApplyPreset(presetTarget)}
+            >
+              Apply preset
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Uninstall confirm dialog */}
       <AlertDialog

--- a/src/lib/actions/plugins.ts
+++ b/src/lib/actions/plugins.ts
@@ -75,6 +75,16 @@ export async function setPluginEnabled(pluginId: string, enabled: boolean): Prom
   revalidatePath("/", "layout");
 }
 
+/** Apply a preset to the ACTIVE business — the Plugins-page entry point (the
+ *  core applyIndustryPreset takes an explicit id for the signup path, before an
+ *  active-business cookie exists). */
+export async function applyPresetToActiveBusiness(presetId: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  await applyIndustryPreset(businessId, presetId);
+}
+
 /** Apply an industry preset to a business: sets businesses.industry_preset and
  *  writes explicit enable/disable rows for every optional module. Explicit
  *  action only (signup step or Plugins page) — never automatic. */


### PR DESCRIPTION
## What

Phase 1 of the plugin roadmap (`docs/SEO_AGENCY_PLAN.md`) — *"zero new SEO code; prove the multi-vertical thesis."* The `trades` / `agency` presets already existed but could only be applied during signup. This adds the **"apply preset" control the plan calls for** ("changeable later in Settings → Plugins").

- New **Industry preset** section on the Plugins page (`/agents`): a card per preset, the active one badged, `Apply` / `Re-apply` button.
- **Confirm dialog** spells out exactly which modules turn **on** and which get **hidden**, with the standing reassurance: *hidden modules keep all their data.*
- `applyPresetToActiveBusiness(presetId)` — active-business wrapper over the existing `applyIndustryPreset` (which takes an explicit id for the pre-cookie signup path).
- Page now reads `businesses.industry_preset` so the applied preset is highlighted.

## Data safety

Applying a preset only writes enable/disable rows + sets `industry_preset` — it **never deletes data** (disabling hides; re-enabling restores). Gated to owners/admins (`assertCanManage`). No new MCP tool needed — `apply_industry_preset` already exists at parity.

## Why it matters

This is the switch that lets one codebase present as two different apps: apply **agency** to Connected Studio (Proposals / Clients / Projects vocab, field-ops modules hidden) while Crown Roofers stays **trades** (everything as today). Once merged, that live switch is one click on the Plugins page.

## Verification

tsc clean · 17/17 tests · full build green (`/agents` compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)