### PR TITLE
feat(seo): SEO Production plugin + data model foundation (Phase 2)

### DIFF
--- a/src/app/(dashboard)/seo/page.tsx
+++ b/src/app/(dashboard)/seo/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { listSeoSites } from "@/lib/actions/seo";
+import { SeoSitesView } from "@/components/seo/seo-sites-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function SeoPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const businessId = await getActiveBizId(supabase as any, user.id);
+
+  const [sites, { data: customers }] = await Promise.all([
+    listSeoSites(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase as any)
+      .from("customers")
+      .select("id, name")
+      .eq("business_id", businessId)
+      .order("name")
+      .limit(500),
+  ]);
+
+  return <SeoSitesView sites={sites} customers={(customers ?? []) as { id: string; name: string }[]} />;
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -59,6 +59,9 @@ const navSections: NavSection[] = [
   { section: "Workforce", items: [
     { label: "Team",       href: "/team",       icon: Users2                        },
     { label: "Plugins",    href: "/agents",     icon: Bot                           },
+  ]},
+  { section: "SEO", items: [
+    { label: "SEO Production", href: "/seo", icon: Search, plugin: "seo-production" },
   ]},
   { section: "Insights", items: [
     { label: "Analytics",  href: "/analytics",  icon: TrendingUp,    plugin: "analytics" },

--- a/src/components/seo/seo-sites-view.tsx
+++ b/src/components/seo/seo-sites-view.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Search, Plus, Trash2, Globe } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/layout/page-header";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { createSeoSite, deleteSeoSite } from "@/lib/actions/seo";
+import type { SeoSite, SeoPlatform, SeoPlaybook } from "@/types/database";
+
+interface Props {
+  sites: SeoSite[];
+  customers: { id: string; name: string }[];
+}
+
+const PLATFORM_LABEL: Record<SeoPlatform, string> = {
+  wordpress: "WordPress", shopify: "Shopify", other: "Other",
+};
+const PLAYBOOK_LABEL: Record<SeoPlaybook, string> = {
+  local: "Local", ecommerce: "E-commerce",
+};
+
+const selectCls =
+  "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function SeoSitesView({ sites, customers }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [addOpen, setAddOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<SeoSite | null>(null);
+
+  // add-form state
+  const [domain, setDomain] = useState("");
+  const [customerId, setCustomerId] = useState("");
+  const [platform, setPlatform] = useState<SeoPlatform>("other");
+  const [playbook, setPlaybook] = useState<SeoPlaybook>("local");
+  const [notes, setNotes] = useState("");
+
+  function resetForm() {
+    setDomain(""); setCustomerId(""); setPlatform("other"); setPlaybook("local"); setNotes("");
+  }
+
+  function handleAdd() {
+    if (!domain.trim()) { toast.error("Enter a domain"); return; }
+    startTransition(async () => {
+      try {
+        await createSeoSite({
+          domain,
+          customer_id: customerId || null,
+          platform, playbook,
+          notes: notes || null,
+        });
+        toast.success("Client site added");
+        setAddOpen(false);
+        resetForm();
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't add site");
+      }
+    });
+  }
+
+  function handleDelete(site: SeoSite) {
+    startTransition(async () => {
+      try {
+        await deleteSeoSite(site.id);
+        toast.success("Site removed");
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't remove site");
+      } finally {
+        setDeleteTarget(null);
+      }
+    });
+  }
+
+  const customerName = (id: string | null) =>
+    id ? customers.find((c) => c.id === id)?.name ?? null : null;
+
+  return (
+    <>
+      <PageHeader
+        title="SEO Production"
+        subtitle="Client sites you manage — connectors, opportunities and content pipeline"
+        accent="linear-gradient(180deg, #10b981 0%, #047857 100%)"
+        actions={
+          <Button onClick={() => setAddOpen(true)} disabled={isPending}>
+            <Plus className="w-4 h-4 mr-1.5" /> Add site
+          </Button>
+        }
+      />
+
+      {sites.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3">
+            <Search className="w-6 h-6 text-muted-foreground" />
+          </div>
+          <p className="font-semibold">No client sites yet</p>
+          <p className="text-sm text-muted-foreground mt-1 max-w-sm mx-auto">
+            Add the first site you manage. Connectors, the opportunity queue and the content pipeline all hang off a site.
+          </p>
+          <Button className="mt-4" onClick={() => setAddOpen(true)}>
+            <Plus className="w-4 h-4 mr-1.5" /> Add your first site
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {sites.map((site) => (
+            <div key={site.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0">
+                  <Globe className="w-4.5 h-4.5 text-foreground/70" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold break-words">{site.domain}</p>
+                  {customerName(site.customer_id) && (
+                    <p className="text-xs text-muted-foreground mt-0.5 truncate">{customerName(site.customer_id)}</p>
+                  )}
+                </div>
+                <button
+                  onClick={() => setDeleteTarget(site)}
+                  disabled={isPending}
+                  className="text-muted-foreground hover:text-destructive shrink-0"
+                  aria-label="Remove site"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="flex items-center gap-1.5 flex-wrap">
+                <span className="text-[10px] font-medium bg-muted rounded-full px-2 py-0.5">{PLATFORM_LABEL[site.platform]}</span>
+                <span className="text-[10px] font-medium bg-muted rounded-full px-2 py-0.5">{PLAYBOOK_LABEL[site.playbook]}</span>
+                <span className={`text-[10px] font-medium rounded-full px-2 py-0.5 ${site.status === "active" ? "bg-emerald-100 text-emerald-700" : "bg-muted text-muted-foreground"}`}>{site.status}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add-site dialog */}
+      <Dialog open={addOpen} onOpenChange={(o) => { setAddOpen(o); if (!o) resetForm(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add a client site</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="seo-domain">Domain</Label>
+              <Input id="seo-domain" placeholder="example.com" value={domain} onChange={(e) => setDomain(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="seo-customer">Client (optional)</Label>
+              <select id="seo-customer" className={selectCls} value={customerId} onChange={(e) => setCustomerId(e.target.value)}>
+                <option value="">— No linked client —</option>
+                {customers.map((c) => (
+                  <option key={c.id} value={c.id}>{c.name}</option>
+                ))}
+              </select>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="seo-platform">Platform</Label>
+                <select id="seo-platform" className={selectCls} value={platform} onChange={(e) => setPlatform(e.target.value as SeoPlatform)}>
+                  <option value="other">Other</option>
+                  <option value="wordpress">WordPress</option>
+                  <option value="shopify">Shopify</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="seo-playbook">Playbook</Label>
+                <select id="seo-playbook" className={selectCls} value={playbook} onChange={(e) => setPlaybook(e.target.value as SeoPlaybook)}>
+                  <option value="local">Local</option>
+                  <option value="ecommerce">E-commerce</option>
+                </select>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="seo-notes">Notes (optional)</Label>
+              <Textarea id="seo-notes" rows={2} value={notes} onChange={(e) => setNotes(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setAddOpen(false)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleAdd} disabled={isPending}>Add site</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirm */}
+      <AlertDialog open={!!deleteTarget} onOpenChange={(o) => !o && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove {deleteTarget?.domain}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This deletes the site and all its SEO data (connections, keyword history, content). This can’t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive hover:bg-destructive/90"
+              onClick={() => deleteTarget && handleDelete(deleteTarget)}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -27,6 +27,7 @@ export {
   CreditCard,
   Crown,
   Database,
+  Globe,
   Eye,
   Lock,
   FileText,

--- a/src/lib/actions/seo.ts
+++ b/src/lib/actions/seo.ts
@@ -1,0 +1,131 @@
+"use server";
+
+/**
+ * SEO Production — client-site management (docs/SEO_AGENCY_PLAN.md, Phase 2).
+ *
+ * First usable slice: an agency registers the client sites it works on. The
+ * connectors (GSC etc.), opportunity scout, content pipeline and job engine
+ * land in later PRs and hang off these sites. AI-tool-first: every action here
+ * has a matching MCP tool in register-tools (scopes seo:read / seo:write).
+ */
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { SeoSite, SeoPlatform, SeoPlaybook, SeoSiteStatus } from "@/types/database";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uid = (v: string | null | undefined) => (v && UUID_RE.test(v.trim()) ? v.trim() : null);
+
+// seo_* tables aren't in the hand-maintained Database type yet — same escape
+// hatch the other recent actions use (forms.ts / onboarding.ts).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+/** Normalise a domain input to a bare host (strip scheme, path, trailing slash). */
+function normalizeDomain(input: string): string {
+  let d = input.trim().toLowerCase();
+  d = d.replace(/^https?:\/\//, "").replace(/^www\./, "");
+  d = d.split("/")[0].split("?")[0];
+  return d.replace(/\/+$/, "");
+}
+
+export async function listSeoSites(): Promise<SeoSite[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data, error } = await tbl(supabase, "seo_sites")
+    .select("*")
+    .eq("business_id", businessId)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as SeoSite[];
+}
+
+export async function getSeoSite(siteId: string): Promise<SeoSite | null> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "seo_sites")
+    .select("*")
+    .eq("id", siteId)
+    .eq("business_id", businessId)
+    .maybeSingle();
+  return (data as SeoSite) ?? null;
+}
+
+export async function createSeoSite(input: {
+  domain: string;
+  customer_id?: string | null;
+  platform?: SeoPlatform;
+  playbook?: SeoPlaybook;
+  notes?: string | null;
+}): Promise<SeoSite> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const domain = normalizeDomain(input.domain);
+  if (!domain) throw new Error("A domain is required");
+
+  const { data, error } = await tbl(supabase, "seo_sites")
+    .insert({
+      business_id: businessId,
+      customer_id: uid(input.customer_id),
+      domain,
+      platform: input.platform ?? "other",
+      playbook: input.playbook ?? "local",
+      notes: input.notes?.trim() || null,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/seo");
+  return data as SeoSite;
+}
+
+export async function updateSeoSite(
+  siteId: string,
+  patch: {
+    domain?: string;
+    customer_id?: string | null;
+    platform?: SeoPlatform;
+    playbook?: SeoPlaybook;
+    status?: SeoSiteStatus;
+    notes?: string | null;
+  },
+): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const clean: Record<string, unknown> = {};
+  if (patch.domain !== undefined) clean.domain = normalizeDomain(patch.domain);
+  if (patch.customer_id !== undefined) clean.customer_id = uid(patch.customer_id);
+  if (patch.platform !== undefined) clean.platform = patch.platform;
+  if (patch.playbook !== undefined) clean.playbook = patch.playbook;
+  if (patch.status !== undefined) clean.status = patch.status;
+  if (patch.notes !== undefined) clean.notes = patch.notes?.trim() || null;
+  if (Object.keys(clean).length === 0) return;
+
+  const { error } = await tbl(supabase, "seo_sites")
+    .update(clean)
+    .eq("id", siteId)
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/seo");
+  revalidatePath(`/seo/${siteId}`);
+}
+
+export async function deleteSeoSite(siteId: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "seo_sites")
+    .delete()
+    .eq("id", siteId)
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/seo");
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -31,6 +31,7 @@ import { customerAllowsCard } from "@/lib/payment-methods";
 import type { LineItem } from "@/types/database";
 import { ctxFrom, appBase, UUID, getOrMintPortalToken } from "./tools/shared";
 import { registerPluginFormTools } from "./tools/plugin-form-tools";
+import { registerSeoTools } from "./tools/seo-tools";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -1387,6 +1388,9 @@ export function registerTools(server: McpServer): void {
   // ===== PLUGINS · PRESETS · FORM BUILDER · ONBOARDING · CONTRACTS =====
   // Registered from ./tools/plugin-form-tools to keep this file focused.
   registerPluginFormTools(tool);
+
+  // ===== SEO PRODUCTION (docs/SEO_AGENCY_PLAN.md, Phase 2) =====
+  registerSeoTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -1,0 +1,97 @@
+/**
+ * MCP tools for the SEO Production plugin (docs/SEO_AGENCY_PLAN.md, Phase 2).
+ * First slice = client-site CRUD; connectors / opportunities / content pipeline
+ * tools land alongside those features. Scopes: seo:read / seo:write.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+const DOMAIN = z.string().min(1).describe("Client site domain, e.g. example.com");
+
+function normalizeDomain(input: string): string {
+  return input.trim().toLowerCase()
+    .replace(/^https?:\/\//, "").replace(/^www\./, "")
+    .split("/")[0].split("?")[0].replace(/\/+$/, "");
+}
+
+export function registerSeoTools(tool: ToolFn): void {
+  tool("list_seo_sites", "List the client sites this business manages for SEO.",
+    { status: z.enum(["active", "paused", "archived"]).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      let q = t(ctx, "seo_sites")
+        .select("id, domain, platform, playbook, status, customer_id, created_at")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false }).limit(200);
+      if (args.status) q = q.eq("status", args.status);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("get_seo_site", "Get one client SEO site including its notes.",
+    { site_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      const { data } = await t(ctx, "seo_sites")
+        .select("*, customers(name, email)").eq("id", args.site_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!data) return errorText("Site not found");
+      return text(data);
+    });
+
+  tool("create_seo_site",
+    "Register a client site for SEO work. platform = wordpress|shopify|other; playbook = local|ecommerce. Link it to a customer with customer_id (the agency's client).",
+    {
+      domain: DOMAIN,
+      customer_id: UUID.optional(),
+      platform: z.enum(["wordpress", "shopify", "other"]).optional(),
+      playbook: z.enum(["local", "ecommerce"]).optional(),
+      notes: z.string().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const domain = normalizeDomain(args.domain);
+      if (!domain) return errorText("A domain is required");
+      const { data, error } = await t(ctx, "seo_sites").insert({
+        business_id: ctx.businessId,
+        customer_id: args.customer_id ?? null,
+        domain,
+        platform: args.platform ?? "other",
+        playbook: args.playbook ?? "local",
+        notes: args.notes?.trim() || null,
+      }).select("id, domain, platform, playbook, status").single();
+      if (error) throw error;
+      return text({ created: true, site: data });
+    });
+
+  tool("update_seo_site", "Update a client site's domain / platform / playbook / status / notes.",
+    {
+      site_id: UUID,
+      domain: DOMAIN.optional(),
+      customer_id: UUID.optional(),
+      platform: z.enum(["wordpress", "shopify", "other"]).optional(),
+      playbook: z.enum(["local", "ecommerce"]).optional(),
+      status: z.enum(["active", "paused", "archived"]).optional(),
+      notes: z.string().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { site_id, domain, ...rest } = args;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clean: Record<string, any> = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (domain !== undefined) clean.domain = normalizeDomain(domain);
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "seo_sites").update(clean).eq("id", site_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("delete_seo_site", "Delete a client site and all its SEO data (connections, snapshots, content).",
+    { site_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { error } = await t(ctx, "seo_sites").delete().eq("id", args.site_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+}

--- a/src/lib/plugins/presets.ts
+++ b/src/lib/plugins/presets.ts
@@ -43,6 +43,21 @@ export const INDUSTRY_PRESETS: IndustryPreset[] = [
       "/customers": "Clients",
     },
   },
+  {
+    id: "seo-agency-local",
+    label: "SEO agency (local services)",
+    description: "Local-business SEO: client sites, GSC connector, opportunity queue, content pipeline and white-label reporting.",
+    // Agency operating layer + the SEO production engine. Field-ops modules off.
+    plugins: [
+      "leads", "quotes", "invoicing", "recurring-billing", "contracts",
+      "messages", "analytics", "client-onboarding", "form-builder",
+      "seo-production",
+    ],
+    vocab: {
+      "/customers": "Clients",
+      "/quotes": "Proposals",
+    },
+  },
 ];
 
 export const PRESETS_BY_ID: Record<string, IndustryPreset> =

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -75,6 +75,9 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "quoting-agent", icon: "sparkles",     name: "Quoting Agent",     description: "AI that learns your pricing and writes quotes.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "quoting_agent_settings", routePrefixes: ["/quoting-agent"] },
   { id: "client-onboarding", icon: "clipboard-list", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
   { id: "form-builder", icon: "list-checks",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "sales", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
+
+  // ── SEO vertical (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────
+  { id: "seo-production", icon: "trending-up", name: "SEO Production", description: "Manage client sites: connectors, opportunity queue, content pipeline and reporting.", kind: "module", category: "seo", defaultEnabled: false, routePrefixes: ["/seo"] },
 ];
 
 export const PLUGINS_BY_ID: Record<string, PluginDefinition> =

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -551,6 +551,114 @@ export interface PublicFormSubmission {
   created_at: string;
 }
 
+// ── SEO Production (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────
+export type SeoPlatform = 'wordpress' | 'shopify' | 'other';
+export type SeoPlaybook = 'local' | 'ecommerce';
+export type SeoSiteStatus = 'active' | 'paused' | 'archived';
+export type SeoProvider = 'gsc' | 'shopify' | 'wordpress' | 'gbp';
+export type SeoConnectionStatus = 'connected' | 'disconnected' | 'error';
+export type SeoOpportunityStatus = 'queued' | 'in_progress' | 'done' | 'dismissed';
+export type SeoContentStatus = 'brief' | 'draft' | 'approved' | 'published';
+export type SeoJobStatus = 'queued' | 'running' | 'awaiting_approval' | 'done' | 'failed';
+
+export interface SeoSite {
+  id: string;
+  business_id: string;
+  customer_id: string | null;
+  domain: string;
+  platform: SeoPlatform;
+  playbook: SeoPlaybook;
+  status: SeoSiteStatus;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SeoConnection {
+  id: string;
+  business_id: string;
+  site_id: string;
+  provider: SeoProvider;
+  status: SeoConnectionStatus;
+  account_ref: string | null;
+  secret: string | null;   // AES-256-GCM ciphertext — never exposed to the client
+  meta: Record<string, unknown>;
+  connected_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SeoKeywordSnapshot {
+  id: string;
+  business_id: string;
+  site_id: string;
+  keyword: string;
+  position: number | null;
+  clicks: number;
+  impressions: number;
+  ctr: number | null;
+  captured_at: string;
+  created_at: string;
+}
+
+export interface SeoOpportunity {
+  id: string;
+  business_id: string;
+  site_id: string;
+  type: string;
+  title: string;
+  detail: string | null;
+  priority: number;
+  status: SeoOpportunityStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SeoContentPiece {
+  id: string;
+  business_id: string;
+  site_id: string;
+  opportunity_id: string | null;
+  title: string;
+  target_keyword: string | null;
+  status: SeoContentStatus;
+  brief: Record<string, unknown>;
+  html: string | null;
+  published_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SeoJob {
+  id: string;
+  business_id: string;
+  site_id: string | null;
+  type: string;
+  status: SeoJobStatus;
+  step: number;
+  checkpoint: Record<string, unknown>;
+  input: Record<string, unknown>;
+  output: Record<string, unknown>;
+  cost_cents: number;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SeoBrandProfile {
+  id: string;
+  business_id: string;
+  customer_id: string | null;
+  site_id: string | null;
+  voice: string | null;
+  tone: string | null;
+  audience: string | null;
+  notes: string | null;
+  profile: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface CustomerPortalToken {
   token: string;
   business_id: string;
@@ -1100,6 +1208,8 @@ export type ApiScope =
   | 'onboarding:write'
   | 'forms:read'
   | 'forms:write'
+  | 'seo:read'
+  | 'seo:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1130,6 +1240,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'onboarding:write', label: 'Create / send onboarding forms', group: 'Onboarding' },
   { value: 'forms:read',       label: 'Read public forms & submissions', group: 'Forms' },
   { value: 'forms:write',      label: 'Create / publish public forms', group: 'Forms' },
+  { value: 'seo:read',         label: 'Read SEO sites & pipeline', group: 'SEO' },
+  { value: 'seo:write',        label: 'Manage SEO sites & content', group: 'SEO' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260708120000_seo_foundation.sql
+++ b/supabase/migrations/20260708120000_seo_foundation.sql
@@ -1,0 +1,187 @@
+-- SEO Production engine — data model foundation (docs/SEO_AGENCY_PLAN.md, Phase 2.1).
+--
+-- The agency is the BUSINESS; each of their clients is a CUSTOMER, so every SEO
+-- entity hangs off (business_id, customer_id/site). Additive only — new tables,
+-- no changes to existing tables or data. Gated behind the "seo-production"
+-- plugin (business_agent_installs, default off), so nothing appears for any
+-- current business until they enable it or apply the seo-agency-local preset.
+--
+-- Connector tokens (seo_connections.secret) are stored encrypted by the
+-- application layer (shared crypto helper, added with the connector work) — the
+-- column is plain TEXT holding ciphertext, never plaintext.
+
+-- ── Client sites ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.seo_sites (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  customer_id UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+  domain      TEXT NOT NULL,
+  platform    TEXT NOT NULL DEFAULT 'other'  CHECK (platform IN ('wordpress','shopify','other')),
+  playbook    TEXT NOT NULL DEFAULT 'local'  CHECK (playbook IN ('local','ecommerce')),
+  status      TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','archived')),
+  notes       TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_sites_business ON public.seo_sites (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_sites_customer ON public.seo_sites (customer_id);
+
+-- ── Per-site connector auth (GSC / Shopify / WordPress / GBP) ─────────────────
+CREATE TABLE IF NOT EXISTS public.seo_connections (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id     UUID NOT NULL REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  provider    TEXT NOT NULL CHECK (provider IN ('gsc','shopify','wordpress','gbp')),
+  status      TEXT NOT NULL DEFAULT 'disconnected' CHECK (status IN ('connected','disconnected','error')),
+  account_ref TEXT,                                  -- external account/property id
+  secret      TEXT,                                  -- AES-256-GCM ciphertext (refresh token etc.)
+  meta        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  connected_at TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (site_id, provider)
+);
+CREATE INDEX IF NOT EXISTS idx_seo_connections_business ON public.seo_connections (business_id);
+CREATE INDEX IF NOT EXISTS idx_seo_connections_site ON public.seo_connections (site_id);
+
+-- ── Keyword time-series (nightly GSC pull) ───────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.seo_keyword_snapshots (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id     UUID NOT NULL REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  keyword     TEXT NOT NULL,
+  position    NUMERIC,
+  clicks      INTEGER NOT NULL DEFAULT 0,
+  impressions INTEGER NOT NULL DEFAULT 0,
+  ctr         NUMERIC,
+  captured_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_kw_snapshots_site ON public.seo_keyword_snapshots (site_id, captured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_kw_snapshots_keyword ON public.seo_keyword_snapshots (site_id, keyword, captured_at DESC);
+
+-- ── Opportunity queue (the scout's output) ───────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.seo_opportunities (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id     UUID NOT NULL REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  type        TEXT NOT NULL,                          -- e.g. content_gap, quick_win, technical
+  title       TEXT NOT NULL,
+  detail      TEXT,
+  priority    INTEGER NOT NULL DEFAULT 0,
+  status      TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','in_progress','done','dismissed')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_opportunities_site ON public.seo_opportunities (site_id, status, priority DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_opportunities_business ON public.seo_opportunities (business_id, created_at DESC);
+
+-- ── Content pipeline (brief → draft → approved → published) ──────────────────
+CREATE TABLE IF NOT EXISTS public.seo_content_pieces (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id    UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id        UUID NOT NULL REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  opportunity_id UUID REFERENCES public.seo_opportunities(id) ON DELETE SET NULL,
+  title          TEXT NOT NULL,
+  target_keyword TEXT,
+  status         TEXT NOT NULL DEFAULT 'brief' CHECK (status IN ('brief','draft','approved','published')),
+  brief          JSONB NOT NULL DEFAULT '{}'::jsonb,
+  html           TEXT,
+  published_url  TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_content_site ON public.seo_content_pieces (site_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_content_business ON public.seo_content_pieces (business_id, created_at DESC);
+
+-- ── Job engine (Vercel-native, step-wise + checkpointed) ─────────────────────
+CREATE TABLE IF NOT EXISTS public.seo_jobs (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id     UUID REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  type        TEXT NOT NULL,                          -- keyword_strategy, opportunity_scout, brief, draft, ...
+  status      TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','running','awaiting_approval','done','failed')),
+  step        INTEGER NOT NULL DEFAULT 0,
+  checkpoint  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  input       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  output      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  cost_cents  INTEGER NOT NULL DEFAULT 0,
+  error       TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+-- Partial index on the runner's hot path: the next claimable job.
+CREATE INDEX IF NOT EXISTS idx_seo_jobs_queued ON public.seo_jobs (created_at) WHERE status = 'queued';
+CREATE INDEX IF NOT EXISTS idx_seo_jobs_business ON public.seo_jobs (business_id, created_at DESC);
+
+-- ── Brand voice / tone per client (seeds agent copy) ─────────────────────────
+CREATE TABLE IF NOT EXISTS public.seo_brand_profiles (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  customer_id UUID REFERENCES public.customers(id) ON DELETE CASCADE,
+  site_id     UUID REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  voice       TEXT,
+  tone        TEXT,
+  audience    TEXT,
+  notes       TEXT,
+  profile     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_brand_profiles_business ON public.seo_brand_profiles (business_id);
+CREATE INDEX IF NOT EXISTS idx_seo_brand_profiles_site ON public.seo_brand_profiles (site_id);
+
+-- ── RLS — read: members except workers · write: owner / admin / editor ───────
+-- (crons write via the service-role client, which bypasses RLS.)
+ALTER TABLE public.seo_sites             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.seo_connections       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.seo_keyword_snapshots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.seo_opportunities     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.seo_content_pieces    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.seo_jobs              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.seo_brand_profiles    ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'seo_sites','seo_connections','seo_keyword_snapshots','seo_opportunities',
+    'seo_content_pieces','seo_jobs','seo_brand_profiles'
+  ] LOOP
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, t);
+  END LOOP;
+END $$;
+
+-- ── updated_at triggers ──────────────────────────────────────────────────────
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'seo_sites','seo_connections','seo_opportunities',
+    'seo_content_pieces','seo_jobs','seo_brand_profiles'
+  ] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %1$s_updated_at ON public.%1$s;
+      CREATE TRIGGER %1$s_updated_at BEFORE UPDATE ON public.%1$s
+      FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();', t);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## What

Kicks off **Phase 2** of `docs/SEO_AGENCY_PLAN.md` — the dependency-free **foundation** of the SEO production engine. (The GSC connector needs a Google Cloud OAuth client from the user, so it's deferred to a follow-up.)

### Data model — migration `20260708120000_seo_foundation.sql` (applied + recorded on remote)
7 **additive** tables, each with the standard RLS (read: members except workers · write: owner/admin/editor), `(business_id, …)` indexes, and `updated_at` triggers:
`seo_sites` · `seo_connections` · `seo_keyword_snapshots` · `seo_opportunities` · `seo_content_pieces` · `seo_jobs` · `seo_brand_profiles`.

**Additive only — zero impact on existing business data.** Verified live: all 7 tables created, 2 policies each.

### Plugin + preset
- Registry: new **`seo-production`** plugin (category `seo`, **default OFF**).
- New **`seo-agency-local`** industry preset (agency operating layer + the SEO engine).

### First usable slice — client-site CRUD
- Actions (`src/lib/actions/seo.ts`) + **MCP tools** (`tools/seo-tools.ts`, scopes `seo:read` / `seo:write`) — standing MCP-parity rule satisfied.
- Gated **`/seo`** page to add / list / remove client sites, with a plugin-gated "SEO" sidebar section.
- `database.ts` gains the SEO row types + `seo:*` scopes.

## Data safety

Nothing appears for any current business: the plugin is **default off**, and `/seo` is **route-gated + nav-gated**. It only becomes visible when a business enables the plugin or applies the `seo-agency-local` preset. Disabling hides; never deletes.

## Follow-ups (next PRs)

Connectors (GSC — needs Google OAuth client), opportunity scout, content pipeline, and the Vercel-native job engine (`seo_jobs` runner). Shared crypto helper lands with the first connector that stores tokens.

## Verification

tsc clean · 17/17 tests · full build (`/seo` + `/api/mcp` compile) · migration applied + verified on the live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)