### PR TITLE
feat(seo): live web search for the research + audit agents

### DIFF
--- a/src/lib/seo/engine.ts
+++ b/src/lib/seo/engine.ts
@@ -71,11 +71,18 @@ export async function runAgent(agentId: string, piece: PieceLike): Promise<RunRe
   const agent = SEO_AGENTS_BY_ID[agentId];
   const model = MODEL[agent?.model ?? "sonnet"];
 
+  // Research / audit agents get live web search (server-side tool — Anthropic
+  // runs the searches and returns the grounded answer in one call).
+  const tools = agent?.tools?.includes("web_search")
+    ? ([{ type: "web_search_20250305", name: "web_search", max_uses: 6 }] as Anthropic.Messages.MessageCreateParams["tools"])
+    : undefined;
+
   const res = await anthropic.messages.create({
     model,
     max_tokens: 8192,
     system,
     messages: [{ role: "user", content: buildInput(agentId, piece) }],
+    ...(tools ? { tools } : {}),
   });
 
   const content = res.content


### PR DESCRIPTION
## What

Wires Anthropic's server-side **`web_search`** tool into every SEO agent whose registry entry declares it — opportunity scout, keyword strategist, SERP analyst, editor/fact-checker, long-form copywriter, technical auditor.

They now ground their work in **live search results** (real SERPs, "people also ask", competitor pages) instead of model knowledge alone — the biggest single quality lever on the pipeline. Anthropic executes the searches server-side and returns the grounded answer in one call; the text extraction already skips the tool-use/result blocks.

## Risk

Server-only, one-line-ish change in `engine.ts`. No schema, no UI, no client bundle impact. Adds search cost on the research steps (expected).

Verified: tsc · 17 tests · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)