### PR TITLE
feat(seo): per-business monthly budget cap on the agent engine

### DIFF
--- a/src/app/(dashboard)/seo/content/page.tsx
+++ b/src/app/(dashboard)/seo/content/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { listSeoSites } from "@/lib/actions/seo";
-import { listContentPieces } from "@/lib/actions/seo-pipeline";
+import { listContentPieces, getSeoBudget } from "@/lib/actions/seo-pipeline";
 import { SeoContentList } from "@/components/seo/seo-content-list";
 
 export const dynamic = "force-dynamic";
@@ -14,12 +14,13 @@ export default async function SeoContentPage() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await getActiveBizId(supabase as any, user.id);
 
-  const [pieces, sites] = await Promise.all([listContentPieces(), listSeoSites()]);
+  const [pieces, sites, budget] = await Promise.all([listContentPieces(), listSeoSites(), getSeoBudget()]);
   return (
     <SeoContentList
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pieces={pieces as any}
       sites={sites.map((s) => ({ id: s.id, domain: s.domain }))}
+      budget={budget}
     />
   );
 }

--- a/src/components/seo/seo-content-list.tsx
+++ b/src/components/seo/seo-content-list.tsx
@@ -11,7 +11,7 @@ import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { startContentPipeline } from "@/lib/actions/seo-pipeline";
+import { startContentPipeline, setSeoBudget } from "@/lib/actions/seo-pipeline";
 import type { SeoContentType } from "@/types/database";
 
 interface Piece {
@@ -22,7 +22,10 @@ interface Piece {
 interface Props {
   pieces: Piece[];
   sites: { id: string; domain: string }[];
+  budget: { spentCents: number; budgetCents: number; ok: boolean };
 }
+
+const money = (cents: number) => `$${(cents / 100).toFixed(2)}`;
 
 const STATUS_TONE: Record<string, string> = {
   running: "bg-blue-100 text-blue-700",
@@ -34,13 +37,28 @@ const STATUS_TONE: Record<string, string> = {
 
 const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
 
-export function SeoContentList({ pieces, sites }: Props) {
+export function SeoContentList({ pieces, sites, budget }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
   const [siteId, setSiteId] = useState(sites[0]?.id ?? "");
   const [topic, setTopic] = useState("");
   const [contentType, setContentType] = useState<SeoContentType>("blog");
+  const [budgetOpen, setBudgetOpen] = useState(false);
+  const [budgetDollars, setBudgetDollars] = useState(String((budget.budgetCents / 100).toFixed(0)));
+
+  function handleSaveBudget() {
+    startTransition(async () => {
+      try {
+        await setSeoBudget(Math.round(parseFloat(budgetDollars || "0") * 100));
+        toast.success("Budget updated");
+        setBudgetOpen(false);
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't update budget");
+      }
+    });
+  }
 
   function handleStart() {
     if (!siteId) { toast.error("Add a client site first"); return; }
@@ -73,6 +91,19 @@ export function SeoContentList({ pieces, sites }: Props) {
           </>
         }
       />
+
+      {/* Budget strip */}
+      <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl border border-border bg-card px-4 py-2.5 mb-5">
+        <div className="text-sm">
+          <span className="text-muted-foreground">This month: </span>
+          <span className="font-semibold">{money(budget.spentCents)}</span>
+          <span className="text-muted-foreground"> of {budget.budgetCents === 0 ? "unlimited" : money(budget.budgetCents)}</span>
+          {!budget.ok && <span className="ml-2 text-[11px] font-medium text-amber-700 bg-amber-100 rounded-full px-2 py-0.5">budget reached</span>}
+        </div>
+        <button onClick={() => setBudgetOpen(true)} className="text-xs text-muted-foreground hover:text-foreground underline">
+          Set budget
+        </button>
+      </div>
 
       {sites.length === 0 && (
         <p className="text-sm text-muted-foreground mb-4">Add a client site on the <Link href="/seo" className="underline">Sites</Link> page first.</p>
@@ -133,6 +164,21 @@ export function SeoContentList({ pieces, sites }: Props) {
           <DialogFooter>
             <Button variant="ghost" onClick={() => setOpen(false)} disabled={isPending}>Cancel</Button>
             <Button onClick={handleStart} disabled={isPending}>Start pipeline</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={budgetOpen} onOpenChange={setBudgetOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Monthly SEO budget</DialogTitle></DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="c-budget">Cap ($ per month, 0 = unlimited)</Label>
+            <Input id="c-budget" type="number" min={0} value={budgetDollars} onChange={(e) => setBudgetDollars(e.target.value)} />
+            <p className="text-xs text-muted-foreground">The agents stop running once the month&apos;s spend reaches this. Currently spent {money(budget.spentCents)}.</p>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setBudgetOpen(false)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleSaveBudget} disabled={isPending}>Save</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/lib/actions/seo-pipeline.ts
+++ b/src/lib/actions/seo-pipeline.ts
@@ -13,7 +13,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
-import { advanceContentJob, type ContentType } from "@/lib/seo/engine";
+import { advanceContentJob, seoSpendStatus, type ContentType } from "@/lib/seo/engine";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -112,4 +112,22 @@ export async function getContentPiece(pieceId: string) {
   const { data } = await tbl(supabase, "seo_content_pieces")
     .select("*, seo_sites(domain)").eq("id", pieceId).eq("business_id", businessId).maybeSingle();
   return data ?? null;
+}
+
+/** Month-to-date SEO spend vs. the monthly budget cap (cents). */
+export async function getSeoBudget(): Promise<{ spentCents: number; budgetCents: number; ok: boolean }> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  return seoSpendStatus(supabase, businessId);
+}
+
+/** Set the monthly SEO budget (cents; 0 = unlimited). RLS gates this to owners. */
+export async function setSeoBudget(cents: number): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const v = Math.max(0, Math.round(cents));
+  const { error } = await tbl(supabase, "businesses").update({ seo_monthly_budget_cents: v }).eq("id", businessId);
+  if (error) throw error;
+  revalidatePath("/seo");
+  revalidatePath("/seo/content");
 }

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -6,7 +6,7 @@
 import { z } from "zod";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, UUID, type ToolFn } from "./shared";
-import { advanceContentJob } from "@/lib/seo/engine";
+import { advanceContentJob, seoSpendStatus } from "@/lib/seo/engine";
 
 const DOMAIN = z.string().min(1).describe("Client site domain, e.g. example.com");
 
@@ -168,5 +168,22 @@ export function registerSeoTools(tool: ToolFn): void {
       await t(ctx, "seo_content_pieces").update({ pipeline_status: "done", status: "approved" }).eq("id", args.piece_id);
       if (piece.job_id) await t(ctx, "seo_jobs").update({ status: "done" }).eq("id", piece.job_id);
       return text({ approved: true });
+    });
+
+  // ── Budget cap ──────────────────────────────────────────────────────────────
+  tool("get_seo_budget", "Get this month's SEO agent spend vs. the monthly budget cap (cents).",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      return text(await seoSpendStatus(ctx.sb, ctx.businessId));
+    });
+
+  tool("set_seo_budget", "Set the monthly SEO agent budget cap in cents (0 = unlimited). The engine stops running agents once the month's spend reaches it.",
+    { cents: z.number().int().min(0) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { error } = await t(ctx, "businesses").update({ seo_monthly_budget_cents: args.cents }).eq("id", ctx.businessId);
+      if (error) throw error;
+      return text({ budget_cents: args.cents });
     });
 }

--- a/src/lib/seo/engine.ts
+++ b/src/lib/seo/engine.ts
@@ -98,6 +98,22 @@ export async function runAgent(agentId: string, piece: PieceLike): Promise<RunRe
   return { content, costCents };
 }
 
+/** Month-to-date SEO spend vs. the business's monthly budget (cents).
+ *  budgetCents === 0 means unlimited (explicit opt-out). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function seoSpendStatus(sb: any, businessId: string): Promise<{ spentCents: number; budgetCents: number; ok: boolean }> {
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+  const [{ data: biz }, { data: jobs }] = await Promise.all([
+    sb.from("businesses").select("seo_monthly_budget_cents").eq("id", businessId).maybeSingle(),
+    sb.from("seo_jobs").select("cost_cents").eq("business_id", businessId).gte("created_at", monthStart),
+  ]);
+  const budgetCents = biz?.seo_monthly_budget_cents ?? 2000;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spentCents = (jobs ?? []).reduce((s: number, r: any) => s + (r.cost_cents ?? 0), 0);
+  return { spentCents, budgetCents, ok: budgetCents === 0 || spentCents < budgetCents };
+}
+
 interface Job { id: string; business_id: string; step: number; input: { content_piece_id?: string }; cost_cents: number }
 
 /**
@@ -126,6 +142,15 @@ export async function advanceContentJob(sb: any, job: Job): Promise<{ status: st
     await sb.from("seo_content_pieces").update({ pipeline_status: "awaiting_approval" }).eq("id", pieceId);
     await sb.from("seo_jobs").update({ status: "awaiting_approval" }).eq("id", job.id);
     return { status: "awaiting_approval" };
+  }
+
+  // Budget gate — the non-negotiable cost cap. Stop before spending more.
+  const budget = await seoSpendStatus(sb, job.business_id);
+  if (!budget.ok) {
+    const msg = `Monthly SEO budget reached ($${(budget.budgetCents / 100).toFixed(2)}). Raise it in SEO settings to continue.`;
+    await sb.from("seo_content_pieces").update({ pipeline_status: "failed" }).eq("id", pieceId);
+    await sb.from("seo_jobs").update({ status: "failed", error: msg }).eq("id", job.id);
+    return { status: "failed" };
   }
 
   const agentId = steps[idx];

--- a/supabase/migrations/20260708180000_seo_budget.sql
+++ b/supabase/migrations/20260708180000_seo_budget.sql
@@ -1,0 +1,6 @@
+-- SEO per-business monthly budget cap (docs/SEO_AGENCY_PLAN.md §11 — non-negotiable).
+-- Additive: a monthly ceiling (cents) the job engine enforces before each agent
+-- step. Default $20/mo; 0 = unlimited (explicit opt-out). Existing businesses
+-- get the default and are unaffected until they enable the SEO plugin.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS seo_monthly_budget_cents INTEGER NOT NULL DEFAULT 2000;


### PR DESCRIPTION
## What

The **non-negotiable cost guard** (`SEO_AGENCY_PLAN.md` §11). Now that the cron makes real Claude + web-search calls, this stops spend from running away.

- **Migration `20260708180000`** (applied + recorded): `businesses.seo_monthly_budget_cents` (default **$20/mo**; `0` = unlimited). Additive.
- **`engine.seoSpendStatus()`** sums this month's `seo_jobs.cost_cents`; **`advanceContentJob` gates on it** — before each agent step, if month-to-date spend ≥ budget the job stops (`failed` with "Monthly SEO budget reached — raise it in settings").
- Actions `getSeoBudget` / `setSeoBudget`; **MCP** `get_seo_budget` / `set_seo_budget`.
- **UI**: the Content page shows a spend strip (`$X of $Y this month` + a "budget reached" badge) with a **Set budget** dialog.

## Safety

Additive column only; SEO plugin still default-off/route-gated. Existing businesses get the default cap and are unaffected.

Verified: tsc · 17 tests · build · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)