### PR TITLE
feat(seo): live agent activity terminal (event logging)

### DIFF
--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -18,13 +18,11 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
   const site = await getSeoSite(id);
   if (!site) notFound();
 
-  const [pieces, budget, connectionsRes, jobsRes] = await Promise.all([
+  const [pieces, budget, connectionsRes] = await Promise.all([
     listContentPieces(id),
     getSeoBudget(),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (supabase as any).from("seo_connections").select("provider, status, account_ref, connected_at").eq("business_id", businessId).eq("site_id", id),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (supabase as any).from("seo_jobs").select("id, type, status, step, cost_cents, error, created_at, updated_at").eq("business_id", businessId).eq("site_id", id).order("created_at", { ascending: false }).limit(20),
   ]);
 
   return (
@@ -34,7 +32,6 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pieces={pieces as any}
       connections={(connectionsRes.data ?? []) as { provider: string; status: string; account_ref: string | null; connected_at: string | null }[]}
-      jobs={(jobsRes.data ?? []) as { id: string; type: string; status: string; step: number; cost_cents: number; error: string | null; created_at: string }[]}
       budget={budget}
     />
   );

--- a/src/components/seo/seo-activity-terminal.tsx
+++ b/src/components/seo/seo-activity-terminal.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { listSeoActivity } from "@/lib/actions/seo-pipeline";
+import { cn } from "@/lib/utils";
+
+interface Event { id: string; agent_id: string | null; level: string; message: string; cost_cents: number; created_at: string }
+
+/** Live terminal of agent activity for a site — polls every 3s and auto-scrolls. */
+export function SeoActivityTerminal({ siteId }: { siteId: string }) {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let alive = true;
+    async function poll() {
+      try {
+        const e = await listSeoActivity(siteId);
+        if (alive) { setEvents(e as Event[]); setLoaded(true); }
+      } catch { /* keep last good state */ }
+    }
+    poll();
+    const iv = setInterval(poll, 3000);
+    return () => { alive = false; clearInterval(iv); };
+  }, [siteId]);
+
+  useEffect(() => {
+    boxRef.current?.scrollTo({ top: boxRef.current.scrollHeight });
+  }, [events]);
+
+  const levelColor = (l: string) =>
+    l === "error" ? "text-red-400" : l === "success" ? "text-emerald-400" : "text-blue-300";
+
+  return (
+    <div className="rounded-xl border border-border bg-[#0c0d0f] text-[#d6d3ca] font-mono text-xs overflow-hidden">
+      <div className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" aria-hidden />
+        <span className="text-[11px] uppercase tracking-wider text-white/50">Agent activity · live</span>
+      </div>
+      <div ref={boxRef} className="p-4 space-y-1 max-h-[30rem] overflow-y-auto">
+        {!loaded ? (
+          <p className="text-white/40">connecting…</p>
+        ) : events.length === 0 ? (
+          <p className="text-white/40">No activity yet. Start a content piece and the agents show up here in real time.</p>
+        ) : (
+          events.map((e) => (
+            <div key={e.id} className="flex items-start gap-2">
+              <span className="text-white/30 shrink-0">{new Date(e.created_at).toLocaleTimeString()}</span>
+              <span className={cn("min-w-0 break-words", levelColor(e.level))}>{e.message}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -12,7 +12,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { startContentPipeline } from "@/lib/actions/seo-pipeline";
-import { executableSteps, SEO_AGENTS_BY_ID } from "@/lib/seo/pipeline";
+import { SeoActivityTerminal } from "@/components/seo/seo-activity-terminal";
 import type { SeoSite, SeoContentType } from "@/types/database";
 
 interface Piece {
@@ -20,13 +20,11 @@ interface Piece {
   status: string; pipeline_status: string; current_stage: string | null; created_at: string;
 }
 interface Connection { provider: string; status: string; account_ref: string | null; connected_at: string | null }
-interface Job { id: string; type: string; status: string; step: number; cost_cents: number; error: string | null; created_at: string }
 
 interface Props {
   site: SeoSite & { seo_sites?: unknown };
   pieces: Piece[];
   connections: Connection[];
-  jobs: Job[];
   budget: { spentCents: number; budgetCents: number; ok: boolean };
 }
 
@@ -50,7 +48,7 @@ const CONNECTORS = [
   { provider: "gbp", name: "Google Business Profile", desc: "Local-pack signals and profile posts.", ready: false },
 ];
 
-export function SeoSiteHub({ site, pieces, connections, jobs, budget }: Props) {
+export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("overview");
   const [isPending, startTransition] = useTransition();
@@ -192,31 +190,7 @@ export function SeoSiteHub({ site, pieces, connections, jobs, budget }: Props) {
       )}
 
       {/* ── Activity ── */}
-      {tab === "activity" && (
-        jobs.length === 0 ? (
-          <EmptyState icon={Activity} title="No runs yet" body="When you start a content piece, each agent run shows up here." />
-        ) : (
-          <div className="rounded-xl border border-border bg-[#0c0d0f] text-[#d6d3ca] font-mono text-xs overflow-x-auto">
-            <div className="px-4 py-2 border-b border-white/10 text-[11px] uppercase tracking-wider text-white/50">Agent activity · {site.domain}</div>
-            <div className="p-4 space-y-1.5">
-              {jobs.map((j) => {
-                const steps = executableSteps("blog");
-                const agent = SEO_AGENTS_BY_ID[steps[Math.min(j.step, steps.length - 1)]];
-                return (
-                  <div key={j.id} className="flex items-start gap-2">
-                    <span className="text-white/40 shrink-0">{new Date(j.created_at).toLocaleTimeString()}</span>
-                    <span className={cn("shrink-0", j.status === "failed" ? "text-red-400" : j.status === "done" || j.status === "awaiting_approval" ? "text-emerald-400" : "text-blue-400")}>[{j.status}]</span>
-                    <span className="min-w-0">
-                      {j.type} · step {j.step}{agent ? ` (${agent.name})` : ""}{j.cost_cents > 0 ? ` · ${money(j.cost_cents)}` : ""}
-                      {j.error && <span className="text-red-400 block break-words">↳ {j.error}</span>}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )
-      )}
+      {tab === "activity" && <SeoActivityTerminal siteId={site.id} />}
 
       {/* New content dialog */}
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/lib/actions/seo-pipeline.ts
+++ b/src/lib/actions/seo-pipeline.ts
@@ -58,8 +58,23 @@ export async function startContentPipeline(input: {
   if (jobErr) throw jobErr;
 
   await tbl(admin, "seo_content_pieces").update({ job_id: job.id }).eq("id", piece.id);
+  await tbl(admin, "seo_job_events").insert({
+    business_id: businessId, site_id: input.site_id, job_id: job.id, level: "info",
+    message: `Queued "${input.topic.trim()}" (${contentType})`,
+  });
   revalidatePath("/seo");
   return { piece_id: piece.id };
+}
+
+/** Agent activity events for a site (chronological) — powers the terminal. */
+export async function listSeoActivity(siteId: string, limit = 80) {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { data } = await tbl(supabase, "seo_job_events")
+    .select("id, agent_id, level, message, cost_cents, created_at")
+    .eq("business_id", businessId).eq("site_id", siteId)
+    .order("created_at", { ascending: false }).limit(limit);
+  return ((data ?? []) as Array<{ id: string; agent_id: string | null; level: string; message: string; cost_cents: number; created_at: string }>).reverse();
 }
 
 /** Advance a piece's pipeline by one agent step (returns the new status). */

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -120,6 +120,10 @@ export function registerSeoTools(tool: ToolFn): void {
       }).select("id").single();
       if (jErr) throw jErr;
       await t(ctx, "seo_content_pieces").update({ job_id: job.id }).eq("id", piece.id);
+      await t(ctx, "seo_job_events").insert({
+        business_id: ctx.businessId, site_id: args.site_id, job_id: job.id, level: "info",
+        message: `Queued "${args.topic.trim()}" (${contentType})`,
+      });
       return text({ started: true, piece_id: piece.id, note: "The cron advances it, or call advance_content_pipeline to run the next step now." });
     });
 
@@ -185,5 +189,17 @@ export function registerSeoTools(tool: ToolFn): void {
       const { error } = await t(ctx, "businesses").update({ seo_monthly_budget_cents: args.cents }).eq("id", ctx.businessId);
       if (error) throw error;
       return text({ budget_cents: args.cents });
+    });
+
+  tool("list_seo_activity", "Read the agent activity log for a site (chronological) — what the agents have been doing.",
+    { site_id: UUID, limit: z.number().int().min(1).max(200).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      const { data, error } = await t(ctx, "seo_job_events")
+        .select("agent_id, level, message, cost_cents, created_at")
+        .eq("business_id", ctx.businessId).eq("site_id", args.site_id)
+        .order("created_at", { ascending: false }).limit(args.limit ?? 80);
+      if (error) throw error;
+      return text((data ?? []).reverse());
     });
 }

--- a/src/lib/seo/engine.ts
+++ b/src/lib/seo/engine.ts
@@ -114,6 +114,21 @@ export async function seoSpendStatus(sb: any, businessId: string): Promise<{ spe
   return { spentCents, budgetCents, ok: budgetCents === 0 || spentCents < budgetCents };
 }
 
+/** Append an agent-activity event (the "terminal" feed). Never throws — logging
+ *  must not break the pipeline. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function logEvent(sb: any, e: {
+  business_id: string; site_id?: string | null; job_id?: string; agent_id?: string;
+  level?: "info" | "success" | "error"; message: string; cost_cents?: number;
+}): Promise<void> {
+  try {
+    await sb.from("seo_job_events").insert({
+      business_id: e.business_id, site_id: e.site_id ?? null, job_id: e.job_id ?? null,
+      agent_id: e.agent_id ?? null, level: e.level ?? "info", message: e.message, cost_cents: e.cost_cents ?? 0,
+    });
+  } catch { /* best-effort */ }
+}
+
 interface Job { id: string; business_id: string; step: number; input: { content_piece_id?: string }; cost_cents: number }
 
 /**
@@ -134,6 +149,7 @@ export async function advanceContentJob(sb: any, job: Job): Promise<{ status: st
   if (!piece) throw new Error("Content piece not found");
 
   const contentType = (piece.content_type ?? "blog") as ContentType;
+  const siteId = piece.site_id as string | null;
   const steps = resolveSteps(contentType);
   const idx = job.step;
 
@@ -150,16 +166,20 @@ export async function advanceContentJob(sb: any, job: Job): Promise<{ status: st
     const msg = `Monthly SEO budget reached ($${(budget.budgetCents / 100).toFixed(2)}). Raise it in SEO settings to continue.`;
     await sb.from("seo_content_pieces").update({ pipeline_status: "failed" }).eq("id", pieceId);
     await sb.from("seo_jobs").update({ status: "failed", error: msg }).eq("id", job.id);
+    await logEvent(sb, { business_id: job.business_id, site_id: siteId, job_id: job.id, level: "error", message: `Budget cap reached — ${msg}` });
     return { status: "failed" };
   }
 
   const agentId = steps[idx];
+  const agentName = SEO_AGENTS_BY_ID[agentId]?.name ?? agentId;
   const pieceLike: PieceLike = {
     topic: piece.topic,
     content_type: contentType,
     artifacts: piece.artifacts ?? {},
     domain: piece.seo_sites?.domain ?? null,
   };
+
+  await logEvent(sb, { business_id: job.business_id, site_id: siteId, job_id: job.id, agent_id: agentId, message: `▶ ${agentName} — step ${idx + 1}/${steps.length}` });
 
   try {
     const { content, costCents } = await runAgent(agentId, pieceLike);
@@ -170,6 +190,9 @@ export async function advanceContentJob(sb: any, job: Job): Promise<{ status: st
     }
 
     const isLast = idx + 1 >= steps.length;
+    const producedLabels = (agent?.produces ?? []).map((k) => SEO_ARTIFACTS[k as SeoArtifactKey]?.label ?? k).join(", ");
+    await logEvent(sb, { business_id: job.business_id, site_id: siteId, job_id: job.id, agent_id: agentId, level: "success", cost_cents: costCents, message: `✓ ${agentName} → ${producedLabels} · $${(costCents / 100).toFixed(2)}` });
+    if (isLast) await logEvent(sb, { business_id: job.business_id, site_id: siteId, job_id: job.id, level: "success", message: "✓ Draft complete — awaiting your approval" });
     await sb.from("seo_content_pieces").update({
       artifacts,
       current_stage: agent?.stage ?? null,
@@ -189,6 +212,7 @@ export async function advanceContentJob(sb: any, job: Job): Promise<{ status: st
     const msg = e instanceof Error ? e.message : String(e);
     await sb.from("seo_content_pieces").update({ pipeline_status: "failed" }).eq("id", pieceId);
     await sb.from("seo_jobs").update({ status: "failed", error: msg }).eq("id", job.id);
+    await logEvent(sb, { business_id: job.business_id, site_id: siteId, job_id: job.id, agent_id: agentId, level: "error", message: `✗ ${agentName} failed — ${msg}` });
     return { status: "failed" };
   }
 }

--- a/supabase/migrations/20260708200000_seo_job_events.sql
+++ b/supabase/migrations/20260708200000_seo_job_events.sql
@@ -1,0 +1,26 @@
+-- SEO agent activity log (docs/SEO_AGENCY_PLAN.md, Phase 2) — the "terminal".
+-- One row per agent-step lifecycle event so the site hub can stream what the
+-- agents are doing. Written by the service-role engine (bypasses RLS); read by
+-- members (except workers). Additive.
+CREATE TABLE IF NOT EXISTS public.seo_job_events (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id     UUID REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  job_id      UUID REFERENCES public.seo_jobs(id) ON DELETE CASCADE,
+  agent_id    TEXT,
+  level       TEXT NOT NULL DEFAULT 'info' CHECK (level IN ('info','success','error')),
+  message     TEXT NOT NULL,
+  cost_cents  INTEGER NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_job_events_site ON public.seo_job_events (site_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_job_events_business ON public.seo_job_events (business_id, created_at DESC);
+
+ALTER TABLE public.seo_job_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS seo_job_events_read ON public.seo_job_events;
+CREATE POLICY seo_job_events_read ON public.seo_job_events FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);


### PR DESCRIPTION
## What

The **"see what the agents are doing in a terminal"** piece.

Every agent step now logs lifecycle events, and the site hub's **Activity** tab is a **live terminal** that polls them every 3s and auto-scrolls:

```
16:04:01  Queued "emergency roof repairs" (blog)
16:04:03  ▶ Keyword Strategist — step 1/8
16:04:22  ✓ Keyword Strategist → Keyword research · $0.02
16:04:24  ▶ SERP & Competitor Analyst — step 2/8
...
16:07:10  ✓ Draft complete — awaiting your approval
```

- **Migration `20260708200000`** (applied + recorded): `seo_job_events` (service-role writes, member-read RLS). Additive.
- `engine.logEvent()` wired through the step runner — running / success (with cost) / failed / budget-cap / awaiting-approval. Start logs a "queued" event for instant feedback.
- `SeoActivityTerminal` (polls `listSeoActivity`) in the hub Activity tab.
- **MCP**: `list_seo_activity` (`seo:read`).

## Safety

Additive table; logging is best-effort (wrapped in try/catch — can never break a run). SEO plugin still default-off/route-gated.

Verified: tsc · 17 tests · build · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)