### PR TITLE
feat(seo): connector framework — wire up all publishing gateways

### DIFF
--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getSeoSite } from "@/lib/actions/seo";
 import { listContentPieces, getSeoBudget } from "@/lib/actions/seo-pipeline";
+import { listConnections } from "@/lib/actions/seo-connections";
 import { SeoSiteHub } from "@/components/seo/seo-site-hub";
 
 export const dynamic = "force-dynamic";
@@ -13,16 +14,15 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/auth/login");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const businessId = await getActiveBizId(supabase as any, user.id);
+  await getActiveBizId(supabase as any, user.id);
 
   const site = await getSeoSite(id);
   if (!site) notFound();
 
-  const [pieces, budget, connectionsRes] = await Promise.all([
+  const [pieces, budget, connections] = await Promise.all([
     listContentPieces(id),
     getSeoBudget(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (supabase as any).from("seo_connections").select("provider, status, account_ref, connected_at").eq("business_id", businessId).eq("site_id", id),
+    listConnections(id),
   ]);
 
   return (
@@ -31,7 +31,7 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
       site={site as any}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pieces={pieces as any}
-      connections={(connectionsRes.data ?? []) as { provider: string; status: string; account_ref: string | null; connected_at: string | null }[]}
+      connections={connections}
       budget={budget}
     />
   );

--- a/src/components/seo/seo-connections.tsx
+++ b/src/components/seo/seo-connections.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Plug, Check, Trash2 } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { CONNECTORS, CONNECTORS_BY_ID, type ConnectorDef, type ConnectionView } from "@/lib/seo/connectors";
+import { saveConnection, deleteConnection } from "@/lib/actions/seo-connections";
+
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function SeoConnections({ siteId, connections }: { siteId: string; connections: ConnectionView[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [editing, setEditing] = useState<{ def: ConnectorDef; conn?: ConnectionView } | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  function openConnect(def: ConnectorDef, conn?: ConnectionView) {
+    const v: Record<string, string> = {};
+    for (const f of def.fields) v[f.key] = f.secret ? "" : (conn?.meta?.[f.key] ?? f.default ?? "");
+    setValues(v);
+    setEditing({ def, conn });
+  }
+
+  function handleSave() {
+    if (!editing) return;
+    startTransition(async () => {
+      try {
+        await saveConnection({ site_id: siteId, provider: editing.def.id, values, connection_id: editing.conn?.id });
+        toast.success(`${editing.def.name} ${editing.conn ? "updated" : "connected"}`);
+        setEditing(null);
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't save connection");
+      }
+    });
+  }
+
+  function handleDelete(conn: ConnectionView) {
+    startTransition(async () => {
+      try {
+        await deleteConnection(conn.id, siteId);
+        toast.success("Connection removed");
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't remove");
+      }
+    });
+  }
+
+  const publish = CONNECTORS.filter((c) => c.auth === "token");
+  const data = CONNECTORS.filter((c) => c.auth === "oauth");
+
+  return (
+    <div className="space-y-8">
+      {/* Connected */}
+      {connections.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Connected</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {connections.map((conn) => {
+              const def = CONNECTORS_BY_ID[conn.provider];
+              return (
+                <div key={conn.id} className="rounded-xl border border-emerald-500/40 bg-card p-4 flex items-start gap-3">
+                  <div className="w-9 h-9 rounded-lg bg-emerald-50 flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-emerald-700" /></div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-semibold">{conn.label || def?.name || conn.provider}</p>
+                      <span className="inline-flex items-center gap-1 text-[10px] font-medium text-emerald-700 bg-emerald-50 rounded-full px-1.5 py-0.5"><Check className="w-3 h-3" /> Connected</span>
+                    </div>
+                    {conn.account_ref && <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{conn.account_ref}</p>}
+                    <div className="flex gap-2 mt-2">
+                      {def && <button onClick={() => openConnect(def, conn)} className="text-xs text-muted-foreground hover:text-foreground underline">Edit</button>}
+                      <button onClick={() => handleDelete(conn)} disabled={isPending} className="text-xs text-muted-foreground hover:text-destructive underline">Remove</button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Publishing gateways */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Publishing gateways</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {publish.map((def) => (
+            <div key={def.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-foreground/70" /></div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold">{def.name}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">{def.description}</p>
+                </div>
+              </div>
+              <div><Button size="sm" variant="outline" className="text-xs h-7" onClick={() => openConnect(def)}>Connect</Button></div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Data sources (OAuth) */}
+      <section>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Data sources</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {data.map((def) => (
+            <div key={def.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-foreground/70" /></div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2"><p className="text-sm font-semibold">{def.name}</p><span className="text-[10px] font-medium text-muted-foreground bg-muted rounded-full px-1.5 py-0.5">OAuth soon</span></div>
+                  <p className="text-xs text-muted-foreground mt-0.5">{def.description}</p>
+                </div>
+              </div>
+              <div><Button size="sm" variant="outline" className="text-xs h-7" disabled>Needs Google setup</Button></div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Connect / edit dialog */}
+      <Dialog open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          <DialogHeader><DialogTitle>{editing?.conn ? "Edit" : "Connect"} {editing?.def.name}</DialogTitle></DialogHeader>
+          {editing && (
+            <div className="space-y-3">
+              {editing.def.docsHint && <p className="text-xs text-muted-foreground">{editing.def.docsHint}</p>}
+              {editing.def.fields.map((f) => (
+                <div key={f.key} className="space-y-1.5">
+                  <Label htmlFor={`f-${f.key}`}>{f.label}{f.required && <span className="text-destructive"> *</span>}</Label>
+                  {f.type === "textarea" ? (
+                    <Textarea id={`f-${f.key}`} rows={3} className="font-mono text-xs" placeholder={f.placeholder} value={values[f.key] ?? ""} onChange={(e) => setValues((p) => ({ ...p, [f.key]: e.target.value }))} />
+                  ) : f.type === "select" ? (
+                    <select id={`f-${f.key}`} className={selectCls} value={values[f.key] ?? ""} onChange={(e) => setValues((p) => ({ ...p, [f.key]: e.target.value }))}>
+                      {(f.options ?? []).map((o) => <option key={o} value={o}>{o}</option>)}
+                    </select>
+                  ) : (
+                    <Input id={`f-${f.key}`} type={f.type === "password" ? "password" : "text"} placeholder={f.secret && editing.conn?.hasSecret ? "•••••• (leave blank to keep current)" : f.placeholder} value={values[f.key] ?? ""} onChange={(e) => setValues((p) => ({ ...p, [f.key]: e.target.value }))} />
+                  )}
+                  {f.help && <p className="text-[11px] text-muted-foreground">{f.help}</p>}
+                </div>
+              ))}
+              <p className={cn("text-[11px]", "text-muted-foreground")}>Credentials are encrypted at rest and never shown again.</p>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setEditing(null)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleSave} disabled={isPending}>{editing?.conn ? "Save" : "Connect"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
-import { ArrowLeft, Plus, FileText, Search, Globe, Plug, Activity, Check } from "@/components/ui/icons";
+import { ArrowLeft, Plus, FileText, Search, Globe, Plug, Activity } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,18 +13,18 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { cn } from "@/lib/utils";
 import { startContentPipeline } from "@/lib/actions/seo-pipeline";
 import { SeoActivityTerminal } from "@/components/seo/seo-activity-terminal";
+import { SeoConnections } from "@/components/seo/seo-connections";
+import { CONNECTORS, type ConnectionView } from "@/lib/seo/connectors";
 import type { SeoSite, SeoContentType } from "@/types/database";
 
 interface Piece {
   id: string; title: string; topic: string | null; content_type: string;
   status: string; pipeline_status: string; current_stage: string | null; created_at: string;
 }
-interface Connection { provider: string; status: string; account_ref: string | null; connected_at: string | null }
-
 interface Props {
   site: SeoSite & { seo_sites?: unknown };
   pieces: Piece[];
-  connections: Connection[];
+  connections: ConnectionView[];
   budget: { spentCents: number; budgetCents: number; ok: boolean };
 }
 
@@ -41,13 +41,6 @@ const STATUS_TONE: Record<string, string> = {
 };
 const money = (c: number) => `$${(c / 100).toFixed(2)}`;
 
-const CONNECTORS = [
-  { provider: "gsc", name: "Google Search Console", desc: "Real keyword positions, clicks & impressions feed the scout.", ready: false },
-  { provider: "git", name: "Git publisher", desc: "Push approved articles straight into the site's repo (Astro/Hugo/…).", ready: false },
-  { provider: "wordpress", name: "WordPress", desc: "Publish to a WordPress site via the REST API.", ready: false },
-  { provider: "gbp", name: "Google Business Profile", desc: "Local-pack signals and profile posts.", ready: false },
-];
-
 export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("overview");
@@ -56,7 +49,6 @@ export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
   const [topic, setTopic] = useState("");
   const [contentType, setContentType] = useState<SeoContentType>("blog");
 
-  const connByProvider = new Map(connections.map((c) => [c.provider, c]));
   const connectedCount = connections.filter((c) => c.status === "connected").length;
   const approvedCount = pieces.filter((p) => p.status === "approved" || p.pipeline_status === "done").length;
 
@@ -158,36 +150,7 @@ export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
       )}
 
       {/* ── Connections ── */}
-      {tab === "connections" && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {CONNECTORS.map((c) => {
-            const conn = connByProvider.get(c.provider);
-            const connected = conn?.status === "connected";
-            return (
-              <div key={c.provider} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
-                <div className="flex items-start gap-3">
-                  <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-foreground/70" /></div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-semibold">{c.name}</p>
-                      {connected
-                        ? <span className="inline-flex items-center gap-1 text-[10px] font-medium text-emerald-700 bg-emerald-50 rounded-full px-1.5 py-0.5"><Check className="w-3 h-3" /> Connected</span>
-                        : !c.ready && <span className="text-[10px] font-medium text-muted-foreground bg-muted rounded-full px-1.5 py-0.5">Soon</span>}
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-0.5">{c.desc}</p>
-                    {connected && conn?.account_ref && <p className="text-[11px] text-muted-foreground mt-1 truncate">{conn.account_ref}</p>}
-                  </div>
-                </div>
-                <div>
-                  <Button size="sm" variant={connected ? "outline" : "default"} disabled={!c.ready} className="text-xs h-7">
-                    {connected ? "Manage" : c.ready ? "Connect" : "Setup coming"}
-                  </Button>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
+      {tab === "connections" && <SeoConnections siteId={site.id} connections={connections} />}
 
       {/* ── Activity ── */}
       {tab === "activity" && <SeoActivityTerminal siteId={site.id} />}

--- a/src/lib/actions/seo-connections.ts
+++ b/src/lib/actions/seo-connections.ts
@@ -1,0 +1,114 @@
+"use server";
+
+/**
+ * SEO connector connections — save / list / delete (docs/SEO_AGENCY_PLAN.md).
+ *
+ * Secrets (tokens/keys) are split out of the config, encrypted as one blob into
+ * seo_connections.secret, and NEVER returned to the client. Non-secret config
+ * lives in meta and is safe to show. RLS gates writes to owner/admin/editor.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
+import { CONNECTORS_BY_ID, secretFieldKeys, type ConnectionView } from "@/lib/seo/connectors";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function biz(): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  return getActiveBizId(supabase, user.id);
+}
+
+/** A human identifier to show on the connection card. */
+function accountRef(provider: string, meta: Record<string, string>): string | null {
+  switch (provider) {
+    case "git-github": return meta.repo ?? null;
+    case "wordpress": return meta.site_url ?? null;
+    case "sanity": return meta.project_id ? `${meta.project_id}/${meta.dataset ?? ""}` : null;
+    case "payload": return meta.base_url ?? null;
+    case "rest":
+    case "graphql": return meta.endpoint ?? null;
+    default: return null;
+  }
+}
+
+/** Connections for a site — secrets redacted. */
+export async function listConnections(siteId: string): Promise<ConnectionView[]> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { data } = await tbl(supabase, "seo_connections")
+    .select("id, provider, label, status, account_ref, connected_at, meta, secret")
+    .eq("business_id", businessId).eq("site_id", siteId).order("created_at", { ascending: true });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((data ?? []) as any[]).map((r) => ({
+    id: r.id, provider: r.provider, label: r.label, status: r.status,
+    account_ref: r.account_ref, connected_at: r.connected_at,
+    meta: (r.meta ?? {}) as Record<string, string>, hasSecret: !!r.secret,
+  }));
+}
+
+export async function saveConnection(input: {
+  site_id: string;
+  provider: string;
+  values: Record<string, string>;
+  connection_id?: string;
+  label?: string;
+}): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const def = CONNECTORS_BY_ID[input.provider];
+  if (!def) throw new Error(`Unknown connector "${input.provider}"`);
+
+  const secretKeys = new Set(secretFieldKeys(def));
+  const meta: Record<string, string> = {};
+  const secrets: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input.values)) {
+    if (v == null || v === "") continue;
+    if (secretKeys.has(k)) secrets[k] = v; else meta[k] = v;
+  }
+  // Fill non-secret defaults.
+  for (const f of def.fields) {
+    if (!f.secret && meta[f.key] == null && f.default) meta[f.key] = f.default;
+  }
+  // Required non-secret validation.
+  for (const f of def.fields) {
+    if (f.required && !f.secret && !meta[f.key]) throw new Error(`${f.label} is required`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row: Record<string, any> = {
+    business_id: businessId, site_id: input.site_id, provider: input.provider,
+    label: input.label?.trim() || def.name, meta,
+    status: "connected", account_ref: accountRef(input.provider, meta),
+    connected_at: new Date().toISOString(),
+  };
+  if (Object.keys(secrets).length > 0) {
+    if (!encryptionAvailable()) throw new Error("Credential storage needs APP_ENCRYPTION_KEY set on the server.");
+    row.secret = encryptSecret(JSON.stringify(secrets));
+  } else if (!input.connection_id) {
+    // New connection with a required secret but none provided.
+    const needsSecret = def.fields.some((f) => f.secret && f.required);
+    if (needsSecret) throw new Error("A credential is required to connect.");
+  }
+
+  if (input.connection_id) {
+    const { error } = await tbl(supabase, "seo_connections").update(row).eq("id", input.connection_id).eq("business_id", businessId);
+    if (error) throw error;
+  } else {
+    const { error } = await tbl(supabase, "seo_connections").insert(row);
+    if (error) throw error;
+  }
+  revalidatePath(`/seo/${input.site_id}`);
+}
+
+export async function deleteConnection(connectionId: string, siteId: string): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { error } = await tbl(supabase, "seo_connections").delete().eq("id", connectionId).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath(`/seo/${siteId}`);
+}

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,51 @@
+/**
+ * App-wide AES-256-GCM secret encryption — used to store third-party
+ * credentials (connector tokens/API keys) at rest. Ciphertext lives in the DB;
+ * plaintext is only ever decrypted server-side to make an outbound API call and
+ * is NEVER returned to the browser or over MCP.
+ *
+ * Key: APP_ENCRYPTION_KEY (64 hex chars = 32 bytes), falling back to
+ * ONBOARDING_SECRET_KEY so a single key can cover both. Generate with:
+ *   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ * Treat it like a database credential — rotating it makes stored secrets
+ * unreadable.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const VERSION = "v1";
+
+function keyHex(): string | undefined {
+  return (process.env.APP_ENCRYPTION_KEY ?? process.env.ONBOARDING_SECRET_KEY)?.trim();
+}
+
+/** True when an encryption key is configured (credential storage usable). */
+export function encryptionAvailable(): boolean {
+  const hex = keyHex();
+  return Boolean(hex && /^[0-9a-f]{64}$/i.test(hex));
+}
+
+function key(): Buffer {
+  const hex = keyHex();
+  if (!hex || !/^[0-9a-f]{64}$/i.test(hex)) {
+    throw new Error(
+      "Credential storage needs APP_ENCRYPTION_KEY (64 hex chars) set on the server.",
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+export function encryptSecret(plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key(), iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [VERSION, iv.toString("base64"), tag.toString("base64"), ct.toString("base64")].join(".");
+}
+
+export function decryptSecret(payload: string): string {
+  const [version, ivB64, tagB64, ctB64] = payload.split(".");
+  if (version !== VERSION || !ivB64 || !tagB64 || !ctB64) throw new Error("Malformed secret payload");
+  const decipher = createDecipheriv("aes-256-gcm", key(), Buffer.from(ivB64, "base64"));
+  decipher.setAuthTag(Buffer.from(tagB64, "base64"));
+  return Buffer.concat([decipher.update(Buffer.from(ctB64, "base64")), decipher.final()]).toString("utf8");
+}

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -202,4 +202,26 @@ export function registerSeoTools(tool: ToolFn): void {
       if (error) throw error;
       return text((data ?? []).reverse());
     });
+
+  // ── Gateway connections (read/manage only — connecting with a token is
+  //    web-UI-only so credentials never transit MCP/chat). ─────────────────────
+  tool("list_seo_connections", "List a site's connected publishing gateways (git/wordpress/sanity/payload/rest/graphql). Secrets are redacted.",
+    { site_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      const { data, error } = await t(ctx, "seo_connections")
+        .select("id, provider, label, status, account_ref, connected_at, meta")
+        .eq("business_id", ctx.businessId).eq("site_id", args.site_id);
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("delete_seo_connection", "Remove a gateway connection from a site.",
+    { connection_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { error } = await t(ctx, "seo_connections").delete().eq("id", args.connection_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
 }

--- a/src/lib/seo/connectors.ts
+++ b/src/lib/seo/connectors.ts
@@ -1,0 +1,153 @@
+/**
+ * SEO connector registry — the publishing/data gateways a client site can wire
+ * up (docs/SEO_AGENCY_PLAN.md, Phase 2). Each connector declares the config
+ * fields the user fills in; fields marked `secret` are encrypted at rest and
+ * never leave the server. This registry drives the connect form, the save
+ * validation, and (in the publish PR) the adapter dispatch.
+ *
+ * Plain module — safe to import from client and server.
+ */
+
+export type ConnectorFieldType = "text" | "password" | "textarea" | "select";
+
+export interface ConnectorField {
+  key: string;
+  label: string;
+  type: ConnectorFieldType;
+  placeholder?: string;
+  help?: string;
+  required?: boolean;
+  secret?: boolean;          // stored encrypted, never returned to client/MCP
+  options?: string[];        // for type: "select"
+  default?: string;
+}
+
+export interface ConnectorDef {
+  id: string;                // stored as seo_connections.provider
+  name: string;
+  category: "publish" | "data";
+  /** token = fill a form (API key/token); oauth = 3-legged flow (separate). */
+  auth: "token" | "oauth";
+  description: string;
+  docsHint?: string;
+  fields: ConnectorField[];
+}
+
+export const CONNECTORS: ConnectorDef[] = [
+  {
+    id: "git-github",
+    name: "Git (GitHub)",
+    category: "publish",
+    auth: "token",
+    description: "Commit approved articles as markdown into the site's repo (Astro, Hugo, Eleventy, Next content…).",
+    docsHint: "Create a fine-grained token scoped to just this repo with Contents: read & write.",
+    fields: [
+      { key: "repo", label: "Repository", type: "text", placeholder: "owner/repo", required: true },
+      { key: "branch", label: "Branch", type: "text", default: "main", required: true },
+      { key: "content_path", label: "Content folder", type: "text", placeholder: "src/content/blog", default: "src/content/blog", required: true },
+      { key: "extension", label: "File type", type: "select", options: ["md", "mdx", "mdoc"], default: "md" },
+      { key: "token", label: "GitHub token", type: "password", secret: true, required: true, help: "Fine-grained PAT, Contents: read/write on this repo only." },
+    ],
+  },
+  {
+    id: "wordpress",
+    name: "WordPress",
+    category: "publish",
+    auth: "token",
+    description: "Publish to a WordPress site via the REST API.",
+    docsHint: "Users → Profile → Application Passwords creates the password.",
+    fields: [
+      { key: "site_url", label: "Site URL", type: "text", placeholder: "https://example.com", required: true },
+      { key: "username", label: "Username", type: "text", required: true },
+      { key: "app_password", label: "Application password", type: "password", secret: true, required: true },
+      { key: "status", label: "Publish as", type: "select", options: ["draft", "publish"], default: "draft" },
+    ],
+  },
+  {
+    id: "sanity",
+    name: "Sanity",
+    category: "publish",
+    auth: "token",
+    description: "Create documents in a Sanity dataset via the mutations API (Next.js + Sanity).",
+    docsHint: "manage.sanity.io → API → Tokens (Editor/write).",
+    fields: [
+      { key: "project_id", label: "Project ID", type: "text", required: true },
+      { key: "dataset", label: "Dataset", type: "text", default: "production", required: true },
+      { key: "api_version", label: "API version", type: "text", default: "2024-01-01" },
+      { key: "doc_type", label: "Document type", type: "text", placeholder: "post", default: "post", required: true },
+      { key: "token", label: "Write token", type: "password", secret: true, required: true },
+    ],
+  },
+  {
+    id: "payload",
+    name: "Payload CMS",
+    category: "publish",
+    auth: "token",
+    description: "Create documents in a Payload collection via its REST API (Next.js + Payload).",
+    docsHint: "Use an API key from a Payload user with create rights on the collection.",
+    fields: [
+      { key: "base_url", label: "API base URL", type: "text", placeholder: "https://cms.example.com/api", required: true },
+      { key: "collection", label: "Collection slug", type: "text", placeholder: "posts", required: true },
+      { key: "api_key", label: "API key", type: "password", secret: true, required: true, help: "Sent as Authorization: <collection>-API-Key <key>." },
+    ],
+  },
+  {
+    id: "rest",
+    name: "Custom REST API",
+    category: "publish",
+    auth: "token",
+    description: "POST the article to any REST endpoint with a JSON body you map.",
+    docsHint: "Use {{title}}, {{slug}}, {{description}}, {{html}}, {{markdown}}, {{keyword}} in the body template.",
+    fields: [
+      { key: "endpoint", label: "Endpoint URL", type: "text", placeholder: "https://api.example.com/posts", required: true },
+      { key: "method", label: "Method", type: "select", options: ["POST", "PUT"], default: "POST" },
+      { key: "auth_header", label: "Auth header", type: "text", default: "Authorization", help: "Header name for the secret below." },
+      { key: "auth_value", label: "Auth value", type: "password", secret: true, help: "e.g. Bearer <token>. Sent as the auth header." },
+      { key: "body_template", label: "JSON body template", type: "textarea", required: true, placeholder: '{ "title": "{{title}}", "content": "{{html}}", "slug": "{{slug}}" }' },
+    ],
+  },
+  {
+    id: "graphql",
+    name: "Custom GraphQL",
+    category: "publish",
+    auth: "token",
+    description: "Run a GraphQL mutation against any endpoint with variables you map.",
+    docsHint: "Use {{title}}, {{slug}}, {{description}}, {{html}}, {{markdown}}, {{keyword}} in the variables template.",
+    fields: [
+      { key: "endpoint", label: "GraphQL endpoint", type: "text", placeholder: "https://api.example.com/graphql", required: true },
+      { key: "mutation", label: "Mutation", type: "textarea", required: true, placeholder: "mutation($input: PostInput!) { createPost(input: $input) { id url } }" },
+      { key: "variables_template", label: "Variables (JSON template)", type: "textarea", required: true, placeholder: '{ "input": { "title": "{{title}}", "body": "{{html}}" } }' },
+      { key: "auth_header", label: "Auth header", type: "text", default: "Authorization" },
+      { key: "auth_value", label: "Auth value", type: "password", secret: true },
+    ],
+  },
+  {
+    id: "gsc",
+    name: "Google Search Console",
+    category: "data",
+    auth: "oauth",
+    description: "Pull real keyword positions, clicks and impressions to feed the opportunity scout.",
+    docsHint: "Requires a Google Cloud OAuth client (Search Console read-only). Coming with the OAuth flow.",
+    fields: [],
+  },
+];
+
+export const CONNECTORS_BY_ID: Record<string, ConnectorDef> =
+  Object.fromEntries(CONNECTORS.map((c) => [c.id, c]));
+
+/** Field keys that are secret for a connector. */
+export function secretFieldKeys(def: ConnectorDef): string[] {
+  return def.fields.filter((f) => f.secret).map((f) => f.key);
+}
+
+/** A connection as shown to the client — secrets redacted. */
+export interface ConnectionView {
+  id: string;
+  provider: string;
+  label: string | null;
+  status: string;
+  account_ref: string | null;
+  connected_at: string | null;
+  meta: Record<string, string>;
+  hasSecret: boolean;
+}

--- a/supabase/migrations/20260708220000_seo_connectors.sql
+++ b/supabase/migrations/20260708220000_seo_connectors.sql
@@ -1,0 +1,9 @@
+-- SEO publishing gateways (docs/SEO_AGENCY_PLAN.md, Phase 2) — open up
+-- seo_connections to arbitrary connector types (git, wordpress, sanity,
+-- payload, rest, graphql, …). Provider is now validated in code by the
+-- connector registry rather than a DB CHECK, and a site can have more than one
+-- connection (e.g. two REST endpoints). Config lives in meta jsonb; the token/
+-- key lives in `secret` (AES-256-GCM ciphertext). Additive/relaxing only.
+ALTER TABLE public.seo_connections DROP CONSTRAINT IF EXISTS seo_connections_provider_check;
+ALTER TABLE public.seo_connections DROP CONSTRAINT IF EXISTS seo_connections_site_id_provider_key;
+ALTER TABLE public.seo_connections ADD COLUMN IF NOT EXISTS label TEXT;


### PR DESCRIPTION
## What

The connection layer to wire Kirei into any client's stack. A per-site **Connections** tab where you connect publishing gateways — credentials **encrypted at rest**.

### Gateways (registry-driven connect forms)
- **Git (GitHub)** — Astro / Hugo / Eleventy / Next content (commit markdown to the repo)
- **WordPress** — REST API
- **Sanity** — mutations API (Next.js + Sanity)
- **Payload CMS** — REST
- **Custom REST** — POST to any endpoint with a mapped JSON body
- **Custom GraphQL** — any mutation with mapped variables
- **Google Search Console** — shown, OAuth flow pending your Google client

### Framework
- `src/lib/crypto.ts` — shared AES-256-GCM (`APP_ENCRYPTION_KEY`, falls back to `ONBOARDING_SECRET_KEY`). Secrets → one encrypted blob in `seo_connections.secret`; config → `meta`. **Never** returned to browser/MCP.
- Migration `20260708220000` (applied + recorded): opens `seo_connections.provider` to registry-validated values, allows multiple connections per site, adds `label`.
- Actions `saveConnection` / `listConnections` (redacted) / `deleteConnection`; a dynamic connect/edit dialog per gateway.
- **MCP**: `list_seo_connections` (redacted) + `delete_seo_connection`. **No** save-with-token tool by design — connecting is web-UI-only so credentials never pass through MCP/chat.

## Needs one env var

Storing a credential requires **`APP_ENCRYPTION_KEY`** (64 hex chars) on Vercel. Generate: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`. Without it the connect form loads but saving a token returns a clear error.

## Next

**Publish adapters** — the code that actually pushes an approved article through each gateway (git commit / WP post / Sanity doc / REST / GraphQL), plus a "Publish to…" action on approved pieces.

## Safety

Additive/relaxing migration only. SEO plugin still default-off/route-gated. Secrets encrypted, redacted everywhere.

Verified: tsc · 17 tests · build (all `/seo` routes) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)