### PR TITLE
feat(seo): Opportunity Scout — agents decide what to write

### DIFF
--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -2,11 +2,14 @@ import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getSeoSite } from "@/lib/actions/seo";
-import { listContentPieces, getSeoBudget } from "@/lib/actions/seo-pipeline";
+import { listContentPieces, getSeoBudget, listOpportunities } from "@/lib/actions/seo-pipeline";
 import { listConnections } from "@/lib/actions/seo-connections";
 import { SeoSiteHub } from "@/components/seo/seo-site-hub";
 
 export const dynamic = "force-dynamic";
+// The Opportunity Scout (opus + web search) runs as a server action from this
+// route — give it room so it isn't cut off mid-scan.
+export const maxDuration = 300;
 
 export default async function SeoSiteHubPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -19,10 +22,11 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
   const site = await getSeoSite(id);
   if (!site) notFound();
 
-  const [pieces, budget, connections] = await Promise.all([
+  const [pieces, budget, connections, opportunities] = await Promise.all([
     listContentPieces(id),
     getSeoBudget(),
     listConnections(id),
+    listOpportunities(id),
   ]);
 
   return (
@@ -32,6 +36,7 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pieces={pieces as any}
       connections={connections}
+      opportunities={opportunities}
       budget={budget}
     />
   );

--- a/src/components/seo/seo-opportunities.tsx
+++ b/src/components/seo/seo-opportunities.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Search, Sparkles, Plus, ChevronDown, ChevronRight } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { scanOpportunities, writeOpportunity, setOpportunityStatus } from "@/lib/actions/seo-pipeline";
+
+interface Opp { id: string; type: string; title: string; detail: string | null; priority: number; status: string; created_at: string }
+
+const TYPE_TONE: Record<string, string> = {
+  quick_win: "bg-emerald-50 text-emerald-700",
+  content_gap: "bg-blue-50 text-blue-700",
+  question: "bg-violet-50 text-violet-700",
+  technical: "bg-amber-50 text-amber-700",
+  refresh: "bg-slate-100 text-slate-700",
+};
+
+export function SeoOpportunities({ siteId, opportunities }: { siteId: string; opportunities: Opp[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [scanning, setScanning] = useState(false);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  function handleScan() {
+    setScanning(true);
+    scanOpportunities(siteId)
+      .then((r) => { toast.success(r.inserted ? `Found ${r.inserted} opportunities` : "No new opportunities"); router.refresh(); })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Scan failed"))
+      .finally(() => setScanning(false));
+  }
+
+  function handleWrite(o: Opp) {
+    startTransition(async () => {
+      try {
+        const { piece_id } = await writeOpportunity(o.id, siteId);
+        toast.success("Pipeline started");
+        router.push(`/seo/content/${piece_id}`);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't start");
+      }
+    });
+  }
+
+  function handleStatus(o: Opp, status: string) {
+    startTransition(async () => {
+      try { await setOpportunityStatus(o.id, status, siteId); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update"); }
+    });
+  }
+
+  const active = opportunities.filter((o) => o.status !== "dismissed");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <p className="text-sm text-muted-foreground">The scout studies the niche and ranks what to write or fix. Click <strong>Write this</strong> to send one into the pipeline.</p>
+        <Button onClick={handleScan} disabled={scanning || isPending}>
+          <Sparkles className="w-4 h-4 mr-1.5" /> {scanning ? "Scanning…" : "Scan for opportunities"}
+        </Button>
+      </div>
+
+      {active.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Search className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No opportunities yet</p>
+          <p className="text-sm text-muted-foreground mt-1 max-w-sm mx-auto">Run a scan and the scout returns a ranked queue of content gaps, quick wins and questions to target.</p>
+          <Button className="mt-4" onClick={handleScan} disabled={scanning}><Sparkles className="w-4 h-4 mr-1.5" /> {scanning ? "Scanning…" : "Scan now"}</Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {active.map((o) => {
+            const expanded = openId === o.id;
+            const done = o.status !== "queued";
+            return (
+              <div key={o.id} className={cn("rounded-xl border bg-card", done ? "border-border opacity-70" : "border-border")}>
+                <div className="p-4 flex items-start gap-3">
+                  <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center text-xs font-bold shrink-0" title="priority">{o.priority}</div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="text-sm font-semibold break-words">{o.title}</p>
+                      <span className={cn("text-[10px] font-medium rounded-full px-1.5 py-0.5", TYPE_TONE[o.type] ?? "bg-muted text-muted-foreground")}>{o.type.replace("_", " ")}</span>
+                      {o.status !== "queued" && <span className="text-[10px] font-medium rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground">{o.status.replace("_", " ")}</span>}
+                    </div>
+                    {o.detail && (
+                      <button onClick={() => setOpenId(expanded ? null : o.id)} className="mt-1 text-xs text-muted-foreground inline-flex items-center gap-1 hover:text-foreground">
+                        {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />} why
+                      </button>
+                    )}
+                    {expanded && o.detail && <p className="text-xs text-muted-foreground mt-1 whitespace-pre-wrap">{o.detail}</p>}
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    {o.status === "queued" && (
+                      <Button size="sm" className="h-7 text-xs" onClick={() => handleWrite(o)} disabled={isPending}><Plus className="w-3.5 h-3.5 mr-1" /> Write this</Button>
+                    )}
+                    <button onClick={() => handleStatus(o, "dismissed")} disabled={isPending} className="text-xs text-muted-foreground hover:text-foreground underline px-1">Dismiss</button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -14,8 +14,11 @@ import { cn } from "@/lib/utils";
 import { startContentPipeline } from "@/lib/actions/seo-pipeline";
 import { SeoActivityTerminal } from "@/components/seo/seo-activity-terminal";
 import { SeoConnections } from "@/components/seo/seo-connections";
+import { SeoOpportunities } from "@/components/seo/seo-opportunities";
 import { CONNECTORS, type ConnectionView } from "@/lib/seo/connectors";
 import type { SeoSite, SeoContentType } from "@/types/database";
+
+interface Opportunity { id: string; type: string; title: string; detail: string | null; priority: number; status: string; created_at: string }
 
 interface Piece {
   id: string; title: string; topic: string | null; content_type: string;
@@ -25,10 +28,11 @@ interface Props {
   site: SeoSite & { seo_sites?: unknown };
   pieces: Piece[];
   connections: ConnectionView[];
+  opportunities: Opportunity[];
   budget: { spentCents: number; budgetCents: number; ok: boolean };
 }
 
-type Tab = "overview" | "content" | "connections" | "activity";
+type Tab = "overview" | "content" | "opportunities" | "connections" | "activity";
 
 const STATUS_TONE: Record<string, string> = {
   running: "bg-blue-100 text-blue-700",
@@ -41,7 +45,7 @@ const STATUS_TONE: Record<string, string> = {
 };
 const money = (c: number) => `$${(c / 100).toFixed(2)}`;
 
-export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
+export function SeoSiteHub({ site, pieces, connections, opportunities, budget }: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("overview");
   const [isPending, startTransition] = useTransition();
@@ -68,6 +72,7 @@ export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
   const tabs: { id: Tab; label: string; icon: typeof FileText }[] = [
     { id: "overview", label: "Overview", icon: Globe },
     { id: "content", label: "Content", icon: FileText },
+    { id: "opportunities", label: "Opportunities", icon: Search },
     { id: "connections", label: "Connections", icon: Plug },
     { id: "activity", label: "Activity", icon: Activity },
   ];
@@ -148,6 +153,9 @@ export function SeoSiteHub({ site, pieces, connections, budget }: Props) {
           </div>
         )
       )}
+
+      {/* ── Opportunities ── */}
+      {tab === "opportunities" && <SeoOpportunities siteId={site.id} opportunities={opportunities} />}
 
       {/* ── Connections ── */}
       {tab === "connections" && <SeoConnections siteId={site.id} connections={connections} />}

--- a/src/lib/actions/seo-pipeline.ts
+++ b/src/lib/actions/seo-pipeline.ts
@@ -13,7 +13,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
-import { advanceContentJob, seoSpendStatus, type ContentType } from "@/lib/seo/engine";
+import { advanceContentJob, seoSpendStatus, runOpportunityScout, type ContentType } from "@/lib/seo/engine";
 import { publishContent } from "@/lib/seo/publish";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -65,6 +65,45 @@ export async function startContentPipeline(input: {
   });
   revalidatePath("/seo");
   return { piece_id: piece.id };
+}
+
+/** Run the Opportunity Scout on a site — populates the queue. */
+export async function scanOpportunities(siteId: string): Promise<{ inserted: number }> {
+  const businessId = await biz();
+  const admin = createAdminClient();
+  const { data: site } = await tbl(admin, "seo_sites").select("id").eq("id", siteId).eq("business_id", businessId).maybeSingle();
+  if (!site) throw new Error("Site not found");
+  const res = await runOpportunityScout(admin, { businessId, siteId });
+  revalidatePath(`/seo/${siteId}`);
+  return res;
+}
+
+export async function listOpportunities(siteId: string) {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { data } = await tbl(supabase, "seo_opportunities")
+    .select("id, type, title, detail, priority, status, created_at")
+    .eq("business_id", businessId).eq("site_id", siteId)
+    .order("priority", { ascending: false }).order("created_at", { ascending: false }).limit(200);
+  return (data ?? []) as Array<{ id: string; type: string; title: string; detail: string | null; priority: number; status: string; created_at: string }>;
+}
+
+export async function setOpportunityStatus(id: string, status: string, siteId: string): Promise<void> {
+  const businessId = await biz();
+  const admin = createAdminClient();
+  await tbl(admin, "seo_opportunities").update({ status }).eq("id", id).eq("business_id", businessId);
+  revalidatePath(`/seo/${siteId}`);
+}
+
+/** Start a content pipeline from an opportunity and mark it in-progress. */
+export async function writeOpportunity(opportunityId: string, siteId: string, contentType?: ContentType): Promise<{ piece_id: string }> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { data: opp } = await tbl(supabase, "seo_opportunities").select("title").eq("id", opportunityId).eq("business_id", businessId).maybeSingle();
+  if (!opp) throw new Error("Opportunity not found");
+  const started = await startContentPipeline({ site_id: siteId, topic: opp.title, content_type: contentType });
+  await setOpportunityStatus(opportunityId, "in_progress", siteId);
+  return started;
 }
 
 /** Publish an approved piece through a connected gateway. */

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -6,7 +6,7 @@
 import { z } from "zod";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, UUID, type ToolFn } from "./shared";
-import { advanceContentJob, seoSpendStatus } from "@/lib/seo/engine";
+import { advanceContentJob, seoSpendStatus, runOpportunityScout } from "@/lib/seo/engine";
 import { publishContent } from "@/lib/seo/publish";
 
 const DOMAIN = z.string().min(1).describe("Client site domain, e.g. example.com");
@@ -232,5 +232,36 @@ export function registerSeoTools(tool: ToolFn): void {
       const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
       const res = await publishContent(ctx.sb, { businessId: ctx.businessId, pieceId: args.piece_id, connectionId: args.connection_id });
       return text({ published: true, ...res });
+    });
+
+  // ── Opportunity scout (discovery) ────────────────────────────────────────────
+  tool("run_opportunity_scout", "Run the Opportunity Scout on a site — studies the niche via web search and populates a ranked opportunity queue.",
+    { site_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const res = await runOpportunityScout(ctx.sb, { businessId: ctx.businessId, siteId: args.site_id });
+      return text(res);
+    });
+
+  tool("list_seo_opportunities", "List a site's opportunity queue (what to write or fix), highest priority first.",
+    { site_id: UUID, status: z.enum(["queued", "in_progress", "done", "dismissed"]).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      let q = t(ctx, "seo_opportunities").select("id, type, title, detail, priority, status, created_at")
+        .eq("business_id", ctx.businessId).eq("site_id", args.site_id)
+        .order("priority", { ascending: false }).order("created_at", { ascending: false }).limit(200);
+      if (args.status) q = q.eq("status", args.status);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("set_opportunity_status", "Update an opportunity's status (queued / in_progress / done / dismissed).",
+    { opportunity_id: UUID, status: z.enum(["queued", "in_progress", "done", "dismissed"]) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { error } = await t(ctx, "seo_opportunities").update({ status: args.status }).eq("id", args.opportunity_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
     });
 }

--- a/src/lib/seo/engine.ts
+++ b/src/lib/seo/engine.ts
@@ -129,6 +129,79 @@ async function logEvent(sb: any, e: {
   } catch { /* best-effort */ }
 }
 
+/** Pull a JSON array out of an agent reply (```json fence or first [ … ]). */
+function extractJsonArray(text: string): unknown[] {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const raw = fence ? fence[1] : text;
+  const start = raw.indexOf("[");
+  const end = raw.lastIndexOf("]");
+  if (start === -1 || end === -1 || end < start) throw new Error("no JSON array in reply");
+  const parsed = JSON.parse(raw.slice(start, end + 1));
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+/**
+ * Discovery — the Opportunity Scout studies the site's niche (via live web
+ * search) and writes a ranked queue into seo_opportunities. One-shot agent
+ * (not the content chain). Budget-gated, logs to the activity terminal.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function runOpportunityScout(sb: any, args: { businessId: string; siteId: string }): Promise<{ inserted: number }> {
+  const { data: site } = await sb.from("seo_sites").select("domain, playbook").eq("id", args.siteId).eq("business_id", args.businessId).maybeSingle();
+  if (!site) throw new Error("Site not found");
+
+  const budget = await seoSpendStatus(sb, args.businessId);
+  if (!budget.ok) throw new Error(`Monthly SEO budget reached ($${(budget.budgetCents / 100).toFixed(2)}). Raise it to run the scout.`);
+
+  await logEvent(sb, { business_id: args.businessId, site_id: args.siteId, agent_id: "seo-opportunity-scout", message: "▶ Opportunity Scout — scanning the niche" });
+
+  const system = AGENT_PROMPTS["seo-opportunity-scout"];
+  const user = [
+    "You are running in a server pipeline — there is NO filesystem. Ignore any instructions about reading or writing files/paths.",
+    `Client site: ${site.domain} (playbook: ${site.playbook}).`,
+    "You have live web search — study the site's niche, its competitors and the questions real searchers ask.",
+    "Return ONLY a JSON array of the 12–15 highest-leverage opportunities — no prose, no markdown outside the array — in exactly this shape:",
+    '[{"type":"content_gap|quick_win|technical|question|refresh","title":"short imperative","detail":"why now + the evidence","priority":1-10}]',
+  ].join("\n");
+
+  let textOut = "";
+  let costCents = 0;
+  try {
+    const res = await anthropic.messages.create({
+      model: MODEL.opus, max_tokens: 4096, system,
+      messages: [{ role: "user", content: user }],
+      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 6 }] as Anthropic.Messages.MessageCreateParams["tools"],
+    });
+    textOut = res.content.filter((b): b is Anthropic.TextBlock => b.type === "text").map((b) => b.text).join("\n");
+    costCents = Math.ceil((res.usage.input_tokens / 1000) * CENTS_PER_1K_IN + (res.usage.output_tokens / 1000) * CENTS_PER_1K_OUT);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await logEvent(sb, { business_id: args.businessId, site_id: args.siteId, level: "error", message: `✗ Opportunity Scout failed — ${msg}` });
+    throw e;
+  }
+
+  let items: unknown[];
+  try { items = extractJsonArray(textOut); }
+  catch {
+    await logEvent(sb, { business_id: args.businessId, site_id: args.siteId, level: "error", message: "✗ Opportunity Scout returned no usable opportunities" });
+    throw new Error("The scout didn't return usable opportunities — try again.");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (items as any[]).filter((x) => x && typeof x.title === "string").slice(0, 25).map((x) => ({
+    business_id: args.businessId, site_id: args.siteId,
+    type: String(x.type ?? "content_gap").slice(0, 40),
+    title: String(x.title).slice(0, 300),
+    detail: x.detail != null ? String(x.detail).slice(0, 2000) : null,
+    priority: Number.isFinite(x.priority) ? Math.max(0, Math.min(10, Math.round(x.priority))) : 5,
+    status: "queued",
+  }));
+  if (rows.length) { const { error } = await sb.from("seo_opportunities").insert(rows); if (error) throw error; }
+
+  await logEvent(sb, { business_id: args.businessId, site_id: args.siteId, agent_id: "seo-opportunity-scout", level: "success", cost_cents: costCents, message: `✓ Opportunity Scout → ${rows.length} opportunities · $${(costCents / 100).toFixed(2)}` });
+  return { inserted: rows.length };
+}
+
 interface Job { id: string; business_id: string; step: number; input: { content_piece_id?: string }; cost_cents: number }
 
 /**


### PR DESCRIPTION
## What

Completes the **discover → write → publish** loop. Until now you had to hand the pipeline a topic. The **Opportunity Scout** studies a site's niche (live web search) and returns a **ranked queue** of what to write or fix — and one click sends any item into the pipeline.

- **`engine.runOpportunityScout`** — Opus + web search, structured-JSON output parsed into `seo_opportunities`, budget-gated, logs to the activity terminal.
- Actions `scanOpportunities` / `listOpportunities` / `setOpportunityStatus` / `writeOpportunity` (starts a pipeline from an opportunity + marks it in-progress).
- Hub gains an **Opportunities** tab: **Scan** button, ranked cards (type · priority · why, expandable), **Write this** and **Dismiss**.
- **MCP**: `run_opportunity_scout`, `list_seo_opportunities`, `set_opportunity_status`.
- `/seo/[id]` `maxDuration = 300` so the scan isn't cut off mid-run.

No migration (`seo_opportunities` already existed). Works from the site + web search today; sharper once GSC ranking data is connected.

## The full loop now

**Scan** → ranked opportunities → **Write this** → agents research/write/refine → **Approve** → **Publish** to the gateway. The agents now decide *what* to do, not just execute a topic.

## Safety

No schema change. SEO plugin still default-off/route-gated. Budget-gated like the rest of the engine.

Verified: tsc · 17 tests · build · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)