### PR TITLE
docs: record plugin system + SEO agent platform (July 2026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,16 @@ User's accumulated preferences:
 - **Never trust empty input** — coerce, validate, soft-fail
 - Current accent name: **teal**; sidebar: **light**; canvas: warm off-white. Don't revert to flux lime unless explicitly asked.
 
-## Session log (June 2026) — Stripe payments + email templates (MOST RECENT — pick up here)
+## Session log (July 2026) — Plugin system + SEO agent platform (MOST RECENT — pick up here)
+
+The **plugin system** (P0) and the **SEO agent platform** (P2 core) shipped — see `docs/SEO_AGENCY_PLAN.md` (updated status) and the `[[project-seo-agent-platform]]` memory for the full map. In brief, all on `main` / production, migrations applied + recorded:
+
+- **Plugins + presets** (PRs #359/#360): registry + resolver + 3-layer gating (nav/route/MCP), industry presets (trades/agency/seo-agency-local) applied at signup or the Plugins store, minimal vocab layer, `businesses.industry_preset`. Data-safe: optional plugins resolve `settingsTable ?? installRow ?? defaultEnabled`, so no install row = today's behaviour and legacy modules stay on.
+- **Anti-bloat hardening** (#361–#363): CI **bundle-size budget** (`scripts/check-bundle-size.mjs`, blocking), **gated Sentry** (`src/instrumentation.ts`, inert without `SENTRY_DSN`), and **split the MCP monolith** — churned domains live in `src/lib/mcp/tools/*` (shared.ts, plugin-form-tools.ts, seo-tools.ts) registered from `register-tools.ts`.
+- **SEO Production plugin** (#365–#374, default OFF, route-gated `/seo`): 7-table data model; the **content pipeline engine** (`src/lib/seo/engine.ts` — 13 agents in `src/lib/seo/agents/*.md` compiled by `scripts/build-agent-prompts.mjs` → `agent-prompts.generated.ts`; `seo_jobs` runner `/api/cron/seo-jobs`; one Claude call/step + web search); per-site **hub** `/seo/[id]`; **live agent terminal** (`seo_job_events`); **budget cap** (`seo_monthly_budget_cents`); **Opportunity Scout**; **publish gateways** (Git/GitHub, WordPress, Sanity, Payload, custom REST/GraphQL — `src/lib/seo/{connectors,publish}.ts`, creds encrypted via `src/lib/crypto.ts`).
+- **🔴 To actually RUN it:** top up the **`ANTHROPIC_API_KEY`** account (was out of credits — blocks the whole pipeline) and set **`APP_ENCRYPTION_KEY`** (64 hex) on Vercel (blocks storing connector credentials). GSC connector + configurable Git frontmatter are the known not-yet-built items.
+
+## Session log (June 2026) — Stripe payments + email templates
 
 Big multi-day push: per-business email templates, then a full Stripe Connect payments stack. All shipped to `main` (production = kireihq.com) and DB migrations applied + recorded on remote.
 

--- a/docs/SEO_AGENCY_PLAN.md
+++ b/docs/SEO_AGENCY_PLAN.md
@@ -1,7 +1,20 @@
 # SEO Agency Platform — Kirei-scoped build plan
 
-**Status:** approved direction, not yet started · **Owner doc** for the "plugins + SEO agency vertical" initiative (July 2026).
+**Status:** **P0 + P2 core SHIPPED** (July 2026, PRs #359–#374) · **Owner doc** for the "plugins + SEO agency vertical" initiative.
 **Decisions locked:** built **inside Kirei as plugins** (not a separate app + SSO) · **Local-service playbook first**, Shopify second · industry presets are a core requirement.
+
+### Shipped so far
+- **P0** — plugin registry + resolver + 3-layer gating, industry presets (trades / agency / seo-agency-local), Plugins store, vocab. `businesses.industry_preset`.
+- **P2** — SEO data model (7 tables) · the **content pipeline engine** (13 agents in `src/lib/seo/agents/*.md` → `agent-prompts.generated.ts`; `seo_jobs` runner `/api/cron/seo-jobs`; one Claude call/step, checkpointed) with **live web search** for research agents · per-site **hub** (`/seo/[id]`) with Overview/Content/Opportunities/Connections/Activity · **live agent terminal** (`seo_job_events`) · **per-business budget cap** (`seo_monthly_budget_cents`) · **Opportunity Scout** (discovery) · **publish gateways** — Git/GitHub, WordPress, Sanity, Payload, custom REST, custom GraphQL (adapters in `src/lib/seo/publish.ts`, creds encrypted via `src/lib/crypto.ts`).
+
+### 🔴 Blocking real use (user must set on Vercel)
+1. **`ANTHROPIC_API_KEY`** account was out of credits — the pipeline can't run until topped up (same key all AI features use).
+2. **`APP_ENCRYPTION_KEY`** (64 hex) — required to store any connector credential.
+
+### Not yet built
+- **GSC connector** (needs a Google Cloud OAuth client from the user — the one Phase-2 item Claude can't do alone).
+- **Configurable Git frontmatter** (adapter currently writes generic title/description/pubDate/draft — per-site Astro schemas will need mapping).
+- P3 reporting · P4 instant-audit · P5 Shopify · P6 scale.
 
 The source vision is the "SEO Agency Platform — Build Plan" (agency operating layer / vertical playbooks / agent engine / connectors). This doc maps it onto Kirei's actual codebase: what's reused, what's new, and in what order. Guiding fact: **Kirei already IS the agency CRM layer** — clients, contracts + e-sign, recurring retainer billing, Stripe, client portal, onboarding forms (with encrypted credentials), public lead-capture forms, tasks kanban, per-business branded email, PDF pipeline. We are adding **the plugin foundation, the SEO production engine, and reporting** on top.
 


### PR DESCRIPTION
Docs-only. Updates `docs/SEO_AGENCY_PLAN.md` status (P0 + P2 core shipped, remaining work, the two env-var blockers) and adds a CLAUDE.md session-log entry for PRs #359–#374 so the next session has the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)