### PR TITLE
feat(seo): white-label client reports (Phase 3, core)

### DIFF
--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getActiveBizId } from "@/lib/active-business";
 import { getSeoSite } from "@/lib/actions/seo";
 import { listContentPieces, getSeoBudget, listOpportunities } from "@/lib/actions/seo-pipeline";
 import { listConnections } from "@/lib/actions/seo-connections";
+import { listSeoReports } from "@/lib/actions/seo-reports";
 import { SeoSiteHub } from "@/components/seo/seo-site-hub";
 
 export const dynamic = "force-dynamic";
@@ -22,11 +23,12 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
   const site = await getSeoSite(id);
   if (!site) notFound();
 
-  const [pieces, budget, connections, opportunities] = await Promise.all([
+  const [pieces, budget, connections, opportunities, reports] = await Promise.all([
     listContentPieces(id),
     getSeoBudget(),
     listConnections(id),
     listOpportunities(id),
+    listSeoReports(id),
   ]);
 
   return (
@@ -37,6 +39,7 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
       pieces={pieces as any}
       connections={connections}
       opportunities={opportunities}
+      reports={reports}
       budget={budget}
     />
   );

--- a/src/app/api/pdf/seo-report/[id]/route.ts
+++ b/src/app/api/pdf/seo-report/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const token = req.nextUrl.searchParams.get("token");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tbl = (s: any, n: string) => s.from(n);
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let report: any;
+    const admin = createAdminClient();
+
+    if (token) {
+      const { data: link } = await tbl(admin, "customer_portal_tokens")
+        .select("business_id, customer_id, expires_at, revoked_at").eq("token", token).maybeSingle();
+      if (!link || link.revoked_at) return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      if (link.expires_at && new Date(link.expires_at) < new Date()) return NextResponse.json({ error: "Token expired" }, { status: 401 });
+      const { data } = await tbl(admin, "seo_reports").select("*, seo_sites(domain, customer_id)").eq("id", id).eq("business_id", link.business_id).maybeSingle();
+      if (!data || data.seo_sites?.customer_id !== link.customer_id) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      report = data;
+    } else {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      const { data } = await tbl(supabase, "seo_reports").select("*, seo_sites(domain, customer_id)").eq("id", id).maybeSingle();
+      if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      report = data;
+    }
+
+    const [{ data: business }, { data: customer }] = await Promise.all([
+      tbl(admin, "businesses").select("*").eq("id", report.business_id).maybeSingle(),
+      report.seo_sites?.customer_id
+        ? tbl(admin, "customers").select("name").eq("id", report.seo_sites.customer_id).maybeSingle()
+        : Promise.resolve({ data: null }),
+    ]);
+
+    const { renderToStream } = await import("@react-pdf/renderer");
+    const { SeoReportPDFDocument } = await import("@/components/seo/seo-report-pdf-document");
+    const React = await import("react");
+
+    const element = React.createElement(SeoReportPDFDocument, {
+      report, business, siteDomain: report.seo_sites?.domain ?? "", clientName: customer?.name ?? null,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = await renderToStream(element as any);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+
+    return new NextResponse(Buffer.concat(chunks), {
+      headers: { "Content-Type": "application/pdf", "Content-Disposition": `inline; filename="seo-report.pdf"` },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[seo-report PDF]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/seo/seo-report-pdf-document.tsx
+++ b/src/components/seo/seo-report-pdf-document.tsx
@@ -1,0 +1,129 @@
+import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/renderer";
+
+function fmtDate(d: string): string {
+  return new Date(d).toLocaleDateString("en-AU", { day: "2-digit", month: "short", year: "numeric" });
+}
+
+interface Ranking { keyword: string; from: number | null; to: number | null; change: number | null; clicks: number; impressions: number }
+interface Report {
+  title: string | null;
+  period_start: string;
+  period_end: string;
+  metrics: { rankings?: Ranking[]; totalClicks?: number; totalImpressions?: number; trackedKeywords?: number };
+  work_log: { contentShipped?: { title: string; url: string | null }[]; opportunitiesDone?: { title: string; type: string }[] };
+  plan: { next?: { title: string; type: string }[] };
+}
+interface Props {
+  report: Report;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  business: any;
+  siteDomain: string;
+  clientName?: string | null;
+}
+
+export function SeoReportPDFDocument({ report, business, siteDomain, clientName }: Props) {
+  const primary: string = business?.pdf_settings?.primary_color ?? "#047857";
+  const logo: string | null = business?.pdf_settings?.logo_url ?? business?.logo_url ?? null;
+  const muted = "#64748b", border = "#e2e8f0", text = "#0f172a";
+
+  const s = StyleSheet.create({
+    page: { padding: 40, fontSize: 10, color: text, fontFamily: "Helvetica" },
+    row: { flexDirection: "row" },
+    between: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+    brand: { fontSize: 16, fontFamily: "Helvetica-Bold", color: primary },
+    h1: { fontSize: 18, fontFamily: "Helvetica-Bold", marginBottom: 2 },
+    h2: { fontSize: 12, fontFamily: "Helvetica-Bold", color: primary, marginTop: 20, marginBottom: 8 },
+    muted: { color: muted },
+    card: { flex: 1, borderWidth: 1, borderColor: border, borderRadius: 6, padding: 10, marginRight: 8 },
+    stat: { fontSize: 18, fontFamily: "Helvetica-Bold" },
+    th: { flexDirection: "row", borderBottomWidth: 1, borderColor: border, paddingBottom: 4, marginBottom: 4 },
+    td: { flexDirection: "row", paddingVertical: 3, borderBottomWidth: 0.5, borderColor: border },
+    cKw: { flex: 3 }, cNum: { flex: 1, textAlign: "right" },
+    li: { flexDirection: "row", marginBottom: 3 },
+    bullet: { width: 10, color: primary },
+    foot: { position: "absolute", bottom: 24, left: 40, right: 40, textAlign: "center", fontSize: 8, color: muted },
+  });
+
+  const rankings = report.metrics?.rankings ?? [];
+  const content = report.work_log?.contentShipped ?? [];
+  const oppsDone = report.work_log?.opportunitiesDone ?? [];
+  const plan = report.plan?.next ?? [];
+
+  return (
+    <Document>
+      <Page size="A4" style={s.page}>
+        <View style={s.between}>
+          <View>
+            {logo ? <Image src={logo} style={{ height: 34, marginBottom: 6 }} /> : <Text style={s.brand}>{business?.name ?? "SEO Report"}</Text>}
+            <Text style={s.muted}>{business?.name}</Text>
+          </View>
+          <View style={{ textAlign: "right" }}>
+            <Text style={s.h1}>SEO Report</Text>
+            <Text style={s.muted}>{fmtDate(report.period_start)} – {fmtDate(report.period_end)}</Text>
+          </View>
+        </View>
+
+        <View style={{ marginTop: 14 }}>
+          <Text style={{ fontFamily: "Helvetica-Bold", fontSize: 12 }}>{clientName ?? siteDomain}</Text>
+          <Text style={s.muted}>{siteDomain}</Text>
+        </View>
+
+        {/* Summary */}
+        <View style={[s.row, { marginTop: 18 }]}>
+          <View style={s.card}><Text style={s.muted}>Tracked keywords</Text><Text style={s.stat}>{report.metrics?.trackedKeywords ?? 0}</Text></View>
+          <View style={s.card}><Text style={s.muted}>Clicks</Text><Text style={s.stat}>{report.metrics?.totalClicks ?? 0}</Text></View>
+          <View style={s.card}><Text style={s.muted}>Impressions</Text><Text style={s.stat}>{report.metrics?.totalImpressions ?? 0}</Text></View>
+          <View style={[s.card, { marginRight: 0 }]}><Text style={s.muted}>Content shipped</Text><Text style={s.stat}>{content.length}</Text></View>
+        </View>
+
+        {/* Rankings */}
+        <Text style={s.h2}>Rankings movement</Text>
+        {rankings.length === 0 ? (
+          <Text style={s.muted}>No ranking data for this period yet. Connect Google Search Console to track keyword positions, clicks and impressions.</Text>
+        ) : (
+          <View>
+            <View style={s.th}><Text style={s.cKw}>Keyword</Text><Text style={s.cNum}>From</Text><Text style={s.cNum}>To</Text><Text style={s.cNum}>Change</Text><Text style={s.cNum}>Clicks</Text></View>
+            {rankings.map((r, i) => (
+              <View style={s.td} key={i}>
+                <Text style={s.cKw}>{r.keyword}</Text>
+                <Text style={s.cNum}>{r.from ?? "–"}</Text>
+                <Text style={s.cNum}>{r.to ?? "–"}</Text>
+                <Text style={[s.cNum, { color: (r.change ?? 0) > 0 ? "#047857" : (r.change ?? 0) < 0 ? "#b91c1c" : muted }]}>{r.change == null ? "–" : r.change > 0 ? `+${r.change}` : r.change}</Text>
+                <Text style={s.cNum}>{r.clicks}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Work delivered */}
+        <Text style={s.h2}>Work delivered</Text>
+        {content.length === 0 && oppsDone.length === 0 ? (
+          <Text style={s.muted}>No content shipped in this period.</Text>
+        ) : (
+          <View>
+            {content.map((c, i) => (
+              <View style={s.li} key={`c${i}`}><Text style={s.bullet}>•</Text><Text>Published: {c.title}{c.url ? ` (${c.url})` : ""}</Text></View>
+            ))}
+            {oppsDone.map((o, i) => (
+              <View style={s.li} key={`o${i}`}><Text style={s.bullet}>•</Text><Text>{o.title}</Text></View>
+            ))}
+          </View>
+        )}
+
+        {/* Plan */}
+        <Text style={s.h2}>Plan for next period</Text>
+        {plan.length === 0 ? (
+          <Text style={s.muted}>Run the Opportunity Scout to build next period&apos;s plan.</Text>
+        ) : (
+          <View>
+            {plan.map((p, i) => (
+              <View style={s.li} key={`p${i}`}><Text style={s.bullet}>•</Text><Text>{p.title} <Text style={s.muted}>({p.type.replace("_", " ")})</Text></Text></View>
+            ))}
+          </View>
+        )}
+
+        <Text style={s.foot} fixed>{business?.name} · Prepared {fmtDate(report.period_end)}</Text>
+      </Page>
+    </Document>
+  );
+}

--- a/src/components/seo/seo-reports.tsx
+++ b/src/components/seo/seo-reports.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { FileText, Plus, Check, Trash2, Download } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { generateSeoReport, approveSeoReport, deleteSeoReport } from "@/lib/actions/seo-reports";
+
+interface Report { id: string; title: string | null; period_start: string; period_end: string; status: string; created_at: string; sent_at: string | null }
+
+const TONE: Record<string, string> = {
+  draft: "bg-muted text-muted-foreground",
+  approved: "bg-emerald-100 text-emerald-700",
+  sent: "bg-blue-100 text-blue-700",
+};
+const fmt = (d: string) => new Date(d).toLocaleDateString("en-AU", { day: "2-digit", month: "short" });
+
+export function SeoReports({ siteId, reports }: { siteId: string; reports: Report[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [generating, setGenerating] = useState(false);
+
+  function handleGenerate() {
+    setGenerating(true);
+    generateSeoReport(siteId)
+      .then(() => { toast.success("Report generated"); router.refresh(); })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Couldn't generate"))
+      .finally(() => setGenerating(false));
+  }
+
+  function handleApprove(r: Report) {
+    startTransition(async () => {
+      try { await approveSeoReport(r.id, siteId); toast.success("Approved"); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't approve"); }
+    });
+  }
+
+  function handleDelete(r: Report) {
+    startTransition(async () => {
+      try { await deleteSeoReport(r.id, siteId); toast.success("Deleted"); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't delete"); }
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <p className="text-sm text-muted-foreground">Monthly client report — rankings movement, work delivered and next-period plan, as a branded PDF.</p>
+        <Button onClick={handleGenerate} disabled={generating || isPending}>
+          <Plus className="w-4 h-4 mr-1.5" /> {generating ? "Generating…" : "Generate report"}
+        </Button>
+      </div>
+
+      {reports.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><FileText className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No reports yet</p>
+          <p className="text-sm text-muted-foreground mt-1 max-w-sm mx-auto">Generate a report and it pulls the last 30 days of rankings, content shipped and the upcoming plan into a client-ready PDF.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {reports.map((r) => (
+            <div key={r.id} className="rounded-xl border border-border bg-card p-4 flex items-center gap-3">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold break-words">{fmt(r.period_start)} – {fmt(r.period_end)}</p>
+                <p className="text-xs text-muted-foreground">Generated {new Date(r.created_at).toLocaleDateString("en-AU")}</p>
+              </div>
+              <span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 shrink-0", TONE[r.status])}>{r.status}</span>
+              <a href={`/api/pdf/seo-report/${r.id}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground rounded-md border border-border px-2 py-1">
+                <Download className="w-3.5 h-3.5" /> PDF
+              </a>
+              {r.status === "draft" && (
+                <button onClick={() => handleApprove(r)} disabled={isPending} className="inline-flex items-center gap-1 text-xs text-emerald-700 hover:text-emerald-800"><Check className="w-3.5 h-3.5" /> Approve</button>
+              )}
+              <button onClick={() => handleDelete(r)} disabled={isPending} className="text-muted-foreground hover:text-destructive" aria-label="Delete report"><Trash2 className="w-4 h-4" /></button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -15,10 +15,12 @@ import { startContentPipeline } from "@/lib/actions/seo-pipeline";
 import { SeoActivityTerminal } from "@/components/seo/seo-activity-terminal";
 import { SeoConnections } from "@/components/seo/seo-connections";
 import { SeoOpportunities } from "@/components/seo/seo-opportunities";
+import { SeoReports } from "@/components/seo/seo-reports";
 import { CONNECTORS, type ConnectionView } from "@/lib/seo/connectors";
 import type { SeoSite, SeoContentType } from "@/types/database";
 
 interface Opportunity { id: string; type: string; title: string; detail: string | null; priority: number; status: string; created_at: string }
+interface Report { id: string; title: string | null; period_start: string; period_end: string; status: string; created_at: string; sent_at: string | null }
 
 interface Piece {
   id: string; title: string; topic: string | null; content_type: string;
@@ -29,10 +31,11 @@ interface Props {
   pieces: Piece[];
   connections: ConnectionView[];
   opportunities: Opportunity[];
+  reports: Report[];
   budget: { spentCents: number; budgetCents: number; ok: boolean };
 }
 
-type Tab = "overview" | "content" | "opportunities" | "connections" | "activity";
+type Tab = "overview" | "content" | "opportunities" | "connections" | "reports" | "activity";
 
 const STATUS_TONE: Record<string, string> = {
   running: "bg-blue-100 text-blue-700",
@@ -45,7 +48,7 @@ const STATUS_TONE: Record<string, string> = {
 };
 const money = (c: number) => `$${(c / 100).toFixed(2)}`;
 
-export function SeoSiteHub({ site, pieces, connections, opportunities, budget }: Props) {
+export function SeoSiteHub({ site, pieces, connections, opportunities, reports, budget }: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("overview");
   const [isPending, startTransition] = useTransition();
@@ -74,6 +77,7 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, budget }:
     { id: "content", label: "Content", icon: FileText },
     { id: "opportunities", label: "Opportunities", icon: Search },
     { id: "connections", label: "Connections", icon: Plug },
+    { id: "reports", label: "Reports", icon: FileText },
     { id: "activity", label: "Activity", icon: Activity },
   ];
 
@@ -159,6 +163,9 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, budget }:
 
       {/* ── Connections ── */}
       {tab === "connections" && <SeoConnections siteId={site.id} connections={connections} />}
+
+      {/* ── Reports ── */}
+      {tab === "reports" && <SeoReports siteId={site.id} reports={reports} />}
 
       {/* ── Activity ── */}
       {tab === "activity" && <SeoActivityTerminal siteId={site.id} />}

--- a/src/lib/actions/seo-reports.ts
+++ b/src/lib/actions/seo-reports.ts
@@ -1,0 +1,66 @@
+"use server";
+
+/**
+ * White-label SEO reports (docs/SEO_AGENCY_PLAN.md, Phase 3). Assembles a
+ * period report from existing SEO data — rankings movement (from keyword
+ * snapshots), work delivered (content shipped + opportunities done), and a
+ * next-month plan (top queued opportunities). Rendered to a branded PDF by
+ * /api/pdf/seo-report. Dependency-free: no ranking data yet just means the
+ * rankings section is empty with a "connect Search Console" note.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { assembleReport } from "@/lib/seo/report";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function biz(): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  return getActiveBizId(supabase, user.id);
+}
+
+export async function generateSeoReport(siteId: string, periodDays = 30): Promise<{ report_id: string }> {
+  const businessId = await biz();
+  const supabase = await createClient();
+
+  const { data: site } = await tbl(supabase, "seo_sites").select("id, domain").eq("id", siteId).eq("business_id", businessId).maybeSingle();
+  if (!site) throw new Error("Site not found");
+
+  const fields = await assembleReport(supabase, businessId, siteId, site.domain, periodDays);
+  const { data: report, error } = await tbl(supabase, "seo_reports").insert({
+    business_id: businessId, site_id: siteId, status: "draft", ...fields,
+  }).select("id").single();
+  if (error) throw error;
+
+  revalidatePath(`/seo/${siteId}`);
+  return { report_id: report.id };
+}
+
+export async function listSeoReports(siteId: string) {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { data } = await tbl(supabase, "seo_reports")
+    .select("id, title, period_start, period_end, status, created_at, sent_at")
+    .eq("business_id", businessId).eq("site_id", siteId).order("created_at", { ascending: false }).limit(100);
+  return (data ?? []) as Array<{ id: string; title: string | null; period_start: string; period_end: string; status: string; created_at: string; sent_at: string | null }>;
+}
+
+export async function approveSeoReport(id: string, siteId: string): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { error } = await tbl(supabase, "seo_reports").update({ status: "approved" }).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath(`/seo/${siteId}`);
+}
+
+export async function deleteSeoReport(id: string, siteId: string): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { error } = await tbl(supabase, "seo_reports").delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath(`/seo/${siteId}`);
+}

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -8,6 +8,7 @@ import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, UUID, type ToolFn } from "./shared";
 import { advanceContentJob, seoSpendStatus, runOpportunityScout } from "@/lib/seo/engine";
 import { publishContent } from "@/lib/seo/publish";
+import { assembleReport } from "@/lib/seo/report";
 
 const DOMAIN = z.string().min(1).describe("Client site domain, e.g. example.com");
 
@@ -263,5 +264,29 @@ export function registerSeoTools(tool: ToolFn): void {
       const { error } = await t(ctx, "seo_opportunities").update({ status: args.status }).eq("id", args.opportunity_id).eq("business_id", ctx.businessId);
       if (error) throw error;
       return text({ updated: true });
+    });
+
+  // ── White-label reports ──────────────────────────────────────────────────────
+  tool("generate_seo_report", "Generate a client SEO report for a site (rankings movement, work delivered, next-period plan). PDF at /api/pdf/seo-report/<id>.",
+    { site_id: UUID, period_days: z.number().int().min(1).max(365).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { data: site } = await t(ctx, "seo_sites").select("domain").eq("id", args.site_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!site) return errorText("Site not found");
+      const fields = await assembleReport(ctx.sb, ctx.businessId, args.site_id, site.domain, args.period_days ?? 30);
+      const { data: report, error } = await t(ctx, "seo_reports").insert({ business_id: ctx.businessId, site_id: args.site_id, status: "draft", ...fields }).select("id").single();
+      if (error) throw error;
+      return text({ report_id: report.id, title: fields.title });
+    });
+
+  tool("list_seo_reports", "List a site's SEO reports.",
+    { site_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      const { data, error } = await t(ctx, "seo_reports")
+        .select("id, title, period_start, period_end, status, created_at, sent_at")
+        .eq("business_id", ctx.businessId).eq("site_id", args.site_id).order("created_at", { ascending: false }).limit(100);
+      if (error) throw error;
+      return text(data);
     });
 }

--- a/src/lib/seo/report.ts
+++ b/src/lib/seo/report.ts
@@ -1,0 +1,73 @@
+/**
+ * SEO report assembly (docs/SEO_AGENCY_PLAN.md, Phase 3). Pulls a period's
+ * rankings movement, work delivered and next-period plan from existing SEO
+ * data into the fields stored on seo_reports. Shared by the server action and
+ * the MCP tool. Server-only (takes a Supabase client). Dependency-free — no
+ * ranking data yet just yields an empty rankings section.
+ */
+
+function isoDate(d: Date): string { return d.toISOString().split("T")[0]; }
+
+export interface ReportFields {
+  title: string;
+  period_start: string;
+  period_end: string;
+  metrics: Record<string, unknown>;
+  work_log: Record<string, unknown>;
+  plan: Record<string, unknown>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function assembleReport(sb: any, businessId: string, siteId: string, domain: string, periodDays = 30): Promise<ReportFields> {
+  const end = new Date();
+  const start = new Date(end.getTime() - periodDays * 86400000);
+  const startISO = start.toISOString();
+  const tbl = (n: string) => sb.from(n);
+
+  const [snapsRes, contentRes, oppsDoneRes, oppsPlanRes] = await Promise.all([
+    tbl("seo_keyword_snapshots").select("keyword, position, clicks, impressions, captured_at")
+      .eq("business_id", businessId).eq("site_id", siteId).gte("captured_at", isoDate(start)).order("captured_at", { ascending: true }),
+    tbl("seo_content_pieces").select("title, published_url, status, updated_at")
+      .eq("business_id", businessId).eq("site_id", siteId).in("status", ["published", "approved"]).gte("updated_at", startISO).order("updated_at", { ascending: false }),
+    tbl("seo_opportunities").select("title, type, updated_at")
+      .eq("business_id", businessId).eq("site_id", siteId).eq("status", "done").gte("updated_at", startISO),
+    tbl("seo_opportunities").select("title, type, priority")
+      .eq("business_id", businessId).eq("site_id", siteId).eq("status", "queued").order("priority", { ascending: false }).limit(6),
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const byKw = new Map<string, { first: any; last: any }>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const s of (snapsRes.data ?? []) as any[]) {
+    const cur = byKw.get(s.keyword);
+    if (!cur) byKw.set(s.keyword, { first: s, last: s });
+    else cur.last = s;
+  }
+  const rankings = [...byKw.entries()].map(([keyword, { first, last }]) => ({
+    keyword,
+    from: first.position ?? null,
+    to: last.position ?? null,
+    change: first.position != null && last.position != null ? Math.round((first.position - last.position) * 10) / 10 : null,
+    clicks: last.clicks ?? 0,
+    impressions: last.impressions ?? 0,
+  })).sort((a, b) => (b.change ?? -999) - (a.change ?? -999)).slice(0, 25);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const content = ((contentRes.data ?? []) as any[]).map((c) => ({ title: c.title, url: c.published_url, date: c.updated_at }));
+  const totalClicks = rankings.reduce((n, r) => n + (r.clicks || 0), 0);
+  const totalImpressions = rankings.reduce((n, r) => n + (r.impressions || 0), 0);
+
+  return {
+    title: `SEO report — ${domain} · ${isoDate(start)} to ${isoDate(end)}`,
+    period_start: isoDate(start),
+    period_end: isoDate(end),
+    metrics: { rankings, totalClicks, totalImpressions, trackedKeywords: byKw.size },
+    work_log: {
+      contentShipped: content,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      opportunitiesDone: ((oppsDoneRes.data ?? []) as any[]).map((o) => ({ title: o.title, type: o.type })),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    plan: { next: ((oppsPlanRes.data ?? []) as any[]).map((o) => ({ title: o.title, type: o.type })) },
+  };
+}

--- a/supabase/migrations/20260709120000_seo_reports.sql
+++ b/supabase/migrations/20260709120000_seo_reports.sql
@@ -1,0 +1,51 @@
+-- White-label SEO client reports (docs/SEO_AGENCY_PLAN.md, Phase 3).
+-- A monthly report per site: rankings movement, work delivered, next-month
+-- plan — assembled from existing SEO data, rendered to a branded PDF, and
+-- (in a follow-up) delivered to the client portal. Additive.
+CREATE TABLE IF NOT EXISTS public.seo_reports (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  site_id      UUID NOT NULL REFERENCES public.seo_sites(id) ON DELETE CASCADE,
+  title        TEXT,
+  period_start DATE NOT NULL,
+  period_end   DATE NOT NULL,
+  metrics      JSONB NOT NULL DEFAULT '{}'::jsonb,   -- rankings / traffic
+  work_log     JSONB NOT NULL DEFAULT '{}'::jsonb,   -- content shipped, opps done
+  plan         JSONB NOT NULL DEFAULT '{}'::jsonb,   -- next-month plan
+  status       TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','approved','sent')),
+  sent_at      TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_reports_site ON public.seo_reports (site_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_reports_business ON public.seo_reports (business_id, created_at DESC);
+
+ALTER TABLE public.seo_reports ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  EXECUTE $f$
+    DROP POLICY IF EXISTS seo_reports_read ON public.seo_reports;
+    CREATE POLICY seo_reports_read ON public.seo_reports FOR SELECT USING (
+      business_id IN (
+        SELECT id FROM public.businesses WHERE user_id = auth.uid()
+        UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+      ) AND NOT public.is_business_worker(business_id)
+    );
+    DROP POLICY IF EXISTS seo_reports_write ON public.seo_reports;
+    CREATE POLICY seo_reports_write ON public.seo_reports FOR ALL USING (
+      business_id IN (
+        SELECT id FROM public.businesses WHERE user_id = auth.uid()
+        UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+      )
+    ) WITH CHECK (
+      business_id IN (
+        SELECT id FROM public.businesses WHERE user_id = auth.uid()
+        UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+      )
+    );
+  $f$;
+END $$;
+
+DROP TRIGGER IF EXISTS seo_reports_updated_at ON public.seo_reports;
+CREATE TRIGGER seo_reports_updated_at BEFORE UPDATE ON public.seo_reports
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
## What

**Phase 3** — a branded monthly SEO report per site: **rankings movement · work delivered · next-period plan**, assembled from existing SEO data and rendered to a PDF.

- **Migration `20260709120000`** (applied + recorded): `seo_reports` (period, `metrics`/`work_log`/`plan` jsonb, status draft/approved/sent) + RLS + trigger.
- **`src/lib/seo/report.ts` `assembleReport()`** — rankings (first-vs-last keyword snapshots), content shipped, opportunities done, and top queued opportunities as next month's plan. **Dependency-free** — empty rankings until GSC is connected (with a "connect Search Console" note in the PDF).
- **Branded PDF** (`seo-report-pdf-document.tsx`) using the business's `pdf_settings` (colour/logo). Route `/api/pdf/seo-report/[id]` — authed user **or** portal `?token=` (mirrors the invoice route, so it's ready for portal delivery).
- Actions generate/list/approve/delete; **MCP** `generate_seo_report` + `list_seo_reports`. Hub gains a **Reports** tab (generate · status · download PDF · approve).

## Next (P3 follow-up)

Portal page `/portal/[token]/seo-report/[id]`, email send via the per-business sender, and the monthly auto-generate cron + approval gate.

## Safety

Additive table + one new PDF route (token-or-auth). SEO plugin still default-off/route-gated.

Verified: tsc · 17 tests · build (PDF route compiles) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)