### PR TITLE
feat(seo): report delivery — client portal + email + monthly cron (Phase 3)

### DIFF
--- a/src/app/api/cron/seo-reports/route.ts
+++ b/src/app/api/cron/seo-reports/route.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/cron/seo-reports — monthly.
+ *
+ * Auto-generates a DRAFT SEO report for every active site that has a linked
+ * client, so the account manager just reviews + sends (approval gate; we never
+ * auto-send). Skips sites that already got a report in the last 25 days.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { assembleReport } from "@/lib/seo/report";
+
+export const maxDuration = 300;
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: sites } = await (sb as any)
+    .from("seo_sites").select("id, business_id, domain, customer_id")
+    .eq("status", "active").not("customer_id", "is", null).limit(500);
+
+  const since = new Date(Date.now() - 25 * 86_400_000).toISOString();
+  let generated = 0;
+  for (const site of (sites ?? []) as Array<{ id: string; business_id: string; domain: string }>) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: recent } = await (sb as any).from("seo_reports").select("id").eq("site_id", site.id).gte("created_at", since).limit(1).maybeSingle();
+    if (recent) continue;
+    try {
+      const fields = await assembleReport(sb, site.business_id, site.id, site.domain, 30);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any).from("seo_reports").insert({ business_id: site.business_id, site_id: site.id, status: "draft", ...fields });
+      generated++;
+    } catch { /* skip this site, keep going */ }
+  }
+
+  return NextResponse.json({ generated });
+}

--- a/src/app/portal/[token]/seo-report/[id]/page.tsx
+++ b/src/app/portal/[token]/seo-report/[id]/page.tsx
@@ -1,0 +1,102 @@
+import { notFound } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { Card } from "@/components/ui/card";
+import { Download } from "@/components/ui/icons";
+
+export const dynamic = "force-dynamic";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+function fmt(d: string): string {
+  return new Date(d).toLocaleDateString("en-AU", { day: "2-digit", month: "short", year: "numeric" });
+}
+
+export default async function PortalSeoReportPage({ params }: { params: Promise<{ token: string; id: string }> }) {
+  const { token, id } = await params;
+  const sb = createAdminClient();
+
+  const { data: link } = await tbl(sb, "customer_portal_tokens")
+    .select("business_id, customer_id, expires_at, revoked_at").eq("token", token).maybeSingle();
+  if (!link || link.revoked_at) notFound();
+  if (link.expires_at && new Date(link.expires_at) < new Date()) notFound();
+
+  const { data: report } = await tbl(sb, "seo_reports")
+    .select("*, seo_sites(domain, customer_id)").eq("id", id).eq("business_id", link.business_id).maybeSingle();
+  if (!report || report.seo_sites?.customer_id !== link.customer_id) notFound();
+
+  const { data: business } = await tbl(sb, "businesses").select("name, logo_url").eq("id", link.business_id).maybeSingle();
+
+  const m = report.metrics ?? {};
+  const content = report.work_log?.contentShipped ?? [];
+  const rankings = m.rankings ?? [];
+  const pdfHref = `/api/pdf/seo-report/${id}?token=${token}`;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/30">
+      <header className="border-b bg-background/80 backdrop-blur sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto px-6 py-5 flex items-center justify-between gap-4">
+          <div className="font-semibold">{business?.name ?? "SEO Report"}</div>
+          <a href={pdfHref} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 text-sm rounded-md border border-border px-3 py-1.5 hover:bg-muted">
+            <Download className="w-4 h-4" /> Download PDF
+          </a>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold">SEO Report</h1>
+          <p className="text-muted-foreground">{report.seo_sites?.domain} · {fmt(report.period_start)} – {fmt(report.period_end)}</p>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <Stat label="Tracked keywords" value={m.trackedKeywords ?? 0} />
+          <Stat label="Clicks" value={m.totalClicks ?? 0} />
+          <Stat label="Impressions" value={m.totalImpressions ?? 0} />
+          <Stat label="Content shipped" value={content.length} />
+        </div>
+
+        <Card className="p-5">
+          <h2 className="font-semibold mb-3">Rankings movement</h2>
+          {rankings.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Ranking data will appear here once Search Console is connected.</p>
+          ) : (
+            <div className="text-sm">
+              <div className="flex text-xs text-muted-foreground border-b border-border pb-1 mb-1">
+                <span className="flex-[3]">Keyword</span><span className="flex-1 text-right">From</span><span className="flex-1 text-right">To</span><span className="flex-1 text-right">Change</span>
+              </div>
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {rankings.slice(0, 20).map((r: any, i: number) => (
+                <div key={i} className="flex py-1 border-b border-border/50">
+                  <span className="flex-[3] break-words">{r.keyword}</span>
+                  <span className="flex-1 text-right">{r.from ?? "–"}</span>
+                  <span className="flex-1 text-right">{r.to ?? "–"}</span>
+                  <span className={`flex-1 text-right ${(r.change ?? 0) > 0 ? "text-emerald-600" : (r.change ?? 0) < 0 ? "text-red-600" : "text-muted-foreground"}`}>{r.change == null ? "–" : r.change > 0 ? `+${r.change}` : r.change}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+
+        {content.length > 0 && (
+          <Card className="p-5">
+            <h2 className="font-semibold mb-3">Work delivered</h2>
+            <ul className="text-sm space-y-1 list-disc pl-5">
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {content.map((c: any, i: number) => <li key={i}>{c.title}</li>)}
+            </ul>
+          </Card>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </div>
+  );
+}

--- a/src/components/seo/seo-reports.tsx
+++ b/src/components/seo/seo-reports.tsx
@@ -3,10 +3,10 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { FileText, Plus, Check, Trash2, Download } from "@/components/ui/icons";
+import { FileText, Plus, Check, Trash2, Download, Send } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { generateSeoReport, approveSeoReport, deleteSeoReport } from "@/lib/actions/seo-reports";
+import { generateSeoReport, approveSeoReport, deleteSeoReport, sendSeoReport } from "@/lib/actions/seo-reports";
 
 interface Report { id: string; title: string | null; period_start: string; period_end: string; status: string; created_at: string; sent_at: string | null }
 
@@ -44,6 +44,13 @@ export function SeoReports({ siteId, reports }: { siteId: string; reports: Repor
     });
   }
 
+  function handleSend(r: Report) {
+    startTransition(async () => {
+      try { await sendSeoReport(r.id, siteId); toast.success("Sent to client"); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't send"); }
+    });
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-3 flex-wrap">
@@ -73,6 +80,9 @@ export function SeoReports({ siteId, reports }: { siteId: string; reports: Repor
               </a>
               {r.status === "draft" && (
                 <button onClick={() => handleApprove(r)} disabled={isPending} className="inline-flex items-center gap-1 text-xs text-emerald-700 hover:text-emerald-800"><Check className="w-3.5 h-3.5" /> Approve</button>
+              )}
+              {(r.status === "approved" || r.status === "sent") && (
+                <button onClick={() => handleSend(r)} disabled={isPending} className="inline-flex items-center gap-1 text-xs text-primary hover:underline"><Send className="w-3.5 h-3.5" /> {r.status === "sent" ? "Resend" : "Send"}</button>
               )}
               <button onClick={() => handleDelete(r)} disabled={isPending} className="text-muted-foreground hover:text-destructive" aria-label="Delete report"><Trash2 className="w-4 h-4" /></button>
             </div>

--- a/src/lib/actions/seo-reports.ts
+++ b/src/lib/actions/seo-reports.ts
@@ -12,7 +12,9 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { assembleReport } from "@/lib/seo/report";
+import { deliverSeoReport } from "@/lib/seo/deliver";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -54,6 +56,14 @@ export async function approveSeoReport(id: string, siteId: string): Promise<void
   const supabase = await createClient();
   const { error } = await tbl(supabase, "seo_reports").update({ status: "approved" }).eq("id", id).eq("business_id", businessId);
   if (error) throw error;
+  revalidatePath(`/seo/${siteId}`);
+}
+
+export async function sendSeoReport(reportId: string, siteId: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  await deliverSeoReport(createAdminClient(), businessId, user.id, reportId);
   revalidatePath(`/seo/${siteId}`);
 }
 

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -9,6 +9,7 @@ import { ctxFrom, UUID, type ToolFn } from "./shared";
 import { advanceContentJob, seoSpendStatus, runOpportunityScout } from "@/lib/seo/engine";
 import { publishContent } from "@/lib/seo/publish";
 import { assembleReport } from "@/lib/seo/report";
+import { deliverSeoReport } from "@/lib/seo/deliver";
 
 const DOMAIN = z.string().min(1).describe("Client site domain, e.g. example.com");
 
@@ -288,5 +289,13 @@ export function registerSeoTools(tool: ToolFn): void {
         .eq("business_id", ctx.businessId).eq("site_id", args.site_id).order("created_at", { ascending: false }).limit(100);
       if (error) throw error;
       return text(data);
+    });
+
+  tool("send_seo_report", "Email a report to the site's linked client (portal link) and mark it sent. Requires email:send.",
+    { report_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write"); assertScope(ctx, "email:send");
+      const res = await deliverSeoReport(ctx.sb, ctx.businessId, ctx.userId, args.report_id);
+      return text({ sent: true, ...res });
     });
 }

--- a/src/lib/seo/deliver.ts
+++ b/src/lib/seo/deliver.ts
@@ -1,0 +1,62 @@
+/**
+ * Deliver a white-label SEO report to the client (docs/SEO_AGENCY_PLAN.md P3).
+ * Mints/reuses a customer portal token, emails a branded link via the
+ * per-business sender, and marks the report sent. Shared by the server action
+ * and the MCP tool. Server-only.
+ */
+import { randomBytes } from "node:crypto";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { appUrl } from "@/lib/app-url";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function mintToken(sb: any, businessId: string, customerId: string, userId: string): Promise<string> {
+  const { data: existing } = await sb.from("customer_portal_tokens")
+    .select("token").eq("business_id", businessId).eq("customer_id", customerId)
+    .is("revoked_at", null).or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .limit(1).maybeSingle();
+  if (existing?.token) return existing.token;
+  const token = "cust_" + randomBytes(24).toString("hex");
+  await sb.from("customer_portal_tokens").insert({
+    token, business_id: businessId, customer_id: customerId, created_by: userId,
+    expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+  });
+  return token;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function deliverSeoReport(sb: any, businessId: string, userId: string, reportId: string): Promise<{ link: string }> {
+  const { data: report } = await sb.from("seo_reports")
+    .select("id, seo_sites(domain, customer_id)").eq("id", reportId).eq("business_id", businessId).maybeSingle();
+  if (!report) throw new Error("Report not found");
+  const customerId = report.seo_sites?.customer_id;
+  if (!customerId) throw new Error("Link a client (customer) to this site before sending.");
+
+  const [{ data: customer }, { data: business }] = await Promise.all([
+    sb.from("customers").select("name, email").eq("id", customerId).maybeSingle(),
+    sb.from("businesses").select("name, email").eq("id", businessId).maybeSingle(),
+  ]);
+  if (!customer?.email) throw new Error("The linked client has no email address.");
+
+  const token = await mintToken(sb, businessId, customerId, userId);
+  const link = `${appUrl()}/portal/${token}/seo-report/${reportId}`;
+  const domain = report.seo_sites?.domain ?? "your site";
+
+  const html = `<div style="font-family:system-ui,Segoe UI,sans-serif;max-width:520px;margin:0 auto;color:#0f172a">
+    <h2 style="margin:0 0 8px">Your SEO report is ready</h2>
+    <p>Hi ${customer.name ?? "there"}, your latest SEO report for <strong>${domain}</strong> is ready to view.</p>
+    <p style="margin:20px 0"><a href="${link}" style="display:inline-block;background:#047857;color:#fff;padding:11px 20px;border-radius:8px;text-decoration:none;font-weight:600">View your report</a></p>
+    <p style="color:#64748b;font-size:12px;word-break:break-all">${link}</p>
+  </div>`;
+
+  await sendEmail({
+    to: customer.email,
+    subject: `Your SEO report — ${domain}`,
+    html,
+    from: buildBusinessFrom({ name: business?.name ?? "Kirei", localPart: "reports" }),
+    replyTo: business?.email ?? undefined,
+    tags: { business_id: businessId, doc_type: "custom", doc_id: reportId },
+  });
+
+  await sb.from("seo_reports").update({ status: "sent", sent_at: new Date().toISOString() }).eq("id", reportId);
+  return { link };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -43,6 +43,10 @@
     {
       "path": "/api/cron/seo-jobs",
       "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/api/cron/seo-reports",
+      "schedule": "0 7 1 * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Completes **Phase 3**. An approved report is delivered to the client, and reports auto-generate monthly.

- **`src/lib/seo/deliver.ts`** — mints/reuses a customer portal token, emails a **branded link** via the per-business sender, marks the report `sent`. Shared by the action + MCP.
- **Client portal page** `/portal/[token]/seo-report/[id]` — summary stats + rankings + work delivered + **Download PDF** (token-gated PDF route).
- Action `sendSeoReport`; hub Reports tab gets **Send / Resend** (approved → sent).
- **Cron** `/api/cron/seo-reports` (monthly, 1st @ 07:00 UTC) auto-generates **draft** reports for active sites with a linked client — **approval gate, never auto-sends**; skips sites reported in the last 25 days.
- **MCP** `send_seo_report` (`seo:write` + `email:send`).

## The P3 loop

Generate (or auto-generated monthly) → **Approve** → **Send** → client opens the portal link / downloads the branded PDF.

## Safety

No new tables. Reuses the customer-portal token + per-business email pipeline. Portal + cron routes already covered by middleware whitelists. SEO plugin still default-off/route-gated.

Verified: tsc · 17 tests · build (portal + cron routes) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)