### PR TITLE
feat(seo): instant-audit lead magnet — capture (Phase 4, part 1)

### DIFF
--- a/src/app/(dashboard)/seo/audits/page.tsx
+++ b/src/app/(dashboard)/seo/audits/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getAuditLink, listAudits } from "@/lib/actions/seo-audits";
+import { SeoAuditsView } from "@/components/seo/seo-audits-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function SeoAuditsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const [{ url }, audits] = await Promise.all([getAuditLink(), listAudits()]);
+  return <SeoAuditsView link={url} audits={audits} />;
+}

--- a/src/app/api/audit/[slug]/submit/route.ts
+++ b/src/app/api/audit/[slug]/submit/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "node:crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { rateLimit, clientIp } from "@/lib/booking/public";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+function normUrl(input: string): string | null {
+  let u = input.trim().toLowerCase();
+  if (!u) return null;
+  if (!/^https?:\/\//.test(u)) u = "https://" + u;
+  try { const parsed = new URL(u); return parsed.hostname ? parsed.origin + (parsed.pathname === "/" ? "" : parsed.pathname) : null; }
+  catch { return null; }
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  let body: { url?: string; email?: string; name?: string; _hp?: string };
+  try { body = await req.json(); } catch { return NextResponse.json({ error: "Bad request" }, { status: 400 }); }
+
+  if (body._hp) return NextResponse.json({ ok: true }); // honeypot — silently accept
+
+  const ip = clientIp(req);
+  if (!rateLimit(`audit:${slug}:${ip}`, 5, 60_000)) {
+    return NextResponse.json({ error: "Too many requests — try again in a minute." }, { status: 429 });
+  }
+
+  const url = normUrl(body.url ?? "");
+  const email = (body.email ?? "").trim() || null;
+  if (!url) return NextResponse.json({ error: "Enter a valid website URL." }, { status: 422 });
+  if (!email) return NextResponse.json({ error: "Enter your email." }, { status: 422 });
+
+  const sb = createAdminClient();
+  const { data: business } = await tbl(sb, "businesses").select("id, user_id").eq("audit_slug", slug).maybeSingle();
+  if (!business) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const name = (body.name ?? "").trim() || null;
+  const viewToken = "aud_" + randomBytes(20).toString("hex");
+
+  // Create the queued audit.
+  const { data: audit, error: auditErr } = await tbl(sb, "seo_audits").insert({
+    business_id: business.id, url, email, name, status: "queued", view_token: viewToken,
+  }).select("id").single();
+  if (auditErr) return NextResponse.json({ error: "Could not queue the audit." }, { status: 500 });
+
+  // Create/dedup the lead (source seo-audit).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: lead } = await (sb as any).rpc("upsert_lead", {
+    p_business_id: business.id,
+    p_user_id: business.user_id,
+    p_name: name || email,
+    p_email: email,
+    p_phone: null,
+    p_address: null, p_suburb: null, p_service: null,
+    p_property_type: null, p_timing: null,
+    p_notes: `Requested a free SEO audit for ${url}`,
+    p_source: "seo-audit",
+    p_source_ref: slug,
+  }).single();
+  if (lead?.id) await tbl(sb, "seo_audits").update({ lead_id: lead.id }).eq("id", audit.id);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/audit/[slug]/page.tsx
+++ b/src/app/audit/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { AuditLandingForm } from "@/components/seo/audit-landing-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function AuditPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: business } = await (sb as any).from("businesses").select("name, logo_url").eq("audit_slug", slug).maybeSingle();
+  if (!business) notFound();
+  return <AuditLandingForm slug={slug} businessName={business.name ?? "SEO Audit"} logoUrl={business.logo_url ?? null} />;
+}

--- a/src/components/seo/audit-landing-form.tsx
+++ b/src/components/seo/audit-landing-form.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props { slug: string; businessName: string; logoUrl: string | null }
+
+export function AuditLandingForm({ slug, businessName, logoUrl }: Props) {
+  const [url, setUrl] = useState("");
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [hp, setHp] = useState(""); // honeypot
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!url.trim() || !email.trim()) { setError("Enter your website and email."); return; }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/audit/${slug}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, email, name, _hp: hp }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error ?? "Something went wrong");
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white to-emerald-50/40 flex items-center justify-center p-6">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-6">
+          {logoUrl
+            // eslint-disable-next-line @next/next/no-img-element
+            ? <img src={logoUrl} alt={businessName} className="h-10 mx-auto mb-3" />
+            : <p className="text-lg font-bold text-emerald-700">{businessName}</p>}
+          <h1 className="text-2xl font-bold text-slate-900 mt-2">Free SEO audit</h1>
+          <p className="text-sm text-slate-500 mt-1">Get a free report on your site&apos;s SEO health — delivered to your inbox.</p>
+        </div>
+
+        {done ? (
+          <div className="rounded-xl border border-emerald-200 bg-white p-6 text-center">
+            <p className="font-semibold text-slate-900">You&apos;re all set ✓</p>
+            <p className="text-sm text-slate-500 mt-1">Your SEO audit for <strong>{url}</strong> is on its way to {email}. Keep an eye on your inbox.</p>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="rounded-xl border border-slate-200 bg-white p-6 space-y-3 shadow-sm">
+            <input type="text" value={hp} onChange={(e) => setHp(e.target.value)} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden />
+            <div>
+              <label className="text-xs font-medium text-slate-600">Your website</label>
+              <input type="text" value={url} onChange={(e) => setUrl(e.target.value)} placeholder="example.com" className="mt-1 w-full h-10 rounded-md border border-slate-300 px-3 text-sm outline-none focus:ring-2 focus:ring-emerald-500" />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-slate-600">Email</label>
+              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@company.com" className="mt-1 w-full h-10 rounded-md border border-slate-300 px-3 text-sm outline-none focus:ring-2 focus:ring-emerald-500" />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-slate-600">Name (optional)</label>
+              <input type="text" value={name} onChange={(e) => setName(e.target.value)} className="mt-1 w-full h-10 rounded-md border border-slate-300 px-3 text-sm outline-none focus:ring-2 focus:ring-emerald-500" />
+            </div>
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <button type="submit" disabled={submitting} className="w-full h-10 rounded-md bg-emerald-600 text-white text-sm font-semibold hover:bg-emerald-700 disabled:opacity-60">
+              {submitting ? "Sending…" : "Get my free audit"}
+            </button>
+            <p className="text-[11px] text-slate-400 text-center">We&apos;ll email your report. No spam.</p>
+          </form>
+        )}
+        <p className="text-center text-[11px] text-slate-400 mt-4">Powered by {businessName}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/seo/seo-audits-view.tsx
+++ b/src/components/seo/seo-audits-view.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { ArrowLeft, Copy, Search, ExternalLink } from "@/components/ui/icons";
+import { PageHeader } from "@/components/layout/page-header";
+import { cn } from "@/lib/utils";
+
+interface Audit { id: string; url: string; email: string | null; name: string | null; status: string; score: number | null; lead_id: string | null; created_at: string }
+interface Props { link: string; audits: Audit[] }
+
+const TONE: Record<string, string> = {
+  queued: "bg-muted text-muted-foreground",
+  running: "bg-blue-100 text-blue-700",
+  done: "bg-emerald-100 text-emerald-700",
+  failed: "bg-red-100 text-red-700",
+};
+
+export function SeoAuditsView({ link, audits }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  function copy() {
+    navigator.clipboard.writeText(link).then(() => {
+      setCopied(true); toast.success("Link copied");
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Audit tool"
+        subtitle="A free-SEO-audit lead magnet — share the link, prospects who submit become leads."
+        accent="linear-gradient(180deg, #10b981 0%, #047857 100%)"
+        actions={
+          <Link href="/seo" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground rounded-md border border-border px-3 py-1.5">
+            <ArrowLeft className="w-4 h-4" /> Sites
+          </Link>
+        }
+      />
+
+      {/* Shareable link */}
+      <div className="rounded-xl border border-border bg-card p-4 mb-6">
+        <p className="text-sm font-semibold mb-2">Your public audit link</p>
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="flex-1 min-w-0 text-xs bg-muted rounded-md px-3 py-2 break-all">{link}</code>
+          <button onClick={copy} className="inline-flex items-center gap-1.5 text-sm rounded-md border border-border px-3 py-2 hover:bg-muted">
+            <Copy className="w-4 h-4" /> {copied ? "Copied" : "Copy"}
+          </button>
+          <a href={link} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 text-sm rounded-md border border-border px-3 py-2 hover:bg-muted">
+            <ExternalLink className="w-4 h-4" /> Open
+          </a>
+        </div>
+        <p className="text-[11px] text-muted-foreground mt-2">Put it on your site, in your bio, or in outreach. Each submission creates a lead and (once agents are running) emails a branded audit report.</p>
+      </div>
+
+      {audits.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Search className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No audit requests yet</p>
+          <p className="text-sm text-muted-foreground mt-1">Share your link — requests show up here and in Leads.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {audits.map((a) => (
+            <div key={a.id} className="rounded-xl border border-border bg-card p-4 flex items-center gap-3">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold break-words">{a.url}</p>
+                <p className="text-xs text-muted-foreground">{a.name || a.email}{a.name && a.email ? ` · ${a.email}` : ""} · {new Date(a.created_at).toLocaleDateString("en-AU")}</p>
+              </div>
+              {a.score != null && <span className="text-xs font-semibold">{a.score}/100</span>}
+              <span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 shrink-0", TONE[a.status])}>{a.status}</span>
+              {a.lead_id && <Link href={`/leads/${a.lead_id}`} className="text-xs text-primary hover:underline shrink-0">Lead</Link>}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/seo/seo-sites-view.tsx
+++ b/src/components/seo/seo-sites-view.tsx
@@ -104,6 +104,12 @@ export function SeoSitesView({ sites, customers }: Props) {
               <FileText className="w-4 h-4" /> Content
             </Link>
             <Link
+              href="/seo/audits"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground rounded-md border border-border px-3 py-1.5"
+            >
+              <Search className="w-4 h-4" /> Audit tool
+            </Link>
+            <Link
               href="/seo/pipeline"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground rounded-md border border-border px-3 py-1.5"
             >

--- a/src/lib/actions/seo-audits.ts
+++ b/src/lib/actions/seo-audits.ts
@@ -1,0 +1,45 @@
+"use server";
+
+/**
+ * Instant-audit sales engine (docs/SEO_AGENCY_PLAN.md, Phase 4) — agency side.
+ * The agency shares a public audit link; prospects who submit become leads +
+ * queued audits. Running the audit + emailing the report lands in the follow-up.
+ */
+import { randomBytes } from "node:crypto";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { appUrl } from "@/lib/app-url";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function biz(): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  return getActiveBizId(supabase, user.id);
+}
+
+/** The public audit link for this business, minting a slug on first use. */
+export async function getAuditLink(): Promise<{ slug: string; url: string }> {
+  const businessId = await biz();
+  const admin = createAdminClient();
+  const { data: b } = await tbl(admin, "businesses").select("audit_slug").eq("id", businessId).maybeSingle();
+  let slug: string | null = b?.audit_slug ?? null;
+  if (!slug) {
+    slug = "a" + randomBytes(5).toString("hex");
+    const { error } = await tbl(admin, "businesses").update({ audit_slug: slug }).eq("id", businessId);
+    if (error) throw error;
+  }
+  return { slug, url: `${appUrl()}/audit/${slug}` };
+}
+
+export async function listAudits() {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { data } = await tbl(supabase, "seo_audits")
+    .select("id, url, email, name, status, score, lead_id, created_at")
+    .eq("business_id", businessId).order("created_at", { ascending: false }).limit(200);
+  return (data ?? []) as Array<{ id: string; url: string; email: string | null; name: string | null; status: string; score: number | null; lead_id: string | null; created_at: string }>;
+}

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -4,8 +4,9 @@
  * tools land alongside those features. Scopes: seo:read / seo:write.
  */
 import { z } from "zod";
+import { randomBytes } from "node:crypto";
 import { assertScope, t, text, errorText } from "../context";
-import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { ctxFrom, appBase, UUID, type ToolFn } from "./shared";
 import { advanceContentJob, seoSpendStatus, runOpportunityScout } from "@/lib/seo/engine";
 import { publishContent } from "@/lib/seo/publish";
 import { assembleReport } from "@/lib/seo/report";
@@ -297,5 +298,27 @@ export function registerSeoTools(tool: ToolFn): void {
       const ctx = ctxFrom(extra); assertScope(ctx, "seo:write"); assertScope(ctx, "email:send");
       const res = await deliverSeoReport(ctx.sb, ctx.businessId, ctx.userId, args.report_id);
       return text({ sent: true, ...res });
+    });
+
+  // ── Instant-audit lead magnet ────────────────────────────────────────────────
+  tool("get_audit_link", "Get (minting on first use) the business's public free-SEO-audit lead-magnet link.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { data: b } = await t(ctx, "businesses").select("audit_slug").eq("id", ctx.businessId).maybeSingle();
+      let slug: string | null = b?.audit_slug ?? null;
+      if (!slug) { slug = "a" + randomBytes(5).toString("hex"); await t(ctx, "businesses").update({ audit_slug: slug }).eq("id", ctx.businessId); }
+      return text({ slug, url: `${appBase()}/audit/${slug}` });
+    });
+
+  tool("list_seo_audits", "List inbound SEO audit requests (lead-magnet submissions).",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      const { data, error } = await t(ctx, "seo_audits")
+        .select("id, url, email, name, status, score, lead_id, created_at")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false }).limit(200);
+      if (error) throw error;
+      return text(data);
     });
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -60,6 +60,9 @@ export async function updateSession(request: NextRequest) {
     pathname.startsWith("/f/") ||
     pathname.startsWith("/embed/") ||
     pathname.startsWith("/api/f/") ||
+    // Instant-audit lead magnet: public landing page + submit.
+    pathname.startsWith("/audit/") ||
+    pathname.startsWith("/api/audit/") ||
     pathname.startsWith("/api/public/") ||
     pathname === "/api/auth/signup" ||
     pathname.startsWith("/api/v1/") ||

--- a/supabase/migrations/20260709140000_seo_audits.sql
+++ b/supabase/migrations/20260709140000_seo_audits.sql
@@ -1,0 +1,38 @@
+-- Instant-audit sales engine (docs/SEO_AGENCY_PLAN.md, Phase 4).
+-- Public lead magnet: a prospect submits a URL + email on the agency's audit
+-- page; we create a lead and queue an audit that (in the follow-up) runs the
+-- auditor agent → branded PDF → email. Additive.
+ALTER TABLE public.businesses ADD COLUMN IF NOT EXISTS audit_slug TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_businesses_audit_slug ON public.businesses (audit_slug) WHERE audit_slug IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.seo_audits (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  url         TEXT NOT NULL,
+  email       TEXT,
+  name        TEXT,
+  lead_id     UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  status      TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','running','done','failed')),
+  score       INTEGER,
+  result      JSONB NOT NULL DEFAULT '{}'::jsonb,   -- findings + summary
+  view_token  TEXT,                                 -- public result/PDF access
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_seo_audits_business ON public.seo_audits (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_audits_queued ON public.seo_audits (created_at) WHERE status = 'queued';
+
+ALTER TABLE public.seo_audits ENABLE ROW LEVEL SECURITY;
+-- Read: members except workers. Writes go through the service-role client
+-- (public submit + cron), so no anon/write policy here.
+DROP POLICY IF EXISTS seo_audits_read ON public.seo_audits;
+CREATE POLICY seo_audits_read ON public.seo_audits FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+
+DROP TRIGGER IF EXISTS seo_audits_updated_at ON public.seo_audits;
+CREATE TRIGGER seo_audits_updated_at BEFORE UPDATE ON public.seo_audits
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
## What

**Phase 4** acquisition surface — a public **"free SEO audit"** page per agency. A prospect submits a URL + email → a **lead is created** and an audit is **queued**.

**Works today without Anthropic credits** — it captures leads immediately. The AI audit run + branded report is part 2.

- **Migration `20260709140000`** (applied + recorded): `businesses.audit_slug` (unique) + `seo_audits` table (url, email, `lead_id`, status, result, view_token) + RLS.
- **Public page `/audit/[slug]`** (branded to the agency) + submit API `/api/audit/[slug]/submit` — honeypot + rate-limit, creates the queued audit, dedups a lead via `upsert_lead` (source `seo-audit`). Both middleware-whitelisted.
- **Agency side `/seo/audits`** — the shareable link (copy / open) + inbound requests list (status, linked lead). Linked from the `/seo` header.
- Actions `getAuditLink` (mints slug) / `listAudits`; **MCP** `get_audit_link` + `list_seo_audits`.

## Next (P4 part 2)

The audit **run** (technical-seo-auditor agent on the URL) → **score + findings** → branded PDF → **emailed** to the prospect, with a public result page. Credit-gated (runs an agent).

## Safety

Additive schema; public routes are honeypot + rate-limited + service-role-scoped by `audit_slug`. SEO plugin still default-off/route-gated (the public `/audit` page resolves by slug independent of the plugin gate, like public forms).

Verified: tsc · 17 tests · build (audit routes) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)