### PR TITLE
feat(seo): instant-audit run + report (Phase 4, part 2)

### DIFF
--- a/src/app/(dashboard)/seo/audits/page.tsx
+++ b/src/app/(dashboard)/seo/audits/page.tsx
@@ -5,6 +5,8 @@ import { getAuditLink, listAudits } from "@/lib/actions/seo-audits";
 import { SeoAuditsView } from "@/components/seo/seo-audits-view";
 
 export const dynamic = "force-dynamic";
+// runAuditNow runs the auditor agent as a server action from this route.
+export const maxDuration = 300;
 
 export default async function SeoAuditsPage() {
   const supabase = await createClient();

--- a/src/app/api/cron/seo-audits/route.ts
+++ b/src/app/api/cron/seo-audits/route.ts
@@ -1,0 +1,53 @@
+/**
+ * GET /api/cron/seo-audits — runs queued instant audits (Phase 4).
+ * For each queued audit: run the auditor agent, then email the prospect a
+ * branded link to their result page. A few per tick so no run is long.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { runSiteAudit } from "@/lib/seo/engine";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { appUrl } from "@/lib/app-url";
+
+export const maxDuration = 300;
+const MAX_PER_TICK = 3;
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: queued } = await (sb as any)
+    .from("seo_audits").select("id, business_id, url, email, name, view_token")
+    .eq("status", "queued").order("created_at", { ascending: true }).limit(MAX_PER_TICK);
+
+  let done = 0;
+  for (const audit of (queued ?? []) as Array<{ id: string; business_id: string; url: string; email: string | null; name: string | null; view_token: string | null }>) {
+    try {
+      await runSiteAudit(sb, audit.id);
+      if (audit.email) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: business } = await (sb as any).from("businesses").select("name, email").eq("id", audit.business_id).maybeSingle();
+        const link = `${appUrl()}/audit/report/${audit.id}?token=${audit.view_token}`;
+        const html = `<div style="font-family:system-ui,Segoe UI,sans-serif;max-width:520px;margin:0 auto;color:#0f172a">
+          <h2 style="margin:0 0 8px">Your SEO audit is ready</h2>
+          <p>Hi ${audit.name ?? "there"}, we ran a free SEO audit on <strong>${audit.url}</strong>. Here's your report:</p>
+          <p style="margin:20px 0"><a href="${link}" style="display:inline-block;background:#047857;color:#fff;padding:11px 20px;border-radius:8px;text-decoration:none;font-weight:600">View your audit</a></p>
+          <p style="color:#64748b;font-size:12px;word-break:break-all">${link}</p>
+        </div>`;
+        await sendEmail({
+          to: audit.email, subject: `Your SEO audit — ${audit.url}`, html,
+          from: buildBusinessFrom({ name: business?.name ?? "Kirei", localPart: "audit" }),
+          replyTo: business?.email ?? undefined,
+          tags: { business_id: audit.business_id, doc_type: "custom", doc_id: audit.id },
+        });
+      }
+      done++;
+    } catch { /* keep going */ }
+  }
+
+  return NextResponse.json({ processed: done });
+}

--- a/src/app/api/pdf/seo-audit/[id]/route.ts
+++ b/src/app/api/pdf/seo-audit/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const token = req.nextUrl.searchParams.get("token");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tbl = (s: any, n: string) => s.from(n);
+
+  try {
+    const admin = createAdminClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let audit: any;
+    if (token) {
+      const { data } = await tbl(admin, "seo_audits").select("*").eq("id", id).eq("view_token", token).maybeSingle();
+      if (!data) return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      audit = data;
+    } else {
+      const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      const { data } = await tbl(supabase, "seo_audits").select("*").eq("id", id).maybeSingle();
+      if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      audit = data;
+    }
+
+    const { data: business } = await tbl(admin, "businesses").select("*").eq("id", audit.business_id).maybeSingle();
+
+    const { renderToStream } = await import("@react-pdf/renderer");
+    const { SeoAuditPDFDocument } = await import("@/components/seo/seo-audit-pdf-document");
+    const React = await import("react");
+    const element = React.createElement(SeoAuditPDFDocument, { url: audit.url, result: audit.result ?? {}, business });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = await renderToStream(element as any);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return new NextResponse(Buffer.concat(chunks), {
+      headers: { "Content-Type": "application/pdf", "Content-Disposition": `inline; filename="seo-audit.pdf"` },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[seo-audit PDF]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/audit/report/[id]/page.tsx
+++ b/src/app/audit/report/[id]/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { Download } from "@/components/ui/icons";
+
+export const dynamic = "force-dynamic";
+
+const SEV_ORDER = ["critical", "high", "medium", "low"];
+const SEV_TONE: Record<string, string> = {
+  critical: "bg-red-100 text-red-700", high: "bg-orange-100 text-orange-700",
+  medium: "bg-amber-100 text-amber-700", low: "bg-sky-100 text-sky-700",
+};
+
+export default async function AuditReportPage({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<{ token?: string }> }) {
+  const { id } = await params;
+  const { token } = await searchParams;
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: audit } = await (sb as any).from("seo_audits").select("*").eq("id", id).maybeSingle();
+  if (!audit || !token || audit.view_token !== token) notFound();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: business } = await (sb as any).from("businesses").select("name, logo_url").eq("id", audit.business_id).maybeSingle();
+
+  const result = audit.result ?? {};
+  const score = Math.max(0, Math.min(100, Math.round(result.score ?? 0)));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const findings = [...(result.findings ?? [])].sort((a: any, b: any) => SEV_ORDER.indexOf(a.severity) - SEV_ORDER.indexOf(b.severity));
+  const pending = audit.status !== "done";
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white to-emerald-50/40">
+      <header className="border-b bg-white/80 backdrop-blur sticky top-0 z-10">
+        <div className="max-w-2xl mx-auto px-6 py-4 flex items-center justify-between gap-4">
+          <div className="font-semibold text-emerald-700">{business?.name ?? "SEO Audit"}</div>
+          {!pending && (
+            <a href={`/api/pdf/seo-audit/${id}?token=${token}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 text-sm rounded-md border border-slate-200 px-3 py-1.5 hover:bg-slate-50">
+              <Download className="w-4 h-4" /> Download PDF
+            </a>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-6 py-8">
+        <h1 className="text-2xl font-bold text-slate-900">SEO Audit</h1>
+        <p className="text-slate-500">{audit.url}</p>
+
+        {pending ? (
+          <div className="mt-8 rounded-xl border border-slate-200 bg-white p-8 text-center">
+            <p className="font-semibold">Your audit is being prepared…</p>
+            <p className="text-sm text-slate-500 mt-1">Check back in a few minutes — we&apos;ll email you when it&apos;s ready.</p>
+          </div>
+        ) : (
+          <>
+            <div className="mt-6 flex items-center gap-5 rounded-xl border border-slate-200 bg-white p-6">
+              <div className="w-20 h-20 rounded-full border-4 border-emerald-600 flex items-center justify-center shrink-0">
+                <span className="text-2xl font-bold text-emerald-700">{score}</span>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">Overall score</p>
+                <p className="text-sm text-slate-600 mt-1">{result.summary ?? "Audit complete."}</p>
+              </div>
+            </div>
+
+            <h2 className="mt-8 mb-3 font-semibold text-slate-900">Findings ({findings.length})</h2>
+            <div className="space-y-2">
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {findings.map((f: any, i: number) => (
+                <div key={i} className="rounded-xl border border-slate-200 bg-white p-4">
+                  <span className={`text-[10px] font-semibold uppercase rounded-full px-2 py-0.5 ${SEV_TONE[f.severity] ?? "bg-slate-100 text-slate-600"}`}>{f.severity}</span>
+                  <p className="font-semibold text-slate-900 mt-1.5">{f.title}</p>
+                  {f.detail && <p className="text-sm text-slate-600 mt-0.5">{f.detail}</p>}
+                  {f.fix && <p className="text-sm text-emerald-700 mt-1">Fix: {f.fix}</p>}
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 rounded-xl bg-emerald-600 text-white p-6 text-center">
+              <p className="font-semibold">Want {business?.name ?? "us"} to fix these for you?</p>
+              <p className="text-sm text-emerald-50 mt-1">Reply to the email we sent, and we&apos;ll take it from here.</p>
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/seo/seo-audit-pdf-document.tsx
+++ b/src/components/seo/seo-audit-pdf-document.tsx
@@ -1,0 +1,74 @@
+import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/renderer";
+
+interface Finding { severity: string; title: string; detail?: string; fix?: string }
+interface AuditResult { score?: number; summary?: string; findings?: Finding[] }
+interface Props {
+  url: string;
+  result: AuditResult;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  business: any;
+}
+
+const SEV_ORDER = ["critical", "high", "medium", "low"];
+const SEV_COLOR: Record<string, string> = { critical: "#b91c1c", high: "#c2410c", medium: "#a16207", low: "#0369a1" };
+
+export function SeoAuditPDFDocument({ url, result, business }: Props) {
+  const primary: string = business?.pdf_settings?.primary_color ?? "#047857";
+  const logo: string | null = business?.pdf_settings?.logo_url ?? business?.logo_url ?? null;
+  const muted = "#64748b", border = "#e2e8f0", text = "#0f172a";
+  const score = Math.max(0, Math.min(100, Math.round(result?.score ?? 0)));
+  const findings = [...(result?.findings ?? [])].sort((a, b) => SEV_ORDER.indexOf(a.severity) - SEV_ORDER.indexOf(b.severity));
+
+  const s = StyleSheet.create({
+    page: { padding: 40, fontSize: 10, color: text, fontFamily: "Helvetica" },
+    between: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+    brand: { fontSize: 16, fontFamily: "Helvetica-Bold", color: primary },
+    h1: { fontSize: 18, fontFamily: "Helvetica-Bold" },
+    muted: { color: muted },
+    scoreBox: { alignItems: "center", justifyContent: "center", width: 90, height: 90, borderRadius: 45, borderWidth: 4, borderColor: primary },
+    scoreNum: { fontSize: 30, fontFamily: "Helvetica-Bold", color: primary },
+    h2: { fontSize: 12, fontFamily: "Helvetica-Bold", color: primary, marginTop: 22, marginBottom: 8 },
+    finding: { borderWidth: 1, borderColor: border, borderRadius: 6, padding: 10, marginBottom: 8 },
+    pill: { fontSize: 8, fontFamily: "Helvetica-Bold", color: "#fff", paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4, alignSelf: "flex-start", textTransform: "uppercase" },
+    foot: { position: "absolute", bottom: 24, left: 40, right: 40, textAlign: "center", fontSize: 8, color: muted },
+  });
+
+  return (
+    <Document>
+      <Page size="A4" style={s.page}>
+        <View style={s.between}>
+          <View>
+            {logo ? <Image src={logo} style={{ height: 32, marginBottom: 6 }} /> : <Text style={s.brand}>{business?.name ?? "SEO Audit"}</Text>}
+            <Text style={s.muted}>{business?.name}</Text>
+          </View>
+          <View style={{ alignItems: "flex-end" }}>
+            <Text style={s.h1}>SEO Audit</Text>
+            <Text style={s.muted}>{url}</Text>
+          </View>
+        </View>
+
+        <View style={[s.between, { marginTop: 20, alignItems: "center" }]}>
+          <View style={{ flex: 1, paddingRight: 20 }}>
+            <Text style={{ fontFamily: "Helvetica-Bold", marginBottom: 4 }}>Summary</Text>
+            <Text style={s.muted}>{result?.summary ?? "Audit complete."}</Text>
+          </View>
+          <View style={s.scoreBox}><Text style={s.scoreNum}>{score}</Text><Text style={{ fontSize: 8, color: muted }}>/ 100</Text></View>
+        </View>
+
+        <Text style={s.h2}>Findings ({findings.length})</Text>
+        {findings.length === 0 ? (
+          <Text style={s.muted}>No significant issues found.</Text>
+        ) : findings.map((f, i) => (
+          <View style={s.finding} key={i}>
+            <Text style={[s.pill, { backgroundColor: SEV_COLOR[f.severity] ?? muted }]}>{f.severity}</Text>
+            <Text style={{ fontFamily: "Helvetica-Bold", marginTop: 4 }}>{f.title}</Text>
+            {f.detail ? <Text style={{ marginTop: 2 }}>{f.detail}</Text> : null}
+            {f.fix ? <Text style={[s.muted, { marginTop: 2 }]}>Fix: {f.fix}</Text> : null}
+          </View>
+        ))}
+
+        <Text style={s.foot} fixed>Free SEO audit by {business?.name} · Want us to fix these? Get in touch.</Text>
+      </Page>
+    </Document>
+  );
+}

--- a/src/components/seo/seo-audits-view.tsx
+++ b/src/components/seo/seo-audits-view.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowLeft, Copy, Search, ExternalLink } from "@/components/ui/icons";
+import { ArrowLeft, Copy, Search, ExternalLink, Download, Play } from "@/components/ui/icons";
 import { PageHeader } from "@/components/layout/page-header";
 import { cn } from "@/lib/utils";
+import { runAuditNow } from "@/lib/actions/seo-audits";
 
 interface Audit { id: string; url: string; email: string | null; name: string | null; status: string; score: number | null; lead_id: string | null; created_at: string }
 interface Props { link: string; audits: Audit[] }
@@ -18,13 +20,24 @@ const TONE: Record<string, string> = {
 };
 
 export function SeoAuditsView({ link, audits }: Props) {
+  const router = useRouter();
   const [copied, setCopied] = useState(false);
+  const [runningId, setRunningId] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
 
   function copy() {
     navigator.clipboard.writeText(link).then(() => {
       setCopied(true); toast.success("Link copied");
       setTimeout(() => setCopied(false), 1500);
     });
+  }
+
+  function runAudit(a: Audit) {
+    setRunningId(a.id);
+    runAuditNow(a.id)
+      .then((r) => { toast.success(`Audit scored ${r.score}/100`); router.refresh(); })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Audit failed"))
+      .finally(() => setRunningId(null));
   }
 
   return (
@@ -71,6 +84,14 @@ export function SeoAuditsView({ link, audits }: Props) {
               </div>
               {a.score != null && <span className="text-xs font-semibold">{a.score}/100</span>}
               <span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 shrink-0", TONE[a.status])}>{a.status}</span>
+              {(a.status === "queued" || a.status === "failed") && (
+                <button onClick={() => runAudit(a)} disabled={isPending || runningId === a.id} className="inline-flex items-center gap-1 text-xs text-primary hover:underline shrink-0">
+                  <Play className="w-3.5 h-3.5" /> {runningId === a.id ? "Running…" : "Run"}
+                </button>
+              )}
+              {a.status === "done" && (
+                <a href={`/api/pdf/seo-audit/${a.id}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground shrink-0"><Download className="w-3.5 h-3.5" /> PDF</a>
+              )}
               {a.lead_id && <Link href={`/leads/${a.lead_id}`} className="text-xs text-primary hover:underline shrink-0">Lead</Link>}
             </div>
           ))}

--- a/src/lib/actions/seo-audits.ts
+++ b/src/lib/actions/seo-audits.ts
@@ -11,6 +11,8 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { appUrl } from "@/lib/app-url";
+import { revalidatePath } from "next/cache";
+import { runSiteAudit } from "@/lib/seo/engine";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -33,6 +35,17 @@ export async function getAuditLink(): Promise<{ slug: string; url: string }> {
     if (error) throw error;
   }
   return { slug, url: `${appUrl()}/audit/${slug}` };
+}
+
+/** Run a queued audit now (agency-triggered). */
+export async function runAuditNow(auditId: string): Promise<{ score: number }> {
+  const businessId = await biz();
+  const admin = createAdminClient();
+  const { data: audit } = await tbl(admin, "seo_audits").select("id").eq("id", auditId).eq("business_id", businessId).maybeSingle();
+  if (!audit) throw new Error("Audit not found");
+  const res = await runSiteAudit(admin, auditId);
+  revalidatePath("/seo/audits");
+  return res;
 }
 
 export async function listAudits() {

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { randomBytes } from "node:crypto";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, appBase, UUID, type ToolFn } from "./shared";
-import { advanceContentJob, seoSpendStatus, runOpportunityScout } from "@/lib/seo/engine";
+import { advanceContentJob, seoSpendStatus, runOpportunityScout, runSiteAudit } from "@/lib/seo/engine";
 import { publishContent } from "@/lib/seo/publish";
 import { assembleReport } from "@/lib/seo/report";
 import { deliverSeoReport } from "@/lib/seo/deliver";
@@ -320,5 +320,15 @@ export function registerSeoTools(tool: ToolFn): void {
         .eq("business_id", ctx.businessId).order("created_at", { ascending: false }).limit(200);
       if (error) throw error;
       return text(data);
+    });
+
+  tool("run_seo_audit", "Run a queued/failed instant audit now (fetches the page + scores it). Returns the score.",
+    { audit_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:write");
+      const { data: audit } = await t(ctx, "seo_audits").select("id").eq("id", args.audit_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!audit) return errorText("Audit not found");
+      const res = await runSiteAudit(ctx.sb, args.audit_id);
+      return text(res);
     });
 }

--- a/src/lib/seo/engine.ts
+++ b/src/lib/seo/engine.ts
@@ -202,6 +202,73 @@ export async function runOpportunityScout(sb: any, args: { businessId: string; s
   return { inserted: rows.length };
 }
 
+/** Fetch a URL's HTML, best-effort, capped + time-limited. */
+async function fetchPage(url: string): Promise<string> {
+  try {
+    const ctrl = new AbortController();
+    const to = setTimeout(() => ctrl.abort(), 10_000);
+    const res = await fetch(url, { signal: ctrl.signal, headers: { "User-Agent": "Kirei-SEO-Auditor" } });
+    clearTimeout(to);
+    if (!res.ok) return `(could not fetch — HTTP ${res.status})`;
+    const html = await res.text();
+    return html.slice(0, 40_000);
+  } catch (e) {
+    return `(could not fetch — ${e instanceof Error ? e.message : "error"})`;
+  }
+}
+
+/**
+ * Run an instant SEO audit for a prospect's URL (Phase 4). Fetches the page,
+ * asks the technical auditor for a score + findings (structured JSON), and
+ * stores them on the seo_audits row. Budget-gated. Returns the score.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function runSiteAudit(sb: any, auditId: string): Promise<{ score: number }> {
+  const { data: audit } = await sb.from("seo_audits").select("id, business_id, url, status").eq("id", auditId).maybeSingle();
+  if (!audit) throw new Error("Audit not found");
+
+  const budget = await seoSpendStatus(sb, audit.business_id);
+  if (!budget.ok) throw new Error("Monthly SEO budget reached — raise it to run audits.");
+
+  await sb.from("seo_audits").update({ status: "running" }).eq("id", auditId);
+
+  try {
+    const html = await fetchPage(audit.url);
+    const system = AGENT_PROMPTS["technical-seo-auditor"];
+    const user = [
+      "You are running in a server pipeline — no filesystem. Ignore instructions about reading/writing files.",
+      `Audit this page: ${audit.url}`,
+      "Below is the fetched HTML (may be truncated). Base findings on what you can actually see in it; you also have web search for context.",
+      "Return ONLY JSON — no prose — in this shape:",
+      '{"score": 0-100, "summary": "2-3 sentences", "findings": [{"severity":"critical|high|medium|low","title":"...","detail":"the evidence","fix":"what to do"}]}',
+      "\n--- HTML ---\n" + html,
+    ].join("\n");
+
+    const res = await anthropic.messages.create({
+      model: MODEL.sonnet, max_tokens: 4096, system,
+      messages: [{ role: "user", content: user }],
+      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3 }] as Anthropic.Messages.MessageCreateParams["tools"],
+    });
+    const out = res.content.filter((b): b is Anthropic.TextBlock => b.type === "text").map((b) => b.text).join("\n");
+    const costCents = Math.ceil((res.usage.input_tokens / 1000) * CENTS_PER_1K_IN + (res.usage.output_tokens / 1000) * CENTS_PER_1K_OUT);
+
+    const start = out.indexOf("{");
+    const end = out.lastIndexOf("}");
+    if (start === -1 || end === -1) throw new Error("auditor returned no JSON");
+    const parsed = JSON.parse(out.slice(start, end + 1));
+    const score = Math.max(0, Math.min(100, Math.round(Number(parsed.score) || 0)));
+
+    await sb.from("seo_audits").update({ status: "done", score, result: parsed }).eq("id", auditId);
+    // Best-effort cost attribution via a job-events row (site-less).
+    await sb.from("seo_job_events").insert({ business_id: audit.business_id, level: "success", cost_cents: costCents, message: `Audited ${audit.url} — score ${score}` }).then(() => {}, () => {});
+    return { score };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await sb.from("seo_audits").update({ status: "failed", result: { error: msg } }).eq("id", auditId);
+    throw e;
+  }
+}
+
 interface Job { id: string; business_id: string; step: number; input: { content_piece_id?: string }; cost_cents: number }
 
 /**

--- a/vercel.json
+++ b/vercel.json
@@ -47,6 +47,10 @@
     {
       "path": "/api/cron/seo-reports",
       "schedule": "0 7 1 * *"
+    },
+    {
+      "path": "/api/cron/seo-audits",
+      "schedule": "*/3 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Completes **Phase 4**. A queued audit is **run, scored, turned into a branded report, and emailed** to the prospect.

- **`engine.runSiteAudit`** — fetches the prospect's page (capped + time-limited), runs the **technical auditor** (+ web search) for a structured **score + findings**, stores them on `seo_audits`. Budget-gated.
- **Branded PDF** (`seo-audit-pdf-document.tsx` — score dial + findings by severity); route `/api/pdf/seo-audit/[id]` (`view_token` or authed).
- **Public result page** `/audit/report/[id]?token=` — score, findings, "want us to fix these?" CTA.
- **Cron** `/api/cron/seo-audits` (every 3 min) runs queued audits and **emails** the prospect a branded result link via the per-business sender.
- Agency: **Run** (queued/failed) + **PDF** (done) on `/seo/audits`. Action `runAuditNow`; **MCP** `run_seo_audit`. `maxDuration = 300`.

## The full P4 loop

Prospect submits URL+email → **lead created** → audit runs (auditor agent on the fetched page) → score + findings → **branded report emailed** + public result page → acquisition → proposal → retainer.

## Note

Running the audit executes the auditor agent, so it needs **Anthropic credits** to fire (the *capture* half in part 1 works without).

## Safety

Reuses the existing PDF + per-business email + portal-token-style patterns. Additive. SEO plugin still default-off/route-gated.

Verified: tsc · 17 tests · build (audit run + PDF + cron routes) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)