### PR TITLE
feat(seo): connector robustness — configurable git frontmatter + test connection

### DIFF
--- a/src/components/seo/seo-connections.tsx
+++ b/src/components/seo/seo-connections.tsx
@@ -11,7 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { CONNECTORS, CONNECTORS_BY_ID, type ConnectorDef, type ConnectionView } from "@/lib/seo/connectors";
-import { saveConnection, deleteConnection } from "@/lib/actions/seo-connections";
+import { saveConnection, deleteConnection, testSeoConnection } from "@/lib/actions/seo-connections";
 
 const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
 
@@ -54,6 +54,15 @@ export function SeoConnections({ siteId, connections }: { siteId: string; connec
     });
   }
 
+  const [testingId, setTestingId] = useState<string | null>(null);
+  function handleTest(conn: ConnectionView) {
+    setTestingId(conn.id);
+    testSeoConnection(conn.id)
+      .then((r) => r.ok ? toast.success(r.message) : toast.error(r.message))
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Test failed"))
+      .finally(() => setTestingId(null));
+  }
+
   const publish = CONNECTORS.filter((c) => c.auth === "token");
   const data = CONNECTORS.filter((c) => c.auth === "oauth");
 
@@ -76,6 +85,7 @@ export function SeoConnections({ siteId, connections }: { siteId: string; connec
                     </div>
                     {conn.account_ref && <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{conn.account_ref}</p>}
                     <div className="flex gap-2 mt-2">
+                      <button onClick={() => handleTest(conn)} disabled={testingId === conn.id} className="text-xs text-muted-foreground hover:text-foreground underline">{testingId === conn.id ? "Testing…" : "Test"}</button>
                       {def && <button onClick={() => openConnect(def, conn)} className="text-xs text-muted-foreground hover:text-foreground underline">Edit</button>}
                       <button onClick={() => handleDelete(conn)} disabled={isPending} className="text-xs text-muted-foreground hover:text-destructive underline">Remove</button>
                     </div>

--- a/src/lib/actions/seo-connections.ts
+++ b/src/lib/actions/seo-connections.ts
@@ -9,9 +9,11 @@
  */
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
+import { testConnection } from "@/lib/seo/publish";
 import { CONNECTORS_BY_ID, secretFieldKeys, type ConnectionView } from "@/lib/seo/connectors";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -103,6 +105,12 @@ export async function saveConnection(input: {
     if (error) throw error;
   }
   revalidatePath(`/seo/${input.site_id}`);
+}
+
+/** Verify a connection's credentials against the gateway. */
+export async function testSeoConnection(connectionId: string): Promise<{ ok: boolean; message: string }> {
+  const businessId = await biz();
+  return testConnection(createAdminClient(), businessId, connectionId);
 }
 
 export async function deleteConnection(connectionId: string, siteId: string): Promise<void> {

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -8,7 +8,7 @@ import { randomBytes } from "node:crypto";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, appBase, UUID, type ToolFn } from "./shared";
 import { advanceContentJob, seoSpendStatus, runOpportunityScout, runSiteAudit } from "@/lib/seo/engine";
-import { publishContent } from "@/lib/seo/publish";
+import { publishContent, testConnection } from "@/lib/seo/publish";
 import { assembleReport } from "@/lib/seo/report";
 import { deliverSeoReport } from "@/lib/seo/deliver";
 
@@ -227,6 +227,13 @@ export function registerSeoTools(tool: ToolFn): void {
       const { error } = await t(ctx, "seo_connections").delete().eq("id", args.connection_id).eq("business_id", ctx.businessId);
       if (error) throw error;
       return text({ deleted: true });
+    });
+
+  tool("test_seo_connection", "Verify a gateway connection's credentials against the provider (git/wordpress/sanity/payload/rest/graphql).",
+    { connection_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      return text(await testConnection(ctx.sb, ctx.businessId, args.connection_id));
     });
 
   tool("publish_content", "Publish a finished content piece through a connected gateway. connection_id comes from list_seo_connections.",

--- a/src/lib/seo/connectors.ts
+++ b/src/lib/seo/connectors.ts
@@ -46,6 +46,7 @@ export const CONNECTORS: ConnectorDef[] = [
       { key: "branch", label: "Branch", type: "text", default: "main", required: true },
       { key: "content_path", label: "Content folder", type: "text", placeholder: "src/content/blog", default: "src/content/blog", required: true },
       { key: "extension", label: "File type", type: "select", options: ["md", "mdx", "mdoc"], default: "md" },
+      { key: "frontmatter", label: "Frontmatter template (optional)", type: "textarea", placeholder: 'title: "{{title}}"\ndescription: "{{description}}"\npubDate: {{date}}\ndraft: false', help: 'Match your site\'s content schema. Placeholders: {{title}} {{description}} {{slug}} {{date}} {{keyword}}. Leave blank for a sensible default.' },
       { key: "token", label: "GitHub token", type: "password", secret: true, required: true, help: "Fine-grained PAT, Contents: read/write on this repo only." },
     ],
   },

--- a/src/lib/seo/publish.ts
+++ b/src/lib/seo/publish.ts
@@ -54,6 +54,13 @@ interface PublishResult { url: string | null; ref?: string }
 
 // ── Adapters ─────────────────────────────────────────────────────────────────
 
+/** Fill {{title}} / {{description}} / {{slug}} / {{date}} / {{keyword}} in a
+ *  frontmatter template, YAML-escaping (single-line, quotes) each value. */
+function fillFrontmatter(tpl: string, a: Article, date: string): string {
+  const v: Record<string, string> = { title: a.title, description: a.description, slug: a.slug, date, keyword: a.keyword };
+  return tpl.replace(/\{\{(\w+)\}\}/g, (_, k) => String(v[k] ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/[\r\n]+/g, " "));
+}
+
 async function publishGitHub(meta: Meta, secrets: Secrets, a: Article): Promise<PublishResult> {
   const [owner, repo] = (meta.repo ?? "").split("/");
   if (!owner || !repo) throw new Error("Repository must be owner/repo");
@@ -61,7 +68,10 @@ async function publishGitHub(meta: Meta, secrets: Secrets, a: Article): Promise<
   const ext = meta.extension || "md";
   const path = `${(meta.content_path || "").replace(/\/+$/, "")}/${a.slug}.${ext}`.replace(/^\/+/, "");
   const today = new Date().toISOString().split("T")[0];
-  const file = `---\ntitle: "${a.title.replace(/"/g, '\\"')}"\ndescription: "${a.description.replace(/"/g, '\\"')}"\npubDate: ${today}\ndraft: false\n---\n\n${stripLeadingH1(a.markdown)}\n`;
+  const fm = meta.frontmatter?.trim()
+    ? fillFrontmatter(meta.frontmatter, a, today)
+    : `title: "${a.title.replace(/"/g, '\\"')}"\ndescription: "${a.description.replace(/"/g, '\\"')}"\npubDate: ${today}\ndraft: false`;
+  const file = `---\n${fm}\n---\n\n${stripLeadingH1(a.markdown)}\n`;
 
   const api = `https://api.github.com/repos/${owner}/${repo}/contents/${path.split("/").map(encodeURIComponent).join("/")}`;
   const headers = {
@@ -158,6 +168,51 @@ const ADAPTERS: Record<string, (m: Meta, s: Secrets, a: Article) => Promise<Publ
   rest: publishRest,
   graphql: publishGraphql,
 };
+
+/** Lightweight auth probe per connector — surfaces bad creds before publish. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function testConnection(sb: any, businessId: string, connectionId: string): Promise<{ ok: boolean; message: string }> {
+  const { data: conn } = await sb.from("seo_connections").select("id, provider, meta, secret").eq("id", connectionId).eq("business_id", businessId).maybeSingle();
+  if (!conn) throw new Error("Connection not found");
+  let secrets: Secrets = {};
+  if (conn.secret) { try { secrets = JSON.parse(decryptSecret(conn.secret)); } catch { return { ok: false, message: "Couldn't read credentials (encryption key changed?)" }; } }
+  const meta: Meta = conn.meta ?? {};
+
+  try {
+    switch (conn.provider) {
+      case "git-github": {
+        const [owner, repo] = (meta.repo ?? "").split("/");
+        const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers: { Authorization: `Bearer ${secrets.token}`, Accept: "application/vnd.github+json", "User-Agent": "Kirei-SEO" } });
+        return res.ok ? { ok: true, message: `Connected to ${owner}/${repo}` } : { ok: false, message: `GitHub ${res.status} — check the repo and token scope.` };
+      }
+      case "wordpress": {
+        const base = (meta.site_url ?? "").replace(/\/+$/, "");
+        const authv = Buffer.from(`${meta.username}:${secrets.app_password}`).toString("base64");
+        const res = await fetch(`${base}/wp-json/wp/v2/users/me`, { headers: { Authorization: `Basic ${authv}` } });
+        return res.ok ? { ok: true, message: "WordPress authentication OK" } : { ok: false, message: `WordPress ${res.status} — check the URL, username and app password.` };
+      }
+      case "sanity": {
+        const q = encodeURIComponent(`*[_type=="${meta.doc_type || "post"}"][0]._id`);
+        const res = await fetch(`https://${meta.project_id}.api.sanity.io/v${meta.api_version || "2024-01-01"}/data/query/${meta.dataset || "production"}?query=${q}`, { headers: { Authorization: `Bearer ${secrets.token}` } });
+        return res.ok ? { ok: true, message: "Sanity authentication OK" } : { ok: false, message: `Sanity ${res.status} — check the project, dataset and token.` };
+      }
+      case "payload": {
+        const base = (meta.base_url ?? "").replace(/\/+$/, "");
+        const res = await fetch(`${base}/${meta.collection}?limit=1`, { headers: { Authorization: `users API-Key ${secrets.api_key}` } });
+        return res.ok ? { ok: true, message: "Payload authentication OK" } : { ok: false, message: `Payload ${res.status} — check the base URL, collection and key.` };
+      }
+      case "rest":
+      case "graphql": {
+        try { const res = await fetch(meta.endpoint, { method: "OPTIONS" }); return { ok: true, message: `Endpoint reachable (${res.status}). Credentials are verified on the first real publish.` }; }
+        catch { return { ok: false, message: "Endpoint not reachable." }; }
+      }
+      default:
+        return { ok: false, message: "No test available for this connector." };
+    }
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : "Test failed." };
+  }
+}
 
 /** Publish an approved content piece through a connection. Owns all writes. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What

Two robustness items on the connector layer — both dependency-free.

### Configurable Git frontmatter (fixes a known defect)
The git-github connector previously wrote a **hardcoded** frontmatter (`title`/`description`/`pubDate`/`draft`), which would **fail the build** on client Astro sites whose content schema uses different field names. Now it has an optional **frontmatter template** field:
```
title: "{{title}}"
description: "{{description}}"
pubDate: {{date}}
draft: false
```
Placeholders `{{title}} {{description}} {{slug}} {{date}} {{keyword}}` are YAML-escaped. Blank = the previous default, so nothing changes for existing setups.

### Test connection
`publish.testConnection()` — a lightweight per-adapter auth probe (GitHub repo GET · WP `users/me` · Sanity query · Payload list · REST/GraphQL reachability). Surfaced as a **"Test"** button on each connected card, action `testSeoConnection`, and **MCP** `test_seo_connection` — so a typo'd token or wrong repo is caught immediately instead of on the first real publish.

## Safety

No schema change. Test only reads (decrypts server-side to probe, never returns the secret). SEO plugin still default-off/route-gated.

Verified: tsc · 17 tests · build · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)