### PR TITLE
feat(templates): default terms & conditions from the PDF template editor + MCP

### DIFF
--- a/src/components/invoices/invoice-editor.tsx
+++ b/src/components/invoices/invoice-editor.tsx
@@ -82,7 +82,7 @@ export function InvoiceEditor({ customers, products, business, invoice, defaultC
       discount_type: invoice?.discount_type ?? undefined,
       discount_value: invoice?.discount_value ?? 0,
       notes: invoice?.notes ?? business.default_notes ?? "",
-      terms: invoice?.terms ?? business.payment_terms ?? "",
+      terms: invoice?.terms ?? business.default_invoice_terms ?? business.payment_terms ?? "",
     },
   });
 

--- a/src/components/pdf/pdf-settings-panel.tsx
+++ b/src/components/pdf/pdf-settings-panel.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Separator } from "@/components/ui/separator";
 import { savePdfSettings } from "@/lib/actions/business";
@@ -135,6 +136,12 @@ export function PdfSettingsPanel({ settings: initial, business, mode, onSettings
     bank_iban: business.bank_iban ?? "",
   });
 
+  // Default terms & conditions for this document type — pre-fills new docs.
+  const [termsDefault, setTermsDefault] = useState(
+    (mode === "invoice" ? business.default_invoice_terms : business.default_quote_terms)
+      ?? business.payment_terms ?? "",
+  );
+
   const update = (patch: Partial<PdfSettings>) => {
     const next = { ...s, ...patch };
     setS(next);
@@ -150,6 +157,9 @@ export function PdfSettingsPanel({ settings: initial, business, mode, onSettings
           bank_account_number: bank.bank_account_number || null,
           bank_sort_code: bank.bank_sort_code || null,
           bank_iban: bank.bank_iban || null,
+          ...(mode === "invoice"
+            ? { default_invoice_terms: termsDefault.trim() || null }
+            : { default_quote_terms: termsDefault.trim() || null }),
         });
         toast.success("Template settings saved");
         setOpen(false);
@@ -341,6 +351,25 @@ export function PdfSettingsPanel({ settings: initial, business, mode, onSettings
                 </div>
               </div>
             ))}
+          </div>
+
+          <Separator />
+
+          {/* Default terms & conditions for this document type */}
+          <div className="space-y-2">
+            <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Default terms &amp; conditions
+            </Label>
+            <Textarea
+              rows={5}
+              value={termsDefault}
+              onChange={(e) => setTermsDefault(e.target.value)}
+              placeholder={mode === "invoice" ? "Payment due within 30 days…" : "This quote is valid for 30 days…"}
+              className="text-xs"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Pre-fills the terms on new {mode === "invoice" ? "invoices" : "quotes"}. You can still edit them per {mode}.
+            </p>
           </div>
 
           <div className="pt-2 pb-6">

--- a/src/components/quotes/quote-editor.tsx
+++ b/src/components/quotes/quote-editor.tsx
@@ -80,7 +80,7 @@ export function QuoteEditor({ customers, products, business, quote, defaultCusto
       discount_type: quote?.discount_type ?? undefined,
       discount_value: quote?.discount_value ?? 0,
       notes: quote?.notes ?? business.default_notes ?? "",
-      terms: quote?.terms ?? business.payment_terms ?? "",
+      terms: quote?.terms ?? business.default_quote_terms ?? business.payment_terms ?? "",
     },
   });
 

--- a/src/lib/actions/business.ts
+++ b/src/lib/actions/business.ts
@@ -133,6 +133,9 @@ export async function savePdfSettings(
     bank_account_number?: string | null;
     bank_sort_code?: string | null;
     bank_iban?: string | null;
+    // Default terms & conditions per document type (set from the template editor).
+    default_invoice_terms?: string | null;
+    default_quote_terms?: string | null;
   }
 ): Promise<void> {
   const supabase = await createClient();

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -548,13 +548,18 @@ export function registerTools(server: McpServer): void {
       return text(data);
     });
 
-  tool("update_settings", "Update business settings / preferences. Only provided fields change. Common fields: name, email, phone, address, currency, accent_color, sidebar_theme, bg_pattern, invoice_prefix, quote_prefix, bank_name, bank_account_number, bank_account_name, bank_sort_code, license_number.",
+  tool("update_settings", "Update business settings / preferences. Only provided fields change. Common fields: name, email, phone, address, currency, accent_color, sidebar_theme, bg_pattern, invoice_prefix, quote_prefix, bank_name, bank_account_number, bank_account_name, bank_sort_code, license_number. Document defaults: default_notes, payment_terms, and the per-type default terms & conditions default_invoice_terms / default_quote_terms (pre-fill new invoices / quotes — same as the PDF template editor's 'Default terms & conditions').",
     {
       name: z.string().optional(), email: z.string().optional(), phone: z.string().optional(), address: z.string().optional(),
       currency: z.string().optional(), accent_color: z.string().optional(), sidebar_theme: z.string().optional(),
       bg_pattern: z.string().optional(), invoice_prefix: z.string().optional(), quote_prefix: z.string().optional(),
       bank_name: z.string().optional(), bank_account_number: z.string().optional(), bank_account_name: z.string().optional(),
       bank_sort_code: z.string().optional(), license_number: z.string().optional(),
+      // Document defaults pre-filled on new invoices/quotes.
+      default_notes: z.string().nullable().optional(),
+      payment_terms: z.string().nullable().optional(),
+      default_invoice_terms: z.string().nullable().optional(),
+      default_quote_terms: z.string().nullable().optional(),
       // Stripe / payments: platform fee % and the quote-accept deposit %.
       platform_fee_percent: z.number().min(0).max(30).nullable().optional(),
       deposit_percent: z.number().min(0).max(100).nullable().optional(),

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -66,6 +66,10 @@ export interface Business {
   pdf_settings: PdfSettings | null;
   payment_terms: string | null;
   default_notes: string | null;
+  /** Default terms & conditions pre-filled on new invoices / quotes (set from
+   *  the PDF template editor). Fall back to payment_terms. */
+  default_invoice_terms: string | null;
+  default_quote_terms: string | null;
   bank_name: string | null;
   bank_account_name: string | null;
   bank_account_number: string | null;

--- a/supabase/migrations/20260710120000_default_document_terms.sql
+++ b/supabase/migrations/20260710120000_default_document_terms.sql
@@ -1,0 +1,6 @@
+-- Default terms & conditions per document type, settable from the PDF template
+-- editor. New invoices/quotes pre-fill their terms from these (falling back to
+-- the legacy payment_terms). Additive.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS default_invoice_terms TEXT,
+  ADD COLUMN IF NOT EXISTS default_quote_terms   TEXT;


### PR DESCRIPTION
## What

Set the **default terms & conditions** per document type directly in the **Template** editor (the "Template" sheet on the invoice/quote pages). New invoices/quotes pre-fill their terms from it.

- **Migration `20260710120000`** (applied + recorded): `businesses.default_invoice_terms` + `default_quote_terms`.
- **`PdfSettingsPanel`** gains a **mode-aware "Default terms & conditions"** textarea — shows the invoice default on invoices, the quote default on quotes. Saved via the panel's existing `savePdfSettings` (which already writes business columns alongside `pdf_settings`).
- **Defaulting**: new invoice `terms` = `default_invoice_terms ?? payment_terms`; new quote `terms` = `default_quote_terms ?? payment_terms`. Existing `payment_terms` still works (back-compat).
- **MCP**: `update_settings` gains `default_invoice_terms` / `default_quote_terms` (+ `default_notes` / `payment_terms`); `get_settings` already returns them — so an agent can set the defaults too.

## How to use it

Open an invoice or quote → **Template** → scroll to **Default terms & conditions** → type them → **Save template settings**. Every new invoice/quote of that type starts with those terms (still editable per doc). Or via MCP: `update_settings({ default_invoice_terms: "…" })`.

## Safety

Additive columns; existing `payment_terms` preserved as the fallback. No PDF change (the doc's `terms` field renders as before — this just pre-fills it).

Verified: tsc · 17 tests · build · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)