### PR TITLE
feat(plugin): Expenses & job costing (field-services)

### DIFF
--- a/src/app/(dashboard)/expenses/page.tsx
+++ b/src/app/(dashboard)/expenses/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { listExpenses } from "@/lib/actions/expenses";
+import { ExpensesView } from "@/components/expenses/expenses-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function ExpensesPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const businessId = await getActiveBizId(supabase as any, user.id);
+
+  const [expenses, workOrdersRes] = await Promise.all([
+    listExpenses(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase as any).from("work_orders").select("id, number, title").eq("business_id", businessId).order("created_at", { ascending: false }).limit(300),
+  ]);
+
+  return (
+    <ExpensesView
+      expenses={expenses}
+      workOrders={(workOrdersRes.data ?? []) as { id: string; number: string | null; title: string | null }[]}
+    />
+  );
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -9,7 +9,7 @@ import {
   Settings, Trash2, Plus, Lock,
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
-  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles,
+  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -74,6 +74,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   "message-square": MessageSquare,
   "trending-up": TrendingUp,
   sparkles: Sparkles,
+  receipt: Receipt,
 };
 
 // Module plugins shown in the Modules section. The two verticals that already

--- a/src/components/expenses/expenses-view.tsx
+++ b/src/components/expenses/expenses-view.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Receipt, Plus, Trash2, FileText } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/layout/page-header";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { createExpense, deleteExpense, uploadReceipt, getReceiptUrl } from "@/lib/actions/expenses";
+import type { Expense } from "@/types/database";
+
+interface WO { id: string; number: string | null; title: string | null }
+interface Props { expenses: Expense[]; workOrders: WO[] }
+
+const CATEGORIES = ["materials", "fuel", "tools", "subcontractor", "equipment-hire", "permits", "vehicle", "office", "travel", "other"];
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+const money = (n: number) => `$${(Number(n) || 0).toFixed(2)}`;
+const woLabel = (w?: WO) => w ? (w.title || w.number || "Job") : null;
+
+export function ExpensesView({ expenses, workOrders }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const [amount, setAmount] = useState("");
+  const [tax, setTax] = useState("");
+  const [category, setCategory] = useState("materials");
+  const [vendor, setVendor] = useState("");
+  const [description, setDescription] = useState("");
+  const [spentOn, setSpentOn] = useState(new Date().toISOString().split("T")[0]);
+  const [paymentMethod, setPaymentMethod] = useState("card");
+  const [workOrderId, setWorkOrderId] = useState("");
+  const [billable, setBillable] = useState(false);
+  const [receiptPath, setReceiptPath] = useState<string | null>(null);
+
+  const woById = new Map(workOrders.map((w) => [w.id, w]));
+
+  // KPI: this month
+  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString().split("T")[0];
+  const monthExpenses = expenses.filter((e) => e.spent_on >= monthStart);
+  const monthTotal = monthExpenses.reduce((s, e) => s + Number(e.amount) + Number(e.tax_amount), 0);
+  const billableTotal = expenses.filter((e) => e.billable).reduce((s, e) => s + Number(e.amount) + Number(e.tax_amount), 0);
+
+  function reset() {
+    setAmount(""); setTax(""); setCategory("materials"); setVendor(""); setDescription("");
+    setSpentOn(new Date().toISOString().split("T")[0]); setPaymentMethod("card");
+    setWorkOrderId(""); setBillable(false); setReceiptPath(null);
+  }
+
+  async function onReceipt(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const fd = new FormData(); fd.append("file", file);
+      const path = await uploadReceipt(fd);
+      setReceiptPath(path);
+      toast.success("Receipt attached");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Upload failed");
+    } finally { setUploading(false); }
+  }
+
+  function handleAdd() {
+    if (!amount || Number(amount) <= 0) { toast.error("Enter an amount"); return; }
+    startTransition(async () => {
+      try {
+        await createExpense({
+          amount, tax_amount: tax, category, vendor, description, spent_on: spentOn,
+          payment_method: paymentMethod, work_order_id: workOrderId || null, billable, receipt_path: receiptPath,
+        });
+        toast.success("Expense recorded");
+        setOpen(false); reset(); router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Couldn't save");
+      }
+    });
+  }
+
+  function handleDelete(id: string) {
+    startTransition(async () => {
+      try { await deleteExpense(id); toast.success("Deleted"); router.refresh(); }
+      catch (err) { toast.error(err instanceof Error ? err.message : "Couldn't delete"); }
+    });
+  }
+
+  async function viewReceipt(path: string) {
+    const url = await getReceiptUrl(path);
+    if (url) window.open(url, "_blank");
+    else toast.error("Receipt unavailable");
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Expenses"
+        subtitle="Track job and business costs — receipts, categories and true profit per job"
+        actions={<Button onClick={() => setOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add expense</Button>}
+      />
+
+      {/* KPI strip */}
+      <div className="grid grid-cols-3 gap-3 mb-6">
+        <Stat label="This month" value={money(monthTotal)} sub={`${monthExpenses.length} expenses`} />
+        <Stat label="Billable (rebillable)" value={money(billableTotal)} />
+        <Stat label="Total records" value={String(expenses.length)} />
+      </div>
+
+      {expenses.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Receipt className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No expenses yet</p>
+          <p className="text-sm text-muted-foreground mt-1">Log a cost, attach the receipt, and link it to a job to see real profit per job.</p>
+          <Button className="mt-4" onClick={() => setOpen(true)}><Plus className="w-4 h-4 mr-1.5" /> Add your first expense</Button>
+        </div>
+      ) : (
+        <div className="ch-table-wrap">
+          <table className="ch-table w-full">
+            <thead><tr>
+              <th>Date</th><th>Category</th><th>Vendor</th><th>Job</th><th className="num">Amount</th><th></th><th></th>
+            </tr></thead>
+            <tbody>
+              {expenses.map((e) => (
+                <tr key={e.id}>
+                  <td>{new Date(e.spent_on).toLocaleDateString("en-AU")}</td>
+                  <td><span className="capitalize">{e.category.replace("-", " ")}</span>{e.billable && <span className="ml-2 text-[10px] font-medium bg-emerald-100 text-emerald-700 rounded-full px-1.5 py-0.5">billable</span>}</td>
+                  <td className="break-words">{e.vendor ?? "—"}</td>
+                  <td>{e.work_order_id ? (woLabel(woById.get(e.work_order_id)) ?? "Job") : "—"}</td>
+                  <td className="num">{money(Number(e.amount) + Number(e.tax_amount))}</td>
+                  <td>{e.receipt_path && <button onClick={() => viewReceipt(e.receipt_path!)} className="text-muted-foreground hover:text-foreground" title="View receipt"><FileText className="w-4 h-4" /></button>}</td>
+                  <td><button onClick={() => handleDelete(e.id)} disabled={isPending} className="text-muted-foreground hover:text-destructive" aria-label="Delete"><Trash2 className="w-4 h-4" /></button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Add dialog */}
+      <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }}>
+        <DialogContent className="max-h-[88vh] overflow-y-auto">
+          <DialogHeader><DialogTitle>Add expense</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="e-amount">Amount (ex-tax)</Label><Input id="e-amount" type="number" step="0.01" value={amount} onChange={(e) => setAmount(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="e-tax">Tax</Label><Input id="e-tax" type="number" step="0.01" value={tax} onChange={(e) => setTax(e.target.value)} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="e-cat">Category</Label>
+                <select id="e-cat" className={selectCls} value={category} onChange={(e) => setCategory(e.target.value)}>
+                  {CATEGORIES.map((c) => <option key={c} value={c} className="capitalize">{c.replace("-", " ")}</option>)}
+                </select>
+              </div>
+              <div className="space-y-1.5"><Label htmlFor="e-date">Date</Label><Input id="e-date" type="date" value={spentOn} onChange={(e) => setSpentOn(e.target.value)} /></div>
+            </div>
+            <div className="space-y-1.5"><Label htmlFor="e-vendor">Vendor</Label><Input id="e-vendor" placeholder="Bunnings, fuel station…" value={vendor} onChange={(e) => setVendor(e.target.value)} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="e-pm">Paid by</Label>
+                <select id="e-pm" className={selectCls} value={paymentMethod} onChange={(e) => setPaymentMethod(e.target.value)}>
+                  <option value="card">Card</option><option value="cash">Cash</option><option value="bank">Bank</option><option value="other">Other</option>
+                </select>
+              </div>
+              <div className="space-y-1.5"><Label htmlFor="e-wo">Link to job</Label>
+                <select id="e-wo" className={selectCls} value={workOrderId} onChange={(e) => setWorkOrderId(e.target.value)}>
+                  <option value="">— No job —</option>
+                  {workOrders.map((w) => <option key={w.id} value={w.id}>{woLabel(w)}</option>)}
+                </select>
+              </div>
+            </div>
+            <div className="space-y-1.5"><Label htmlFor="e-desc">Notes</Label><Textarea id="e-desc" rows={2} value={description} onChange={(e) => setDescription(e.target.value)} /></div>
+            <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={billable} onChange={(e) => setBillable(e.target.checked)} /> Rebill to the customer</label>
+            <div className="space-y-1.5">
+              <Label>Receipt</Label>
+              <div className="flex items-center gap-2">
+                <input type="file" accept="image/*,application/pdf" onChange={onReceipt} className="text-xs" disabled={uploading} />
+                {uploading && <span className="text-xs text-muted-foreground">uploading…</span>}
+                {receiptPath && <span className="text-xs text-emerald-600">attached ✓</span>}
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleAdd} disabled={isPending || uploading}>Save expense</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className={cn("rounded-xl border border-border bg-card p-4")}>
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+      {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -41,6 +41,7 @@ const navSections: NavSection[] = [
     { label: "Site Reports",  href: "/reports",       icon: ClipboardList, plugin: "site-reports"     },
     { label: "Recurring",     href: "/recurring",     icon: Repeat,       plugin: "recurring-jobs"    },
     { label: "Recurring billing", href: "/recurring-invoices", icon: Repeat, plugin: "recurring-billing" },
+    { label: "Expenses",      href: "/expenses",      icon: Receipt,      plugin: "expenses"          },
   ]},
   { section: "Service", items: [
     { label: "Work Orders",    href: "/work-orders",     icon: Wrench,        worker: true, plugin: "jobs" },

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -1,0 +1,130 @@
+"use server";
+
+/**
+ * Expenses & job costing (field-services plugin). Track business/job costs with
+ * a receipt, optionally linked to a work order. AI-tool-first: every action has
+ * a matching MCP tool (scopes expenses:read / expenses:write).
+ */
+import { randomUUID } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { Expense, ExpenseStatus } from "@/types/database";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uid = (v: string | null | undefined) => (v && UUID_RE.test(v.trim()) ? v.trim() : null);
+const num = (v: unknown) => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function biz(): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  return getActiveBizId(supabase, user.id);
+}
+
+export async function listExpenses(filters?: { work_order_id?: string; limit?: number }): Promise<Expense[]> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  let q = tbl(supabase, "expenses").select("*").eq("business_id", businessId)
+    .order("spent_on", { ascending: false }).limit(filters?.limit ?? 300);
+  if (filters?.work_order_id) q = q.eq("work_order_id", filters.work_order_id);
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data ?? []) as Expense[];
+}
+
+export async function createExpense(input: {
+  amount: number | string;
+  category?: string;
+  vendor?: string | null;
+  description?: string | null;
+  tax_amount?: number | string;
+  spent_on?: string | null;
+  payment_method?: string | null;
+  work_order_id?: string | null;
+  billable?: boolean;
+  reimbursable?: boolean;
+  receipt_path?: string | null;
+}): Promise<Expense> {
+  const businessId = await biz();
+  const user = await getUser();
+  const supabase = await createClient();
+  const { data, error } = await tbl(supabase, "expenses").insert({
+    business_id: businessId,
+    user_id: user.id,
+    amount: num(input.amount),
+    tax_amount: num(input.tax_amount),
+    category: input.category?.trim() || "other",
+    vendor: input.vendor?.trim() || null,
+    description: input.description?.trim() || null,
+    spent_on: input.spent_on?.trim() || new Date().toISOString().split("T")[0],
+    payment_method: input.payment_method?.trim() || null,
+    work_order_id: uid(input.work_order_id),
+    billable: !!input.billable,
+    reimbursable: !!input.reimbursable,
+    receipt_path: input.receipt_path?.trim() || null,
+  }).select().single();
+  if (error) throw error;
+  revalidatePath("/expenses");
+  return data as Expense;
+}
+
+export async function updateExpense(id: string, patch: Partial<{
+  amount: number | string; tax_amount: number | string; category: string; vendor: string | null;
+  description: string | null; spent_on: string; payment_method: string | null; work_order_id: string | null;
+  billable: boolean; reimbursable: boolean; status: ExpenseStatus; receipt_path: string | null;
+}>): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const clean: Record<string, unknown> = {};
+  if (patch.amount !== undefined) clean.amount = num(patch.amount);
+  if (patch.tax_amount !== undefined) clean.tax_amount = num(patch.tax_amount);
+  if (patch.category !== undefined) clean.category = patch.category?.trim() || "other";
+  if (patch.vendor !== undefined) clean.vendor = patch.vendor?.trim() || null;
+  if (patch.description !== undefined) clean.description = patch.description?.trim() || null;
+  if (patch.spent_on !== undefined) clean.spent_on = patch.spent_on;
+  if (patch.payment_method !== undefined) clean.payment_method = patch.payment_method?.trim() || null;
+  if (patch.work_order_id !== undefined) clean.work_order_id = uid(patch.work_order_id);
+  if (patch.billable !== undefined) clean.billable = !!patch.billable;
+  if (patch.reimbursable !== undefined) clean.reimbursable = !!patch.reimbursable;
+  if (patch.status !== undefined) clean.status = patch.status;
+  if (patch.receipt_path !== undefined) clean.receipt_path = patch.receipt_path?.trim() || null;
+  if (Object.keys(clean).length === 0) return;
+  const { error } = await tbl(supabase, "expenses").update(clean).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/expenses");
+}
+
+export async function deleteExpense(id: string): Promise<void> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const { error } = await tbl(supabase, "expenses").delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/expenses");
+}
+
+/** Upload a receipt image; returns the storage path (private bucket). */
+export async function uploadReceipt(formData: FormData): Promise<string> {
+  const businessId = await biz();
+  const file = formData.get("file") as File | null;
+  if (!file) throw new Error("No file");
+  if (file.size > 10 * 1024 * 1024) throw new Error("Receipt must be under 10MB");
+  const ext = (file.name.split(".").pop() || "jpg").toLowerCase().replace(/[^a-z0-9]/g, "");
+  const path = `${businessId}/${randomUUID()}.${ext}`;
+  const admin = createAdminClient();
+  const { error } = await admin.storage.from("expense-receipts").upload(path, file, { contentType: file.type || undefined, upsert: false });
+  if (error) throw error;
+  return path;
+}
+
+/** Signed URL for a stored receipt. */
+export async function getReceiptUrl(path: string): Promise<string | null> {
+  await biz();
+  const admin = createAdminClient();
+  const { data } = await admin.storage.from("expense-receipts").createSignedUrl(path, 3600);
+  return data?.signedUrl ?? null;
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -32,6 +32,7 @@ import type { LineItem } from "@/types/database";
 import { ctxFrom, appBase, UUID, getOrMintPortalToken } from "./tools/shared";
 import { registerPluginFormTools } from "./tools/plugin-form-tools";
 import { registerSeoTools } from "./tools/seo-tools";
+import { registerExpenseTools } from "./tools/expenses-tools";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -1396,6 +1397,9 @@ export function registerTools(server: McpServer): void {
 
   // ===== SEO PRODUCTION (docs/SEO_AGENCY_PLAN.md, Phase 2) =====
   registerSeoTools(tool);
+
+  // ===== EXPENSES & JOB COSTING =====
+  registerExpenseTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/expenses-tools.ts
+++ b/src/lib/mcp/tools/expenses-tools.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP tools for the Expenses & job-costing plugin. Scopes: expenses:read /
+ * expenses:write. (Receipt uploads stay web-only — no binary over MCP.)
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+export function registerExpenseTools(tool: ToolFn): void {
+  tool("list_expenses", "List expenses (optionally for one job), newest first.",
+    { work_order_id: UUID.optional(), limit: z.number().int().min(1).max(500).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:read");
+      let q = t(ctx, "expenses").select("id, spent_on, category, vendor, description, amount, tax_amount, billable, status, work_order_id")
+        .eq("business_id", ctx.businessId).order("spent_on", { ascending: false }).limit(args.limit ?? 200);
+      if (args.work_order_id) q = q.eq("work_order_id", args.work_order_id);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_expense", "Record an expense. Link it to a job with work_order_id for job costing; set billable to rebill the customer.",
+    {
+      amount: z.number(),
+      category: z.string().optional(),
+      vendor: z.string().optional(),
+      description: z.string().optional(),
+      tax_amount: z.number().optional(),
+      spent_on: z.string().optional(),
+      payment_method: z.string().optional(),
+      work_order_id: UUID.optional(),
+      billable: z.boolean().optional(),
+      reimbursable: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const { data, error } = await t(ctx, "expenses").insert({
+        business_id: ctx.businessId, user_id: ctx.userId,
+        amount: args.amount, tax_amount: args.tax_amount ?? 0,
+        category: args.category?.trim() || "other", vendor: args.vendor?.trim() || null,
+        description: args.description?.trim() || null,
+        spent_on: args.spent_on || new Date().toISOString().split("T")[0],
+        payment_method: args.payment_method?.trim() || null,
+        work_order_id: args.work_order_id ?? null,
+        billable: !!args.billable, reimbursable: !!args.reimbursable,
+      }).select("id").single();
+      if (error) throw error;
+      return text({ created: true, expense_id: data.id });
+    });
+
+  tool("update_expense", "Update an expense (amount / category / vendor / billable / status / job link).",
+    {
+      expense_id: UUID,
+      amount: z.number().optional(), tax_amount: z.number().optional(), category: z.string().optional(),
+      vendor: z.string().optional(), description: z.string().optional(), spent_on: z.string().optional(),
+      payment_method: z.string().optional(), work_order_id: UUID.nullable().optional(),
+      billable: z.boolean().optional(), reimbursable: z.boolean().optional(),
+      status: z.enum(["recorded", "reimbursed", "invoiced"]).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const { expense_id, ...rest } = args;
+      const clean = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "expenses").update(clean).eq("id", expense_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("delete_expense", "Delete an expense.",
+    { expense_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const { error } = await t(ctx, "expenses").delete().eq("id", args.expense_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("get_job_costing", "Cost summary for a job: total expenses (+billable) plus labour/material context lives on the work order.",
+    { work_order_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:read");
+      const { data } = await t(ctx, "expenses").select("amount, tax_amount, billable, category")
+        .eq("business_id", ctx.businessId).eq("work_order_id", args.work_order_id);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = (data ?? []) as any[];
+      const total = rows.reduce((s, e) => s + Number(e.amount) + Number(e.tax_amount), 0);
+      const billable = rows.filter((e) => e.billable).reduce((s, e) => s + Number(e.amount) + Number(e.tax_amount), 0);
+      return text({ work_order_id: args.work_order_id, expense_total: total, billable_total: billable, count: rows.length });
+    });
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -66,6 +66,8 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "recurring-jobs", icon: "repeat", name: "Recurring jobs", description: "Repeating jobs that generate work orders (and optionally invoices).", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/recurring"] },
   { id: "booking", icon: "calendar-days",    name: "Online booking", description: "Public booking pages with reminders.",   kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/bookings"] },
 
+  { id: "expenses", icon: "receipt", name: "Expenses", description: "Track job & business costs with receipts — true profit per job.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/expenses"] },
+
   // ── Catalog / comms / insights ────────────────────────────────────────────
   { id: "products", icon: "package",   name: "Products",      description: "Price list used across quotes and invoices.", kind: "module", category: "catalog", defaultEnabled: true, routePrefixes: ["/products"] },
   { id: "messages", icon: "message-square",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "communication", defaultEnabled: true, routePrefixes: ["/messages"] },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -555,6 +555,28 @@ export interface PublicFormSubmission {
   created_at: string;
 }
 
+// ── Expenses & job costing (field-services plugin) ──────────────────────────
+export type ExpenseStatus = 'recorded' | 'reimbursed' | 'invoiced';
+export interface Expense {
+  id: string;
+  business_id: string;
+  user_id: string | null;
+  work_order_id: string | null;
+  vendor: string | null;
+  category: string;
+  description: string | null;
+  amount: number;
+  tax_amount: number;
+  spent_on: string;
+  payment_method: string | null;
+  billable: boolean;
+  reimbursable: boolean;
+  receipt_path: string | null;
+  status: ExpenseStatus;
+  created_at: string;
+  updated_at: string;
+}
+
 // ── SEO Production (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────
 export type SeoPlatform = 'wordpress' | 'shopify' | 'other';
 export type SeoPlaybook = 'local' | 'ecommerce';
@@ -1225,6 +1247,8 @@ export type ApiScope =
   | 'forms:write'
   | 'seo:read'
   | 'seo:write'
+  | 'expenses:read'
+  | 'expenses:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1257,6 +1281,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'forms:write',      label: 'Create / publish public forms', group: 'Forms' },
   { value: 'seo:read',         label: 'Read SEO sites & pipeline', group: 'SEO' },
   { value: 'seo:write',        label: 'Manage SEO sites & content', group: 'SEO' },
+  { value: 'expenses:read',    label: 'Read expenses', group: 'Expenses' },
+  { value: 'expenses:write',   label: 'Create / edit expenses', group: 'Expenses' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260710140000_expenses.sql
+++ b/supabase/migrations/20260710140000_expenses.sql
@@ -1,0 +1,52 @@
+-- Expenses & job costing plugin (field-services). Track business + job costs
+-- (materials, fuel, subcontractors, hire…) with a receipt, optionally linked to
+-- a work order for true profit-per-job. Additive.
+CREATE TABLE IF NOT EXISTS public.expenses (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id       UUID,
+  work_order_id UUID REFERENCES public.work_orders(id) ON DELETE SET NULL,
+  vendor        TEXT,
+  category      TEXT NOT NULL DEFAULT 'other',
+  description   TEXT,
+  amount        NUMERIC NOT NULL DEFAULT 0,   -- ex-tax
+  tax_amount    NUMERIC NOT NULL DEFAULT 0,
+  spent_on      DATE NOT NULL DEFAULT CURRENT_DATE,
+  payment_method TEXT,                         -- card | cash | bank | other
+  billable      BOOLEAN NOT NULL DEFAULT FALSE,
+  reimbursable  BOOLEAN NOT NULL DEFAULT FALSE,
+  receipt_path  TEXT,
+  status        TEXT NOT NULL DEFAULT 'recorded' CHECK (status IN ('recorded','reimbursed','invoiced')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_expenses_business ON public.expenses (business_id, spent_on DESC);
+CREATE INDEX IF NOT EXISTS idx_expenses_work_order ON public.expenses (work_order_id);
+
+ALTER TABLE public.expenses ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS expenses_read ON public.expenses;
+CREATE POLICY expenses_read ON public.expenses FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+DROP POLICY IF EXISTS expenses_write ON public.expenses;
+CREATE POLICY expenses_write ON public.expenses FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+);
+
+DROP TRIGGER IF EXISTS expenses_updated_at ON public.expenses;
+CREATE TRIGGER expenses_updated_at BEFORE UPDATE ON public.expenses
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+INSERT INTO storage.buckets (id, name, public) VALUES ('expense-receipts', 'expense-receipts', false)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## What

First of the **field-services plugins** — **Expenses & job costing**. Log business/job costs with a receipt, link to a work order for **true profit per job**.

- **Migration `20260710140000`** (applied + recorded): `expenses` table + RLS (members-except-workers) + private **`expense-receipts`** bucket.
- **Registry**: `expenses` plugin (default **OFF**, route `/expenses`); sidebar item (Sales) + Plugins-store card. The **trades preset** includes it.
- **Actions**: list / create / update / delete + `uploadReceipt` (admin-scoped, business-pathed) + `getReceiptUrl` (signed URL).
- **UI `/expenses`**: KPI strip (this month · billable · count), add dialog (amount, tax, category, vendor, **link to job**, billable, **receipt upload**), table with receipt view + delete.
- **MCP** (`expenses:read` / `expenses:write`): `list/create/update/delete_expense` + `get_job_costing`.

## Data safety

Default-off + route-gated; existing businesses unaffected until they enable it (or apply the trades preset). Additive schema.

## Next field-services plugins

Inventory & stock → Timesheets & payroll → Assets & equipment (each its own PR).

Verified: tsc · 17 tests · build (`/expenses`) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)