### PR TITLE
feat(plugin): Inventory & stock (field-services)

### DIFF
--- a/src/app/(dashboard)/inventory/page.tsx
+++ b/src/app/(dashboard)/inventory/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { listInventory } from "@/lib/actions/inventory";
+import { InventoryView } from "@/components/inventory/inventory-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function InventoryPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const items = await listInventory();
+  return <InventoryView items={items} />;
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -9,7 +9,7 @@ import {
   Settings, Trash2, Plus, Lock,
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
-  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt,
+  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -75,6 +75,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   "trending-up": TrendingUp,
   sparkles: Sparkles,
   receipt: Receipt,
+  boxes: Boxes,
 };
 
 // Module plugins shown in the Modules section. The two verticals that already

--- a/src/components/inventory/inventory-view.tsx
+++ b/src/components/inventory/inventory-view.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Boxes, Plus } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PageHeader } from "@/components/layout/page-header";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { createStockItem, adjustStock } from "@/lib/actions/inventory";
+import type { InventoryProduct, StockReason } from "@/types/database";
+
+const money = (n: number | null) => n == null ? "—" : `$${Number(n).toFixed(2)}`;
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function InventoryView({ items }: { items: InventoryProduct[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [addOpen, setAddOpen] = useState(false);
+  const [adjustFor, setAdjustFor] = useState<InventoryProduct | null>(null);
+
+  // add-item form
+  const [name, setName] = useState(""); const [unit, setUnit] = useState("");
+  const [qty, setQty] = useState(""); const [reorder, setReorder] = useState("");
+  const [cost, setCost] = useState(""); const [price, setPrice] = useState("");
+  // adjust form
+  const [delta, setDelta] = useState(""); const [reason, setReason] = useState<StockReason>("received"); const [note, setNote] = useState("");
+
+  const lowStock = items.filter((p) => p.reorder_point != null && Number(p.stock_qty) <= Number(p.reorder_point));
+  const stockValue = items.reduce((s, p) => s + Number(p.stock_qty) * Number(p.unit_cost ?? 0), 0);
+
+  function handleAdd() {
+    if (!name.trim()) { toast.error("Enter a name"); return; }
+    startTransition(async () => {
+      try {
+        await createStockItem({ name, unit, stock_qty: qty, reorder_point: reorder || null, unit_cost: cost || null, unit_price: price });
+        toast.success("Stock item added");
+        setAddOpen(false); setName(""); setUnit(""); setQty(""); setReorder(""); setCost(""); setPrice("");
+        router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't add"); }
+    });
+  }
+
+  function openAdjust(p: InventoryProduct) { setAdjustFor(p); setDelta(""); setReason("received"); setNote(""); }
+  function handleAdjust(sign: 1 | -1) {
+    if (!adjustFor) return;
+    const d = Number(delta);
+    if (!d || d <= 0) { toast.error("Enter a quantity"); return; }
+    startTransition(async () => {
+      try {
+        const r = await adjustStock({ product_id: adjustFor.id, delta: sign * d, reason, note });
+        toast.success(`On hand: ${r.stock_qty}`);
+        setAdjustFor(null); router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't adjust"); }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Inventory"
+        subtitle="Stock on hand, reorder points and usage"
+        actions={<Button onClick={() => setAddOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add stock item</Button>}
+      />
+
+      <div className="grid grid-cols-3 gap-3 mb-6">
+        <Stat label="Tracked items" value={String(items.length)} />
+        <Stat label="Low stock" value={String(lowStock.length)} tone={lowStock.length ? "warn" : undefined} />
+        <Stat label="Stock value" value={`$${stockValue.toFixed(2)}`} />
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Boxes className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No tracked stock yet</p>
+          <p className="text-sm text-muted-foreground mt-1">Add a stock item (or turn on tracking for a product) to track quantities and get low-stock alerts.</p>
+          <Button className="mt-4" onClick={() => setAddOpen(true)}><Plus className="w-4 h-4 mr-1.5" /> Add stock item</Button>
+        </div>
+      ) : (
+        <div className="ch-table-wrap">
+          <table className="ch-table w-full">
+            <thead><tr><th>Item</th><th className="num">On hand</th><th className="num">Reorder at</th><th className="num">Unit cost</th><th></th></tr></thead>
+            <tbody>
+              {items.map((p) => {
+                const low = p.reorder_point != null && Number(p.stock_qty) <= Number(p.reorder_point);
+                return (
+                  <tr key={p.id}>
+                    <td className="break-words">{p.name}{p.unit && <span className="text-muted-foreground"> / {p.unit}</span>}{low && <span className="ml-2 text-[10px] font-medium bg-amber-100 text-amber-700 rounded-full px-1.5 py-0.5">low</span>}</td>
+                    <td className="num font-semibold">{Number(p.stock_qty)}</td>
+                    <td className="num">{p.reorder_point ?? "—"}</td>
+                    <td className="num">{money(p.unit_cost)}</td>
+                    <td><button onClick={() => openAdjust(p)} className="text-xs text-primary hover:underline">Adjust</button></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Add item */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add stock item</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5"><Label htmlFor="i-name">Name</Label><Input id="i-name" value={name} onChange={(e) => setName(e.target.value)} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="i-unit">Unit</Label><Input id="i-unit" placeholder="ea, box, m…" value={unit} onChange={(e) => setUnit(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="i-qty">On hand</Label><Input id="i-qty" type="number" step="0.01" value={qty} onChange={(e) => setQty(e.target.value)} /></div>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="i-reorder">Reorder at</Label><Input id="i-reorder" type="number" step="0.01" value={reorder} onChange={(e) => setReorder(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="i-cost">Unit cost</Label><Input id="i-cost" type="number" step="0.01" value={cost} onChange={(e) => setCost(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="i-price">Sell price</Label><Input id="i-price" type="number" step="0.01" value={price} onChange={(e) => setPrice(e.target.value)} /></div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setAddOpen(false)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleAdd} disabled={isPending}>Add item</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Adjust */}
+      <Dialog open={!!adjustFor} onOpenChange={(o) => !o && setAdjustFor(null)}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Adjust stock — {adjustFor?.name}</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">On hand: <span className="font-semibold text-foreground">{Number(adjustFor?.stock_qty ?? 0)}</span></p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="a-qty">Quantity</Label><Input id="a-qty" type="number" step="0.01" value={delta} onChange={(e) => setDelta(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="a-reason">Reason</Label>
+                <select id="a-reason" className={selectCls} value={reason} onChange={(e) => setReason(e.target.value as StockReason)}>
+                  <option value="received">Received</option><option value="usage">Used on job</option><option value="count">Stock count</option><option value="adjustment">Adjustment</option>
+                </select>
+              </div>
+            </div>
+            <div className="space-y-1.5"><Label htmlFor="a-note">Note</Label><Input id="a-note" value={note} onChange={(e) => setNote(e.target.value)} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleAdjust(-1)} disabled={isPending}>− Remove</Button>
+            <Button onClick={() => handleAdjust(1)} disabled={isPending}>+ Add</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "warn" }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className={cn("text-2xl font-bold mt-1", tone === "warn" && "text-amber-600")}>{value}</p>
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -56,6 +56,7 @@ const navSections: NavSection[] = [
   ]},
   { section: "Catalog", items: [
     { label: "Products",   href: "/products",   icon: Package,       plugin: "products" },
+    { label: "Inventory",  href: "/inventory",  icon: Boxes,         plugin: "inventory" },
   ]},
   { section: "Workforce", items: [
     { label: "Team",       href: "/team",       icon: Users2                        },

--- a/src/lib/actions/inventory.ts
+++ b/src/lib/actions/inventory.ts
@@ -1,0 +1,98 @@
+"use server";
+
+/**
+ * Inventory & stock (field-services plugin) — extends products with stock
+ * tracking + a movements ledger. Uses the products:read/write scope surface.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { InventoryProduct, StockMovement, StockReason } from "@/types/database";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uid = (v: string | null | undefined) => (v && UUID_RE.test(v.trim()) ? v.trim() : null);
+const num = (v: unknown, d = 0) => { const n = Number(v); return Number.isFinite(n) ? n : d; };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, user, businessId };
+}
+
+export async function listInventory(): Promise<InventoryProduct[]> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "products").select("*")
+    .eq("business_id", businessId).eq("track_stock", true).eq("archived", false).order("name");
+  if (error) throw error;
+  return (data ?? []) as InventoryProduct[];
+}
+
+/** Create a tracked stock item (a product with stock tracking on). */
+export async function createStockItem(input: {
+  name: string; unit?: string | null; stock_qty?: number | string;
+  reorder_point?: number | string | null; unit_cost?: number | string | null; unit_price?: number | string;
+}): Promise<InventoryProduct> {
+  const { supabase, user, businessId } = await ctx();
+  if (!input.name?.trim()) throw new Error("Name is required");
+  const { data, error } = await tbl(supabase, "products").insert({
+    business_id: businessId, user_id: user.id, name: input.name.trim(),
+    unit: input.unit?.trim() || null, unit_price: num(input.unit_price), tax_rate: 0,
+    track_stock: true, stock_qty: num(input.stock_qty),
+    reorder_point: input.reorder_point != null && input.reorder_point !== "" ? num(input.reorder_point) : null,
+    unit_cost: input.unit_cost != null && input.unit_cost !== "" ? num(input.unit_cost) : null,
+  }).select().single();
+  if (error) throw error;
+  revalidatePath("/inventory");
+  return data as InventoryProduct;
+}
+
+/** Turn stock tracking on/off for an existing product + set its levels. */
+export async function setStockTracking(productId: string, patch: {
+  track_stock?: boolean; stock_qty?: number | string; reorder_point?: number | string | null; unit_cost?: number | string | null;
+}): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const clean: Record<string, unknown> = {};
+  if (patch.track_stock !== undefined) clean.track_stock = !!patch.track_stock;
+  if (patch.stock_qty !== undefined) clean.stock_qty = num(patch.stock_qty);
+  if (patch.reorder_point !== undefined) clean.reorder_point = patch.reorder_point === null || patch.reorder_point === "" ? null : num(patch.reorder_point);
+  if (patch.unit_cost !== undefined) clean.unit_cost = patch.unit_cost === null || patch.unit_cost === "" ? null : num(patch.unit_cost);
+  if (Object.keys(clean).length === 0) return;
+  const { error } = await tbl(supabase, "products").update(clean).eq("id", productId).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/inventory");
+}
+
+/** Record a stock movement and update the product's on-hand quantity. */
+export async function adjustStock(input: {
+  product_id: string; delta: number | string; reason?: StockReason; note?: string | null; work_order_id?: string | null;
+}): Promise<{ stock_qty: number }> {
+  const { supabase, user, businessId } = await ctx();
+  const delta = num(input.delta);
+  if (delta === 0) throw new Error("Enter a non-zero quantity");
+
+  const { data: prod } = await tbl(supabase, "products").select("stock_qty").eq("id", input.product_id).eq("business_id", businessId).maybeSingle();
+  if (!prod) throw new Error("Product not found");
+  const next = num(prod.stock_qty) + delta;
+
+  const { error: mErr } = await tbl(supabase, "stock_movements").insert({
+    business_id: businessId, product_id: input.product_id, delta,
+    reason: input.reason ?? "adjustment", note: input.note?.trim() || null,
+    work_order_id: uid(input.work_order_id), created_by: user.id,
+  });
+  if (mErr) throw mErr;
+  const { error: pErr } = await tbl(supabase, "products").update({ stock_qty: next }).eq("id", input.product_id).eq("business_id", businessId);
+  if (pErr) throw pErr;
+  revalidatePath("/inventory");
+  return { stock_qty: next };
+}
+
+export async function listStockMovements(productId: string): Promise<StockMovement[]> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "stock_movements").select("*")
+    .eq("business_id", businessId).eq("product_id", productId).order("created_at", { ascending: false }).limit(100);
+  return (data ?? []) as StockMovement[];
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -33,6 +33,7 @@ import { ctxFrom, appBase, UUID, getOrMintPortalToken } from "./tools/shared";
 import { registerPluginFormTools } from "./tools/plugin-form-tools";
 import { registerSeoTools } from "./tools/seo-tools";
 import { registerExpenseTools } from "./tools/expenses-tools";
+import { registerInventoryTools } from "./tools/inventory-tools";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -1400,6 +1401,9 @@ export function registerTools(server: McpServer): void {
 
   // ===== EXPENSES & JOB COSTING =====
   registerExpenseTools(tool);
+
+  // ===== INVENTORY & STOCK =====
+  registerInventoryTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/inventory-tools.ts
+++ b/src/lib/mcp/tools/inventory-tools.ts
@@ -1,0 +1,68 @@
+/**
+ * MCP tools for the Inventory & stock plugin. Reuses the products:read/write
+ * scope (inventory extends products).
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+export function registerInventoryTools(tool: ToolFn): void {
+  tool("list_inventory", "List tracked stock items with on-hand quantities and reorder points.",
+    { low_only: z.boolean().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "products:read");
+      const { data, error } = await t(ctx, "products")
+        .select("id, name, unit, stock_qty, reorder_point, unit_cost")
+        .eq("business_id", ctx.businessId).eq("track_stock", true).eq("archived", false).order("name");
+      if (error) throw error;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let rows = (data ?? []) as any[];
+      if (args.low_only) rows = rows.filter((p) => p.reorder_point != null && Number(p.stock_qty) <= Number(p.reorder_point));
+      return text(rows);
+    });
+
+  tool("create_stock_item", "Create a tracked stock item (a product with stock tracking on).",
+    { name: z.string().min(1), unit: z.string().optional(), stock_qty: z.number().optional(), reorder_point: z.number().optional(), unit_cost: z.number().optional(), unit_price: z.number().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "products:write");
+      const { data, error } = await t(ctx, "products").insert({
+        business_id: ctx.businessId, user_id: ctx.userId, name: args.name.trim(),
+        unit: args.unit?.trim() || null, unit_price: args.unit_price ?? 0, tax_rate: 0,
+        track_stock: true, stock_qty: args.stock_qty ?? 0,
+        reorder_point: args.reorder_point ?? null, unit_cost: args.unit_cost ?? null,
+      }).select("id").single();
+      if (error) throw error;
+      return text({ created: true, product_id: data.id });
+    });
+
+  tool("set_stock_tracking", "Turn stock tracking on/off for a product and set its levels.",
+    { product_id: UUID, track_stock: z.boolean().optional(), stock_qty: z.number().optional(), reorder_point: z.number().nullable().optional(), unit_cost: z.number().nullable().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "products:write");
+      const { product_id, ...rest } = args;
+      const clean = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "products").update(clean).eq("id", product_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("adjust_stock", "Record a stock movement (delta) and update on-hand. reason = received | usage | count | adjustment. Link usage to a job with work_order_id.",
+    { product_id: UUID, delta: z.number(), reason: z.enum(["received", "usage", "count", "adjustment"]).optional(), note: z.string().optional(), work_order_id: UUID.optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "products:write");
+      if (args.delta === 0) return errorText("delta must be non-zero.");
+      const { data: prod } = await t(ctx, "products").select("stock_qty").eq("id", args.product_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!prod) return errorText("Product not found");
+      const next = Number(prod.stock_qty) + args.delta;
+      const { error: mErr } = await t(ctx, "stock_movements").insert({
+        business_id: ctx.businessId, product_id: args.product_id, delta: args.delta,
+        reason: args.reason ?? "adjustment", note: args.note?.trim() || null,
+        work_order_id: args.work_order_id ?? null, created_by: ctx.userId,
+      });
+      if (mErr) throw mErr;
+      const { error: pErr } = await t(ctx, "products").update({ stock_qty: next }).eq("id", args.product_id).eq("business_id", ctx.businessId);
+      if (pErr) throw pErr;
+      return text({ product_id: args.product_id, stock_qty: next });
+    });
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -70,6 +70,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
 
   // ── Catalog / comms / insights ────────────────────────────────────────────
   { id: "products", icon: "package",   name: "Products",      description: "Price list used across quotes and invoices.", kind: "module", category: "catalog", defaultEnabled: true, routePrefixes: ["/products"] },
+  { id: "inventory", icon: "boxes", name: "Inventory", description: "Track stock on hand, reorder points and usage per job.", kind: "module", category: "catalog", defaultEnabled: false, dependencies: ["products"], routePrefixes: ["/inventory"] },
   { id: "messages", icon: "message-square",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "communication", defaultEnabled: true, routePrefixes: ["/messages"] },
   { id: "analytics", icon: "trending-up",  name: "Analytics",     description: "Revenue and pipeline insight.",          kind: "module", category: "insights", defaultEnabled: true, routePrefixes: ["/analytics"] },
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -132,6 +132,27 @@ export interface Product {
   updated_at: string;
 }
 
+/** Product with the inventory columns (migration 20260710160000). */
+export interface InventoryProduct extends Product {
+  track_stock: boolean;
+  stock_qty: number;
+  reorder_point: number | null;
+  unit_cost: number | null;
+}
+
+export type StockReason = 'adjustment' | 'received' | 'usage' | 'count';
+export interface StockMovement {
+  id: string;
+  business_id: string;
+  product_id: string;
+  delta: number;
+  reason: StockReason;
+  work_order_id: string | null;
+  note: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
 export interface Invoice {
   id: string;
   user_id: string;

--- a/supabase/migrations/20260710160000_inventory.sql
+++ b/supabase/migrations/20260710160000_inventory.sql
@@ -1,0 +1,42 @@
+-- Inventory & stock plugin (field-services). Extends products with stock
+-- tracking + a movements ledger. Additive.
+ALTER TABLE public.products
+  ADD COLUMN IF NOT EXISTS track_stock   BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS stock_qty     NUMERIC NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS reorder_point NUMERIC,
+  ADD COLUMN IF NOT EXISTS unit_cost     NUMERIC;
+
+CREATE TABLE IF NOT EXISTS public.stock_movements (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  product_id    UUID NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  delta         NUMERIC NOT NULL,
+  reason        TEXT NOT NULL DEFAULT 'adjustment' CHECK (reason IN ('adjustment','received','usage','count')),
+  work_order_id UUID REFERENCES public.work_orders(id) ON DELETE SET NULL,
+  note          TEXT,
+  created_by    UUID,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_stock_movements_business ON public.stock_movements (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_stock_movements_product ON public.stock_movements (product_id, created_at DESC);
+
+ALTER TABLE public.stock_movements ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS stock_movements_read ON public.stock_movements;
+CREATE POLICY stock_movements_read ON public.stock_movements FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+DROP POLICY IF EXISTS stock_movements_write ON public.stock_movements;
+CREATE POLICY stock_movements_write ON public.stock_movements FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+);


### PR DESCRIPTION
## What

Second **field-services plugin** — **Inventory & stock**, extending Products.

- **Migration `20260710160000`** (applied + recorded): products stock columns (`track_stock`, `stock_qty`, `reorder_point`, `unit_cost`) + **`stock_movements`** ledger + RLS. `InventoryProduct` type extends `Product` (base `Product` untouched, so nothing else breaks).
- **Registry**: `inventory` plugin (default **OFF**, depends on `products`, route `/inventory`); sidebar item (Catalog) + store card. Trades preset includes it.
- **Actions**: `listInventory` · `createStockItem` · `setStockTracking` · `adjustStock` (writes a movement + updates on-hand) · `listStockMovements`.
- **UI `/inventory`**: KPI strip (items · **low-stock** · stock value), add-item dialog, table with low-stock badge, **+/- adjust** dialog (received / used-on-job / count / adjustment).
- **MCP** (`products:read` / `products:write`): `list_inventory`, `create_stock_item`, `set_stock_tracking`, `adjust_stock`.

## Data safety

Default-off + route-gated; product stock columns are additive with defaults. Existing businesses unaffected.

## Next

Timesheets & payroll → Assets & equipment.

Verified: tsc · 17 tests · build (`/inventory`) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)