### PR TITLE
feat(plugin): Timesheets & payroll (field-services)

### DIFF
--- a/src/app/(dashboard)/timesheets/page.tsx
+++ b/src/app/(dashboard)/timesheets/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getTimesheet } from "@/lib/actions/timesheets";
+import { TimesheetsView } from "@/components/timesheets/timesheets-view";
+
+export const dynamic = "force-dynamic";
+
+function mondayOf(dateISO: string): string {
+  const d = new Date(dateISO + "T00:00:00Z");
+  const day = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - day);
+  return d.toISOString().split("T")[0];
+}
+function addDays(dateISO: string, n: number): string {
+  const d = new Date(dateISO + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().split("T")[0];
+}
+
+export default async function TimesheetsPage({ searchParams }: { searchParams: Promise<{ week?: string }> }) {
+  const { week } = await searchParams;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const weekStart = mondayOf(week && /^\d{4}-\d{2}-\d{2}$/.test(week) ? week : new Date().toISOString().split("T")[0]);
+  const data = await getTimesheet(weekStart);
+
+  return <TimesheetsView data={data} prevWeek={addDays(weekStart, -7)} nextWeek={addDays(weekStart, 7)} />;
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -9,7 +9,7 @@ import {
   Settings, Trash2, Plus, Lock,
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
-  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes,
+  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -76,6 +76,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   sparkles: Sparkles,
   receipt: Receipt,
   boxes: Boxes,
+  clock: Clock,
 };
 
 // Module plugins shown in the Modules section. The two verticals that already

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -60,6 +60,7 @@ const navSections: NavSection[] = [
   ]},
   { section: "Workforce", items: [
     { label: "Team",       href: "/team",       icon: Users2                        },
+    { label: "Timesheets", href: "/timesheets", icon: Clock,        plugin: "timesheets" },
     { label: "Plugins",    href: "/agents",     icon: Bot                           },
   ]},
   { section: "SEO", items: [

--- a/src/components/timesheets/timesheets-view.tsx
+++ b/src/components/timesheets/timesheets-view.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ChevronLeft, ChevronRight, Download } from "@/components/ui/icons";
+import { PageHeader } from "@/components/layout/page-header";
+import { setMemberRate } from "@/lib/actions/timesheets";
+
+interface TimesheetRow {
+  user_id: string; member_id: string | null; name: string; hourly_rate: number | null;
+  days: number[]; hours: number; pay: number;
+}
+interface Data { week_start: string; week_end: string; rows: TimesheetRow[]; total_hours: number; total_pay: number }
+interface Props { data: Data; prevWeek: string; nextWeek: string }
+
+const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const money = (n: number) => `$${n.toFixed(2)}`;
+const fmt = (d: string) => new Date(d + "T00:00:00Z").toLocaleDateString("en-AU", { day: "2-digit", month: "short", timeZone: "UTC" });
+
+export function TimesheetsView({ data, prevWeek, nextWeek }: Props) {
+  const router = useRouter();
+  const [rates, setRates] = useState<Record<string, string>>(
+    Object.fromEntries(data.rows.filter((r) => r.member_id).map((r) => [r.member_id as string, r.hourly_rate != null ? String(r.hourly_rate) : ""])),
+  );
+
+  function saveRate(memberId: string) {
+    const v = rates[memberId];
+    setMemberRate(memberId, v === "" ? null : Number(v))
+      .then(() => { toast.success("Rate saved"); router.refresh(); })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Couldn't save"));
+  }
+
+  function exportCsv() {
+    const header = ["Worker", ...DAYS, "Total hours", "Rate", "Pay"];
+    const lines = data.rows.map((r) => [r.name, ...r.days.map((h) => h.toFixed(2)), r.hours.toFixed(2), r.hourly_rate ?? "", r.pay.toFixed(2)]);
+    const csv = [header, ...lines, ["Total", "", "", "", "", "", "", "", data.total_hours.toFixed(2), "", data.total_pay.toFixed(2)]]
+      .map((row) => row.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(",")).join("\n");
+    const url = URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
+    const a = document.createElement("a"); a.href = url; a.download = `timesheet-${data.week_start}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Timesheets"
+        subtitle="Hours per worker from job time — pay + CSV export"
+        actions={
+          data.rows.length > 0 && (
+            <button onClick={exportCsv} className="inline-flex items-center gap-1.5 text-sm rounded-md border border-border px-3 py-1.5 hover:bg-muted">
+              <Download className="w-4 h-4" /> Export CSV
+            </button>
+          )
+        }
+      />
+
+      {/* Week nav */}
+      <div className="flex items-center justify-between gap-3 mb-6">
+        <Link href={`/timesheets?week=${prevWeek}`} className="inline-flex items-center gap-1 text-sm rounded-md border border-border px-3 py-1.5 hover:bg-muted"><ChevronLeft className="w-4 h-4" /> Prev</Link>
+        <div className="text-sm font-semibold">{fmt(data.week_start)} – {fmt(data.week_end)}</div>
+        <Link href={`/timesheets?week=${nextWeek}`} className="inline-flex items-center gap-1 text-sm rounded-md border border-border px-3 py-1.5 hover:bg-muted">Next <ChevronRight className="w-4 h-4" /></Link>
+      </div>
+
+      {data.rows.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <p className="font-semibold">No time logged this week</p>
+          <p className="text-sm text-muted-foreground mt-1">Hours logged on jobs (work + travel) roll up here per worker. Set an hourly rate to calculate pay.</p>
+        </div>
+      ) : (
+        <div className="ch-table-wrap">
+          <table className="ch-table w-full">
+            <thead><tr>
+              <th>Worker</th>{DAYS.map((d) => <th key={d} className="num">{d}</th>)}<th className="num">Hours</th><th className="num">Rate</th><th className="num">Pay</th>
+            </tr></thead>
+            <tbody>
+              {data.rows.map((r) => (
+                <tr key={r.user_id}>
+                  <td className="break-words font-medium">{r.name}</td>
+                  {r.days.map((h, i) => <td key={i} className="num">{h ? h.toFixed(1) : "—"}</td>)}
+                  <td className="num font-semibold">{r.hours.toFixed(2)}</td>
+                  <td className="num">
+                    {r.member_id ? (
+                      <input type="number" step="0.01" value={rates[r.member_id] ?? ""} onChange={(e) => setRates((p) => ({ ...p, [r.member_id as string]: e.target.value }))} onBlur={() => saveRate(r.member_id as string)} className="w-16 h-7 text-right rounded border border-input bg-background px-1 text-xs" placeholder="—" />
+                    ) : (r.hourly_rate ?? "—")}
+                  </td>
+                  <td className="num">{r.hourly_rate != null ? money(r.pay) : "—"}</td>
+                </tr>
+              ))}
+              <tr className="font-semibold border-t-2 border-border">
+                <td>Total</td><td colSpan={7}></td><td className="num">{data.total_hours.toFixed(2)}</td><td></td><td className="num">{money(data.total_pay)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/actions/timesheets.ts
+++ b/src/lib/actions/timesheets.ts
@@ -1,0 +1,98 @@
+"use server";
+
+/**
+ * Timesheets & payroll (field-services plugin). Rolls up job_time_entries per
+ * worker for a week (work + travel = paid; break excluded), joins the member's
+ * hourly_rate for pay. Scopes: timesheets:read / timesheets:write.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+const num = (v: unknown) => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
+
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, businessId };
+}
+
+/** Monday 00:00 of the week containing `d` (ISO date). */
+export async function weekStartOf(dateISO: string): Promise<string> {
+  const d = new Date(dateISO + "T00:00:00Z");
+  const day = (d.getUTCDay() + 6) % 7; // 0 = Monday
+  d.setUTCDate(d.getUTCDate() - day);
+  return d.toISOString().split("T")[0];
+}
+
+interface TimesheetRow {
+  user_id: string; member_id: string | null; name: string; hourly_rate: number | null;
+  days: number[]; hours: number; pay: number;
+}
+
+export async function getTimesheet(weekStartISO: string): Promise<{
+  week_start: string; week_end: string; rows: TimesheetRow[]; total_hours: number; total_pay: number;
+}> {
+  const { supabase, businessId } = await ctx();
+  const start = new Date(weekStartISO + "T00:00:00Z");
+  const end = new Date(start.getTime() + 7 * 86400000);
+
+  const [entriesRes, membersRes] = await Promise.all([
+    tbl(supabase, "job_time_entries").select("user_id, started_at, duration_seconds, type")
+      .eq("business_id", businessId).gte("started_at", start.toISOString()).lt("started_at", end.toISOString()),
+    tbl(supabase, "member_profiles").select("id, user_id, name, email, hourly_rate").eq("business_id", businessId),
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const members = new Map<string, any>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const m of (membersRes.data ?? []) as any[]) if (m.user_id) members.set(m.user_id, m);
+
+  const byUser = new Map<string, TimesheetRow>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const e of (entriesRes.data ?? []) as any[]) {
+    if (e.type === "break") continue;
+    const uidKey = e.user_id ?? "unknown";
+    if (!byUser.has(uidKey)) {
+      const m = members.get(uidKey);
+      byUser.set(uidKey, {
+        user_id: uidKey, member_id: m?.id ?? null,
+        name: m?.name || m?.email || "Team member", hourly_rate: m?.hourly_rate != null ? num(m.hourly_rate) : null,
+        days: [0, 0, 0, 0, 0, 0, 0], hours: 0, pay: 0,
+      });
+    }
+    const row = byUser.get(uidKey)!;
+    const hrs = num(e.duration_seconds) / 3600;
+    const dayIdx = (new Date(e.started_at).getUTCDay() + 6) % 7;
+    row.days[dayIdx] += hrs;
+    row.hours += hrs;
+  }
+
+  const rows = [...byUser.values()].map((r) => ({
+    ...r,
+    hours: Math.round(r.hours * 100) / 100,
+    days: r.days.map((h) => Math.round(h * 100) / 100),
+    pay: r.hourly_rate != null ? Math.round(r.hours * r.hourly_rate * 100) / 100 : 0,
+  })).sort((a, b) => b.hours - a.hours);
+
+  return {
+    week_start: weekStartISO,
+    week_end: new Date(end.getTime() - 86400000).toISOString().split("T")[0],
+    rows,
+    total_hours: Math.round(rows.reduce((s, r) => s + r.hours, 0) * 100) / 100,
+    total_pay: Math.round(rows.reduce((s, r) => s + r.pay, 0) * 100) / 100,
+  };
+}
+
+export async function setMemberRate(memberId: string, hourlyRate: number | null): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const { error } = await tbl(supabase, "member_profiles")
+    .update({ hourly_rate: hourlyRate == null || Number.isNaN(Number(hourlyRate)) ? null : Number(hourlyRate) })
+    .eq("id", memberId).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/timesheets");
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -34,6 +34,7 @@ import { registerPluginFormTools } from "./tools/plugin-form-tools";
 import { registerSeoTools } from "./tools/seo-tools";
 import { registerExpenseTools } from "./tools/expenses-tools";
 import { registerInventoryTools } from "./tools/inventory-tools";
+import { registerTimesheetTools } from "./tools/timesheets-tools";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -1404,6 +1405,9 @@ export function registerTools(server: McpServer): void {
 
   // ===== INVENTORY & STOCK =====
   registerInventoryTools(tool);
+
+  // ===== TIMESHEETS & PAYROLL =====
+  registerTimesheetTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/timesheets-tools.ts
+++ b/src/lib/mcp/tools/timesheets-tools.ts
@@ -1,0 +1,54 @@
+/**
+ * MCP tools for the Timesheets & payroll plugin. Scopes: timesheets:read /
+ * timesheets:write.
+ */
+import { z } from "zod";
+import { assertScope, t, text } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+function mondayOf(dateISO: string): string {
+  const d = new Date(dateISO + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return d.toISOString().split("T")[0];
+}
+
+export function registerTimesheetTools(tool: ToolFn): void {
+  tool("get_timesheet", "Weekly hours per worker (work + travel, break excluded) with pay. week = any date in the week (defaults to this week).",
+    { week: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "timesheets:read");
+      const weekStart = mondayOf(args.week && /^\d{4}-\d{2}-\d{2}$/.test(args.week) ? args.week : new Date().toISOString().split("T")[0]);
+      const start = new Date(weekStart + "T00:00:00Z");
+      const end = new Date(start.getTime() + 7 * 86400000);
+
+      const [entriesRes, membersRes] = await Promise.all([
+        t(ctx, "job_time_entries").select("user_id, duration_seconds, type").eq("business_id", ctx.businessId)
+          .gte("started_at", start.toISOString()).lt("started_at", end.toISOString()),
+        t(ctx, "member_profiles").select("user_id, name, email, hourly_rate").eq("business_id", ctx.businessId),
+      ]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const members = new Map<string, any>();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for (const m of (membersRes.data ?? []) as any[]) if (m.user_id) members.set(m.user_id, m);
+      const byUser = new Map<string, { name: string; hours: number; rate: number | null }>();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for (const e of (entriesRes.data ?? []) as any[]) {
+        if (e.type === "break") continue;
+        const k = e.user_id ?? "unknown";
+        const m = members.get(k);
+        if (!byUser.has(k)) byUser.set(k, { name: m?.name || m?.email || "Team member", hours: 0, rate: m?.hourly_rate != null ? Number(m.hourly_rate) : null });
+        byUser.get(k)!.hours += Number(e.duration_seconds || 0) / 3600;
+      }
+      const rows = [...byUser.values()].map((r) => ({ name: r.name, hours: Math.round(r.hours * 100) / 100, hourly_rate: r.rate, pay: r.rate != null ? Math.round(r.hours * r.rate * 100) / 100 : 0 }));
+      return text({ week_start: weekStart, rows, total_hours: Math.round(rows.reduce((s, r) => s + r.hours, 0) * 100) / 100, total_pay: Math.round(rows.reduce((s, r) => s + r.pay, 0) * 100) / 100 });
+    });
+
+  tool("set_member_rate", "Set a team member's hourly pay rate (member_id from list_team).",
+    { member_id: UUID, hourly_rate: z.number().nullable() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "timesheets:write");
+      const { error } = await t(ctx, "member_profiles").update({ hourly_rate: args.hourly_rate }).eq("id", args.member_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -64,6 +64,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "jobs", icon: "wrench",       name: "Work Orders",   description: "Jobs with photos, time, materials and timelines.", kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/work-orders"] },
   { id: "scheduling", icon: "calendar-days", name: "Schedule",      description: "Calendar and dispatch board for the crew.", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/schedule"] },
   { id: "recurring-jobs", icon: "repeat", name: "Recurring jobs", description: "Repeating jobs that generate work orders (and optionally invoices).", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/recurring"] },
+  { id: "timesheets", icon: "clock", name: "Timesheets", description: "Weekly hours per worker from job time, with pay + CSV export.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/timesheets"] },
   { id: "booking", icon: "calendar-days",    name: "Online booking", description: "Public booking pages with reminders.",   kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/bookings"] },
 
   { id: "expenses", icon: "receipt", name: "Expenses", description: "Track job & business costs with receipts — true profit per job.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/expenses"] },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1270,6 +1270,8 @@ export type ApiScope =
   | 'seo:write'
   | 'expenses:read'
   | 'expenses:write'
+  | 'timesheets:read'
+  | 'timesheets:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1304,6 +1306,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'seo:write',        label: 'Manage SEO sites & content', group: 'SEO' },
   { value: 'expenses:read',    label: 'Read expenses', group: 'Expenses' },
   { value: 'expenses:write',   label: 'Create / edit expenses', group: 'Expenses' },
+  { value: 'timesheets:read',  label: 'Read timesheets', group: 'Timesheets' },
+  { value: 'timesheets:write', label: 'Set pay rates', group: 'Timesheets' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260710180000_timesheets.sql
+++ b/supabase/migrations/20260710180000_timesheets.sql
@@ -1,0 +1,3 @@
+-- Timesheets & payroll plugin (field-services). Rolls up job_time_entries per
+-- worker per week; hourly_rate on the member profile drives pay. Additive.
+ALTER TABLE public.member_profiles ADD COLUMN IF NOT EXISTS hourly_rate NUMERIC;


### PR DESCRIPTION
## What

Third **field-services plugin** — **Timesheets & payroll**. Rolls up job time into weekly timesheets with pay + CSV export.

- **Migration `20260710180000`** (applied + recorded): `member_profiles.hourly_rate`.
- **Registry**: `timesheets` plugin (default **OFF**, route `/timesheets`); sidebar item (Workforce) + store card. Trades preset. Scopes `timesheets:*`.
- **Actions**: `getTimesheet(weekStart)` rolls up `job_time_entries` per worker (work + travel = paid, break excluded) with a per-day breakdown + pay; `setMemberRate`.
- **UI `/timesheets`**: week nav (`?week=`), worker × per-day hours × total × **editable rate** × pay with totals, **Export CSV** (client-side).
- **MCP**: `get_timesheet`, `set_member_rate`.

## Data safety

Additive column only; reads existing job time. Default-off + route-gated.

## Next

Assets & equipment (last of the core field-services set).

Verified: tsc · 17 tests · build (`/timesheets`) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)