### PR TITLE
feat(plugin): Assets & equipment (field-services)

### DIFF
--- a/src/app/(dashboard)/assets/page.tsx
+++ b/src/app/(dashboard)/assets/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { listAssets } from "@/lib/actions/assets";
+import { AssetsView } from "@/components/assets/assets-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function AssetsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const businessId = await getActiveBizId(supabase as any, user.id);
+
+  const [assets, membersRes] = await Promise.all([
+    listAssets(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase as any).from("member_profiles").select("id, name").eq("business_id", businessId).eq("is_active", true).order("name"),
+  ]);
+
+  return <AssetsView assets={assets} members={(membersRes.data ?? []) as { id: string; name: string }[]} />;
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -9,7 +9,7 @@ import {
   Settings, Trash2, Plus, Lock,
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
-  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock,
+  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock, Hammer,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -77,6 +77,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   receipt: Receipt,
   boxes: Boxes,
   clock: Clock,
+  hammer: Hammer,
 };
 
 // Module plugins shown in the Modules section. The two verticals that already

--- a/src/components/assets/assets-view.tsx
+++ b/src/components/assets/assets-view.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Hammer, Plus, Trash2, Wrench } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/layout/page-header";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { createAsset, updateAsset, deleteAsset, logAssetService } from "@/lib/actions/assets";
+import type { Asset, AssetCategory, AssetStatus } from "@/types/database";
+
+interface Member { id: string; name: string }
+interface Props { assets: Asset[]; members: Member[] }
+
+const CATEGORIES: AssetCategory[] = ["tool", "vehicle", "equipment", "other"];
+const STATUS_TONE: Record<string, string> = { active: "bg-emerald-100 text-emerald-700", in_repair: "bg-amber-100 text-amber-700", retired: "bg-muted text-muted-foreground" };
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+const todayISO = () => new Date().toISOString().split("T")[0];
+
+export function AssetsView({ assets, members }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [addOpen, setAddOpen] = useState(false);
+  const [serviceFor, setServiceFor] = useState<Asset | null>(null);
+
+  // add form
+  const [name, setName] = useState(""); const [category, setCategory] = useState<AssetCategory>("tool");
+  const [identifier, setIdentifier] = useState(""); const [assignedTo, setAssignedTo] = useState("");
+  const [nextService, setNextService] = useState(""); const [cost, setCost] = useState("");
+  // service form
+  const [svcDate, setSvcDate] = useState(todayISO()); const [svcDesc, setSvcDesc] = useState(""); const [svcCost, setSvcCost] = useState(""); const [svcNext, setSvcNext] = useState("");
+
+  const memberName = (id: string | null) => id ? (members.find((m) => m.id === id)?.name ?? null) : null;
+  const soon = (d: string | null) => d != null && d <= new Date(Date.now() + 14 * 86400000).toISOString().split("T")[0];
+  const dueCount = assets.filter((a) => a.status !== "retired" && soon(a.next_service_on)).length;
+  const inRepair = assets.filter((a) => a.status === "in_repair").length;
+
+  function handleAdd() {
+    if (!name.trim()) { toast.error("Enter a name"); return; }
+    startTransition(async () => {
+      try {
+        await createAsset({ name, category, identifier, assigned_to: assignedTo || null, next_service_on: nextService || null, purchase_cost: cost || null });
+        toast.success("Asset added");
+        setAddOpen(false); setName(""); setCategory("tool"); setIdentifier(""); setAssignedTo(""); setNextService(""); setCost("");
+        router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't add"); }
+    });
+  }
+  function handleStatus(a: Asset, status: AssetStatus) {
+    startTransition(async () => { try { await updateAsset(a.id, { status }); router.refresh(); } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update"); } });
+  }
+  function handleDelete(id: string) {
+    startTransition(async () => { try { await deleteAsset(id); toast.success("Deleted"); router.refresh(); } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't delete"); } });
+  }
+  function handleLogService() {
+    if (!serviceFor) return;
+    startTransition(async () => {
+      try {
+        await logAssetService({ asset_id: serviceFor.id, serviced_on: svcDate, description: svcDesc, cost: svcCost || null, next_due: svcNext || null });
+        toast.success("Service logged");
+        setServiceFor(null); setSvcDate(todayISO()); setSvcDesc(""); setSvcCost(""); setSvcNext("");
+        router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't log"); }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader title="Assets & equipment" subtitle="Tools, vehicles and equipment — assignment and service schedules"
+        actions={<Button onClick={() => setAddOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add asset</Button>} />
+
+      <div className="grid grid-cols-3 gap-3 mb-6">
+        <Stat label="Assets" value={String(assets.length)} />
+        <Stat label="In repair" value={String(inRepair)} tone={inRepair ? "warn" : undefined} />
+        <Stat label="Service due soon" value={String(dueCount)} tone={dueCount ? "warn" : undefined} />
+      </div>
+
+      {assets.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Hammer className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No assets yet</p>
+          <p className="text-sm text-muted-foreground mt-1">Add your tools, vehicles and equipment to track assignment and servicing.</p>
+          <Button className="mt-4" onClick={() => setAddOpen(true)}><Plus className="w-4 h-4 mr-1.5" /> Add asset</Button>
+        </div>
+      ) : (
+        <div className="ch-table-wrap">
+          <table className="ch-table w-full">
+            <thead><tr><th>Asset</th><th>Category</th><th>Assigned</th><th>Next service</th><th>Status</th><th></th><th></th></tr></thead>
+            <tbody>
+              {assets.map((a) => (
+                <tr key={a.id}>
+                  <td className="break-words font-medium">{a.name}{a.identifier && <span className="text-muted-foreground text-xs"> · {a.identifier}</span>}</td>
+                  <td className="capitalize">{a.category}</td>
+                  <td>{memberName(a.assigned_to) ?? "—"}</td>
+                  <td>{a.next_service_on ? <span className={cn(soon(a.next_service_on) && a.status !== "retired" && "text-amber-600 font-medium")}>{new Date(a.next_service_on).toLocaleDateString("en-AU")}</span> : "—"}</td>
+                  <td>
+                    <select value={a.status} onChange={(e) => handleStatus(a, e.target.value as AssetStatus)} className={cn("text-[11px] rounded-full px-2 py-0.5 border-0 outline-none", STATUS_TONE[a.status])}>
+                      <option value="active">active</option><option value="in_repair">in repair</option><option value="retired">retired</option>
+                    </select>
+                  </td>
+                  <td><button onClick={() => setServiceFor(a)} className="text-muted-foreground hover:text-foreground" title="Log service"><Wrench className="w-4 h-4" /></button></td>
+                  <td><button onClick={() => handleDelete(a.id)} disabled={isPending} className="text-muted-foreground hover:text-destructive" aria-label="Delete"><Trash2 className="w-4 h-4" /></button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Add */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add asset</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5"><Label htmlFor="as-name">Name</Label><Input id="as-name" value={name} onChange={(e) => setName(e.target.value)} /></div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="as-cat">Category</Label>
+                <select id="as-cat" className={selectCls} value={category} onChange={(e) => setCategory(e.target.value as AssetCategory)}>{CATEGORIES.map((c) => <option key={c} value={c} className="capitalize">{c}</option>)}</select>
+              </div>
+              <div className="space-y-1.5"><Label htmlFor="as-id">Serial / rego</Label><Input id="as-id" value={identifier} onChange={(e) => setIdentifier(e.target.value)} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="as-assign">Assigned to</Label>
+                <select id="as-assign" className={selectCls} value={assignedTo} onChange={(e) => setAssignedTo(e.target.value)}>
+                  <option value="">— Unassigned —</option>{members.map((m) => <option key={m.id} value={m.id}>{m.name}</option>)}
+                </select>
+              </div>
+              <div className="space-y-1.5"><Label htmlFor="as-next">Next service</Label><Input id="as-next" type="date" value={nextService} onChange={(e) => setNextService(e.target.value)} /></div>
+            </div>
+            <div className="space-y-1.5"><Label htmlFor="as-cost">Purchase cost</Label><Input id="as-cost" type="number" step="0.01" value={cost} onChange={(e) => setCost(e.target.value)} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setAddOpen(false)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleAdd} disabled={isPending}>Add asset</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Log service */}
+      <Dialog open={!!serviceFor} onOpenChange={(o) => !o && setServiceFor(null)}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Log service — {serviceFor?.name}</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="sv-date">Serviced on</Label><Input id="sv-date" type="date" value={svcDate} onChange={(e) => setSvcDate(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="sv-next">Next due</Label><Input id="sv-next" type="date" value={svcNext} onChange={(e) => setSvcNext(e.target.value)} /></div>
+            </div>
+            <div className="space-y-1.5"><Label htmlFor="sv-cost">Cost</Label><Input id="sv-cost" type="number" step="0.01" value={svcCost} onChange={(e) => setSvcCost(e.target.value)} /></div>
+            <div className="space-y-1.5"><Label htmlFor="sv-desc">What was done</Label><Textarea id="sv-desc" rows={2} value={svcDesc} onChange={(e) => setSvcDesc(e.target.value)} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setServiceFor(null)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleLogService} disabled={isPending}>Log service</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "warn" }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className={cn("text-2xl font-bold mt-1", tone === "warn" && "text-amber-600")}>{value}</p>
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -48,6 +48,7 @@ const navSections: NavSection[] = [
     { label: "Schedule",       href: "/schedule",        icon: CalendarDays,  worker: true, plugin: "scheduling" },
     { label: "Bookings",       href: "/bookings",        icon: CalendarDays,  plugin: "booking" },
     { label: "Online Booking", href: "/settings/booking", icon: CalendarDays,  plugin: "booking" },
+    { label: "Assets",         href: "/assets",          icon: Hammer,        plugin: "assets" },
   ]},
   { section: "Contacts", items: [
     { label: "Customers",  href: "/customers",  icon: Users                         },

--- a/src/lib/actions/assets.ts
+++ b/src/lib/actions/assets.ts
@@ -1,0 +1,103 @@
+"use server";
+
+/**
+ * Assets & equipment (field-services plugin). Track tools/vehicles/equipment,
+ * assignment and service schedules. Scopes: assets:read / assets:write.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { Asset, AssetServiceLog, AssetCategory, AssetStatus } from "@/types/database";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uid = (v: string | null | undefined) => (v && UUID_RE.test(v.trim()) ? v.trim() : null);
+const num = (v: unknown) => { const n = Number(v); return Number.isFinite(n) ? n : null; };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, user, businessId };
+}
+
+export async function listAssets(): Promise<Asset[]> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "assets").select("*").eq("business_id", businessId).order("created_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as Asset[];
+}
+
+export async function createAsset(input: {
+  name: string; category?: AssetCategory; identifier?: string | null; assigned_to?: string | null;
+  purchase_date?: string | null; purchase_cost?: number | string | null; next_service_on?: string | null; notes?: string | null;
+}): Promise<Asset> {
+  const { supabase, businessId } = await ctx();
+  if (!input.name?.trim()) throw new Error("Name is required");
+  const { data, error } = await tbl(supabase, "assets").insert({
+    business_id: businessId, name: input.name.trim(), category: input.category ?? "tool",
+    identifier: input.identifier?.trim() || null, assigned_to: uid(input.assigned_to),
+    purchase_date: input.purchase_date?.trim() || null,
+    purchase_cost: input.purchase_cost != null && input.purchase_cost !== "" ? num(input.purchase_cost) : null,
+    next_service_on: input.next_service_on?.trim() || null, notes: input.notes?.trim() || null,
+  }).select().single();
+  if (error) throw error;
+  revalidatePath("/assets");
+  return data as Asset;
+}
+
+export async function updateAsset(id: string, patch: Partial<{
+  name: string; category: AssetCategory; identifier: string | null; status: AssetStatus; assigned_to: string | null;
+  purchase_date: string | null; purchase_cost: number | string | null; next_service_on: string | null; notes: string | null;
+}>): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const clean: Record<string, unknown> = {};
+  if (patch.name !== undefined) clean.name = patch.name?.trim();
+  if (patch.category !== undefined) clean.category = patch.category;
+  if (patch.identifier !== undefined) clean.identifier = patch.identifier?.trim() || null;
+  if (patch.status !== undefined) clean.status = patch.status;
+  if (patch.assigned_to !== undefined) clean.assigned_to = uid(patch.assigned_to);
+  if (patch.purchase_date !== undefined) clean.purchase_date = patch.purchase_date || null;
+  if (patch.purchase_cost !== undefined) clean.purchase_cost = patch.purchase_cost === null || patch.purchase_cost === "" ? null : num(patch.purchase_cost);
+  if (patch.next_service_on !== undefined) clean.next_service_on = patch.next_service_on || null;
+  if (patch.notes !== undefined) clean.notes = patch.notes?.trim() || null;
+  if (Object.keys(clean).length === 0) return;
+  const { error } = await tbl(supabase, "assets").update(clean).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/assets");
+}
+
+export async function deleteAsset(id: string): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const { error } = await tbl(supabase, "assets").delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/assets");
+}
+
+/** Log a service; advances the asset's next-service date to next_due. */
+export async function logAssetService(input: {
+  asset_id: string; serviced_on?: string; description?: string | null; cost?: number | string | null; next_due?: string | null;
+}): Promise<void> {
+  const { supabase, user, businessId } = await ctx();
+  const { error: lErr } = await tbl(supabase, "asset_service_logs").insert({
+    business_id: businessId, asset_id: input.asset_id,
+    serviced_on: input.serviced_on || new Date().toISOString().split("T")[0],
+    description: input.description?.trim() || null,
+    cost: input.cost != null && input.cost !== "" ? num(input.cost) : null,
+    next_due: input.next_due?.trim() || null, created_by: user.id,
+  });
+  if (lErr) throw lErr;
+  if (input.next_due) {
+    await tbl(supabase, "assets").update({ next_service_on: input.next_due }).eq("id", input.asset_id).eq("business_id", businessId);
+  }
+  revalidatePath("/assets");
+}
+
+export async function listAssetServiceLogs(assetId: string): Promise<AssetServiceLog[]> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "asset_service_logs").select("*")
+    .eq("business_id", businessId).eq("asset_id", assetId).order("serviced_on", { ascending: false }).limit(100);
+  return (data ?? []) as AssetServiceLog[];
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -35,6 +35,7 @@ import { registerSeoTools } from "./tools/seo-tools";
 import { registerExpenseTools } from "./tools/expenses-tools";
 import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
+import { registerAssetTools } from "./tools/assets-tools";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -1408,6 +1409,9 @@ export function registerTools(server: McpServer): void {
 
   // ===== TIMESHEETS & PAYROLL =====
   registerTimesheetTools(tool);
+
+  // ===== ASSETS & EQUIPMENT =====
+  registerAssetTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/assets-tools.ts
+++ b/src/lib/mcp/tools/assets-tools.ts
@@ -1,0 +1,76 @@
+/**
+ * MCP tools for the Assets & equipment plugin. Scopes: assets:read /
+ * assets:write.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+export function registerAssetTools(tool: ToolFn): void {
+  tool("list_assets", "List tools/vehicles/equipment (optionally only those due for service soon).",
+    { due_soon: z.boolean().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "assets:read");
+      const { data, error } = await t(ctx, "assets")
+        .select("id, name, category, identifier, status, assigned_to, next_service_on")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let rows = (data ?? []) as any[];
+      if (args.due_soon) {
+        const cutoff = new Date(Date.now() + 14 * 86400000).toISOString().split("T")[0];
+        rows = rows.filter((a) => a.status !== "retired" && a.next_service_on != null && a.next_service_on <= cutoff);
+      }
+      return text(rows);
+    });
+
+  tool("create_asset", "Add a tool/vehicle/equipment. category = tool | vehicle | equipment | other.",
+    { name: z.string().min(1), category: z.enum(["tool", "vehicle", "equipment", "other"]).optional(), identifier: z.string().optional(), assigned_to: UUID.optional(), purchase_date: z.string().optional(), purchase_cost: z.number().optional(), next_service_on: z.string().optional(), notes: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "assets:write");
+      const { data, error } = await t(ctx, "assets").insert({
+        business_id: ctx.businessId, name: args.name.trim(), category: args.category ?? "tool",
+        identifier: args.identifier?.trim() || null, assigned_to: args.assigned_to ?? null,
+        purchase_date: args.purchase_date || null, purchase_cost: args.purchase_cost ?? null,
+        next_service_on: args.next_service_on || null, notes: args.notes?.trim() || null,
+      }).select("id").single();
+      if (error) throw error;
+      return text({ created: true, asset_id: data.id });
+    });
+
+  tool("update_asset", "Update an asset (status / assignment / next service / details).",
+    { asset_id: UUID, name: z.string().optional(), category: z.enum(["tool", "vehicle", "equipment", "other"]).optional(), identifier: z.string().nullable().optional(), status: z.enum(["active", "in_repair", "retired"]).optional(), assigned_to: UUID.nullable().optional(), next_service_on: z.string().nullable().optional(), notes: z.string().nullable().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "assets:write");
+      const { asset_id, ...rest } = args;
+      const clean = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "assets").update(clean).eq("id", asset_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("delete_asset", "Delete an asset and its service history.",
+    { asset_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "assets:write");
+      const { error } = await t(ctx, "assets").delete().eq("id", args.asset_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("log_asset_service", "Log a service on an asset; next_due advances its next-service date.",
+    { asset_id: UUID, serviced_on: z.string().optional(), description: z.string().optional(), cost: z.number().optional(), next_due: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "assets:write");
+      const { error } = await t(ctx, "asset_service_logs").insert({
+        business_id: ctx.businessId, asset_id: args.asset_id,
+        serviced_on: args.serviced_on || new Date().toISOString().split("T")[0],
+        description: args.description?.trim() || null, cost: args.cost ?? null,
+        next_due: args.next_due || null, created_by: ctx.userId,
+      });
+      if (error) throw error;
+      if (args.next_due) await t(ctx, "assets").update({ next_service_on: args.next_due }).eq("id", args.asset_id).eq("business_id", ctx.businessId);
+      return text({ logged: true });
+    });
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -65,6 +65,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "scheduling", icon: "calendar-days", name: "Schedule",      description: "Calendar and dispatch board for the crew.", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/schedule"] },
   { id: "recurring-jobs", icon: "repeat", name: "Recurring jobs", description: "Repeating jobs that generate work orders (and optionally invoices).", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/recurring"] },
   { id: "timesheets", icon: "clock", name: "Timesheets", description: "Weekly hours per worker from job time, with pay + CSV export.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/timesheets"] },
+  { id: "assets", icon: "hammer", name: "Assets & equipment", description: "Track tools, vehicles and equipment with service schedules.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/assets"] },
   { id: "booking", icon: "calendar-days",    name: "Online booking", description: "Public booking pages with reminders.",   kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/bookings"] },
 
   { id: "expenses", icon: "receipt", name: "Expenses", description: "Track job & business costs with receipts — true profit per job.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/expenses"] },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -598,6 +598,36 @@ export interface Expense {
   updated_at: string;
 }
 
+// ── Assets & equipment (field-services plugin) ──────────────────────────────
+export type AssetCategory = 'tool' | 'vehicle' | 'equipment' | 'other';
+export type AssetStatus = 'active' | 'in_repair' | 'retired';
+export interface Asset {
+  id: string;
+  business_id: string;
+  name: string;
+  category: AssetCategory;
+  identifier: string | null;
+  status: AssetStatus;
+  assigned_to: string | null;
+  purchase_date: string | null;
+  purchase_cost: number | null;
+  next_service_on: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+export interface AssetServiceLog {
+  id: string;
+  business_id: string;
+  asset_id: string;
+  serviced_on: string;
+  description: string | null;
+  cost: number | null;
+  next_due: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
 // ── SEO Production (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────
 export type SeoPlatform = 'wordpress' | 'shopify' | 'other';
 export type SeoPlaybook = 'local' | 'ecommerce';
@@ -1272,6 +1302,8 @@ export type ApiScope =
   | 'expenses:write'
   | 'timesheets:read'
   | 'timesheets:write'
+  | 'assets:read'
+  | 'assets:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1308,6 +1340,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'expenses:write',   label: 'Create / edit expenses', group: 'Expenses' },
   { value: 'timesheets:read',  label: 'Read timesheets', group: 'Timesheets' },
   { value: 'timesheets:write', label: 'Set pay rates', group: 'Timesheets' },
+  { value: 'assets:read',      label: 'Read assets & equipment', group: 'Assets' },
+  { value: 'assets:write',     label: 'Manage assets & equipment', group: 'Assets' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260710200000_assets.sql
+++ b/supabase/migrations/20260710200000_assets.sql
@@ -1,0 +1,64 @@
+-- Assets & equipment plugin (field-services). Track tools/vehicles/equipment,
+-- assignment, and service schedules. Additive.
+CREATE TABLE IF NOT EXISTS public.assets (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name          TEXT NOT NULL,
+  category      TEXT NOT NULL DEFAULT 'tool' CHECK (category IN ('tool','vehicle','equipment','other')),
+  identifier    TEXT,                          -- serial / rego / asset tag
+  status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','in_repair','retired')),
+  assigned_to   UUID REFERENCES public.member_profiles(id) ON DELETE SET NULL,
+  purchase_date DATE,
+  purchase_cost NUMERIC,
+  next_service_on DATE,
+  notes         TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_assets_business ON public.assets (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_assets_service ON public.assets (business_id, next_service_on);
+
+CREATE TABLE IF NOT EXISTS public.asset_service_logs (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  asset_id    UUID NOT NULL REFERENCES public.assets(id) ON DELETE CASCADE,
+  serviced_on DATE NOT NULL DEFAULT CURRENT_DATE,
+  description TEXT,
+  cost        NUMERIC,
+  next_due    DATE,
+  created_by  UUID,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_asset_logs_asset ON public.asset_service_logs (asset_id, serviced_on DESC);
+
+DO $$
+DECLARE tb TEXT;
+BEGIN
+  FOREACH tb IN ARRAY ARRAY['assets','asset_service_logs'] LOOP
+    EXECUTE format('ALTER TABLE public.%1$s ENABLE ROW LEVEL SECURITY;', tb);
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, tb);
+  END LOOP;
+END $$;
+
+DROP TRIGGER IF EXISTS assets_updated_at ON public.assets;
+CREATE TRIGGER assets_updated_at BEFORE UPDATE ON public.assets FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
## What

Fourth **field-services plugin** — **Assets & equipment**. Completes the core set (Expenses · Inventory · Timesheets · Assets).

- **Migration `20260710200000`** (applied + recorded): `assets` + `asset_service_logs` tables + RLS + trigger.
- **Registry**: `assets` plugin (default **OFF**, route `/assets`); sidebar item (Service) + store card. Trades preset. Scopes `assets:*`.
- **Actions**: list / create / update / delete + `logAssetService` (advances the next-service date) + `listAssetServiceLogs`.
- **UI `/assets`**: KPI strip (assets · in-repair · **service due soon**), add dialog, table with assigned member, **next-service due badge**, inline status change, **log-service** dialog, delete.
- **MCP**: `list_assets` (with `due_soon`), `create/update/delete_asset`, `log_asset_service`.

## Data safety

Additive tables; default-off + route-gated. Existing businesses unaffected.

## The field-services set is now complete
Expenses & job costing · Inventory & stock · Timesheets & payroll · Assets & equipment.

Verified: tsc · 17 tests · build (`/assets`) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)