### PR TITLE
feat(plugin): Prospects — core (PR1)

### DIFF
--- a/src/app/(dashboard)/prospects/[id]/page.tsx
+++ b/src/app/(dashboard)/prospects/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getProspect } from "@/lib/actions/prospects";
+import { ProspectDetail } from "@/components/prospects/prospect-detail";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProspectDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const prospect = await getProspect(id);
+  if (!prospect) notFound();
+  return <ProspectDetail prospect={prospect} />;
+}

--- a/src/app/(dashboard)/prospects/page.tsx
+++ b/src/app/(dashboard)/prospects/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { listProspects } from "@/lib/actions/prospects";
+import { ProspectsView } from "@/components/prospects/prospects-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProspectsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const prospects = await listProspects();
+  return <ProspectsView prospects={prospects} />;
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -9,7 +9,7 @@ import {
   Settings, Trash2, Plus, Lock,
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
-  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock, Hammer,
+  Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock, Hammer, Target,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -78,6 +78,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   boxes: Boxes,
   clock: Clock,
   hammer: Hammer,
+  target: Target,
 };
 
 // Module plugins shown in the Modules section. The two verticals that already

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer,
+  Package, Settings, FileStack, X, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -51,6 +51,7 @@ const navSections: NavSection[] = [
     { label: "Assets",         href: "/assets",          icon: Hammer,        plugin: "assets" },
   ]},
   { section: "Contacts", items: [
+    { label: "Prospects",  href: "/prospects",  icon: Target,        plugin: "prospects" },
     { label: "Customers",  href: "/customers",  icon: Users                         },
     { label: "Contacts",   href: "/contacts",   icon: Users2                        },
     { label: "Onboarding", href: "/onboarding-forms", icon: ClipboardList, plugin: "client-onboarding" },

--- a/src/components/prospects/prospect-detail.tsx
+++ b/src/components/prospects/prospect-detail.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ArrowLeft, Trash2, UserPlus, Check } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/layout/page-header";
+import { cn } from "@/lib/utils";
+import { updateProspect, deleteProspect, convertProspectToLead } from "@/lib/actions/prospects";
+import type { Prospect, ProspectStatus } from "@/types/database";
+
+const STATUSES: ProspectStatus[] = ["new", "contacted", "responded", "qualified", "unqualified", "converted"];
+const TONE: Record<string, string> = {
+  new: "bg-muted text-muted-foreground", contacted: "bg-blue-100 text-blue-700", responded: "bg-violet-100 text-violet-700",
+  qualified: "bg-emerald-100 text-emerald-700", unqualified: "bg-red-100 text-red-700", converted: "bg-emerald-600 text-white",
+};
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function ProspectDetail({ prospect }: { prospect: Prospect }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [f, setF] = useState({
+    name: prospect.name ?? "", email: prospect.email ?? "", phone: prospect.phone ?? "", company: prospect.company ?? "",
+    title: prospect.title ?? "", website: prospect.website ?? "", source: prospect.source ?? "",
+    status: prospect.status, notes: prospect.notes ?? "",
+  });
+  const set = (k: keyof typeof f, v: string) => setF((p) => ({ ...p, [k]: v }));
+  const converted = prospect.status === "converted";
+  const customFields = Object.entries(prospect.custom_fields ?? {});
+
+  function save() {
+    startTransition(async () => {
+      try { await updateProspect(prospect.id, { ...f, status: f.status as ProspectStatus }); toast.success("Saved"); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't save"); }
+    });
+  }
+  function convert() {
+    startTransition(async () => {
+      try { const r = await convertProspectToLead(prospect.id); toast.success("Converted to lead"); if (r.lead_id) router.push(`/leads/${r.lead_id}`); else router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't convert"); }
+    });
+  }
+  function remove() {
+    startTransition(async () => {
+      try { await deleteProspect(prospect.id); toast.success("Deleted"); router.push("/prospects"); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't delete"); }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={prospect.name || prospect.email || "Prospect"}
+        subtitle={<span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 capitalize", TONE[prospect.status])}>{prospect.status}</span>}
+        actions={
+          <>
+            <Link href="/prospects" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground rounded-md border border-border px-3 py-1.5"><ArrowLeft className="w-4 h-4" /> Prospects</Link>
+            {!converted && <Button variant="outline" onClick={convert} disabled={isPending}><UserPlus className="w-4 h-4 mr-1.5" /> Convert to lead</Button>}
+            {converted && prospect.lead_id && <Link href={`/leads/${prospect.lead_id}`} className="inline-flex items-center gap-1.5 text-sm rounded-md border border-emerald-500/40 text-emerald-700 px-3 py-1.5"><Check className="w-4 h-4" /> View lead</Link>}
+          </>
+        }
+      />
+
+      <div className="max-w-2xl space-y-4">
+        <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Name" v={f.name} onChange={(v) => set("name", v)} />
+            <Field label="Company" v={f.company} onChange={(v) => set("company", v)} />
+            <Field label="Email" v={f.email} onChange={(v) => set("email", v)} type="email" />
+            <Field label="Phone" v={f.phone} onChange={(v) => set("phone", v)} />
+            <Field label="Title" v={f.title} onChange={(v) => set("title", v)} />
+            <Field label="Website" v={f.website} onChange={(v) => set("website", v)} />
+            <Field label="Source" v={f.source} onChange={(v) => set("source", v)} />
+            <div className="space-y-1.5">
+              <Label htmlFor="pd-status">Status</Label>
+              <select id="pd-status" className={selectCls} value={f.status} onChange={(e) => set("status", e.target.value)}>
+                {STATUSES.map((s) => <option key={s} value={s} className="capitalize">{s}</option>)}
+              </select>
+            </div>
+          </div>
+          <div className="space-y-1.5"><Label htmlFor="pd-notes">Notes</Label><Textarea id="pd-notes" rows={3} value={f.notes} onChange={(e) => set("notes", e.target.value)} /></div>
+          <div className="flex justify-between items-center pt-1">
+            <button onClick={remove} disabled={isPending} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-destructive"><Trash2 className="w-4 h-4" /> Delete</button>
+            <Button onClick={save} disabled={isPending}>Save</Button>
+          </div>
+        </div>
+
+        {customFields.length > 0 && (
+          <div className="rounded-xl border border-border bg-card p-5">
+            <p className="text-sm font-semibold mb-2">Imported fields</p>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+              {customFields.map(([k, v]) => (<div key={k} className="contents"><dt className="text-muted-foreground truncate">{k}</dt><dd className="break-words">{String(v)}</dd></div>))}
+            </dl>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function Field({ label, v, onChange, type }: { label: string; v: string; onChange: (v: string) => void; type?: string }) {
+  const id = `pd-${label.toLowerCase()}`;
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input id={id} type={type ?? "text"} value={v} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}

--- a/src/components/prospects/prospects-view.tsx
+++ b/src/components/prospects/prospects-view.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useTransition, useMemo } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Target, Plus, Search } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PageHeader } from "@/components/layout/page-header";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { createProspect } from "@/lib/actions/prospects";
+import type { Prospect, ProspectStatus } from "@/types/database";
+
+const STATUSES: ProspectStatus[] = ["new", "contacted", "responded", "qualified", "unqualified", "converted"];
+const TONE: Record<string, string> = {
+  new: "bg-muted text-muted-foreground", contacted: "bg-blue-100 text-blue-700", responded: "bg-violet-100 text-violet-700",
+  qualified: "bg-emerald-100 text-emerald-700", unqualified: "bg-red-100 text-red-700", converted: "bg-emerald-600 text-white",
+};
+const selectCls = "h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<ProspectStatus | "">("");
+
+  const [name, setName] = useState(""); const [email, setEmail] = useState(""); const [company, setCompany] = useState("");
+  const [phone, setPhone] = useState(""); const [source, setSource] = useState("");
+
+  const filtered = useMemo(() => {
+    const s = search.trim().toLowerCase();
+    return prospects.filter((p) => {
+      if (statusFilter && p.status !== statusFilter) return false;
+      if (s && !`${p.name ?? ""} ${p.email ?? ""} ${p.company ?? ""}`.toLowerCase().includes(s)) return false;
+      return true;
+    });
+  }, [prospects, search, statusFilter]);
+
+  function handleAdd() {
+    if (!name.trim() && !email.trim()) { toast.error("Enter a name or email"); return; }
+    startTransition(async () => {
+      try {
+        await createProspect({ name, email, company, phone, source });
+        toast.success("Prospect added");
+        setOpen(false); setName(""); setEmail(""); setCompany(""); setPhone(""); setSource("");
+        router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't add"); }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Prospects"
+        subtitle="Your cold-outreach list — import, reach out, and convert the good ones to leads"
+        actions={<Button onClick={() => setOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add prospect</Button>}
+      />
+
+      {/* Filters */}
+      <div className="flex items-center gap-2 mb-5 flex-wrap">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="w-4 h-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search name, email, company…" className="pl-8" />
+        </div>
+        <select className={selectCls} value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as ProspectStatus | "")}>
+          <option value="">All statuses</option>
+          {STATUSES.map((s) => <option key={s} value={s} className="capitalize">{s}</option>)}
+        </select>
+      </div>
+
+      {prospects.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+          <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Target className="w-6 h-6 text-muted-foreground" /></div>
+          <p className="font-semibold">No prospects yet</p>
+          <p className="text-sm text-muted-foreground mt-1">Add prospects manually, or import a list. Reach out, and convert the interested ones to leads.</p>
+          <Button className="mt-4" onClick={() => setOpen(true)}><Plus className="w-4 h-4 mr-1.5" /> Add prospect</Button>
+        </div>
+      ) : (
+        <div className="ch-table-wrap">
+          <table className="ch-table w-full">
+            <thead><tr><th>Name</th><th>Company</th><th>Email</th><th>Source</th><th>Status</th></tr></thead>
+            <tbody>
+              {filtered.map((p) => (
+                <tr key={p.id} className="cursor-pointer hover:bg-muted/40" onClick={() => router.push(`/prospects/${p.id}`)}>
+                  <td className="font-medium">{p.name || "—"}</td>
+                  <td>{p.company || "—"}</td>
+                  <td className="break-words">{p.email || "—"}</td>
+                  <td>{p.source || "—"}</td>
+                  <td><span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 capitalize", TONE[p.status])}>{p.status}</span></td>
+                </tr>
+              ))}
+              {filtered.length === 0 && <tr><td colSpan={5} className="text-center text-muted-foreground py-6">No prospects match.</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="text-[11px] text-muted-foreground mt-3">
+        <Link href="/prospects" className="underline">CSV import, bulk actions and outreach</Link> arrive with the next updates.
+      </p>
+
+      {/* Add dialog */}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add prospect</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="p-name">Name</Label><Input id="p-name" value={name} onChange={(e) => setName(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="p-company">Company</Label><Input id="p-company" value={company} onChange={(e) => setCompany(e.target.value)} /></div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5"><Label htmlFor="p-email">Email</Label><Input id="p-email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} /></div>
+              <div className="space-y-1.5"><Label htmlFor="p-phone">Phone</Label><Input id="p-phone" value={phone} onChange={(e) => setPhone(e.target.value)} /></div>
+            </div>
+            <div className="space-y-1.5"><Label htmlFor="p-source">Source</Label><Input id="p-source" placeholder="e.g. LinkedIn, referral, list" value={source} onChange={(e) => setSource(e.target.value)} /></div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)} disabled={isPending}>Cancel</Button>
+            <Button onClick={handleAdd} disabled={isPending}>Add prospect</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -29,6 +29,7 @@ export {
   Database,
   Globe,
   Plug,
+  Target,
   Eye,
   Lock,
   FileText,

--- a/src/lib/actions/prospects.ts
+++ b/src/lib/actions/prospects.ts
@@ -1,0 +1,141 @@
+"use server";
+
+/**
+ * Prospects plugin — a cold list that feeds Leads. Manual CRUD + array import
+ * (dedup by email) + convert-to-lead. Bulk actions, CSV import UI and outreach
+ * land in later PRs. Scopes: prospects:read / prospects:write.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { Prospect, ProspectStatus } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+const clean = (v: string | null | undefined) => (v?.trim() ? v.trim() : null);
+
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, user, businessId };
+}
+
+interface ProspectInput {
+  name?: string | null; email?: string | null; phone?: string | null; company?: string | null;
+  title?: string | null; website?: string | null; source?: string | null;
+  status?: ProspectStatus; tags?: string[]; notes?: string | null; custom_fields?: Record<string, unknown>;
+}
+
+export async function listProspects(filters?: { status?: ProspectStatus; search?: string; tag?: string; limit?: number }): Promise<Prospect[]> {
+  const { supabase, businessId } = await ctx();
+  let q = tbl(supabase, "prospects").select("*").eq("business_id", businessId)
+    .order("created_at", { ascending: false }).limit(filters?.limit ?? 500);
+  if (filters?.status) q = q.eq("status", filters.status);
+  if (filters?.tag) q = q.contains("tags", [filters.tag]);
+  if (filters?.search?.trim()) {
+    const s = `%${filters.search.trim()}%`;
+    q = q.or(`name.ilike.${s},email.ilike.${s},company.ilike.${s}`);
+  }
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data ?? []) as Prospect[];
+}
+
+export async function getProspect(id: string): Promise<Prospect | null> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "prospects").select("*").eq("id", id).eq("business_id", businessId).maybeSingle();
+  return (data as Prospect) ?? null;
+}
+
+export async function createProspect(input: ProspectInput): Promise<Prospect> {
+  const { supabase, user, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "prospects").insert({
+    business_id: businessId, user_id: user.id,
+    name: clean(input.name), email: clean(input.email)?.toLowerCase() ?? null, phone: clean(input.phone),
+    company: clean(input.company), title: clean(input.title), website: clean(input.website), source: clean(input.source) ?? "manual",
+    status: input.status ?? "new", tags: input.tags ?? [], notes: clean(input.notes), custom_fields: input.custom_fields ?? {},
+  }).select().single();
+  if (error) {
+    if (String(error.message ?? "").includes("idx_prospects_biz_email")) throw new Error("A prospect with that email already exists.");
+    throw error;
+  }
+  revalidatePath("/prospects");
+  return data as Prospect;
+}
+
+export async function updateProspect(id: string, patch: ProspectInput & { status?: ProspectStatus }): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const c: Record<string, unknown> = {};
+  if (patch.name !== undefined) c.name = clean(patch.name);
+  if (patch.email !== undefined) c.email = clean(patch.email)?.toLowerCase() ?? null;
+  if (patch.phone !== undefined) c.phone = clean(patch.phone);
+  if (patch.company !== undefined) c.company = clean(patch.company);
+  if (patch.title !== undefined) c.title = clean(patch.title);
+  if (patch.website !== undefined) c.website = clean(patch.website);
+  if (patch.source !== undefined) c.source = clean(patch.source);
+  if (patch.status !== undefined) c.status = patch.status;
+  if (patch.tags !== undefined) c.tags = patch.tags;
+  if (patch.notes !== undefined) c.notes = clean(patch.notes);
+  if (patch.custom_fields !== undefined) c.custom_fields = patch.custom_fields;
+  if (Object.keys(c).length === 0) return;
+  const { error } = await tbl(supabase, "prospects").update(c).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/prospects");
+  revalidatePath(`/prospects/${id}`);
+}
+
+export async function deleteProspect(id: string): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const { error } = await tbl(supabase, "prospects").delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/prospects");
+}
+
+/** Import an array of prospects, deduped by email (existing emails skipped). */
+export async function importProspects(rows: ProspectInput[]): Promise<{ imported: number; skipped: number }> {
+  const { supabase, user, businessId } = await ctx();
+  const { data: existing } = await tbl(supabase, "prospects").select("email").eq("business_id", businessId).not("email", "is", null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const seen = new Set(((existing ?? []) as any[]).map((r) => String(r.email).toLowerCase()));
+  const toInsert: Record<string, unknown>[] = [];
+  let skipped = 0;
+  for (const r of rows) {
+    const email = clean(r.email)?.toLowerCase() ?? null;
+    if (email && seen.has(email)) { skipped++; continue; }
+    if (email) seen.add(email);
+    toInsert.push({
+      business_id: businessId, user_id: user.id, name: clean(r.name), email, phone: clean(r.phone),
+      company: clean(r.company), title: clean(r.title), website: clean(r.website), source: clean(r.source) ?? "import",
+      status: r.status ?? "new", tags: r.tags ?? [], notes: clean(r.notes), custom_fields: r.custom_fields ?? {},
+    });
+  }
+  if (toInsert.length) {
+    const { error } = await tbl(supabase, "prospects").insert(toInsert);
+    if (error) throw error;
+  }
+  revalidatePath("/prospects");
+  return { imported: toInsert.length, skipped };
+}
+
+/** Convert a prospect into a Lead (dedup via upsert_lead) + mark converted. */
+export async function convertProspectToLead(id: string): Promise<{ lead_id: string | null }> {
+  const { supabase, businessId } = await ctx();
+  const { data: p } = await tbl(supabase, "prospects").select("*").eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (!p) throw new Error("Prospect not found");
+  const { data: business } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).maybeSingle();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: lead, error } = await (supabase as any).rpc("upsert_lead", {
+    p_business_id: businessId, p_user_id: business?.user_id, p_name: p.name || p.email || "Prospect",
+    p_email: p.email, p_phone: p.phone, p_address: null, p_suburb: null, p_service: null,
+    p_property_type: null, p_timing: null,
+    p_notes: `Converted from prospect${p.company ? ` (${p.company})` : ""}`, p_source: "prospect", p_source_ref: id,
+  }).single();
+  if (error) throw error;
+  await tbl(supabase, "prospects").update({ status: "converted", lead_id: lead?.id ?? null }).eq("id", id).eq("business_id", businessId);
+  revalidatePath("/prospects");
+  revalidatePath(`/prospects/${id}`);
+  return { lead_id: lead?.id ?? null };
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -36,6 +36,7 @@ import { registerExpenseTools } from "./tools/expenses-tools";
 import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
+import { registerProspectTools } from "./tools/prospects-tools";
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -1412,6 +1413,9 @@ export function registerTools(server: McpServer): void {
 
   // ===== ASSETS & EQUIPMENT =====
   registerAssetTools(tool);
+
+  // ===== PROSPECTS =====
+  registerProspectTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/prospects-tools.ts
+++ b/src/lib/mcp/tools/prospects-tools.ts
@@ -1,0 +1,114 @@
+/**
+ * MCP tools for the Prospects plugin. Scopes: prospects:read / prospects:write
+ * (convert also needs leads:write). Bulk + outreach tools land with those PRs.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+const STATUS = z.enum(["new", "contacted", "responded", "qualified", "unqualified", "converted"]);
+const PFIELDS = {
+  name: z.string().optional(), email: z.string().optional(), phone: z.string().optional(),
+  company: z.string().optional(), title: z.string().optional(), website: z.string().optional(),
+  source: z.string().optional(), status: STATUS.optional(), tags: z.array(z.string()).optional(), notes: z.string().optional(),
+};
+const clean = (v?: string) => (v?.trim() ? v.trim() : null);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function row(businessId: string, userId: string, p: any) {
+  return {
+    business_id: businessId, user_id: userId, name: clean(p.name), email: clean(p.email)?.toLowerCase() ?? null,
+    phone: clean(p.phone), company: clean(p.company), title: clean(p.title), website: clean(p.website),
+    source: clean(p.source) ?? "import", status: p.status ?? "new", tags: p.tags ?? [], notes: clean(p.notes), custom_fields: p.custom_fields ?? {},
+  };
+}
+
+export function registerProspectTools(tool: ToolFn): void {
+  tool("list_prospects", "List prospects (cold outreach list). Filter by status / tag / free-text search.",
+    { status: STATUS.optional(), search: z.string().optional(), tag: z.string().optional(), limit: z.number().int().min(1).max(500).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");
+      let q = t(ctx, "prospects").select("id, name, email, company, phone, source, status, tags, last_contacted_at, lead_id, created_at")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false }).limit(args.limit ?? 200);
+      if (args.status) q = q.eq("status", args.status);
+      if (args.tag) q = q.contains("tags", [args.tag]);
+      if (args.search?.trim()) { const s = `%${args.search.trim()}%`; q = q.or(`name.ilike.${s},email.ilike.${s},company.ilike.${s}`); }
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("get_prospect", "Get one prospect with all fields.",
+    { prospect_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");
+      const { data } = await t(ctx, "prospects").select("*").eq("id", args.prospect_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!data) return errorText("Prospect not found");
+      return text(data);
+    });
+
+  tool("create_prospect", "Add a prospect to the cold list.",
+    PFIELDS,
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { data, error } = await t(ctx, "prospects").insert({ ...row(ctx.businessId, ctx.userId, args), source: clean(args.source) ?? "manual" }).select("id").single();
+      if (error) return errorText(String(error.message ?? "").includes("idx_prospects_biz_email") ? "A prospect with that email already exists." : String(error.message));
+      return text({ created: true, prospect_id: data.id });
+    });
+
+  tool("import_prospects", "Bulk-import prospects (deduped by email — existing emails are skipped). Great for CSV/list ingestion.",
+    { prospects: z.array(z.object(PFIELDS)).min(1).max(1000) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { data: existing } = await t(ctx, "prospects").select("email").eq("business_id", ctx.businessId).not("email", "is", null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const seen = new Set(((existing ?? []) as any[]).map((r) => String(r.email).toLowerCase()));
+      const toInsert: unknown[] = []; let skipped = 0;
+      for (const p of args.prospects) {
+        const r = row(ctx.businessId, ctx.userId, p);
+        if (r.email && seen.has(r.email)) { skipped++; continue; }
+        if (r.email) seen.add(r.email);
+        toInsert.push(r);
+      }
+      if (toInsert.length) { const { error } = await t(ctx, "prospects").insert(toInsert); if (error) throw error; }
+      return text({ imported: toInsert.length, skipped });
+    });
+
+  tool("update_prospect", "Update a prospect's fields or status.",
+    { prospect_id: UUID, ...PFIELDS },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { prospect_id, ...rest } = args;
+      const c = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if ("email" in c && typeof c.email === "string") c.email = c.email.toLowerCase();
+      if (Object.keys(c).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "prospects").update(c).eq("id", prospect_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("delete_prospect", "Delete a prospect.",
+    { prospect_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { error } = await t(ctx, "prospects").delete().eq("id", args.prospect_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("convert_prospect", "Convert a prospect into a Lead (deduped) and mark it converted.",
+    { prospect_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write"); assertScope(ctx, "leads:write");
+      const { data: p } = await t(ctx, "prospects").select("*").eq("id", args.prospect_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!p) return errorText("Prospect not found");
+      const { data: biz } = await t(ctx, "businesses").select("user_id").eq("id", ctx.businessId).maybeSingle();
+      const { data: lead, error } = await ctx.sb.rpc("upsert_lead", {
+        p_business_id: ctx.businessId, p_user_id: biz?.user_id, p_name: p.name || p.email || "Prospect",
+        p_email: p.email, p_phone: p.phone, p_address: null, p_suburb: null, p_service: null,
+        p_property_type: null, p_timing: null, p_notes: `Converted from prospect${p.company ? ` (${p.company})` : ""}`, p_source: "prospect", p_source_ref: args.prospect_id,
+      }).single();
+      if (error) throw error;
+      await t(ctx, "prospects").update({ status: "converted", lead_id: lead?.id ?? null }).eq("id", args.prospect_id).eq("business_id", ctx.businessId);
+      return text({ converted: true, lead_id: lead?.id ?? null });
+    });
+}

--- a/src/lib/plugins/presets.ts
+++ b/src/lib/plugins/presets.ts
@@ -33,7 +33,7 @@ export const INDUSTRY_PRESETS: IndustryPreset[] = [
     label: "Agency & creative services",
     description: "Web, marketing, design and studio work — proposals, retainers, contracts and client onboarding.",
     plugins: [
-      "leads", "quotes", "invoicing", "recurring-billing", "contracts",
+      "prospects", "leads", "quotes", "invoicing", "recurring-billing", "contracts",
       "jobs", "messages", "analytics",
       "client-onboarding", "form-builder",
     ],
@@ -49,7 +49,7 @@ export const INDUSTRY_PRESETS: IndustryPreset[] = [
     description: "Local-business SEO: client sites, GSC connector, opportunity queue, content pipeline and white-label reporting.",
     // Agency operating layer + the SEO production engine. Field-ops modules off.
     plugins: [
-      "leads", "quotes", "invoicing", "recurring-billing", "contracts",
+      "prospects", "leads", "quotes", "invoicing", "recurring-billing", "contracts",
       "messages", "analytics", "client-onboarding", "form-builder",
       "seo-production",
     ],

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -53,6 +53,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "settings", icon: "settings",   name: "Settings",      description: "Business profile, appearance, API keys.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/settings", "/agents"] },
 
   // ── Sales ──────────────────────────────────────────────────────────────────
+  { id: "prospects", icon: "target", name: "Prospects", description: "Cold-list of prospects — import, bulk-reach-out and convert to leads.", kind: "module", category: "contacts", defaultEnabled: false, routePrefixes: ["/prospects"] },
   { id: "leads", icon: "user-plus",      name: "Leads",         description: "Capture and work the sales pipeline.",   kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/leads"] },
   { id: "quotes", icon: "file-check",     name: "Quotes",        description: "Build and send quotes customers accept online.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/quotes"] },
   { id: "invoicing", icon: "file-text",  name: "Invoices",      description: "Invoice, take payments, track balances.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/invoices"] },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -598,6 +598,29 @@ export interface Expense {
   updated_at: string;
 }
 
+// ── Prospects (top-of-funnel cold list → converts into leads) ────────────────
+export type ProspectStatus = 'new' | 'contacted' | 'responded' | 'qualified' | 'unqualified' | 'converted';
+export interface Prospect {
+  id: string;
+  business_id: string;
+  user_id: string | null;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  company: string | null;
+  title: string | null;
+  website: string | null;
+  source: string | null;
+  status: ProspectStatus;
+  tags: string[];
+  notes: string | null;
+  custom_fields: Record<string, unknown>;
+  last_contacted_at: string | null;
+  lead_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // ── Assets & equipment (field-services plugin) ──────────────────────────────
 export type AssetCategory = 'tool' | 'vehicle' | 'equipment' | 'other';
 export type AssetStatus = 'active' | 'in_repair' | 'retired';
@@ -1304,6 +1327,8 @@ export type ApiScope =
   | 'timesheets:write'
   | 'assets:read'
   | 'assets:write'
+  | 'prospects:read'
+  | 'prospects:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1342,6 +1367,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'timesheets:write', label: 'Set pay rates', group: 'Timesheets' },
   { value: 'assets:read',      label: 'Read assets & equipment', group: 'Assets' },
   { value: 'assets:write',     label: 'Manage assets & equipment', group: 'Assets' },
+  { value: 'prospects:read',   label: 'Read prospects', group: 'Prospects' },
+  { value: 'prospects:write',  label: 'Create / edit / import prospects', group: 'Prospects' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260710220000_prospects.sql
+++ b/supabase/migrations/20260710220000_prospects.sql
@@ -1,0 +1,49 @@
+-- Prospects plugin — a top-of-funnel cold list that feeds Leads on convert.
+-- Additive. Email-keyed dedupe; converts into leads via upsert_lead.
+CREATE TABLE IF NOT EXISTS public.prospects (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id       UUID,
+  name          TEXT,
+  email         TEXT,
+  phone         TEXT,
+  company       TEXT,
+  title         TEXT,
+  website       TEXT,
+  source        TEXT,
+  status        TEXT NOT NULL DEFAULT 'new' CHECK (status IN ('new','contacted','responded','qualified','unqualified','converted')),
+  tags          TEXT[] NOT NULL DEFAULT '{}',
+  notes         TEXT,
+  custom_fields JSONB NOT NULL DEFAULT '{}'::jsonb,
+  last_contacted_at TIMESTAMPTZ,
+  lead_id       UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prospects_biz_email ON public.prospects (business_id, lower(email)) WHERE email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_prospects_business ON public.prospects (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_prospects_status ON public.prospects (business_id, status);
+
+ALTER TABLE public.prospects ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS prospects_read ON public.prospects;
+CREATE POLICY prospects_read ON public.prospects FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+DROP POLICY IF EXISTS prospects_write ON public.prospects;
+CREATE POLICY prospects_write ON public.prospects FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+);
+
+DROP TRIGGER IF EXISTS prospects_updated_at ON public.prospects;
+CREATE TRIGGER prospects_updated_at BEFORE UPDATE ON public.prospects FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
## What

**Prospects** plugin — a top-of-funnel **cold list** that feeds Leads on convert. This is **PR1 (Core)** of the planned build.

- **Migration `20260710220000`** (applied + recorded): `prospects` table (status, `tags[]`, `custom_fields`, `lead_id`) + **email-keyed unique index** (dedupe) + RLS.
- **Registry**: `prospects` plugin (default **OFF**, route `/prospects`); sidebar item (Contacts) + store card. In the **agency / seo-agency-local** presets (trades gets it via ALL_OPTIONAL). Scopes `prospects:*`.
- **Actions**: `listProspects` (search / status / tag) · `get` · `create` · `update` · `delete` · **`importProspects`** (dedup by email) · **`convertProspectToLead`** (via `upsert_lead`).
- **UI** `/prospects`: searchable + status-filtered table + add dialog; `/prospects/[id]`: editable detail, status, notes, delete, **Convert to lead**, imported custom fields.
- **MCP**: `list/get/create/update/delete_prospect`, **`import_prospects`** (dedup, ≤1000), **`convert_prospect`**.

## Boundary with Leads
Prospects is *upstream* of the Leads pipeline: cold contacts you import + reach out to → **convert into a Lead** when they engage. No two-way sync, no pipeline pollution.

## Next (as planned)
- **PR2** — CSV import (column mapping + dedupe) + bulk paste + bulk update/delete.
- **PR3** — outreach: single custom email + bulk reach-out + activity timeline + unsubscribe/suppression.
- **(Later)** email-source connector (Gmail/Outlook contacts — OAuth).

## Safety
Additive, default-off + route-gated; nothing changes for existing businesses.

Verified: tsc · 17 tests · build (`/prospects`) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)