### PR TITLE
feat(plugin): Prospects — CSV import + bulk actions (PR2)

### DIFF
--- a/src/components/prospects/prospects-import.tsx
+++ b/src/components/prospects/prospects-import.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { importProspects } from "@/lib/actions/prospects";
+
+const FIELDS = ["name", "email", "phone", "company", "title", "website", "source", "notes"] as const;
+const TARGETS = [...FIELDS, "custom", "ignore"] as const;
+type Target = (typeof TARGETS)[number];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = []; let row: string[] = []; let cur = ""; let inQ = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQ) { if (c === '"') { if (text[i + 1] === '"') { cur += '"'; i++; } else inQ = false; } else cur += c; }
+    else if (c === '"') inQ = true;
+    else if (c === ",") { row.push(cur); cur = ""; }
+    else if (c === "\n") { row.push(cur); rows.push(row); row = []; cur = ""; }
+    else if (c !== "\r") cur += c;
+  }
+  if (cur.length || row.length) { row.push(cur); rows.push(row); }
+  return rows.filter((r) => r.some((c) => c.trim() !== ""));
+}
+
+function guess(header: string): Target {
+  const h = header.toLowerCase().replace(/[^a-z]/g, "");
+  if (h.includes("email") || h.includes("mail")) return "email";
+  if (h.includes("phone") || h.includes("mobile") || h.includes("tel")) return "phone";
+  if (h.includes("company") || h.includes("organisation") || h.includes("organization") || h.includes("business")) return "company";
+  if (h.includes("title") || h.includes("role") || h.includes("position")) return "title";
+  if (h.includes("web") || h.includes("url") || h.includes("site")) return "website";
+  if (h === "name" || h.includes("fullname") || h.includes("contact")) return "name";
+  if (h.includes("source")) return "source";
+  if (h.includes("note")) return "notes";
+  return "custom";
+}
+
+const selectCls = "h-8 rounded-md border border-input bg-background px-2 text-xs shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function ProspectsImport({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [mode, setMode] = useState<"csv" | "paste">("csv");
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [dataRows, setDataRows] = useState<string[][]>([]);
+  const [mapping, setMapping] = useState<Target[]>([]);
+  const [paste, setPaste] = useState("");
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]; if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const parsed = parseCsv(String(reader.result ?? ""));
+      if (parsed.length < 2) { toast.error("CSV needs a header row + at least one row"); return; }
+      setHeaders(parsed[0]); setDataRows(parsed.slice(1).slice(0, 5000)); setMapping(parsed[0].map(guess));
+    };
+    reader.readAsText(file);
+  }
+
+  function rowsFromCsv(): Row[] {
+    return dataRows.map((cols) => {
+      const p: Row = { custom_fields: {} };
+      headers.forEach((h, i) => {
+        const target = mapping[i]; const v = (cols[i] ?? "").trim(); if (!v) return;
+        if (target === "ignore") return;
+        if (target === "custom") p.custom_fields[h] = v;
+        else p[target] = v;
+      });
+      return p;
+    }).filter((p) => p.email || p.name);
+  }
+
+  function rowsFromPaste(): Row[] {
+    return paste.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).map((line) => {
+      const m = line.match(/^(.*?)[<(]?([^\s<>()]+@[^\s<>()]+)[>)]?$/);
+      if (m) return { name: m[1].replace(/[",]/g, "").trim() || null, email: m[2].trim(), source: "paste" };
+      const parts = line.split(",").map((s) => s.trim());
+      if (parts.some((p) => p.includes("@"))) return { name: parts[0] || null, email: parts.find((p) => p.includes("@")) ?? null, company: parts[2] ?? null, source: "paste" };
+      return { name: line, source: "paste" };
+    });
+  }
+
+  function doImport() {
+    const rows = mode === "csv" ? rowsFromCsv() : rowsFromPaste();
+    if (rows.length === 0) { toast.error("Nothing to import"); return; }
+    startTransition(async () => {
+      try {
+        const r = await importProspects(rows);
+        toast.success(`Imported ${r.imported}${r.skipped ? `, skipped ${r.skipped} duplicates` : ""}`);
+        onOpenChange(false); setHeaders([]); setDataRows([]); setPaste("");
+        router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Import failed"); }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[88vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader><DialogTitle>Import prospects</DialogTitle></DialogHeader>
+        <div className="flex gap-1 mb-3">
+          {(["csv", "paste"] as const).map((m) => (
+            <button key={m} onClick={() => setMode(m)} className={cn("px-3 py-1.5 rounded-md text-sm font-medium", mode === m ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground")}>{m === "csv" ? "CSV file" : "Paste"}</button>
+          ))}
+        </div>
+
+        {mode === "csv" ? (
+          <div className="space-y-3">
+            <input type="file" accept=".csv,text/csv" onChange={onFile} className="text-sm" />
+            {headers.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">{dataRows.length} rows · map your columns (unmapped “custom” columns are kept on the prospect):</p>
+                <div className="space-y-1.5 max-h-64 overflow-y-auto">
+                  {headers.map((h, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <span className="text-xs flex-1 truncate" title={h}>{h}</span>
+                      <select className={selectCls} value={mapping[i]} onChange={(e) => setMapping((prev) => prev.map((m, j) => j === i ? e.target.value as Target : m))}>
+                        {TARGETS.map((tt) => <option key={tt} value={tt}>{tt}</option>)}
+                      </select>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            <Label htmlFor="pi-paste">Paste one per line</Label>
+            <Textarea id="pi-paste" rows={8} className="font-mono text-xs" placeholder={"jane@acme.com\nJohn Smith <john@co.com>\nSara, sara@x.com, Acme Co"} value={paste} onChange={(e) => setPaste(e.target.value)} />
+            <p className="text-[11px] text-muted-foreground">Emails, “Name &lt;email&gt;”, or “name, email, company”. Duplicates are skipped.</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isPending}>Cancel</Button>
+          <Button onClick={doImport} disabled={isPending}>Import</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/prospects/prospects-view.tsx
+++ b/src/components/prospects/prospects-view.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { useState, useTransition, useMemo } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Target, Plus, Search } from "@/components/ui/icons";
+import { Target, Plus, Search, Upload, Trash2 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { createProspect } from "@/lib/actions/prospects";
+import { createProspect, bulkUpdateProspects, bulkDeleteProspects } from "@/lib/actions/prospects";
+import { ProspectsImport } from "@/components/prospects/prospects-import";
 import type { Prospect, ProspectStatus } from "@/types/database";
 
 const STATUSES: ProspectStatus[] = ["new", "contacted", "responded", "qualified", "unqualified", "converted"];
@@ -25,8 +25,24 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<ProspectStatus | "">("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkStatus, setBulkStatus] = useState<ProspectStatus | "">("");
+  const [bulkTag, setBulkTag] = useState("");
+
+  function toggle(id: string) {
+    setSelected((prev) => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  }
+  function clearSel() { setSelected(new Set()); }
+
+  function runBulk(fn: () => Promise<unknown>, msg: string) {
+    startTransition(async () => {
+      try { await fn(); toast.success(msg); clearSel(); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Bulk action failed"); }
+    });
+  }
 
   const [name, setName] = useState(""); const [email, setEmail] = useState(""); const [company, setCompany] = useState("");
   const [phone, setPhone] = useState(""); const [source, setSource] = useState("");
@@ -57,7 +73,12 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
       <PageHeader
         title="Prospects"
         subtitle="Your cold-outreach list — import, reach out, and convert the good ones to leads"
-        actions={<Button onClick={() => setOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add prospect</Button>}
+        actions={
+          <>
+            <Button variant="outline" onClick={() => setImportOpen(true)} disabled={isPending}><Upload className="w-4 h-4 mr-1.5" /> Import</Button>
+            <Button onClick={() => setOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add prospect</Button>
+          </>
+        }
       />
 
       {/* Filters */}
@@ -80,28 +101,49 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
           <Button className="mt-4" onClick={() => setOpen(true)}><Plus className="w-4 h-4 mr-1.5" /> Add prospect</Button>
         </div>
       ) : (
-        <div className="ch-table-wrap">
-          <table className="ch-table w-full">
-            <thead><tr><th>Name</th><th>Company</th><th>Email</th><th>Source</th><th>Status</th></tr></thead>
-            <tbody>
-              {filtered.map((p) => (
-                <tr key={p.id} className="cursor-pointer hover:bg-muted/40" onClick={() => router.push(`/prospects/${p.id}`)}>
-                  <td className="font-medium">{p.name || "—"}</td>
-                  <td>{p.company || "—"}</td>
-                  <td className="break-words">{p.email || "—"}</td>
-                  <td>{p.source || "—"}</td>
-                  <td><span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 capitalize", TONE[p.status])}>{p.status}</span></td>
-                </tr>
-              ))}
-              {filtered.length === 0 && <tr><td colSpan={5} className="text-center text-muted-foreground py-6">No prospects match.</td></tr>}
-            </tbody>
-          </table>
-        </div>
+        <>
+          {/* Bulk action bar */}
+          {selected.size > 0 && (
+            <div className="flex items-center gap-2 flex-wrap rounded-xl border border-border bg-card px-4 py-2.5 mb-3">
+              <span className="text-sm font-medium">{selected.size} selected</span>
+              <select className={selectCls + " h-8"} value={bulkStatus} onChange={(e) => { const s = e.target.value as ProspectStatus; setBulkStatus(""); if (s) runBulk(() => bulkUpdateProspects([...selected], { status: s }), "Status updated"); }}>
+                <option value="">Set status…</option>{STATUSES.map((s) => <option key={s} value={s} className="capitalize">{s}</option>)}
+              </select>
+              <div className="flex items-center gap-1">
+                <Input value={bulkTag} onChange={(e) => setBulkTag(e.target.value)} placeholder="Add tag" className="h-8 w-28 text-xs" />
+                <Button size="sm" variant="outline" className="h-8" disabled={!bulkTag.trim() || isPending} onClick={() => { runBulk(() => bulkUpdateProspects([...selected], { add_tag: bulkTag.trim() }), "Tag added"); setBulkTag(""); }}>Tag</Button>
+              </div>
+              <button onClick={() => runBulk(() => bulkDeleteProspects([...selected]), "Deleted")} disabled={isPending} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-destructive"><Trash2 className="w-4 h-4" /> Delete</button>
+              <button onClick={clearSel} className="text-xs text-muted-foreground hover:text-foreground ml-auto">Clear</button>
+            </div>
+          )}
+          <div className="ch-table-wrap">
+            <table className="ch-table w-full">
+              <thead><tr>
+                <th className="w-8"><input type="checkbox" checked={filtered.length > 0 && filtered.every((p) => selected.has(p.id))} onChange={(e) => setSelected(e.target.checked ? new Set(filtered.map((p) => p.id)) : new Set())} /></th>
+                <th>Name</th><th>Company</th><th>Email</th><th>Source</th><th>Status</th>
+              </tr></thead>
+              <tbody>
+                {filtered.map((p) => (
+                  <tr key={p.id} className={cn("hover:bg-muted/40", selected.has(p.id) && "bg-muted/50")}>
+                    <td onClick={(e) => e.stopPropagation()}><input type="checkbox" checked={selected.has(p.id)} onChange={() => toggle(p.id)} /></td>
+                    <td className="font-medium cursor-pointer" onClick={() => router.push(`/prospects/${p.id}`)}>{p.name || "—"}</td>
+                    <td className="cursor-pointer" onClick={() => router.push(`/prospects/${p.id}`)}>{p.company || "—"}</td>
+                    <td className="break-words cursor-pointer" onClick={() => router.push(`/prospects/${p.id}`)}>{p.email || "—"}</td>
+                    <td>{p.source || "—"}</td>
+                    <td><span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 capitalize", TONE[p.status])}>{p.status}</span></td>
+                  </tr>
+                ))}
+                {filtered.length === 0 && <tr><td colSpan={6} className="text-center text-muted-foreground py-6">No prospects match.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
 
-      <p className="text-[11px] text-muted-foreground mt-3">
-        <Link href="/prospects" className="underline">CSV import, bulk actions and outreach</Link> arrive with the next updates.
-      </p>
+      <ProspectsImport open={importOpen} onOpenChange={setImportOpen} />
+
+      <p className="text-[11px] text-muted-foreground mt-3">Email outreach (single + bulk reach-out) arrives with the next update.</p>
 
       {/* Add dialog */}
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/lib/actions/prospects.ts
+++ b/src/lib/actions/prospects.ts
@@ -119,6 +119,42 @@ export async function importProspects(rows: ProspectInput[]): Promise<{ imported
   return { imported: toInsert.length, skipped };
 }
 
+/** Bulk-update prospects (status / source / add-remove a tag). */
+export async function bulkUpdateProspects(ids: string[], patch: { status?: ProspectStatus; source?: string | null; add_tag?: string; remove_tag?: string }): Promise<{ updated: number }> {
+  const { supabase, businessId } = await ctx();
+  if (ids.length === 0) return { updated: 0 };
+
+  if (patch.add_tag || patch.remove_tag) {
+    // Tag edits are per-row (array mutation) — fetch, compute, update.
+    const { data } = await tbl(supabase, "prospects").select("id, tags").in("id", ids).eq("business_id", businessId);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const p of (data ?? []) as any[]) {
+      let tags: string[] = Array.isArray(p.tags) ? p.tags : [];
+      if (patch.add_tag && !tags.includes(patch.add_tag)) tags = [...tags, patch.add_tag];
+      if (patch.remove_tag) tags = tags.filter((tg) => tg !== patch.remove_tag);
+      await tbl(supabase, "prospects").update({ tags }).eq("id", p.id).eq("business_id", businessId);
+    }
+  }
+  const flat: Record<string, unknown> = {};
+  if (patch.status !== undefined) flat.status = patch.status;
+  if (patch.source !== undefined) flat.source = clean(patch.source);
+  if (Object.keys(flat).length > 0) {
+    const { error } = await tbl(supabase, "prospects").update(flat).in("id", ids).eq("business_id", businessId);
+    if (error) throw error;
+  }
+  revalidatePath("/prospects");
+  return { updated: ids.length };
+}
+
+export async function bulkDeleteProspects(ids: string[]): Promise<{ deleted: number }> {
+  const { supabase, businessId } = await ctx();
+  if (ids.length === 0) return { deleted: 0 };
+  const { error } = await tbl(supabase, "prospects").delete().in("id", ids).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/prospects");
+  return { deleted: ids.length };
+}
+
 /** Convert a prospect into a Lead (dedup via upsert_lead) + mark converted. */
 export async function convertProspectToLead(id: string): Promise<{ lead_id: string | null }> {
   const { supabase, businessId } = await ctx();

--- a/src/lib/mcp/tools/prospects-tools.ts
+++ b/src/lib/mcp/tools/prospects-tools.ts
@@ -95,6 +95,28 @@ export function registerProspectTools(tool: ToolFn): void {
       return text({ deleted: true });
     });
 
+  tool("bulk_update_prospects", "Set status / source on many prospects at once (by ids).",
+    { prospect_ids: z.array(UUID).min(1).max(1000), status: STATUS.optional(), source: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const c: Record<string, unknown> = {};
+      if (args.status) c.status = args.status;
+      if (args.source !== undefined) c.source = clean(args.source);
+      if (Object.keys(c).length === 0) return errorText("Nothing to update.");
+      const { error } = await t(ctx, "prospects").update(c).in("id", args.prospect_ids).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: args.prospect_ids.length });
+    });
+
+  tool("bulk_delete_prospects", "Delete many prospects at once (by ids).",
+    { prospect_ids: z.array(UUID).min(1).max(1000) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { error } = await t(ctx, "prospects").delete().in("id", args.prospect_ids).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: args.prospect_ids.length });
+    });
+
   tool("convert_prospect", "Convert a prospect into a Lead (deduped) and mark it converted.",
     { prospect_id: UUID },
     async (args, extra) => {


### PR DESCRIPTION
## What

**PR2** of the Prospects plugin — the ingest + bulk-management half.

- **CSV import** with a **column-mapping** step: upload → headers auto-guessed to fields (unmapped columns kept as `custom_fields`) → **dedup-by-email** import. Client-side CSV parser (handles quoted fields), 5k-row cap.
- **Paste mode** — one per line: bare emails, `Name <email>`, or `name, email, company`.
- **Bulk actions** on the list: row checkboxes + **select-all-filtered** + a bulk bar — **set status**, **add tag**, **delete**.
- **MCP**: `bulk_update_prospects`, `bulk_delete_prospects`.

## Next (PR3)
Outreach — single custom email + bulk reach-out + activity timeline + unsubscribe/suppression.

Verified: tsc · 17 tests · build · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)