### PR TITLE
feat(plugin): Prospects — outreach (PR3, completes the plugin)

### DIFF
--- a/src/app/(dashboard)/prospects/[id]/page.tsx
+++ b/src/app/(dashboard)/prospects/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
-import { getProspect } from "@/lib/actions/prospects";
+import { getProspect, listProspectActivities } from "@/lib/actions/prospects";
 import { ProspectDetail } from "@/components/prospects/prospect-detail";
 
 export const dynamic = "force-dynamic";
@@ -16,5 +16,6 @@ export default async function ProspectDetailPage({ params }: { params: Promise<{
 
   const prospect = await getProspect(id);
   if (!prospect) notFound();
-  return <ProspectDetail prospect={prospect} />;
+  const activities = await listProspectActivities(id);
+  return <ProspectDetail prospect={prospect} activities={activities} />;
 }

--- a/src/app/unsubscribe/[token]/page.tsx
+++ b/src/app/unsubscribe/[token]/page.tsx
@@ -1,0 +1,35 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, n: string) => sb.from(n);
+
+export default async function UnsubscribePage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const sb = createAdminClient();
+
+  let done = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: p } = await tbl(sb, "prospects").select("id, business_id, email").eq("unsub_token", token).maybeSingle();
+  if (p?.email) {
+    // Idempotent guarded insert (unique index is on lower(email)).
+    const { data: exists } = await tbl(sb, "prospect_suppressions").select("id").eq("business_id", p.business_id).ilike("email", p.email).maybeSingle();
+    if (!exists) {
+      await tbl(sb, "prospect_suppressions").insert({ business_id: p.business_id, email: p.email, reason: "unsubscribe" });
+      await tbl(sb, "prospect_activities").insert({ business_id: p.business_id, prospect_id: p.id, type: "unsubscribe", summary: "Unsubscribed from outreach" });
+    }
+    done = true;
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-gradient-to-b from-white to-slate-50">
+      <div className="max-w-sm text-center">
+        <h1 className="text-xl font-bold text-slate-900">{done ? "You've been unsubscribed" : "Link not found"}</h1>
+        <p className="text-sm text-slate-500 mt-2">
+          {done ? "You won't receive any more emails from us. Sorry to see you go." : "This unsubscribe link is invalid or expired."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/prospects/prospect-detail.tsx
+++ b/src/components/prospects/prospect-detail.tsx
@@ -4,15 +4,18 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowLeft, Trash2, UserPlus, Check } from "@/components/ui/icons";
+import { ArrowLeft, Trash2, UserPlus, Check, Send } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PageHeader } from "@/components/layout/page-header";
 import { cn } from "@/lib/utils";
-import { updateProspect, deleteProspect, convertProspectToLead } from "@/lib/actions/prospects";
+import { updateProspect, deleteProspect, convertProspectToLead, addProspectNote } from "@/lib/actions/prospects";
+import { ProspectEmailDialog } from "@/components/prospects/prospect-email-dialog";
 import type { Prospect, ProspectStatus } from "@/types/database";
+
+interface Activity { id: string; type: string; summary: string; created_at: string }
 
 const STATUSES: ProspectStatus[] = ["new", "contacted", "responded", "qualified", "unqualified", "converted"];
 const TONE: Record<string, string> = {
@@ -21,9 +24,19 @@ const TONE: Record<string, string> = {
 };
 const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
 
-export function ProspectDetail({ prospect }: { prospect: Prospect }) {
+export function ProspectDetail({ prospect, activities }: { prospect: Prospect; activities: Activity[] }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [emailOpen, setEmailOpen] = useState(false);
+  const [note, setNote] = useState("");
+
+  function saveNote() {
+    if (!note.trim()) return;
+    startTransition(async () => {
+      try { await addProspectNote(prospect.id, note); setNote(""); toast.success("Note added"); router.refresh(); }
+      catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't add note"); }
+    });
+  }
   const [f, setF] = useState({
     name: prospect.name ?? "", email: prospect.email ?? "", phone: prospect.phone ?? "", company: prospect.company ?? "",
     title: prospect.title ?? "", website: prospect.website ?? "", source: prospect.source ?? "",
@@ -60,6 +73,7 @@ export function ProspectDetail({ prospect }: { prospect: Prospect }) {
         actions={
           <>
             <Link href="/prospects" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground rounded-md border border-border px-3 py-1.5"><ArrowLeft className="w-4 h-4" /> Prospects</Link>
+            {prospect.email && <Button variant="outline" onClick={() => setEmailOpen(true)} disabled={isPending}><Send className="w-4 h-4 mr-1.5" /> Send email</Button>}
             {!converted && <Button variant="outline" onClick={convert} disabled={isPending}><UserPlus className="w-4 h-4 mr-1.5" /> Convert to lead</Button>}
             {converted && prospect.lead_id && <Link href={`/leads/${prospect.lead_id}`} className="inline-flex items-center gap-1.5 text-sm rounded-md border border-emerald-500/40 text-emerald-700 px-3 py-1.5"><Check className="w-4 h-4" /> View lead</Link>}
           </>
@@ -98,7 +112,31 @@ export function ProspectDetail({ prospect }: { prospect: Prospect }) {
             </dl>
           </div>
         )}
+
+        {/* Activity */}
+        <div className="rounded-xl border border-border bg-card p-5">
+          <p className="text-sm font-semibold mb-3">Activity</p>
+          <div className="flex gap-2 mb-4">
+            <Input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Add a note…" onKeyDown={(e) => { if (e.key === "Enter") saveNote(); }} />
+            <Button variant="outline" onClick={saveNote} disabled={isPending || !note.trim()}>Add</Button>
+          </div>
+          {activities.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No activity yet. Send an email or add a note.</p>
+          ) : (
+            <ul className="space-y-2">
+              {activities.map((a) => (
+                <li key={a.id} className="flex items-start gap-2 text-sm">
+                  <span className={cn("text-[10px] font-medium rounded-full px-1.5 py-0.5 mt-0.5 shrink-0", a.type === "email" ? "bg-blue-100 text-blue-700" : a.type === "unsubscribe" ? "bg-red-100 text-red-700" : "bg-muted text-muted-foreground")}>{a.type}</span>
+                  <span className="flex-1 min-w-0 break-words">{a.summary}</span>
+                  <span className="text-xs text-muted-foreground shrink-0">{new Date(a.created_at).toLocaleDateString("en-AU")}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
+
+      <ProspectEmailDialog open={emailOpen} onOpenChange={setEmailOpen} prospectIds={[prospect.id]} />
     </>
   );
 }

--- a/src/components/prospects/prospect-email-dialog.tsx
+++ b/src/components/prospects/prospect-email-dialog.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { emailProspects } from "@/lib/actions/prospects";
+
+export function ProspectEmailDialog({ open, onOpenChange, prospectIds }: { open: boolean; onOpenChange: (o: boolean) => void; prospectIds: string[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+
+  function send() {
+    if (!subject.trim() || !body.trim()) { toast.error("Subject and message are required"); return; }
+    startTransition(async () => {
+      try {
+        const r = await emailProspects(prospectIds, subject, body);
+        toast.success(`Sent ${r.sent}${r.skipped ? `, skipped ${r.skipped}` : ""}${r.failed ? `, ${r.failed} failed` : ""}`);
+        onOpenChange(false); setSubject(""); setBody("");
+        router.refresh();
+      } catch (e) { toast.error(e instanceof Error ? e.message : "Send failed"); }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader><DialogTitle>{prospectIds.length > 1 ? `Reach out to ${prospectIds.length} prospects` : "Send email"}</DialogTitle></DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1.5"><Label htmlFor="pe-subject">Subject</Label><Input id="pe-subject" value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="Quick question, {{first_name}}" /></div>
+          <div className="space-y-1.5"><Label htmlFor="pe-body">Message</Label><Textarea id="pe-body" rows={8} value={body} onChange={(e) => setBody(e.target.value)} placeholder={"Hi {{first_name}},\n\n…\n\nCheers"} /></div>
+          <p className="text-[11px] text-muted-foreground">Merge fields: <code>{"{{first_name}}"}</code> <code>{"{{name}}"}</code> <code>{"{{company}}"}</code>. An unsubscribe link is added automatically; suppressed contacts are skipped.</p>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isPending}>Cancel</Button>
+          <Button onClick={send} disabled={isPending}>{isPending ? "Sending…" : "Send"}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/prospects/prospects-view.tsx
+++ b/src/components/prospects/prospects-view.tsx
@@ -10,8 +10,10 @@ import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { Send } from "@/components/ui/icons";
 import { createProspect, bulkUpdateProspects, bulkDeleteProspects } from "@/lib/actions/prospects";
 import { ProspectsImport } from "@/components/prospects/prospects-import";
+import { ProspectEmailDialog } from "@/components/prospects/prospect-email-dialog";
 import type { Prospect, ProspectStatus } from "@/types/database";
 
 const STATUSES: ProspectStatus[] = ["new", "contacted", "responded", "qualified", "unqualified", "converted"];
@@ -26,6 +28,7 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
+  const [emailOpen, setEmailOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<ProspectStatus | "">("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -106,6 +109,7 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
           {selected.size > 0 && (
             <div className="flex items-center gap-2 flex-wrap rounded-xl border border-border bg-card px-4 py-2.5 mb-3">
               <span className="text-sm font-medium">{selected.size} selected</span>
+              <Button size="sm" className="h-8" onClick={() => setEmailOpen(true)} disabled={isPending}><Send className="w-3.5 h-3.5 mr-1" /> Reach out</Button>
               <select className={selectCls + " h-8"} value={bulkStatus} onChange={(e) => { const s = e.target.value as ProspectStatus; setBulkStatus(""); if (s) runBulk(() => bulkUpdateProspects([...selected], { status: s }), "Status updated"); }}>
                 <option value="">Set status…</option>{STATUSES.map((s) => <option key={s} value={s} className="capitalize">{s}</option>)}
               </select>
@@ -142,8 +146,9 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
       )}
 
       <ProspectsImport open={importOpen} onOpenChange={setImportOpen} />
+      <ProspectEmailDialog open={emailOpen} onOpenChange={setEmailOpen} prospectIds={[...selected]} />
 
-      <p className="text-[11px] text-muted-foreground mt-3">Email outreach (single + bulk reach-out) arrives with the next update.</p>
+      <p className="text-[11px] text-muted-foreground mt-3">Select prospects to reach out in bulk. Every email includes an unsubscribe link.</p>
 
       {/* Add dialog */}
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/lib/actions/prospects.ts
+++ b/src/lib/actions/prospects.ts
@@ -9,6 +9,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
+import { sendToProspects } from "@/lib/prospects/outreach";
 import type { Prospect, ProspectStatus } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -153,6 +154,31 @@ export async function bulkDeleteProspects(ids: string[]): Promise<{ deleted: num
   if (error) throw error;
   revalidatePath("/prospects");
   return { deleted: ids.length };
+}
+
+/** Email one or more prospects (merge fields {{name}} {{first_name}} {{company}}). */
+export async function emailProspects(prospectIds: string[], subject: string, body: string): Promise<{ sent: number; skipped: number; failed: number }> {
+  const { supabase, user, businessId } = await ctx();
+  if (!subject.trim() || !body.trim()) throw new Error("Subject and message are required");
+  const res = await sendToProspects(supabase, businessId, user.id, prospectIds, subject, body);
+  revalidatePath("/prospects");
+  for (const id of prospectIds) revalidatePath(`/prospects/${id}`);
+  return res;
+}
+
+export async function addProspectNote(prospectId: string, note: string): Promise<void> {
+  const { supabase, user, businessId } = await ctx();
+  if (!note.trim()) return;
+  const { error } = await tbl(supabase, "prospect_activities").insert({ business_id: businessId, prospect_id: prospectId, type: "note", summary: note.trim(), created_by: user.id });
+  if (error) throw error;
+  revalidatePath(`/prospects/${prospectId}`);
+}
+
+export async function listProspectActivities(prospectId: string) {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "prospect_activities").select("id, type, summary, created_at")
+    .eq("business_id", businessId).eq("prospect_id", prospectId).order("created_at", { ascending: false }).limit(100);
+  return (data ?? []) as Array<{ id: string; type: string; summary: string; created_at: string }>;
 }
 
 /** Convert a prospect into a Lead (dedup via upsert_lead) + mark converted. */

--- a/src/lib/mcp/tools/prospects-tools.ts
+++ b/src/lib/mcp/tools/prospects-tools.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { sendToProspects } from "@/lib/prospects/outreach";
 
 const STATUS = z.enum(["new", "contacted", "responded", "qualified", "unqualified", "converted"]);
 const PFIELDS = {
@@ -115,6 +116,14 @@ export function registerProspectTools(tool: ToolFn): void {
       const { error } = await t(ctx, "prospects").delete().in("id", args.prospect_ids).eq("business_id", ctx.businessId);
       if (error) throw error;
       return text({ deleted: args.prospect_ids.length });
+    });
+
+  tool("email_prospects", "Email one or more prospects (merge fields {{first_name}} {{name}} {{company}}). Adds an unsubscribe link + skips suppressed contacts. Requires email:send.",
+    { prospect_ids: z.array(UUID).min(1).max(500), subject: z.string().min(1), body: z.string().min(1) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write"); assertScope(ctx, "email:send");
+      const res = await sendToProspects(ctx.sb, ctx.businessId, ctx.userId, args.prospect_ids, args.subject, args.body);
+      return text(res);
     });
 
   tool("convert_prospect", "Convert a prospect into a Lead (deduped) and mark it converted.",

--- a/src/lib/prospects/outreach.ts
+++ b/src/lib/prospects/outreach.ts
@@ -1,0 +1,56 @@
+/**
+ * Prospect outreach (PR3). Sends a (merge-fielded) email to prospects, honoring
+ * the suppression list, appending an unsubscribe link, and logging an activity.
+ * Shared by the server actions and the MCP tools. Server-only.
+ */
+import { randomBytes } from "node:crypto";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { appUrl } from "@/lib/app-url";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function merge(tpl: string, p: any): string {
+  const first = String(p.name ?? "").trim().split(/\s+/)[0] || "there";
+  return tpl.replace(/\{\{\s*(name|first_name|company)\s*\}\}/gi, (_m, k: string) => {
+    const key = k.toLowerCase();
+    if (key === "first_name") return first;
+    if (key === "company") return String(p.company ?? "");
+    return String(p.name ?? "there");
+  });
+}
+
+const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function sendToProspects(sb: any, businessId: string, userId: string, prospectIds: string[], subject: string, body: string): Promise<{ sent: number; skipped: number; failed: number }> {
+  if (prospectIds.length === 0) return { sent: 0, skipped: 0, failed: 0 };
+  const [{ data: business }, { data: prospects }, { data: supp }] = await Promise.all([
+    sb.from("businesses").select("name, email").eq("id", businessId).maybeSingle(),
+    sb.from("prospects").select("id, name, email, company, status, unsub_token").in("id", prospectIds).eq("business_id", businessId),
+    sb.from("prospect_suppressions").select("email").eq("business_id", businessId),
+  ]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const suppressed = new Set(((supp ?? []) as any[]).map((s) => String(s.email).toLowerCase()));
+  const from = buildBusinessFrom({ name: business?.name ?? "Kirei", localPart: "hello" });
+  let sent = 0, skipped = 0, failed = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const p of (prospects ?? []) as any[]) {
+    if (!p.email || suppressed.has(String(p.email).toLowerCase())) { skipped++; continue; }
+    let token: string = p.unsub_token;
+    if (!token) { token = "u_" + randomBytes(16).toString("hex"); await sb.from("prospects").update({ unsub_token: token }).eq("id", p.id); }
+    const unsubUrl = `${appUrl()}/unsubscribe/${token}`;
+    const subj = merge(subject, p);
+    const bodyHtml = merge(esc(body), p).replace(/\n/g, "<br>");
+    const html = `<div style="font-family:system-ui,Segoe UI,sans-serif;max-width:560px;margin:0 auto;color:#0f172a;line-height:1.5">${bodyHtml}<hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0 12px"><p style="font-size:11px;color:#94a3b8">You received this from ${esc(business?.name ?? "us")}. <a href="${unsubUrl}" style="color:#94a3b8">Unsubscribe</a>.</p></div>`;
+    try {
+      await sendEmail({ to: p.email, subject: subj, html, from, replyTo: business?.email ?? undefined, tags: { business_id: businessId, doc_type: "custom", doc_id: p.id } });
+      await sb.from("prospect_activities").insert({ business_id: businessId, prospect_id: p.id, type: "email", summary: subj, created_by: userId });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const patch: any = { last_contacted_at: new Date().toISOString() };
+      if (p.status === "new") patch.status = "contacted";
+      await sb.from("prospects").update(patch).eq("id", p.id);
+      sent++;
+    } catch { failed++; }
+  }
+  return { sent, skipped, failed };
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -63,6 +63,8 @@ export async function updateSession(request: NextRequest) {
     // Instant-audit lead magnet: public landing page + submit.
     pathname.startsWith("/audit/") ||
     pathname.startsWith("/api/audit/") ||
+    // Prospect outreach unsubscribe (public, token-gated).
+    pathname.startsWith("/unsubscribe/") ||
     pathname.startsWith("/api/public/") ||
     pathname === "/api/auth/signup" ||
     pathname.startsWith("/api/v1/") ||

--- a/supabase/migrations/20260710240000_prospect_outreach.sql
+++ b/supabase/migrations/20260710240000_prospect_outreach.sql
@@ -1,0 +1,54 @@
+-- Prospects outreach (PR3): activity timeline, unsubscribe suppression, and a
+-- per-prospect unsubscribe token. Additive.
+ALTER TABLE public.prospects ADD COLUMN IF NOT EXISTS unsub_token TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prospects_unsub ON public.prospects (unsub_token) WHERE unsub_token IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.prospect_activities (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  prospect_id UUID NOT NULL REFERENCES public.prospects(id) ON DELETE CASCADE,
+  type        TEXT NOT NULL DEFAULT 'note' CHECK (type IN ('note','email','status','import','unsubscribe')),
+  summary     TEXT NOT NULL,
+  meta        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_by  UUID,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_prospect_activities ON public.prospect_activities (prospect_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.prospect_suppressions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  email       TEXT NOT NULL,
+  reason      TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prospect_suppressions ON public.prospect_suppressions (business_id, lower(email));
+
+DO $$
+DECLARE tb TEXT;
+BEGIN
+  FOREACH tb IN ARRAY ARRAY['prospect_activities','prospect_suppressions'] LOOP
+    EXECUTE format('ALTER TABLE public.%1$s ENABLE ROW LEVEL SECURITY;', tb);
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, tb);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## What

**PR3** — outreach. Completes the Prospects plugin (import → reach out → convert).

- **Migration `20260710240000`** (applied + recorded): `prospect_activities` (timeline), `prospect_suppressions` (unsubscribe list, unique on `lower(email)`), `prospects.unsub_token`.
- **`sendToProspects`** — merge fields (`{{first_name}}`/`{{name}}`/`{{company}}`), per-business sender, appends an **unsubscribe link**, **honors suppressions**, logs an activity, sets `last_contacted_at` + `new → contacted`. Shared by actions + MCP.
- Actions: `emailProspects` (single + bulk) · `addProspectNote` · `listProspectActivities`.
- **Public `/unsubscribe/[token]`** (middleware-whitelisted) — token → suppress the email + log. Idempotent.
- **UI**: compose dialog (subject/body + merge-field hint) on the list bulk bar (**Reach out**) and the detail page (**Send email**); detail gains an **activity timeline** + quick note.
- **MCP**: `email_prospects` (`prospects:write` + `email:send`).

## Compliance note
Bulk sending uses the per-business **Resend** sender — a **verified domain** is required to send beyond the account owner. Unsubscribe + suppression are **enforced in code**; deliverability/compliance (CAN-SPAM/GDPR) is the sender's responsibility.

## The plugin is complete
PR1 core · PR2 CSV import + bulk · PR3 outreach. (Future: Gmail/Outlook contact-import connector — OAuth-dependent.)

Verified: tsc · 17 tests · build (`/unsubscribe`) · bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)