### PR TITLE
perf: colocate compute with Tokyo DB, kill redundant auth, lazy-load heavy client chunks

### DIFF
--- a/src/app/(dashboard)/assets/page.tsx
+++ b/src/app/(dashboard)/assets/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { listAssets } from "@/lib/actions/assets";
 import { AssetsView } from "@/components/assets/assets-view";
 
-export const dynamic = "force-dynamic";
-
 export default async function AssetsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/assistant/page.tsx
+++ b/src/app/(dashboard)/assistant/page.tsx
@@ -1,8 +1,6 @@
 import { Sparkles } from "@/components/ui/icons";
 import { BriefingWidget } from "@/components/briefing/briefing-widget";
 
-export const dynamic = "force-dynamic";
-
 export default function AssistantPage() {
   return (
     <div>

--- a/src/app/(dashboard)/bookings/page.tsx
+++ b/src/app/(dashboard)/bookings/page.tsx
@@ -5,8 +5,6 @@ import { canEdit, type Role } from "@/lib/permissions";
 import { listAppointments, getBookingSettings } from "@/lib/actions/booking";
 import { BookingsPageClient } from "@/components/booking/bookings-page-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function BookingsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/contracts/[id]/page.tsx
+++ b/src/app/(dashboard)/contracts/[id]/page.tsx
@@ -5,8 +5,6 @@ import { canEdit as roleCanEdit, type Role } from "@/lib/permissions";
 import { getContract, renderContractHtml } from "@/lib/actions/contracts";
 import { ContractDetailClient } from "@/components/contracts/contract-detail-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function ContractDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = await createClient();

--- a/src/app/(dashboard)/contracts/page.tsx
+++ b/src/app/(dashboard)/contracts/page.tsx
@@ -5,8 +5,6 @@ import { getContracts, getContractTemplates } from "@/lib/actions/contracts";
 import { getCustomers } from "@/lib/actions/customers";
 import { ContractsClient } from "@/components/contracts/contracts-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function ContractsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
-import { getActiveBizId } from "@/lib/active-business";
-import { isWorker, type Role } from "@/lib/permissions";
+import { getUserOrNull } from "@/lib/auth";
+import { getMyRoleCached } from "@/lib/role";
+import { isWorker } from "@/lib/permissions";
 import { getDashboardStats } from "@/lib/actions/invoices";
 import { getBusiness } from "@/lib/actions/business";
 import { getTodayWorkOrders, getWorkOrders } from "@/lib/actions/work-orders";
@@ -9,27 +9,12 @@ import { DashboardClient } from "@/components/dashboard/dashboard-client";
 import { WorkerDashboard } from "@/components/dashboard/worker-dashboard";
 
 export default async function DashboardPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  // getUserOrNull shares the layout's cached GoTrue call; getMyRoleCached
+  // shares role resolution instead of re-querying businesses/members here.
+  const user = await getUserOrNull();
   if (!user) redirect("/auth/login");
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sb = supabase as any;
-  const businessId = await getActiveBizId(sb, user.id);
-
-  // Resolve role
-  const { data: biz } = await sb.from("businesses").select("user_id").eq("id", businessId).single();
-  let role: Role = "owner";
-  if (biz?.user_id !== user.id) {
-    const { data: m } = await sb
-      .from("business_members")
-      .select("role")
-      .eq("business_id", businessId)
-      .eq("user_id", user.id)
-      .eq("status", "active")
-      .maybeSingle();
-    role = (m?.role ?? "viewer") as Role;
-  }
+  const role = await getMyRoleCached();
 
   if (isWorker(role)) {
     const [business, todayJobs, allJobs] = await Promise.all([

--- a/src/app/(dashboard)/expenses/page.tsx
+++ b/src/app/(dashboard)/expenses/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { listExpenses } from "@/lib/actions/expenses";
 import { ExpensesView } from "@/components/expenses/expenses-view";
 
-export const dynamic = "force-dynamic";
-
 export default async function ExpensesPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/forms/[id]/page.tsx
+++ b/src/app/(dashboard)/forms/[id]/page.tsx
@@ -5,8 +5,6 @@ import { getPublicForm, getFormSubmissions } from "@/lib/actions/forms";
 import { appUrl } from "@/lib/app-url";
 import { FormsBuilderClient } from "@/components/forms/forms-builder-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function FormBuilderPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = await createClient();

--- a/src/app/(dashboard)/forms/page.tsx
+++ b/src/app/(dashboard)/forms/page.tsx
@@ -5,8 +5,6 @@ import { getFormBuilderSettings, getPublicForms } from "@/lib/actions/forms";
 import { appUrl } from "@/lib/app-url";
 import { FormsListClient } from "@/components/forms/forms-list-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function FormsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/inventory/page.tsx
+++ b/src/app/(dashboard)/inventory/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { listInventory } from "@/lib/actions/inventory";
 import { InventoryView } from "@/components/inventory/inventory-view";
 
-export const dynamic = "force-dynamic";
-
 export default async function InventoryPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/onboarding-forms/[id]/page.tsx
+++ b/src/app/(dashboard)/onboarding-forms/[id]/page.tsx
@@ -5,8 +5,6 @@ import { getOnboardingForm, getSecureFieldsAvailable, getOnboardingResponse, get
 import { FormBuilderClient } from "@/components/onboarding/form-builder-client";
 import { ResponseViewerClient } from "@/components/onboarding/response-viewer-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function OnboardingFormBuilderPage({ params, searchParams }: {
   params: Promise<{ id: string }>;
   searchParams: Promise<{ response?: string; view?: string }>;

--- a/src/app/(dashboard)/onboarding-forms/page.tsx
+++ b/src/app/(dashboard)/onboarding-forms/page.tsx
@@ -5,8 +5,6 @@ import { getOnboardingSettings, getOnboardingForms, getOnboardingRequests } from
 import { getCustomers } from "@/lib/actions/customers";
 import { OnboardingFormsClient } from "@/components/onboarding/onboarding-forms-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function OnboardingFormsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/prospects/[id]/page.tsx
+++ b/src/app/(dashboard)/prospects/[id]/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { getProspect, listProspectActivities } from "@/lib/actions/prospects";
 import { ProspectDetail } from "@/components/prospects/prospect-detail";
 
-export const dynamic = "force-dynamic";
-
 export default async function ProspectDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = await createClient();

--- a/src/app/(dashboard)/prospects/page.tsx
+++ b/src/app/(dashboard)/prospects/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { listProspects } from "@/lib/actions/prospects";
 import { ProspectsView } from "@/components/prospects/prospects-view";
 
-export const dynamic = "force-dynamic";
-
 export default async function ProspectsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/recurring-invoices/page.tsx
+++ b/src/app/(dashboard)/recurring-invoices/page.tsx
@@ -7,8 +7,6 @@ import { getCustomers } from "@/lib/actions/customers";
 import { getProducts } from "@/lib/actions/products";
 import { RecurringInvoicesClient } from "@/components/recurring/recurring-invoices-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function RecurringInvoicesPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -7,7 +7,6 @@ import { listConnections } from "@/lib/actions/seo-connections";
 import { listSeoReports } from "@/lib/actions/seo-reports";
 import { SeoSiteHub } from "@/components/seo/seo-site-hub";
 
-export const dynamic = "force-dynamic";
 // The Opportunity Scout (opus + web search) runs as a server action from this
 // route — give it room so it isn't cut off mid-scan.
 export const maxDuration = 300;

--- a/src/app/(dashboard)/seo/audits/page.tsx
+++ b/src/app/(dashboard)/seo/audits/page.tsx
@@ -4,7 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { getAuditLink, listAudits } from "@/lib/actions/seo-audits";
 import { SeoAuditsView } from "@/components/seo/seo-audits-view";
 
-export const dynamic = "force-dynamic";
 // runAuditNow runs the auditor agent as a server action from this route.
 export const maxDuration = 300;
 

--- a/src/app/(dashboard)/seo/content/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/content/[id]/page.tsx
@@ -5,8 +5,6 @@ import { getContentPiece } from "@/lib/actions/seo-pipeline";
 import { listConnections } from "@/lib/actions/seo-connections";
 import { SeoContentDetail } from "@/components/seo/seo-content-detail";
 
-export const dynamic = "force-dynamic";
-
 export default async function SeoContentDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = await createClient();

--- a/src/app/(dashboard)/seo/content/page.tsx
+++ b/src/app/(dashboard)/seo/content/page.tsx
@@ -5,8 +5,6 @@ import { listSeoSites } from "@/lib/actions/seo";
 import { listContentPieces, getSeoBudget } from "@/lib/actions/seo-pipeline";
 import { SeoContentList } from "@/components/seo/seo-content-list";
 
-export const dynamic = "force-dynamic";
-
 export default async function SeoContentPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/seo/page.tsx
+++ b/src/app/(dashboard)/seo/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { listSeoSites } from "@/lib/actions/seo";
 import { SeoSitesView } from "@/components/seo/seo-sites-view";
 
-export const dynamic = "force-dynamic";
-
 export default async function SeoPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/seo/pipeline/page.tsx
+++ b/src/app/(dashboard)/seo/pipeline/page.tsx
@@ -3,8 +3,6 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { SeoPipelineView } from "@/components/seo/seo-pipeline-view";
 
-export const dynamic = "force-dynamic";
-
 export default async function SeoPipelinePage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/settings/booking/page.tsx
+++ b/src/app/(dashboard)/settings/booking/page.tsx
@@ -8,8 +8,6 @@ import {
 } from "@/lib/actions/booking";
 import { BookingAdminClient } from "@/components/booking/booking-admin-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function BookingSettingsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/settings/email-templates/page.tsx
+++ b/src/app/(dashboard)/settings/email-templates/page.tsx
@@ -5,8 +5,6 @@ import { canEdit, type Role } from "@/lib/permissions";
 import { getEmailTemplates } from "@/lib/actions/email-templates";
 import { EmailTemplatesClient } from "@/components/settings/email-templates-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function EmailTemplatesPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/settings/work-order-templates/page.tsx
+++ b/src/app/(dashboard)/settings/work-order-templates/page.tsx
@@ -5,8 +5,6 @@ import { canEdit, type Role } from "@/lib/permissions";
 import { listWorkOrderTemplates } from "@/lib/actions/work-order-templates";
 import { WorkOrderTemplatesClient } from "@/components/work-orders/work-order-templates-client";
 
-export const dynamic = "force-dynamic";
-
 export default async function WorkOrderTemplatesPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -5,8 +5,6 @@ import { listTasks } from "@/lib/actions/tasks";
 import { KanbanBoard } from "@/components/tasks/kanban-board";
 import { PageHeader } from "@/components/layout/page-header";
 
-export const dynamic = "force-dynamic";
-
 type MemberInput = {
   user_id: string | null;
   email: string;

--- a/src/app/(dashboard)/timesheets/page.tsx
+++ b/src/app/(dashboard)/timesheets/page.tsx
@@ -4,8 +4,6 @@ import { getActiveBizId } from "@/lib/active-business";
 import { getTimesheet } from "@/lib/actions/timesheets";
 import { TimesheetsView } from "@/components/timesheets/timesheets-view";
 
-export const dynamic = "force-dynamic";
-
 function mondayOf(dateISO: string): string {
   const d = new Date(dateISO + "T00:00:00Z");
   const day = (d.getUTCDay() + 6) % 7;

--- a/src/components/analytics/analytics-charts.tsx
+++ b/src/components/analytics/analytics-charts.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * Recharts-backed charts for /analytics, split into their own module so the
+ * (heavy) recharts library can be dynamically imported. The analytics page
+ * shell — KPIs, tables, CSS funnels — paints immediately; these stream in
+ * behind a skeleton. Keeps recharts out of the /analytics first-load JS.
+ */
+import {
+  ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid, Legend,
+  PieChart, Pie, Cell,
+} from "recharts";
+import { formatCurrency } from "@/lib/utils";
+import type { AnalyticsPayload } from "@/lib/actions/analytics";
+
+export function RevenueBars({ monthly, currency }: { monthly: AnalyticsPayload["monthly"]; currency: string }) {
+  const fmt = (n: number) => formatCurrency(n, currency);
+  const fmtShort = (n: number) =>
+    Math.abs(n) >= 1000
+      ? `${(n / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })}k`
+      : n.toFixed(0);
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart data={monthly} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+        <XAxis
+          dataKey="month"
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+          tickFormatter={(v: number) => fmtShort(v)}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: "hsl(var(--card))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 8,
+            fontSize: 12,
+          }}
+          formatter={(value, name) => [fmt(Number(value ?? 0)), name === "revenue" ? "Paid" : "Invoiced"]}
+        />
+        <Legend
+          formatter={(v) => v === "revenue" ? "Paid" : "Invoiced"}
+          wrapperStyle={{ fontSize: 11, paddingTop: 8 }}
+        />
+        <Bar dataKey="invoiced" fill="hsl(var(--primary) / 0.18)" radius={[4, 4, 0, 0]} />
+        <Bar dataKey="revenue"  fill="hsl(var(--primary))"        radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function QuoteDonut({ funnel }: { funnel: AnalyticsPayload["quote_funnel"] }) {
+  const total = funnel.draft + funnel.sent + funnel.accepted + funnel.rejected + funnel.expired;
+  if (total === 0) {
+    return (
+      <div className="text-center py-12 text-sm text-muted-foreground">
+        No quotes in this period yet.
+      </div>
+    );
+  }
+  const decided = funnel.accepted + funnel.rejected + funnel.expired;
+  const acceptRate = decided > 0 ? Math.round((funnel.accepted / decided) * 100) : 0;
+
+  const slices = [
+    { name: "Accepted", value: funnel.accepted, fill: "hsl(150 60% 38%)" },
+    { name: "Sent",     value: funnel.sent,     fill: "hsl(var(--primary))" },
+    { name: "Draft",    value: funnel.draft,    fill: "hsl(220 14% 75%)" },
+    { name: "Rejected", value: funnel.rejected, fill: "hsl(0 70% 50%)" },
+    { name: "Expired",  value: funnel.expired,  fill: "hsl(220 14% 60%)" },
+  ].filter((s) => s.value > 0);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative" style={{ width: 160, height: 160 }}>
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie data={slices} dataKey="value" innerRadius={56} outerRadius={78} paddingAngle={2} stroke="none">
+              {slices.map((s, i) => <Cell key={i} fill={s.fill} />)}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+          <span className="font-display text-2xl font-semibold tabular-nums">{acceptRate}%</span>
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">accepted</span>
+        </div>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-xs w-full">
+        {slices.map((s) => (
+          <div key={s.name} className="flex items-center gap-1.5 min-w-0">
+            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: s.fill }} />
+            <span className="text-muted-foreground truncate">{s.name}</span>
+            <span className="font-semibold ml-auto tabular-nums">{s.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/analytics-client.tsx
+++ b/src/components/analytics/analytics-client.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import {
-  ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid, Legend,
-  PieChart, Pie, Cell,
-} from "recharts";
+import dynamic from "next/dynamic";
 import {
   TrendingUp, DollarSign, Clock, AlertTriangle,
   CheckCircle, FileCheck, Users,
@@ -12,6 +9,21 @@ import {
 import { PageHeader } from "@/components/layout/page-header";
 import { formatCurrency } from "@/lib/utils";
 import type { AnalyticsPayload, AnalyticsRange } from "@/lib/actions/analytics";
+
+// recharts is heavy — load the two chart blocks lazily (client-only) so the
+// KPI strip + tables paint immediately and the library stays out of the
+// /analytics first-load JS. Skeleton keeps the layout from jumping.
+const ChartSkeleton = ({ h }: { h: number }) => (
+  <div className="w-full animate-pulse rounded-lg bg-muted" style={{ height: h }} />
+);
+const RevenueBars = dynamic(
+  () => import("./analytics-charts").then((m) => ({ default: m.RevenueBars })),
+  { ssr: false, loading: () => <ChartSkeleton h={260} /> },
+);
+const QuoteDonut = dynamic(
+  () => import("./analytics-charts").then((m) => ({ default: m.QuoteDonut })),
+  { ssr: false, loading: () => <ChartSkeleton h={160} /> },
+);
 
 const RANGE_LABELS: Record<AnalyticsRange, string> = {
   "30d": "30 days", "90d": "90 days", "12m": "12 months", "ytd": "Year to date",
@@ -25,10 +37,6 @@ interface Props {
 export function AnalyticsClient({ data, range }: Props) {
   const c = data.currency;
   const fmt = (n: number) => formatCurrency(n, c);
-  const fmtShort = (n: number) =>
-    Math.abs(n) >= 1000
-      ? `${(n / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })}k`
-      : n.toFixed(0);
 
   return (
     <div>
@@ -101,38 +109,7 @@ export function AnalyticsClient({ data, range }: Props) {
           </div>
         </div>
         <div className="p-4">
-          <ResponsiveContainer width="100%" height={260}>
-            <BarChart data={data.monthly} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
-              <XAxis
-                dataKey="month"
-                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
-                axisLine={false}
-                tickLine={false}
-              />
-              <YAxis
-                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
-                axisLine={false}
-                tickLine={false}
-                tickFormatter={(v: number) => fmtShort(v)}
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "hsl(var(--card))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: 8,
-                  fontSize: 12,
-                }}
-                formatter={(value, name) => [fmt(Number(value ?? 0)), name === "revenue" ? "Paid" : "Invoiced"]}
-              />
-              <Legend
-                formatter={(v) => v === "revenue" ? "Paid" : "Invoiced"}
-                wrapperStyle={{ fontSize: 11, paddingTop: 8 }}
-              />
-              <Bar dataKey="invoiced" fill="hsl(var(--primary) / 0.18)" radius={[4, 4, 0, 0]} />
-              <Bar dataKey="revenue"  fill="hsl(var(--primary))"        radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
+          <RevenueBars monthly={data.monthly} currency={c} />
         </div>
       </div>
 
@@ -223,54 +200,6 @@ export function AnalyticsClient({ data, range }: Props) {
 }
 
 // ─── Sub-components ─────────────────────────────────────────────────────────
-
-function QuoteDonut({ funnel }: { funnel: AnalyticsPayload["quote_funnel"] }) {
-  const total = funnel.draft + funnel.sent + funnel.accepted + funnel.rejected + funnel.expired;
-  if (total === 0) {
-    return (
-      <div className="text-center py-12 text-sm text-muted-foreground">
-        No quotes in this period yet.
-      </div>
-    );
-  }
-  const decided = funnel.accepted + funnel.rejected + funnel.expired;
-  const acceptRate = decided > 0 ? Math.round((funnel.accepted / decided) * 100) : 0;
-
-  const slices = [
-    { name: "Accepted", value: funnel.accepted, fill: "hsl(150 60% 38%)" },
-    { name: "Sent",     value: funnel.sent,     fill: "hsl(var(--primary))" },
-    { name: "Draft",    value: funnel.draft,    fill: "hsl(220 14% 75%)" },
-    { name: "Rejected", value: funnel.rejected, fill: "hsl(0 70% 50%)" },
-    { name: "Expired",  value: funnel.expired,  fill: "hsl(220 14% 60%)" },
-  ].filter((s) => s.value > 0);
-
-  return (
-    <div className="flex flex-col items-center">
-      <div className="relative" style={{ width: 160, height: 160 }}>
-        <ResponsiveContainer>
-          <PieChart>
-            <Pie data={slices} dataKey="value" innerRadius={56} outerRadius={78} paddingAngle={2} stroke="none">
-              {slices.map((s, i) => <Cell key={i} fill={s.fill} />)}
-            </Pie>
-          </PieChart>
-        </ResponsiveContainer>
-        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-          <span className="font-display text-2xl font-semibold tabular-nums">{acceptRate}%</span>
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">accepted</span>
-        </div>
-      </div>
-      <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-xs w-full">
-        {slices.map((s) => (
-          <div key={s.name} className="flex items-center gap-1.5 min-w-0">
-            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: s.fill }} />
-            <span className="text-muted-foreground truncate">{s.name}</span>
-            <span className="font-semibold ml-auto tabular-nums">{s.value}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 function AgingRow({ label, amount, currency, tone }: {
   label: string; amount: number; currency: string; tone: "ok" | "warn" | "bad";

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { Suspense, useState } from "react";
+import dynamic from "next/dynamic";
 import { AppSidebar } from "./app-sidebar";
 import { AppHeader } from "./app-header";
 import { AppearanceProvider } from "./appearance-provider";
 import { AppLoadingProvider } from "./app-loading";
 import { RouteProgress } from "./route-progress";
-import { AgentPanel } from "@/components/agent/agent-panel";
+// The floating AI assistant starts closed and drags in framer-motion + voice
+// capture. Lazy-load it (client-only) so its chunk stays out of every dashboard
+// page's first load — the trigger button appears a beat after hydration.
+const AgentPanel = dynamic(
+  () => import("@/components/agent/agent-panel").then((m) => ({ default: m.AgentPanel })),
+  { ssr: false },
+);
 import type { Business } from "@/types/database";
 import type { Role } from "@/lib/permissions";
 import type { User } from "@supabase/supabase-js";

--- a/src/lib/actions/my-role.ts
+++ b/src/lib/actions/my-role.ts
@@ -1,29 +1,11 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
-import { getActiveBizId } from "@/lib/active-business";
+import { getMyRoleCached } from "@/lib/role";
 import type { Role } from "@/lib/permissions";
 
-import { getUser } from "@/lib/auth";
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const tbl = (sb: any, name: string) => sb.from(name);
-
-/** Resolve the caller's role in the active business. Owner is derived from
- *  businesses.user_id; other roles come from business_members. Cached at the
- *  request level via getActiveBizId. */
+/** Resolve the caller's role in the active business. Thin "use server"
+ *  delegate — the implementation (React-cache()d, parallel lookups) lives in
+ *  src/lib/role.ts so the layout + pages share one resolution per request. */
 export async function getMyRole(): Promise<Role> {
-  const supabase = await createClient();
-  const user = await getUser();
-  const businessId = await getActiveBizId(supabase, user.id);
-
-  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
-  if (biz?.user_id === user.id) return "owner";
-
-  const { data: member } = await tbl(supabase, "business_members")
-    .select("role")
-    .eq("business_id", businessId)
-    .eq("user_id", user.id)
-    .eq("status", "active")
-    .maybeSingle();
-  return (member?.role ?? "viewer") as Role;
+  return getMyRoleCached();
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,19 +9,22 @@ import { createClient } from "@/lib/supabase/server";
  * stacking the same round-trip 5-10× per request. React's `cache()` dedupes
  * inside the same React render scope (server-only).
  *
- * Throws if there is no user — pages/actions should redirect or catch.
+ * There is exactly ONE memoized fetch (`getUserOrNull`) — `getUser` is a thin
+ * throwing wrapper over it, so a layout using getUserOrNull and a page using
+ * getUser share a single GoTrue round trip per request instead of two.
  */
-export const getUser = cache(async () => {
-  const sb = await createClient();
-  const { data: { user } } = await sb.auth.getUser();
-  if (!user) throw new Error("Unauthorized");
-  return user;
-});
 
-/** Variant that returns null instead of throwing. Use in server components
- *  that need to handle anonymous visitors gracefully. */
+/** Returns the user or null. Use in server components that need to handle
+ *  anonymous visitors gracefully. */
 export const getUserOrNull = cache(async () => {
   const sb = await createClient();
   const { data: { user } } = await sb.auth.getUser();
   return user;
 });
+
+/** Throws if there is no user — pages/actions should redirect or catch. */
+export async function getUser() {
+  const user = await getUserOrNull();
+  if (!user) throw new Error("Unauthorized");
+  return user;
+}

--- a/src/lib/role.ts
+++ b/src/lib/role.ts
@@ -1,0 +1,37 @@
+import { cache } from "react";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { Role } from "@/lib/permissions";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/**
+ * Request-scoped cached role resolution for the active business.
+ *
+ * Owner is derived from businesses.user_id; other roles come from
+ * business_members. Wrapped in React cache() so the layout and the page tree
+ * share one resolution per request instead of each re-querying — this lives
+ * in a plain module because a "use server" file may only export plain async
+ * functions (a cache()-wrapped export breaks the build).
+ */
+export const getMyRoleCached = cache(async (): Promise<Role> => {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // Owner check and member lookup are independent — run them in parallel.
+  const [{ data: biz }, { data: member }] = await Promise.all([
+    tbl(supabase, "businesses").select("user_id").eq("id", businessId).single(),
+    tbl(supabase, "business_members")
+      .select("role")
+      .eq("business_id", businessId)
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .maybeSingle(),
+  ]);
+
+  if (biz?.user_id === user.id) return "owner";
+  return (member?.role ?? "viewer") as Role;
+});

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -9,29 +9,6 @@ export async function updateSession(request: NextRequest) {
   requestHeaders.set("x-pathname", request.nextUrl.pathname);
   let supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
 
-  const supabase = createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet: { name: string; value: string; options?: CookieOptions }[]) {
-          cookiesToSet.forEach(({ name, value }) =>
-            request.cookies.set(name, value)
-          );
-          supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
-          cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options)
-          );
-        },
-      },
-    }
-  );
-
-  const { data: { user } } = await supabase.auth.getUser();
-
   const { pathname } = request.nextUrl;
   const isAuthRoute = pathname.startsWith("/auth");
 
@@ -85,13 +62,50 @@ export async function updateSession(request: NextRequest) {
     (isBearerAuthRoute && hasBearer) ||
     (pathname.startsWith("/api/pdf/") && new URL(request.url).searchParams.get("token") !== null);
 
-  if (!user && !isAuthRoute && !isPublicRoute) {
+  // Public / self-authenticating routes never need the session check — return
+  // before touching Supabase auth at all. This keeps portal/booking/form/cron
+  // traffic (and Next's link prefetches to them) off the auth server entirely.
+  if (isPublicRoute) {
+    return supabaseResponse;
+  }
+
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet: { name: string; value: string; options?: CookieOptions }[]) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  // getClaims() resolves the session (refreshing expiring tokens — the
+  // middleware's real job) and verifies the JWT *locally* via cached JWKS when
+  // the project uses asymmetric signing keys — no per-request round trip to
+  // the auth server, unlike getUser(). On legacy symmetric keys it falls back
+  // to a network check, which is still correct, just slower. The redirect
+  // below is UX only — RLS remains the actual security gate on every query.
+  const { data } = await supabase.auth.getClaims();
+  const claims = data?.claims ?? null;
+
+  if (!claims && !isAuthRoute) {
     const url = request.nextUrl.clone();
     url.pathname = "/auth/login";
     return NextResponse.redirect(url);
   }
 
-  if (user && isAuthRoute) {
+  if (claims && isAuthRoute) {
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";
     return NextResponse.redirect(url);

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["hnd1"],
   "crons": [
     {
       "path": "/api/cron/reminders",


### PR DESCRIPTION
## The speed fix — part 1 of the full plan

Root cause of app-wide slowness (diagnosed, confirmed): **Supabase lives in Tokyo (`ap-northeast-1`), all Vercel functions ran in `iad1` (US East)** — every DB/auth round trip paid ~170 ms cross-Pacific, and a `/dashboard` load makes ~4 GoTrue calls + ~12 queries over 6-7 sequential waves, nearly all uncached.

### Commit 1 — client-bundle tuning
- Lazy-load the floating AgentPanel (`next/dynamic`, ssr:false) — its framer-motion + voice-capture chunk leaves every dashboard page's first load.
- Split recharts out of `/analytics` first-load (charts stream in behind skeletons).
- Remove redundant `force-dynamic` from 25 (dashboard) pages (segment is already dynamic via the layout's `cookies()`); kept on admin/public token pages.

### Commit 2 — region colocation + auth round-trip elimination (the big win)
- **`vercel.json` → `"regions": ["hnd1"]`** — functions now run next to the DB: ~170 ms/round-trip → ~2 ms. Stripe/Resend outbound is on async-tolerant paths; all 13 crons are DB-bound and get faster.
- **Middleware:** public/self-authenticating routes (portal/booking/forms/cron/mcp/oauth/tokenised-PDF/bearer) short-circuit **before** any auth call — zero GoTrue traffic incl. prefetches. Protected routes use `getClaims()` (local JWKS verification; session refresh preserved; RLS stays the security gate).
- **Auth dedupe:** `getUser`/`getUserOrNull` share one `cache()` memo; dashboard page's raw `auth.getUser()` + duplicated role queries removed; new request-cached `getMyRoleCached()` with parallel lookups.

### Verification
- tsc clean · 17/17 tests · route table unchanged at **152** (no feature/route removed)
- Post-deploy check: `x-vercel-id` header should contain `hnd1`; Supabase Auth logs should show 0 middleware calls per page load.
- ⚠️ Note: if the Supabase project is still on legacy HS256 signing keys, `getClaims` transparently falls back to a network check (correct, just no extra win) — migrating to asymmetric keys in the Supabase dashboard unlocks it fully.

Part of the approved full speed-fix plan (4 phases). Next: cross-request layout caching + dashboard stats SQL aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)