### PR TITLE
perf: stream heavy pages, complete skeleton coverage, prefetch drill-in nav

### DIFF
--- a/src/app/(dashboard)/assets/loading.tsx
+++ b/src/app/(dashboard)/assets/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/bookings/loading.tsx
+++ b/src/app/(dashboard)/bookings/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/contracts/[id]/loading.tsx
+++ b/src/app/(dashboard)/contracts/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/contracts/loading.tsx
+++ b/src/app/(dashboard)/contracts/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/customers/[id]/loading.tsx
+++ b/src/app/(dashboard)/customers/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
+import { DetailSkeleton } from "@/components/layout/detail-skeleton";
 import { getCustomer } from "@/lib/actions/customers";
 import { getInvoices } from "@/lib/actions/invoices";
 import { getQuotes } from "@/lib/actions/quotes";
@@ -36,6 +38,17 @@ async function loadOnboarding(customerId: string): Promise<CustomerOnboardingDat
 
 export default async function CustomerDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  // Stream: the shell + detail skeleton reach the browser immediately while
+  // the ~11 data fetches below settle (notFound() still works inside the
+  // Suspense child — it propagates to the not-found boundary).
+  return (
+    <Suspense fallback={<DetailSkeleton />}>
+      <CustomerDetailContent id={id} />
+    </Suspense>
+  );
+}
+
+async function CustomerDetailContent({ id }: { id: string }) {
   try {
     const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles, onboarding] = await Promise.all([
       getCustomer(id),

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { getUserOrNull } from "@/lib/auth";
 import { getMyRoleCached } from "@/lib/role";
@@ -7,13 +8,23 @@ import { getBusiness } from "@/lib/actions/business";
 import { getTodayWorkOrders, getWorkOrders } from "@/lib/actions/work-orders";
 import { DashboardClient } from "@/components/dashboard/dashboard-client";
 import { WorkerDashboard } from "@/components/dashboard/worker-dashboard";
+import Skeleton from "../loading";
 
 export default async function DashboardPage() {
-  // getUserOrNull shares the layout's cached GoTrue call; getMyRoleCached
-  // shares role resolution instead of re-querying businesses/members here.
+  // Auth-gate synchronously (cheap: shares the layout's cached GoTrue call),
+  // then stream the data-dependent content behind Suspense so the shell +
+  // skeleton reach the browser before the stats queries settle.
   const user = await getUserOrNull();
   if (!user) redirect("/auth/login");
 
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <DashboardContent userEmail={user.email ?? ""} />
+    </Suspense>
+  );
+}
+
+async function DashboardContent({ userEmail }: { userEmail: string }) {
   const role = await getMyRoleCached();
 
   if (isWorker(role)) {
@@ -24,7 +35,7 @@ export default async function DashboardPage() {
     ]);
     return (
       <WorkerDashboard
-        userEmail={user.email ?? ""}
+        userEmail={userEmail}
         businessName={business?.name ?? "your team"}
         todayJobs={todayJobs}
         allJobs={allJobs}

--- a/src/app/(dashboard)/expenses/loading.tsx
+++ b/src/app/(dashboard)/expenses/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/forms/loading.tsx
+++ b/src/app/(dashboard)/forms/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/help/loading.tsx
+++ b/src/app/(dashboard)/help/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/inventory/loading.tsx
+++ b/src/app/(dashboard)/inventory/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/invoices/[id]/loading.tsx
+++ b/src/app/(dashboard)/invoices/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/leads/[id]/loading.tsx
+++ b/src/app/(dashboard)/leads/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/onboarding-forms/loading.tsx
+++ b/src/app/(dashboard)/onboarding-forms/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/prospects/[id]/loading.tsx
+++ b/src/app/(dashboard)/prospects/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/prospects/loading.tsx
+++ b/src/app/(dashboard)/prospects/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/quotes/[id]/loading.tsx
+++ b/src/app/(dashboard)/quotes/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/quoting-agent/loading.tsx
+++ b/src/app/(dashboard)/quoting-agent/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/recurring-invoices/loading.tsx
+++ b/src/app/(dashboard)/recurring-invoices/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/reports/[id]/loading.tsx
+++ b/src/app/(dashboard)/reports/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/seo/[id]/loading.tsx
+++ b/src/app/(dashboard)/seo/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/seo/loading.tsx
+++ b/src/app/(dashboard)/seo/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/sites/[id]/loading.tsx
+++ b/src/app/(dashboard)/sites/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/app/(dashboard)/timesheets/loading.tsx
+++ b/src/app/(dashboard)/timesheets/loading.tsx
@@ -1,0 +1,2 @@
+/** Page-segment fallback. Reuses the (dashboard)/loading.tsx skeleton. */
+export { default } from "../loading";

--- a/src/app/(dashboard)/work-orders/[id]/loading.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/loading.tsx
@@ -1,0 +1,2 @@
+/** Detail-segment fallback — DetailHero-shaped so the canvas does not reflow. */
+export { default } from "@/components/layout/detail-skeleton";

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -211,6 +211,9 @@ export function CustomersClient({
                 <div
                   key={customer.id}
                   onClick={() => router.push(`/customers/${customer.id}`)}
+                  // Prefetch the detail RSC on hover so the click lands on a
+                  // warm payload instead of a cold dynamic fetch.
+                  onMouseEnter={() => router.prefetch(`/customers/${customer.id}`)}
                   className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
                 >
                   <input

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -176,6 +176,7 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
               <div
                 key={invoice.id}
                 onClick={() => router.push(`/invoices/${invoice.id}`)}
+                onMouseEnter={() => router.prefetch(`/invoices/${invoice.id}`)}
                 onAuxClick={(e) => { if (e.button === 1) window.open(`/invoices/${invoice.id}`, "_blank"); }}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >

--- a/src/components/layout/detail-skeleton.tsx
+++ b/src/components/layout/detail-skeleton.tsx
@@ -1,0 +1,59 @@
+/**
+ * Route-segment fallback for entity DETAIL pages ([id] segments).
+ * The generic (dashboard)/loading.tsx is list-shaped (KPI strip + table),
+ * which visibly reflows when a detail layout arrives — this mirrors the
+ * DetailHero + fact-cards + content-panels shape instead.
+ */
+export function DetailSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      {/* Hero: avatar + title + actions */}
+      <div className="rounded-xl border border-border bg-card p-5">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-4">
+            <div className="h-14 w-14 bg-muted rounded-xl" />
+            <div className="space-y-2">
+              <div className="h-6 w-48 bg-muted rounded-md" />
+              <div className="h-3 w-64 bg-muted rounded-md" />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-9 w-24 bg-muted rounded-xl" />
+            <div className="h-9 w-28 bg-muted rounded-xl" />
+          </div>
+        </div>
+      </div>
+
+      {/* Fact cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="rounded-xl p-4 border border-border bg-card space-y-2">
+            <div className="h-3 w-16 bg-muted rounded-md" />
+            <div className="h-5 w-24 bg-muted rounded-md" />
+          </div>
+        ))}
+      </div>
+
+      {/* Tabs + content panel */}
+      <div className="flex items-center gap-4 border-b border-border pb-2">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-4 w-20 bg-muted rounded-md" />
+        ))}
+      </div>
+      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="h-9 w-9 bg-muted rounded-lg" />
+            <div className="flex-1 space-y-2">
+              <div className="h-3 w-1/2 bg-muted rounded-md" />
+              <div className="h-2.5 w-1/3 bg-muted rounded-md" />
+            </div>
+            <div className="h-4 w-16 bg-muted rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default DetailSkeleton;

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -164,6 +164,7 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
               <div
                 key={quote.id}
                 onClick={() => router.push(`/quotes/${quote.id}`)}
+                onMouseEnter={() => router.prefetch(`/quotes/${quote.id}`)}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
                 <GradientTile gradient={STATUS_GRADIENT[quote.status] ?? "primary"} size={40} radius={10}>

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -137,6 +137,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
               <div
                 key={wo.id}
                 onClick={() => router.push(`/work-orders/${wo.id}`)}
+                onMouseEnter={() => router.prefetch(`/work-orders/${wo.id}`)}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
                 <GradientTile gradient={STATUS_GRADIENT[wo.status] ?? "primary"} size={40} radius={10}>


### PR DESCRIPTION
## The speed fix — part 3 of the full plan (stacked on #391)

Perceived-performance phase: every navigation now shows an instant, correctly-shaped skeleton, and the heaviest pages stream their shell before data settles.

- **Suspense streaming**: `/dashboard` + `/customers/[id]` (11 fetches) render shell-first; data streams in behind skeletons. `notFound()` still works through the boundary.
- **Skeleton coverage completed**: 14 list segments + 10 `[id]` detail segments gained `loading.tsx` (new shared `DetailSkeleton` — detail pages no longer inherit the mismatched list skeleton and reflow).
- **Hover-prefetch on drill-in rows** (customers/invoices/quotes/work-orders): `router.prefetch()` on mouseenter so clicking a row lands on a warm RSC payload. (Chose hover-prefetch over wrapping rows in `<Link>` — rows contain checkboxes/menus/nested links; an anchor wrapper risks nested-anchor hydration errors for the same benefit.)

### Verification
tsc clean · 17/17 tests · page/route count **152** (loading.tsx = boundaries, not routes)

Stacked on #391 → #390. Merge in order; bases retarget automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)