### PR TITLE
perf: lazy-load user-content images + config cleanup

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,6 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: [
       "@phosphor-icons/react",
-      "lucide-react",
       "framer-motion",
       "date-fns",
       "recharts",

--- a/src/app/book/[slug]/booking-widget.tsx
+++ b/src/app/book/[slug]/booking-widget.tsx
@@ -206,7 +206,7 @@ export function BookingWidget({ slug }: { slug: string }) {
             <motion.div initial={{ scale: 0.6, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} transition={{ delay: 0.1, type: "spring", stiffness: 200 }}
               style={{ width: 56, height: 56, borderRadius: 16, background: "rgba(255,255,255,0.2)", border: "2px solid rgba(255,255,255,0.4)", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", flexShrink: 0 }}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={config.branding.logo_url || KIREI_LOGO} alt={config.business_name || "Kirei"}
+              <img loading="lazy" decoding="async" src={config.branding.logo_url || KIREI_LOGO} alt={config.business_name || "Kirei"}
                 style={{ width: "100%", height: "100%", objectFit: "contain", background: config.branding.logo_url ? "transparent" : "#fff", padding: config.branding.logo_url ? 0 : 4 }} />
             </motion.div>
             <div style={{ minWidth: 0 }}>

--- a/src/app/booking/[manage_token]/manage-widget.tsx
+++ b/src/app/booking/[manage_token]/manage-widget.tsx
@@ -119,7 +119,7 @@ export function ManageWidget({ token }: { token: string }) {
           <div style={{ display: "flex", alignItems: "center", gap: 12, position: "relative" }}>
             <div style={{ width: 48, height: 48, borderRadius: 14, background: "rgba(255,255,255,0.2)", border: "2px solid rgba(255,255,255,0.4)", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", flexShrink: 0 }}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={data.branding.logo_url || "/kirei-logo.png"} alt={bizName}
+              <img loading="lazy" decoding="async" src={data.branding.logo_url || "/kirei-logo.png"} alt={bizName}
                 style={{ width: "100%", height: "100%", objectFit: "contain", background: data.branding.logo_url ? "transparent" : "#fff", padding: data.branding.logo_url ? 0 : 4 }} />
             </div>
             <div>

--- a/src/app/jobs/[token]/page.tsx
+++ b/src/app/jobs/[token]/page.tsx
@@ -120,7 +120,7 @@ export default async function PublicJobPage({ params }: { params: Promise<{ toke
                   {photosByPhase[phase].map((p) => (
                     /* eslint-disable-next-line @next/next/no-img-element */
                     <a key={p.id} href={p.url} target="_blank" rel="noopener noreferrer" className="block aspect-square">
-                      <img src={p.url} alt={p.caption ?? ""} className="w-full h-full object-cover rounded" />
+                      <img loading="lazy" decoding="async" src={p.url} alt={p.caption ?? ""} className="w-full h-full object-cover rounded" />
                     </a>
                   ))}
                 </div>
@@ -168,7 +168,7 @@ export default async function PublicJobPage({ params }: { params: Promise<{ toke
                 {sigs.map((s) => (
                   <div key={s.id} className="flex items-center gap-3">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={s.signature_url} alt="signature" className="h-12 w-24 object-contain bg-white border rounded" />
+                    <img loading="lazy" decoding="async" src={s.signature_url} alt="signature" className="h-12 w-24 object-contain bg-white border rounded" />
                     <div className="text-sm">
                       <p className="font-medium">{s.signed_by_name}{s.signed_by_role ? ` (${s.signed_by_role})` : ""}</p>
                       <p className="text-xs text-muted-foreground capitalize">{s.purpose.replace(/_/g, " ")} · {fmtDateTime(s.signed_at)}</p>

--- a/src/app/portal/[token]/contract/[id]/page.tsx
+++ b/src/app/portal/[token]/contract/[id]/page.tsx
@@ -57,7 +57,7 @@ export default async function PortalContractPage({ params }: { params: Promise<{
           <div className="flex items-center gap-3">
             {business?.logo_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={business.logo_url} alt={business.name} className="w-14 h-14 rounded-lg object-contain bg-white border border-border p-1" />
+              <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-14 h-14 rounded-lg object-contain bg-white border border-border p-1" />
             ) : null}
             <div className="text-right">
               <p className="font-semibold text-sm">{business?.name}</p>

--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -79,7 +79,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
           <div className="flex items-center gap-3">
             {business?.logo_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={business.logo_url} alt={business.name} className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg object-contain bg-white border border-border p-1" />
+              <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg object-contain bg-white border border-border p-1" />
             ) : null}
             <div className="text-right">
               <p className="font-semibold text-sm">{business?.name}</p>

--- a/src/app/portal/[token]/onboarding/[id]/page.tsx
+++ b/src/app/portal/[token]/onboarding/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function PortalOnboardingPage({ params }: { params: Promise
           <div className="flex items-center gap-3">
             {business?.logo_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={business.logo_url} alt={business.name} className="w-12 h-12 rounded-lg object-contain bg-white border border-border p-1" />
+              <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-12 h-12 rounded-lg object-contain bg-white border border-border p-1" />
             ) : null}
             <div className="text-right">
               <p className="font-semibold text-sm">{business?.name}</p>

--- a/src/app/portal/[token]/page.tsx
+++ b/src/app/portal/[token]/page.tsx
@@ -84,7 +84,7 @@ export default async function CustomerPortalPage({ params }: { params: Promise<{
           <div className="flex items-center gap-4 min-w-0">
             {business?.logo_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={business.logo_url} alt={business.name} className="w-16 h-16 sm:w-20 sm:h-20 rounded-xl object-contain bg-white border border-border p-1 shadow-sm" />
+              <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-16 h-16 sm:w-20 sm:h-20 rounded-xl object-contain bg-white border border-border p-1 shadow-sm" />
             ) : (
               <div
                 className="w-16 h-16 sm:w-20 sm:h-20 rounded-xl flex items-center justify-center text-white shadow-sm"

--- a/src/app/portal/[token]/quote/[id]/page.tsx
+++ b/src/app/portal/[token]/quote/[id]/page.tsx
@@ -61,7 +61,7 @@ export default async function PortalQuotePage({ params }: { params: Promise<{ to
           <div className="flex items-center gap-3">
             {business?.logo_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={business.logo_url} alt={business.name} className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg object-contain bg-white border border-border p-1" />
+              <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg object-contain bg-white border border-border p-1" />
             ) : null}
             <div className="text-right">
               <p className="font-semibold text-sm">{business?.name}</p>

--- a/src/app/portal/[token]/report/[id]/page.tsx
+++ b/src/app/portal/[token]/report/[id]/page.tsx
@@ -49,7 +49,7 @@ export default async function PortalReportPage({ params }: { params: Promise<{ t
           <div className="flex items-center gap-3">
             {business?.logo_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <img src={business.logo_url} alt={business.name} className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg object-contain bg-white border border-border p-1" />
+              <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg object-contain bg-white border border-border p-1" />
             ) : null}
             <div className="text-right">
               <p className="font-semibold text-sm">{business?.name}</p>
@@ -129,7 +129,7 @@ export default async function PortalReportPage({ params }: { params: Promise<{ t
               {r.photos.map((p) => (
                 <div key={p.id} className="space-y-1">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={p.url} alt={p.caption || "Site photo"} className="w-full aspect-video object-cover rounded" />
+                  <img loading="lazy" decoding="async" src={p.url} alt={p.caption || "Site photo"} className="w-full aspect-video object-cover rounded" />
                   {p.caption && <p className="text-xs text-muted-foreground">{p.caption}</p>}
                 </div>
               ))}

--- a/src/components/ai/ai-image-analyzer.tsx
+++ b/src/components/ai/ai-image-analyzer.tsx
@@ -90,7 +90,7 @@ export function AiImageAnalyzer({ onResult }: AiImageAnalyzerProps) {
             {images.map((img, i) => (
               <div key={i} className="relative group">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={img.preview} alt={img.name} className="h-14 w-14 object-cover rounded border" />
+                <img loading="lazy" decoding="async" src={img.preview} alt={img.name} className="h-14 w-14 object-cover rounded border" />
                 <button
                   type="button"
                   className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground rounded-full w-4 h-4 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"

--- a/src/components/customer-portal/onboarding-fill.tsx
+++ b/src/components/customer-portal/onboarding-fill.tsx
@@ -349,7 +349,7 @@ function UploadControl({ field: f, value, endpoint, onChange }: {
       return (
         <div className="relative inline-block">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={src} alt={meta.name ?? "Uploaded image"}
+          <img loading="lazy" decoding="async" src={src} alt={meta.name ?? "Uploaded image"}
             className="max-h-48 max-w-full rounded-lg border border-border object-contain bg-muted/30" />
           <button type="button" onClick={() => onChange(null)} aria-label="Remove image"
             className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-destructive">

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -318,7 +318,7 @@ function WorkOrderCard({ wo, currency }: { wo: WorkOrderWithCustomer; currency: 
             {photos.map((photo) => (
               <a key={photo.id} href={photo.url} target="_blank" rel="noreferrer" className="aspect-square">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={photo.url} alt="" className="w-full h-full object-cover rounded border hover:opacity-90 transition-opacity" />
+                <img loading="lazy" decoding="async" src={photo.url} alt="" className="w-full h-full object-cover rounded border hover:opacity-90 transition-opacity" />
               </a>
             ))}
           </div>

--- a/src/components/forms/public-form-fill.tsx
+++ b/src/components/forms/public-form-fill.tsx
@@ -179,7 +179,7 @@ function UploadControl({ field: f, value, endpoint, onChange }: { field: Onboard
       return (
         <div className="relative inline-block">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={src} alt={meta.name ?? ""} className="max-h-40 max-w-full rounded-lg border border-border object-contain bg-muted/30" />
+          <img loading="lazy" decoding="async" src={src} alt={meta.name ?? ""} className="max-h-40 max-w-full rounded-lg border border-border object-contain bg-muted/30" />
           <button type="button" onClick={() => onChange(null)} className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-destructive"><X className="w-3.5 h-3.5" /></button>
         </div>
       );

--- a/src/components/forms/public-form-shell.tsx
+++ b/src/components/forms/public-form-shell.tsx
@@ -26,7 +26,7 @@ export async function PublicFormShell({ slug, embed }: { slug: string; embed?: b
         <div className="flex items-center gap-3 mb-6">
           {business?.logo_url ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={business.logo_url} alt={business.name} className="w-11 h-11 rounded-lg object-contain bg-white border border-border p-1" />
+            <img loading="lazy" decoding="async" src={business.logo_url} alt={business.name} className="w-11 h-11 rounded-lg object-contain bg-white border border-border p-1" />
           ) : null}
           <span className="font-semibold">{business?.name}</span>
         </div>

--- a/src/components/reports/report-detail-client.tsx
+++ b/src/components/reports/report-detail-client.tsx
@@ -317,7 +317,7 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
                   {report.photos.map((photo: ReportPhoto) => (
                     <div key={photo.id} className="space-y-1.5">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img src={photo.url} alt={photo.caption} className="w-full aspect-[4/3] object-cover rounded-lg border" />
+                      <img loading="lazy" decoding="async" src={photo.url} alt={photo.caption} className="w-full aspect-[4/3] object-cover rounded-lg border" />
                       <p className="text-[10px] font-semibold text-muted-foreground">Photo {photo.order} of {report.photos.length}</p>
                       {editingCaption === photo.id ? (
                         <div className="space-y-1">

--- a/src/components/reports/report-generator.tsx
+++ b/src/components/reports/report-generator.tsx
@@ -364,7 +364,7 @@ export function ReportGenerator({ customers: initialCustomers, business, default
                     {images.map((img, i) => (
                       <div key={i} className="relative group aspect-square">
                         {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img src={img.preview} alt="" className="w-full h-full object-cover rounded-lg border" />
+                        <img loading="lazy" decoding="async" src={img.preview} alt="" className="w-full h-full object-cover rounded-lg border" />
                         <button
                           type="button"
                           className="absolute -top-1 -right-1 w-5 h-5 bg-destructive text-destructive-foreground rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"

--- a/src/components/seo/audit-landing-form.tsx
+++ b/src/components/seo/audit-landing-form.tsx
@@ -40,7 +40,7 @@ export function AuditLandingForm({ slug, businessName, logoUrl }: Props) {
         <div className="text-center mb-6">
           {logoUrl
             // eslint-disable-next-line @next/next/no-img-element
-            ? <img src={logoUrl} alt={businessName} className="h-10 mx-auto mb-3" />
+            ? <img loading="lazy" decoding="async" src={logoUrl} alt={businessName} className="h-10 mx-auto mb-3" />
             : <p className="text-lg font-bold text-emerald-700">{businessName}</p>}
           <h1 className="text-2xl font-bold text-slate-900 mt-2">Free SEO audit</h1>
           <p className="text-sm text-slate-500 mt-1">Get a free report on your site&apos;s SEO health — delivered to your inbox.</p>

--- a/src/components/team/team-page-client.tsx
+++ b/src/components/team/team-page-client.tsx
@@ -34,7 +34,7 @@ function Avatar({ name, avatarUrl, size = "md" }: { name: string; avatarUrl?: st
   const initials = name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2);
   if (avatarUrl) return (
     // eslint-disable-next-line @next/next/no-img-element
-    <img src={avatarUrl} alt={name} className={`${sizes[size]} rounded-full object-cover flex-shrink-0`} />
+    <img loading="lazy" decoding="async" src={avatarUrl} alt={name} className={`${sizes[size]} rounded-full object-cover flex-shrink-0`} />
   );
   return (
     <div className={`${sizes[size]} rounded-full bg-gradient-to-br from-purple-500 to-violet-600 text-white flex items-center justify-center font-semibold flex-shrink-0`}>

--- a/src/components/work-orders/job-portfolio-client.tsx
+++ b/src/components/work-orders/job-portfolio-client.tsx
@@ -1203,7 +1203,7 @@ function PhotoLightbox({ photos, index, onIndex, onClose, onDownload }: {
           </button>
         )}
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={photo.url} alt={photo.caption ?? ""} className="max-h-full max-w-full object-contain rounded" />
+        <img loading="lazy" decoding="async" src={photo.url} alt={photo.caption ?? ""} className="max-h-full max-w-full object-contain rounded" />
         {index < photos.length - 1 && (
           <button onClick={() => go(1)} className="absolute right-2 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center" aria-label="Next">
             <ChevronRight className="w-5 h-5" />
@@ -1531,7 +1531,7 @@ function SignaturesSection({
               <div className="flex items-center gap-3 min-w-0">
                 <a href={s.signature_url} target="_blank" rel="noopener noreferrer" className="shrink-0">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={s.signature_url} alt="signature" className="h-12 w-24 object-contain bg-white border rounded" />
+                  <img loading="lazy" decoding="async" src={s.signature_url} alt="signature" className="h-12 w-24 object-contain bg-white border rounded" />
                 </a>
                 <div className="min-w-0">
                   <p className="text-sm font-medium break-words">{s.signed_by_name}{s.signed_by_role ? ` (${s.signed_by_role})` : ""}</p>


### PR DESCRIPTION
## The speed fix — part 4 of the full plan (stacked on #392)

- **`loading="lazy" decoding="async"` on every raw `<img>` for user/Supabase content** (22 files: job portfolio, customer/report photos, team avatars, portal/booking/form logos) — offscreen photos stop downloading on page load. This is the zero-risk subset of the planned `next/image` conversion; the full conversion (fill-mode galleries, signed-URL optimizer caching) is staged as a follow-up that needs visual verification on a preview.
- **Removed the phantom `lucide-react` entry** from `optimizePackageImports` (not a dependency — the icon shim re-exports Phosphor).
- (Local-only, not in diff: fixed the literal `\n` inside `.env.local`'s `NEXT_PUBLIC_SUPABASE_URL` — worth checking the Vercel env value is clean too.)

**Deferred with reasoning** (small win post-#391, needs live-preview verification): `router.refresh()` drops on hotspot components — each drop risks stale UI without component-level testing, and the refreshes are cheap now that the layout is cached.

### Verification
tsc clean · 17/17 tests · route count **152**

Stack: #390 → #391 → #392 → this. Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)