### PR TITLE
perf: cross-request layout caching + dashboard stats SQL aggregate

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -6,6 +6,7 @@ import { DashboardShell } from "@/components/layout/dashboard-shell";
 import { isWorker, isPathAllowedForWorker, type Role } from "@/lib/permissions";
 import { resolveEnabledPlugins, ROUTE_GATES } from "@/lib/plugins/registry";
 import { PRESETS_BY_ID } from "@/lib/plugins/presets";
+import { getLayoutBusinesses, fetchLayoutBusinessesDirect, getPluginFlags } from "@/lib/layout-data";
 import type { Business } from "@/types/database";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -14,16 +15,18 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   if (!user) redirect("/auth/login");
 
-  // Fetch owned businesses and memberships in parallel
+  // Owned businesses + memberships — cached cross-request (60s / tag) since
+  // they change rarely but were re-fetched on every navigation.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sb = supabase as any;
-  const [{ data: ownedRaw }, { data: membershipsRaw }] = await Promise.all([
-    sb.from("businesses").select("*").eq("user_id", user.id).order("created_at", { ascending: true }),
-    sb.from("business_members").select("business_id, role, businesses(*)").eq("user_id", user.id).eq("status", "active"),
-  ]);
+  let { owned: ownedBusinesses, memberships } = await getLayoutBusinesses(user.id);
 
-  const ownedBusinesses = (ownedRaw ?? []) as Business[];
-  const memberships = (membershipsRaw ?? []) as { business_id: string; role: string; businesses: Business }[];
+  // Empty-list safety: a brand-new user who just created their first business
+  // must not be bounced to /onboarding by a stale cached empty list — re-check
+  // directly (rare path: only users with zero cached businesses hit this).
+  if (ownedBusinesses.length === 0 && memberships.length === 0) {
+    ({ owned: ownedBusinesses, memberships } = await fetchLayoutBusinessesDirect(user.id));
+  }
 
   // Combine, keeping owned first, deduplicating
   const allBusinesses: Business[] = [...ownedBusinesses];
@@ -67,16 +70,11 @@ export default async function DashboardLayout({ children }: { children: React.Re
   // modules default ON), so existing businesses see zero change until they
   // explicitly toggle something. Legacy settings tables stay authoritative
   // for the three original feature-flagged verticals.
-  const [{ data: installRows }, { data: quotingSettings }, { data: onboardingSettings }, { data: formBuilderSettings }] = await Promise.all([
-    sb.from("business_agent_installs").select("agent_id, enabled").eq("business_id", business.id),
-    sb.from("quoting_agent_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
-    sb.from("onboarding_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
-    sb.from("form_builder_settings").select("enabled").eq("business_id", business.id).maybeSingle(),
-  ]);
-  const plugins = resolveEnabledPlugins(installRows ?? [], {
-    quoting_agent_settings: quotingSettings ? !!quotingSettings.enabled : null,
-    onboarding_settings: onboardingSettings ? !!onboardingSettings.enabled : null,
-    form_builder_settings: formBuilderSettings ? !!formBuilderSettings.enabled : null,
+  const flags = await getPluginFlags(business.id);
+  const plugins = resolveEnabledPlugins(flags.installRows, {
+    quoting_agent_settings: flags.quoting,
+    onboarding_settings: flags.onboarding,
+    form_builder_settings: flags.formBuilder,
   });
 
   // Route-level gating: visiting a disabled plugin's URL redirects home

--- a/src/app/api/activate-invite/route.ts
+++ b/src/app/api/activate-invite/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { cookies } from "next/headers";
+import { bizListTag } from "@/lib/layout-data";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -22,6 +24,9 @@ export async function GET(request: NextRequest) {
   // Activate any pending memberships for this user
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await (supabase as any).rpc("activate_pending_memberships");
+  // The layout's business list is cached per user — the just-activated
+  // membership must show up immediately.
+  revalidateTag(bizListTag(user.id), "max");
 
   if (biz) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/actions/business.ts
+++ b/src/lib/actions/business.ts
@@ -1,9 +1,10 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag, unstable_cache } from "next/cache";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
+import { bizListTag, businessTag } from "@/lib/layout-data";
 import type { Business } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
@@ -27,9 +28,18 @@ export async function getBusiness(): Promise<Business> {
   const user = await getUser();
 
   const businessId = await getActiveBizId(supabase, user.id);
-  const { data, error } = await tbl(supabase, "businesses").select("*").eq("id", businessId).single();
-  if (error) throw error;
-  return data as Business;
+  // Fetched by the layout AND nearly every page — cache cross-request (60s
+  // TTL as the backstop for admin-client writes that bypass tags; mutations
+  // below revalidate `businessTag` for immediate freshness).
+  return unstable_cache(
+    async () => {
+      const { data, error } = await tbl(supabase, "businesses").select("*").eq("id", businessId).single();
+      if (error) throw error;
+      return data as Business;
+    },
+    [`business-${businessId}`],
+    { tags: [businessTag(businessId)], revalidate: 60 }
+  )();
 }
 
 export async function setActiveBusiness(businessId: string): Promise<void> {
@@ -103,6 +113,7 @@ export async function createBusiness(payload: {
     maxAge: 60 * 60 * 24 * 365,
   });
 
+  revalidateTag(bizListTag(user.id), "max");
   revalidatePath("/", "layout");
   return data as Business;
 }
@@ -120,6 +131,8 @@ export async function updateBusiness(payload: Partial<Business>): Promise<Busine
     .select()
     .single();
   if (error) throw error;
+  revalidateTag(businessTag(businessId), "max");
+  revalidateTag(bizListTag(user.id), "max"); // name/branding shows in the switcher list
   revalidatePath("/settings");
   revalidatePath("/dashboard");
   return data as Business;
@@ -170,6 +183,7 @@ export async function savePdfSettings(
     }
   }
 
+  revalidateTag(businessTag(businessId), "max");
   revalidatePath("/settings");
   revalidatePath("/invoices", "layout");
   revalidatePath("/quotes", "layout");
@@ -197,6 +211,8 @@ export async function uploadLogo(formData: FormData): Promise<string> {
     .eq("id", businessId)
     .eq("user_id", user.id);
 
+  revalidateTag(businessTag(businessId), "max");
+  revalidateTag(bizListTag(user.id), "max"); // logo shows in the business switcher
   revalidatePath("/settings");
   revalidatePath("/dashboard");
 

--- a/src/lib/actions/customers.ts
+++ b/src/lib/actions/customers.ts
@@ -18,7 +18,11 @@ export async function getCustomers(includeArchived = false): Promise<Customer[]>
 
   return unstable_cache(
     async () => {
-      let query = tbl(supabase, "customers").select("*").eq("business_id", businessId).order("name");
+      // Bounded: this getter feeds list pages and pickers — an unbounded
+      // select was shipping every customer row (all columns) into the RSC
+      // payload on every consumer page. 1000 covers realistic tenants; a
+      // paginated getter is the follow-up if someone outgrows it.
+      let query = tbl(supabase, "customers").select("*").eq("business_id", businessId).order("name").limit(1000);
       if (!includeArchived) query = query.eq("archived", false);
       const { data, error } = await query;
       if (error) throw error;

--- a/src/lib/actions/forms.ts
+++ b/src/lib/actions/forms.ts
@@ -1,11 +1,12 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { slugifyFormName } from "@/lib/forms/slug";
+import { pluginFlagsTag } from "@/lib/layout-data";
 import type { PublicForm, PublicFormSubmission, OnboardingField } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,6 +44,7 @@ export async function setFormBuilderEnabled(enabled: boolean): Promise<void> {
       { onConflict: "business_id,agent_id" },
     );
   } catch { /* non-fatal */ }
+  revalidateTag(pluginFlagsTag(businessId), "max"); // layout's cached feature flags
   revalidatePath("/forms");
   revalidatePath("/agents");
   revalidatePath("/", "layout");

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -450,39 +450,27 @@ export async function getDashboardStats() {
 
   const businessId = await getActiveBizId(supabase, user.id);
 
-  const { data: invoices } = await tbl(supabase, "invoices")
-    .select("id, number, total, amount_paid, status, issue_date, due_date, created_at, customers(name)")
-    .eq("business_id", businessId);
-
-  if (!invoices) return { totalRevenue: 0, outstanding: 0, overdue: 0, paidThisMonth: 0, recentInvoices: [], monthlyData: [] };
-
-  const now = new Date();
-  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-
+  // Single SQL aggregate (migration 20260716130000_dashboard_stats_rpc) —
+  // replaces fetching EVERY invoice row into Node and reducing in JS. Same
+  // return shape; SECURITY INVOKER so RLS applies exactly as before (workers
+  // get an empty result, not an error).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const inv = invoices as any[];
-  const totalRevenue = inv.filter((i) => i.status === "paid").reduce((sum: number, i) => sum + i.total, 0);
-  const outstanding = inv.filter((i) => ["sent", "partial"].includes(i.status)).reduce((sum: number, i) => sum + (i.total - i.amount_paid), 0);
-  const overdue = inv.filter((i) => ["sent", "partial"].includes(i.status) && new Date(i.due_date) < now).reduce((sum: number, i) => sum + (i.total - i.amount_paid), 0);
-  const paidThisMonth = inv.filter((i) => i.status === "paid" && new Date(i.created_at) >= startOfMonth).reduce((sum: number, i) => sum + i.total, 0);
-
-  const monthlyData: { month: string; revenue: number; invoiced: number }[] = [];
-  for (let i = 5; i >= 0; i--) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const monthLabel = d.toLocaleString("default", { month: "short" });
-    const monthInvoices = inv.filter((invoice) => {
-      const created = new Date(invoice.created_at);
-      return created.getFullYear() === d.getFullYear() && created.getMonth() === d.getMonth();
-    });
-    monthlyData.push({
-      month: monthLabel,
-      revenue: monthInvoices.filter((invoice) => invoice.status === "paid").reduce((s: number, invoice) => s + invoice.total, 0),
-      invoiced: monthInvoices.reduce((s: number, invoice) => s + invoice.total, 0),
-    });
-  }
-
-  const recentInvoices = inv.slice(0, 5);
-  return { totalRevenue, outstanding, overdue, paidThisMonth, recentInvoices, monthlyData };
+  const { data, error } = await (supabase as any).rpc("dashboard_stats", { biz: businessId });
+  if (error) throw error;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d = (data ?? {}) as any;
+  return {
+    totalRevenue: Number(d.totalRevenue ?? 0),
+    outstanding: Number(d.outstanding ?? 0),
+    overdue: Number(d.overdue ?? 0),
+    paidThisMonth: Number(d.paidThisMonth ?? 0),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recentInvoices: ((d.recentInvoices ?? []) as any[]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    monthlyData: ((d.monthlyData ?? []) as any[]).map((m) => ({
+      month: String(m.month), revenue: Number(m.revenue ?? 0), invoiced: Number(m.invoiced ?? 0),
+    })),
+  };
 }
 
 export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[]; subject?: string }): Promise<void> {

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -1,11 +1,12 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { randomBytes } from "node:crypto";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { appUrl } from "@/lib/app-url";
+import { pluginFlagsTag } from "@/lib/layout-data";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { redactSecureAnswers } from "@/lib/onboarding/answers";
 import { decryptSecret, isEncryptedAnswer, secureFieldsAvailable } from "@/lib/onboarding/crypto";
@@ -51,6 +52,7 @@ export async function setOnboardingEnabled(enabled: boolean): Promise<void> {
       { onConflict: "business_id,agent_id" },
     );
   } catch { /* non-fatal */ }
+  revalidateTag(pluginFlagsTag(businessId), "max"); // layout's cached feature flags
   revalidatePath("/onboarding-forms");
   revalidatePath("/agents");
   revalidatePath("/", "layout"); // sidebar flag

--- a/src/lib/actions/plugins.ts
+++ b/src/lib/actions/plugins.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
@@ -9,6 +9,7 @@ import { canManageSettings, type Role } from "@/lib/permissions";
 import { PLUGINS_BY_ID, resolveEnabledPlugins, dependentsOf } from "@/lib/plugins/registry";
 import { PRESETS_BY_ID, presetInstallRows } from "@/lib/plugins/presets";
 import { syncPluginSideEffects } from "@/lib/plugins/sync";
+import { pluginFlagsTag, bizListTag } from "@/lib/layout-data";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -109,6 +110,12 @@ export async function applyIndustryPreset(businessId: string, presetId: string):
       await syncPluginSideEffects(admin, businessId, row.agent_id, row.enabled);
     }
   }
+
+  // Install rows changed even for plugins without a settings table, and
+  // industry_preset (vocab) lives on the cached business list row.
+  revalidateTag(pluginFlagsTag(businessId), "max");
+  const user = await getUser();
+  revalidateTag(bizListTag(user.id), "max");
 
   revalidatePath("/agents");
   revalidatePath("/", "layout");

--- a/src/lib/actions/quoting-agent.ts
+++ b/src/lib/actions/quoting-agent.ts
@@ -1,9 +1,10 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
+import { pluginFlagsTag } from "@/lib/layout-data";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
@@ -66,6 +67,7 @@ export async function setQuotingAgentEnabled(enabled: boolean): Promise<void> {
 
   await tbl(supabase, "quoting_agent_settings")
     .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  revalidateTag(pluginFlagsTag(businessId), "max"); // layout's cached feature flags
   revalidatePath("/quoting-agent");
   revalidatePath("/", "layout"); // sidebar visibility
 }

--- a/src/lib/layout-data.ts
+++ b/src/lib/layout-data.ts
@@ -1,0 +1,92 @@
+/**
+ * Cross-request cached reads for the (dashboard) layout — the queries that run
+ * on EVERY dashboard navigation (business list + plugin feature flags).
+ *
+ * Before this, each navigation re-ran 6 queries (2 business + 4 flag tables)
+ * even though the data changes rarely. Each getter mirrors the established
+ * `getCustomers` unstable_cache pattern: keyed per user/business, tagged so
+ * mutations invalidate precisely, short TTL as the staleness backstop for any
+ * write path that forgets to invalidate (e.g. admin-client writes).
+ *
+ * Plain module (no "use server") — a "use server" file may only export plain
+ * async functions, and we also export tag-name helpers (strings).
+ */
+import { unstable_cache } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import type { Business } from "@/types/database";
+
+/** Tag: a user's business list (owned + memberships). Invalidate on
+ *  create-business, invite activation, and business renames. */
+export const bizListTag = (userId: string) => `biz-list-${userId}`;
+
+/** Tag: a business's plugin/feature flags (installs + legacy settings
+ *  tables). Invalidate from syncPluginSideEffects + the legacy toggles. */
+export const pluginFlagsTag = (businessId: string) => `plugin-flags-${businessId}`;
+
+/** Tag: a single business row (getBusiness). Invalidate on business updates. */
+export const businessTag = (businessId: string) => `business-${businessId}`;
+
+export interface LayoutBusinesses {
+  owned: Business[];
+  memberships: { business_id: string; role: string; businesses: Business }[];
+}
+
+/** Uncached fetch — used by the cache MISS path and as a direct re-check when
+ *  the cached list comes back empty (a brand-new user who just created their
+ *  first business must not be bounced back to /onboarding by a stale cache). */
+export async function fetchLayoutBusinessesDirect(userId: string): Promise<LayoutBusinesses> {
+  const supabase = await createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any;
+  const [{ data: owned }, { data: memberships }] = await Promise.all([
+    sb.from("businesses").select("*").eq("user_id", userId).order("created_at", { ascending: true }),
+    sb.from("business_members").select("business_id, role, businesses(*)").eq("user_id", userId).eq("status", "active"),
+  ]);
+  return {
+    owned: (owned ?? []) as Business[],
+    memberships: (memberships ?? []) as LayoutBusinesses["memberships"],
+  };
+}
+
+/** The user's businesses (owned + member-of), cached 60s / tag-invalidated. */
+export async function getLayoutBusinesses(userId: string): Promise<LayoutBusinesses> {
+  return unstable_cache(
+    () => fetchLayoutBusinessesDirect(userId),
+    [`layout-businesses-${userId}`],
+    { tags: [bizListTag(userId)], revalidate: 60 }
+  )();
+}
+
+export interface PluginFlagRows {
+  installRows: { agent_id: string; enabled: boolean }[];
+  quoting: boolean | null;
+  onboarding: boolean | null;
+  formBuilder: boolean | null;
+}
+
+/** The business's plugin flags (installs + 3 legacy settings tables), cached
+ *  5 min / tag-invalidated from every toggle path (store, legacy actions,
+ *  MCP set_plugin_enabled, industry presets — all via syncPluginSideEffects). */
+export async function getPluginFlags(businessId: string): Promise<PluginFlagRows> {
+  const supabase = await createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any;
+  return unstable_cache(
+    async () => {
+      const [{ data: installRows }, { data: quoting }, { data: onboarding }, { data: formBuilder }] = await Promise.all([
+        sb.from("business_agent_installs").select("agent_id, enabled").eq("business_id", businessId),
+        sb.from("quoting_agent_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
+        sb.from("onboarding_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
+        sb.from("form_builder_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
+      ]);
+      return {
+        installRows: (installRows ?? []) as PluginFlagRows["installRows"],
+        quoting: quoting ? !!quoting.enabled : null,
+        onboarding: onboarding ? !!onboarding.enabled : null,
+        formBuilder: formBuilder ? !!formBuilder.enabled : null,
+      };
+    },
+    [`plugin-flags-${businessId}`],
+    { tags: [pluginFlagsTag(businessId)], revalidate: 300 }
+  )();
+}

--- a/src/lib/plugins/sync.ts
+++ b/src/lib/plugins/sync.ts
@@ -8,11 +8,18 @@
  *   form-builder       ↔ form_builder_settings.enabled
  *   quoting-agent      ↔ quoting_agent_settings.enabled
  */
+import { revalidateTag } from "next/cache";
+import { pluginFlagsTag } from "@/lib/layout-data";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function syncPluginSideEffects(sb: any, businessId: string, pluginId: string, enabled: boolean): Promise<void> {
+  // The layout's plugin-flag reads are cached cross-request — every toggle
+  // path (store, MCP set_plugin_enabled, presets) funnels through here, so
+  // this is the one invalidation point for that cache.
+  revalidateTag(pluginFlagsTag(businessId), "max");
   if (pluginId === "email-lead-scanner") {
     await tbl(sb, "business_email_config").update({ enabled }).eq("business_id", businessId);
   }

--- a/supabase/migrations/20260716130000_dashboard_stats_rpc.sql
+++ b/supabase/migrations/20260716130000_dashboard_stats_rpc.sql
@@ -1,0 +1,63 @@
+-- Dashboard stats as a single SQL aggregate.
+--
+-- getDashboardStats() previously fetched EVERY invoice row for the business
+-- (all columns it needed, all history) into Node on every dashboard load and
+-- reduced in JS. This RPC computes the same shape in one round trip:
+--   { totalRevenue, outstanding, overdue, paidThisMonth,
+--     recentInvoices[5], monthlyData[6] }
+--
+-- SECURITY INVOKER — RLS applies exactly as it did to the old direct query
+-- (workers are blocked from invoices by invoices_no_workers; they get an
+-- empty result, not an error). Also fixes a latent bug: "recent invoices"
+-- had no ORDER BY (arbitrary rows); now it's created_at DESC.
+create or replace function public.dashboard_stats(biz uuid)
+returns jsonb
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with inv as (
+    select id, number, total::numeric as total, amount_paid::numeric as amount_paid,
+           status, issue_date, due_date, created_at, customer_id
+    from invoices
+    where business_id = biz
+  ),
+  months as (
+    select date_trunc('month', now()) - make_interval(months => s) as m
+    from generate_series(5, 0, -1) as s
+  ),
+  monthly as (
+    select m.m,
+           trim(to_char(m.m, 'Mon')) as month,
+           coalesce(sum(i.total) filter (where i.status = 'paid'), 0) as revenue,
+           coalesce(sum(i.total), 0) as invoiced
+    from months m
+    left join inv i on date_trunc('month', i.created_at) = m.m
+    group by m.m
+  ),
+  recent as (
+    select i.id, i.number, i.total, i.amount_paid, i.status, i.issue_date, i.due_date, i.created_at,
+           case when c.id is null then null else jsonb_build_object('name', c.name) end as customers
+    from inv i
+    left join customers c on c.id = i.customer_id
+    order by i.created_at desc
+    limit 5
+  )
+  select jsonb_build_object(
+    'totalRevenue',  coalesce((select sum(total) from inv where status = 'paid'), 0),
+    'outstanding',   coalesce((select sum(total - amount_paid) from inv where status in ('sent','partial')), 0),
+    -- due today counts as overdue, matching the old JS (new Date(due_date) < now)
+    'overdue',       coalesce((select sum(total - amount_paid) from inv
+                               where status in ('sent','partial') and due_date <= now()::date), 0),
+    'paidThisMonth', coalesce((select sum(total) from inv
+                               where status = 'paid' and created_at >= date_trunc('month', now())), 0),
+    'monthlyData',   (select coalesce(jsonb_agg(jsonb_build_object(
+                        'month', month, 'revenue', revenue, 'invoiced', invoiced) order by m), '[]'::jsonb)
+                      from monthly),
+    'recentInvoices',(select coalesce(jsonb_agg(to_jsonb(r) - 'created_at' order by r.created_at desc), '[]'::jsonb)
+                      from recent r)
+  );
+$$;
+
+grant execute on function public.dashboard_stats(uuid) to authenticated;


### PR DESCRIPTION
## The speed fix — part 2 of 4 (replaces #391, which was auto-closed when #390's branch was deleted; rebased onto main)

With compute colocated next to the DB (#390, merged), this phase cuts the **number** of queries per navigation.

- **Layout queries cached cross-request** (`src/lib/layout-data.ts`): business list (60s / `biz-list-{userId}`) + plugin flags (5min / `plugin-flags-{businessId}`) — was 6 fresh queries on every navigation. Tag invalidation wired into every mutation path (business CRUD, plugin toggles incl. MCP + presets, invite activation). Empty-list safety re-check so new users can't get stuck on a stale empty cache.
- **`getBusiness()` cached** (60s / tag) — fetched by the layout AND nearly every page.
- **`getDashboardStats()` → one SQL aggregate** (`dashboard_stats(biz)`, migration `20260716130000`, applied + recorded, SECURITY INVOKER) — was fetching **every invoice row** into Node per dashboard load. Fixes a latent bug: "recent invoices" had no ORDER BY. **Verified on live data: RPC totalRevenue exactly matches direct SQL.**
- `getCustomers` bounded at 1000 rows (was unbounded, feeds 14+ pages).

### Verification
tsc clean · 17/17 tests · route table **152** · RPC cross-checked against direct SQL on production data.

Stack: #390 (merged) → this → #392 → #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)