### PR TITLE
feat(seo): one-click Connect GitHub via a GitHub App

### DIFF
--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -5,14 +5,20 @@ import { getSeoSite } from "@/lib/actions/seo";
 import { listContentPieces, getSeoBudget, listOpportunities } from "@/lib/actions/seo-pipeline";
 import { listConnections } from "@/lib/actions/seo-connections";
 import { listSeoReports } from "@/lib/actions/seo-reports";
+import { githubAppConfigured } from "@/lib/seo/github-app";
 import { SeoSiteHub } from "@/components/seo/seo-site-hub";
 
 // The Opportunity Scout (opus + web search) runs as a server action from this
 // route — give it room so it isn't cut off mid-scan.
 export const maxDuration = 300;
 
-export default async function SeoSiteHubPage({ params }: { params: Promise<{ id: string }> }) {
+type Search = { tab?: string; github?: string; gh?: string };
+
+export default async function SeoSiteHubPage(
+  { params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<Search> },
+) {
   const { id } = await params;
+  const sp = await searchParams;
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/auth/login");
@@ -40,6 +46,12 @@ export default async function SeoSiteHubPage({ params }: { params: Promise<{ id:
       opportunities={opportunities}
       reports={reports}
       budget={budget}
+      // The GitHub callback lands here with ?tab=connections&github=… — resolve
+      // it server-side so the right tab opens with its outcome.
+      initialTab={sp.tab === "connections" ? "connections" : undefined}
+      githubAppReady={githubAppConfigured()}
+      githubStatus={sp.github ?? null}
+      ghToken={sp.gh ?? null}
     />
   );
 }

--- a/src/app/api/seo/github/callback/route.ts
+++ b/src/app/api/seo/github/callback/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getUserOrNull } from "@/lib/auth";
+import { getActiveBizId } from "@/lib/active-business";
+import { appUrl } from "@/lib/app-url";
+import {
+  githubAppConfigured, verifyState, signState, listInstallationRepos,
+} from "@/lib/seo/github-app";
+
+/**
+ * GitHub App Setup URL — where GitHub sends the user's browser after they pick
+ * which repos to grant. Deliberately NOT in the middleware public whitelist:
+ * the user is logged in, so cookie auth applies (same shape as the Stripe
+ * connect return route).
+ *
+ * GitHub appends: ?installation_id=…&setup_action=install|update&state=<ours>
+ *
+ * One granted repo → connect it and land back done (the one-click case).
+ * Several → hand the browser a re-signed state and let the UI show a picker.
+ */
+function back(siteId: string | null, params: string): NextResponse {
+  const base = appUrl() || "https://www.kireihq.com";
+  const path = siteId ? `/seo/${siteId}` : "/seo";
+  return NextResponse.redirect(new URL(`${path}?tab=connections&${params}`, base));
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const installationId = searchParams.get("installation_id");
+  const rawState = searchParams.get("state");
+
+  if (!githubAppConfigured()) return back(null, "github=unconfigured");
+
+  // State proves this callback belongs to a flow *we* started, and carries the
+  // site through GitHub (which has no idea what a Kirei site is).
+  const state = verifyState(rawState);
+  if (!state) return back(null, "github=expired");
+
+  const user = await getUserOrNull();
+  if (!user || user.id !== state.u) return back(state.s, "github=auth");
+  if (!installationId) return back(state.s, "github=cancelled");
+
+  try {
+    const supabase = await createClient();
+    const businessId = await getActiveBizId(supabase, user.id);
+
+    // Re-check the site is still in the caller's active business — the cookie
+    // could have switched businesses mid-flow.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: site } = await (supabase as any)
+      .from("seo_sites").select("id").eq("id", state.s).eq("business_id", businessId).maybeSingle();
+    if (!site) return back(null, "github=site");
+
+    const repos = await listInstallationRepos(installationId);
+    if (repos.length === 0) return back(state.s, "github=norepos");
+
+    // Carry the installation forward in a freshly signed state so the follow-up
+    // server action can trust it without us persisting anything half-done.
+    const token = signState({ u: user.id, s: state.s, i: installationId });
+
+    if (repos.length === 1) {
+      // The common case: they granted exactly the repo they want → one click.
+      const { finalizeGithubConnection } = await import("@/lib/actions/seo-connections");
+      await finalizeGithubConnection({ token, repo: repos[0].full_name });
+      return back(state.s, "github=connected");
+    }
+
+    return back(state.s, `github=pick&gh=${encodeURIComponent(token)}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "GitHub connect failed";
+    return back(state.s, `github=error&msg=${encodeURIComponent(msg.slice(0, 140))}`);
+  }
+}

--- a/src/components/seo/seo-connections.tsx
+++ b/src/components/seo/seo-connections.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Plug, Check, Trash2 } from "@/components/ui/icons";
+import { Plug, Check, GithubLogo } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -11,11 +11,35 @@ import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { CONNECTORS, CONNECTORS_BY_ID, type ConnectorDef, type ConnectionView } from "@/lib/seo/connectors";
-import { saveConnection, deleteConnection, testSeoConnection } from "@/lib/actions/seo-connections";
+import {
+  saveConnection, deleteConnection, testSeoConnection,
+  getGithubConnectUrl, listGithubRepos, finalizeGithubConnection,
+} from "@/lib/actions/seo-connections";
 
 const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
 
-export function SeoConnections({ siteId, connections }: { siteId: string; connections: ConnectionView[] }) {
+interface Props {
+  siteId: string;
+  connections: ConnectionView[];
+  /** Server has a GitHub App configured → show the one-click path. */
+  githubAppReady?: boolean;
+  /** Outcome of a GitHub round trip, from the callback's query string. */
+  githubStatus?: string | null;
+  /** Signed state carrying the installation, when a repo still needs picking. */
+  ghToken?: string | null;
+}
+
+const GH_MESSAGES: Record<string, { ok: boolean; msg: string }> = {
+  connected: { ok: true, msg: "GitHub connected" },
+  cancelled: { ok: false, msg: "GitHub connect was cancelled" },
+  expired: { ok: false, msg: "That connect link expired — try again" },
+  auth: { ok: false, msg: "Sign in again to finish connecting GitHub" },
+  site: { ok: false, msg: "That site isn't in the active business" },
+  norepos: { ok: false, msg: "No repositories were granted — reconnect and pick one" },
+  unconfigured: { ok: false, msg: "The GitHub App isn't set up on this server yet" },
+};
+
+export function SeoConnections({ siteId, connections, githubAppReady, githubStatus, ghToken }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing] = useState<{ def: ConnectorDef; conn?: ConnectionView } | null>(null);
@@ -54,6 +78,52 @@ export function SeoConnections({ siteId, connections }: { siteId: string; connec
     });
   }
 
+  // ── GitHub App flow ────────────────────────────────────────────────────────
+  const [connectingGh, setConnectingGh] = useState(false);
+  const [picker, setPicker] = useState<{ repos: { full_name: string; default_branch: string; private: boolean }[]; repo: string; contentPath: string } | null>(null);
+  const handled = useRef(false);
+
+  /** Report the outcome of a GitHub round trip once, then drop the query
+   *  params so a refresh doesn't replay the toast. */
+  useEffect(() => {
+    if (!githubStatus || handled.current) return;
+    handled.current = true;
+    const known = GH_MESSAGES[githubStatus];
+    if (known) (known.ok ? toast.success : toast.error)(known.msg);
+    else if (githubStatus === "error") toast.error("GitHub connect failed");
+
+    if (githubStatus === "pick" && ghToken) {
+      listGithubRepos(ghToken)
+        .then((repos) => setPicker({ repos, repo: repos[0]?.full_name ?? "", contentPath: "src/content/blog" }))
+        .catch((e) => toast.error(e instanceof Error ? e.message : "Couldn't list repositories"));
+    } else {
+      router.replace(`/seo/${siteId}`, { scroll: false });
+      if (known?.ok) router.refresh();
+    }
+  }, [githubStatus, ghToken, router, siteId]);
+
+  function handleConnectGithub() {
+    setConnectingGh(true);
+    getGithubConnectUrl(siteId)
+      .then((url) => { window.location.href = url; })
+      .catch((e) => { toast.error(e instanceof Error ? e.message : "Couldn't start GitHub connect"); setConnectingGh(false); });
+  }
+
+  function handlePickRepo() {
+    if (!picker || !ghToken || !picker.repo) return;
+    startTransition(async () => {
+      try {
+        await finalizeGithubConnection({ token: ghToken, repo: picker.repo, content_path: picker.contentPath });
+        toast.success("GitHub connected");
+        setPicker(null);
+        router.replace(`/seo/${siteId}`, { scroll: false });
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't connect that repository");
+      }
+    });
+  }
+
   const [testingId, setTestingId] = useState<string | null>(null);
   function handleTest(conn: ConnectionView) {
     setTestingId(conn.id);
@@ -84,6 +154,11 @@ export function SeoConnections({ siteId, connections }: { siteId: string; connec
                       <span className="inline-flex items-center gap-1 text-[10px] font-medium text-emerald-700 bg-emerald-50 rounded-full px-1.5 py-0.5"><Check className="w-3 h-3" /> Connected</span>
                     </div>
                     {conn.account_ref && <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{conn.account_ref}</p>}
+                    {conn.meta?.installation_id && (
+                      <span className="inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground bg-muted rounded-full px-1.5 py-0.5 mt-1">
+                        <GithubLogo className="w-3 h-3" /> via GitHub App
+                      </span>
+                    )}
                     <div className="flex gap-2 mt-2">
                       <button onClick={() => handleTest(conn)} disabled={testingId === conn.id} className="text-xs text-muted-foreground hover:text-foreground underline">{testingId === conn.id ? "Testing…" : "Test"}</button>
                       {def && <button onClick={() => openConnect(def, conn)} className="text-xs text-muted-foreground hover:text-foreground underline">Edit</button>}
@@ -101,18 +176,41 @@ export function SeoConnections({ siteId, connections }: { siteId: string; connec
       <section>
         <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Publishing gateways</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {publish.map((def) => (
-            <div key={def.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
-              <div className="flex items-start gap-3">
-                <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-foreground/70" /></div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold">{def.name}</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">{def.description}</p>
+          {publish.map((def) => {
+            const isGithub = def.id === "git-github";
+            return (
+              <div key={def.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+                <div className="flex items-start gap-3">
+                  <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0">
+                    {isGithub ? <GithubLogo className="w-4.5 h-4.5 text-foreground/70" /> : <Plug className="w-4.5 h-4.5 text-foreground/70" />}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold">{def.name}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{def.description}</p>
+                  </div>
                 </div>
+                {isGithub ? (
+                  // One-click install when the App is configured; the token form
+                  // stays available for GitHub Enterprise / no-App setups.
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Button size="sm" className="text-xs h-7" onClick={handleConnectGithub} disabled={!githubAppReady || connectingGh}>
+                      <GithubLogo className="w-3.5 h-3.5 mr-1.5" /> {connectingGh ? "Opening GitHub…" : "Connect GitHub"}
+                    </Button>
+                    <button onClick={() => openConnect(def)} className="text-xs text-muted-foreground hover:text-foreground underline">
+                      Use a token instead
+                    </button>
+                    {!githubAppReady && (
+                      <p className="text-[11px] text-muted-foreground basis-full">
+                        One-click connect needs the GitHub App configured on the server — use a token for now.
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div><Button size="sm" variant="outline" className="text-xs h-7" onClick={() => openConnect(def)}>Connect</Button></div>
+                )}
               </div>
-              <div><Button size="sm" variant="outline" className="text-xs h-7" onClick={() => openConnect(def)}>Connect</Button></div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
 
@@ -134,6 +232,33 @@ export function SeoConnections({ siteId, connections }: { siteId: string; connec
           ))}
         </div>
       </section>
+
+      {/* Repo picker — shown when the GitHub App was granted several repos */}
+      <Dialog open={!!picker} onOpenChange={(o) => { if (!o) { setPicker(null); router.replace(`/seo/${siteId}`, { scroll: false }); } }}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Pick a repository</DialogTitle></DialogHeader>
+          {picker && (
+            <div className="space-y-3">
+              <p className="text-xs text-muted-foreground">The GitHub App has access to {picker.repos.length} repositories. Choose where articles should be committed.</p>
+              <div className="space-y-1.5">
+                <Label htmlFor="gh-repo">Repository</Label>
+                <select id="gh-repo" className={selectCls} value={picker.repo} onChange={(e) => setPicker((p) => p && { ...p, repo: e.target.value })}>
+                  {picker.repos.map((r) => <option key={r.full_name} value={r.full_name}>{r.full_name}{r.private ? " (private)" : ""}</option>)}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="gh-path">Content folder</Label>
+                <Input id="gh-path" value={picker.contentPath} placeholder="src/content/blog" onChange={(e) => setPicker((p) => p && { ...p, contentPath: e.target.value })} />
+                <p className="text-[11px] text-muted-foreground">Where markdown files land. The branch defaults to the repo&apos;s default branch — change it later under Edit.</p>
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => { setPicker(null); router.replace(`/seo/${siteId}`, { scroll: false }); }} disabled={isPending}>Cancel</Button>
+            <Button onClick={handlePickRepo} disabled={isPending || !picker?.repo}>Connect</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Connect / edit dialog */}
       <Dialog open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -33,6 +33,12 @@ interface Props {
   opportunities: Opportunity[];
   reports: Report[];
   budget: { spentCents: number; budgetCents: number; ok: boolean };
+  /** Server-resolved (from the page's searchParams) so the GitHub callback can
+   *  land the user straight back on the connections tab with its outcome. */
+  initialTab?: Tab;
+  githubAppReady?: boolean;
+  githubStatus?: string | null;
+  ghToken?: string | null;
 }
 
 type Tab = "overview" | "content" | "opportunities" | "connections" | "reports" | "activity";
@@ -48,9 +54,9 @@ const STATUS_TONE: Record<string, string> = {
 };
 const money = (c: number) => `$${(c / 100).toFixed(2)}`;
 
-export function SeoSiteHub({ site, pieces, connections, opportunities, reports, budget }: Props) {
+export function SeoSiteHub({ site, pieces, connections, opportunities, reports, budget, initialTab, githubAppReady, githubStatus, ghToken }: Props) {
   const router = useRouter();
-  const [tab, setTab] = useState<Tab>("overview");
+  const [tab, setTab] = useState<Tab>(initialTab ?? "overview");
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
   const [topic, setTopic] = useState("");
@@ -162,7 +168,15 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, reports, 
       {tab === "opportunities" && <SeoOpportunities siteId={site.id} opportunities={opportunities} />}
 
       {/* ── Connections ── */}
-      {tab === "connections" && <SeoConnections siteId={site.id} connections={connections} />}
+      {tab === "connections" && (
+        <SeoConnections
+          siteId={site.id}
+          connections={connections}
+          githubAppReady={githubAppReady}
+          githubStatus={githubStatus}
+          ghToken={ghToken}
+        />
+      )}
 
       {/* ── Reports ── */}
       {tab === "reports" && <SeoReports siteId={site.id} reports={reports} />}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -34,6 +34,7 @@ export {
   Lock,
   FileText,
   GitBranch,
+  GithubLogo,
   Hammer,
   Info,
   Image,

--- a/src/lib/actions/seo-connections.ts
+++ b/src/lib/actions/seo-connections.ts
@@ -15,6 +15,9 @@ import { getUser } from "@/lib/auth";
 import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
 import { testConnection } from "@/lib/seo/publish";
 import { CONNECTORS_BY_ID, secretFieldKeys, type ConnectionView } from "@/lib/seo/connectors";
+import {
+  githubAppConfigured, installUrl, signState, verifyState, listInstallationRepos,
+} from "@/lib/seo/github-app";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -119,4 +122,83 @@ export async function deleteConnection(connectionId: string, siteId: string): Pr
   const { error } = await tbl(supabase, "seo_connections").delete().eq("id", connectionId).eq("business_id", businessId);
   if (error) throw error;
   revalidatePath(`/seo/${siteId}`);
+}
+
+// ── GitHub App one-click connect ─────────────────────────────────────────────
+// The manual token form above still works; this is the nicer path. Credential
+// handling stays server-side (the App private key mints short-lived tokens), so
+// the web-UI-only rule for connecting is preserved — no MCP tool for this.
+
+/** True when the server has a GitHub App configured (drives the Connect button). */
+export async function isGithubAppConfigured(): Promise<boolean> {
+  return githubAppConfigured();
+}
+
+/** Where to send the browser to install the App / grant repos. State binds the
+ *  flow to this user + site so the callback can't be forged or replayed. */
+export async function getGithubConnectUrl(siteId: string): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  // Confirms the site belongs to the active business (RLS-scoped read).
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data: site } = await tbl(supabase, "seo_sites")
+    .select("id").eq("id", siteId).eq("business_id", businessId).maybeSingle();
+  if (!site) throw new Error("Site not found");
+  if (!githubAppConfigured()) throw new Error("The GitHub App isn't set up on this server yet.");
+  return installUrl(signState({ u: user.id, s: siteId }));
+}
+
+/** Repos granted to an installation — for the picker when the user granted more
+ *  than one. `token` is the signed state handed back by the callback, so a user
+ *  can't enumerate an installation they didn't just connect. */
+export async function listGithubRepos(token: string): Promise<{ full_name: string; default_branch: string; private: boolean }[]> {
+  const user = await getUser();
+  const state = verifyState(token);
+  if (!state || state.u !== user.id) throw new Error("This connect link has expired — start again.");
+  if (!state.i) throw new Error("Missing installation");
+  return listInstallationRepos(state.i);
+}
+
+/** Create the connection once a repo is chosen (or auto-picked by the callback). */
+export async function finalizeGithubConnection(input: {
+  token: string;            // signed state from the callback (carries user/site/installation)
+  repo: string;             // owner/repo
+  branch?: string;
+  content_path?: string;
+  extension?: string;
+}): Promise<{ site_id: string }> {
+  const businessId = await biz();
+  const user = await getUser();
+  const supabase = await createClient();
+
+  const state = verifyState(input.token);
+  if (!state || state.u !== user.id) throw new Error("This connect link has expired — start again.");
+  if (!state.i) throw new Error("Missing installation");
+  const installationId = state.i;
+
+  // Only repos this installation actually granted — stops a forged repo string.
+  const repos = await listInstallationRepos(installationId);
+  const chosen = repos.find((r) => r.full_name === input.repo);
+  if (!chosen) throw new Error("That repository isn't part of this GitHub App installation.");
+
+  const def = CONNECTORS_BY_ID["git-github"];
+  const meta: Record<string, string> = {
+    repo: chosen.full_name,
+    branch: input.branch?.trim() || chosen.default_branch || "main",
+    content_path: input.content_path?.trim() || "src/content/blog",
+    extension: input.extension?.trim() || "md",
+    installation_id: installationId,
+  };
+
+  // No `secret` column write: the App mints tokens on demand, so App-mode
+  // connections work even without APP_ENCRYPTION_KEY configured.
+  const { error } = await tbl(supabase, "seo_connections").insert({
+    business_id: businessId, site_id: state.s, provider: "git-github",
+    label: def?.name ?? "Git (GitHub)", meta,
+    status: "connected", account_ref: chosen.full_name,
+    connected_at: new Date().toISOString(),
+  });
+  if (error) throw error;
+  revalidatePath(`/seo/${state.s}`);
+  return { site_id: state.s };
 }

--- a/src/lib/seo/github-app.ts
+++ b/src/lib/seo/github-app.ts
@@ -1,0 +1,176 @@
+/**
+ * GitHub App plumbing for the one-click "Connect GitHub" publish flow.
+ *
+ * Why an App and not a PAT: the user clicks Connect → GitHub asks which repos to
+ * grant → we get an installation_id back. No long-lived token is ever stored;
+ * at publish time we mint a fresh installation access token (1h) from the App's
+ * private key. The manual PAT form stays as a fallback for GitHub Enterprise or
+ * when the App isn't installed.
+ *
+ * Server-only (reads the App private key, signs JWTs). Never import from a
+ * client component.
+ *
+ * Env (all three required for the flow to light up):
+ *   GITHUB_APP_ID                  — numeric App ID
+ *   GITHUB_APP_SLUG                — url slug, for github.com/apps/<slug>
+ *   GITHUB_APP_PRIVATE_KEY_BASE64  — base64 of the .pem (base64 avoids the
+ *                                    multiline-newline mangling env vars suffer)
+ */
+import { createHmac, createSign, timingSafeEqual } from "node:crypto";
+
+const GH_API = "https://api.github.com";
+const UA = "Kirei-SEO";
+
+function appId(): string | undefined {
+  return process.env.GITHUB_APP_ID?.trim();
+}
+
+function appSlug(): string | undefined {
+  return process.env.GITHUB_APP_SLUG?.trim();
+}
+
+/** The App private key as PEM. Stored base64-encoded to survive env plumbing. */
+function privateKeyPem(): string | undefined {
+  const b64 = process.env.GITHUB_APP_PRIVATE_KEY_BASE64?.trim();
+  if (!b64) return undefined;
+  try {
+    const pem = Buffer.from(b64, "base64").toString("utf8");
+    return pem.includes("PRIVATE KEY") ? pem : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True when the GitHub App is fully configured — gates the Connect button. */
+export function githubAppConfigured(): boolean {
+  return Boolean(appId() && appSlug() && privateKeyPem());
+}
+
+const b64url = (b: Buffer | string) =>
+  (Buffer.isBuffer(b) ? b : Buffer.from(b, "utf8"))
+    .toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+// ── App JWT → installation token ─────────────────────────────────────────────
+
+/** RS256 JWT signed with the App private key (GitHub allows max 10 min life). */
+function mintAppJwt(): string {
+  const pem = privateKeyPem();
+  const id = appId();
+  if (!pem || !id) throw new Error("GitHub App is not configured on this server.");
+  const now = Math.floor(Date.now() / 1000);
+  // iat back-dated 60s to tolerate clock skew; exp well under GitHub's 10-min cap.
+  const header = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = b64url(JSON.stringify({ iat: now - 60, exp: now + 540, iss: id }));
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${payload}`);
+  signer.end();
+  return `${header}.${payload}.${b64url(signer.sign(pem))}`;
+}
+
+/** Installation tokens live 1h — cache in-process so a publish run doesn't
+ *  re-mint per call. Keyed by installation id; refreshed 5 min before expiry. */
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+export async function mintInstallationToken(installationId: string): Promise<string> {
+  const hit = tokenCache.get(installationId);
+  if (hit && hit.expiresAt - 5 * 60_000 > Date.now()) return hit.token;
+
+  const res = await fetch(`${GH_API}/app/installations/${encodeURIComponent(installationId)}/access_tokens`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${mintAppJwt()}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": UA,
+    },
+  });
+  if (!res.ok) {
+    const body = (await res.text()).slice(0, 200);
+    if (res.status === 404) throw new Error("The GitHub App install was removed — reconnect the repository.");
+    throw new Error(`GitHub App token ${res.status}: ${body}`);
+  }
+  const j = (await res.json()) as { token: string; expires_at: string };
+  tokenCache.set(installationId, { token: j.token, expiresAt: Date.parse(j.expires_at) });
+  return j.token;
+}
+
+export interface InstallRepo {
+  full_name: string;
+  default_branch: string;
+  private: boolean;
+}
+
+/** Repos the user granted this installation. */
+export async function listInstallationRepos(installationId: string): Promise<InstallRepo[]> {
+  const token = await mintInstallationToken(installationId);
+  const res = await fetch(`${GH_API}/installation/repositories?per_page=100`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": UA,
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub repositories ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const j = (await res.json()) as { repositories?: InstallRepo[] };
+  return (j.repositories ?? []).map((r) => ({
+    full_name: r.full_name, default_branch: r.default_branch || "main", private: !!r.private,
+  }));
+}
+
+// ── Install URL + signed state ───────────────────────────────────────────────
+
+/** Where to send the browser to install/grant repos. GitHub forwards `state`
+ *  to the App's Setup URL (our callback) after the user picks repos. */
+export function installUrl(state: string): string {
+  const slug = appSlug();
+  if (!slug) throw new Error("GitHub App is not configured on this server.");
+  return `https://github.com/apps/${encodeURIComponent(slug)}/installations/new?state=${encodeURIComponent(state)}`;
+}
+
+export interface ConnectState {
+  /** Kirei user who started the flow — the callback must match. */
+  u: string;
+  /** seo_sites.id the connection belongs to. */
+  s: string;
+  /** installation id — absent on the outbound leg, added by the callback when
+   *  it re-signs the state to hand a repo picker back to the browser. */
+  i?: string;
+  /** expiry (epoch seconds). */
+  e: number;
+}
+
+/** HMAC key: the App private key is server-only and high-entropy, so it doubles
+ *  as the state-signing secret — no extra env var to configure. */
+function stateKey(): string {
+  const pem = privateKeyPem();
+  if (!pem) throw new Error("GitHub App is not configured on this server.");
+  return pem;
+}
+
+/** Stateless signed state — CSRF defence + carries the site through GitHub. */
+export function signState(payload: Omit<ConnectState, "e">, ttlSeconds = 900): string {
+  const body: ConnectState = { ...payload, e: Math.floor(Date.now() / 1000) + ttlSeconds };
+  const data = b64url(JSON.stringify(body));
+  const sig = b64url(createHmac("sha256", stateKey()).update(data).digest());
+  return `${data}.${sig}`;
+}
+
+/** Verify signature + expiry. Returns null on any tamper/expiry. */
+export function verifyState(token: string | null | undefined): ConnectState | null {
+  if (!token) return null;
+  const [data, sig] = token.split(".");
+  if (!data || !sig) return null;
+  const expected = b64url(createHmac("sha256", stateKey()).update(data).digest());
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8")) as ConnectState;
+    if (!parsed.u || !parsed.s || !parsed.e) return null;
+    if (parsed.e < Math.floor(Date.now() / 1000)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/seo/publish.ts
+++ b/src/lib/seo/publish.ts
@@ -7,6 +7,7 @@
 import { marked } from "marked";
 import { decryptSecret } from "@/lib/crypto";
 import { CONNECTORS_BY_ID } from "@/lib/seo/connectors";
+import { mintInstallationToken } from "@/lib/seo/github-app";
 
 interface Article {
   title: string;
@@ -61,9 +62,22 @@ function fillFrontmatter(tpl: string, a: Article, date: string): string {
   return tpl.replace(/\{\{(\w+)\}\}/g, (_, k) => String(v[k] ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/[\r\n]+/g, " "));
 }
 
+/**
+ * A GitHub bearer token for a connection, whichever way it was connected:
+ *  - GitHub App (meta.installation_id) → mint a fresh 1h installation token.
+ *    Nothing sensitive is stored on the row; the App private key does the work.
+ *  - Manual PAT (secrets.token) → the fallback path, unchanged.
+ */
+async function githubBearer(meta: Meta, secrets: Secrets): Promise<string> {
+  if (meta.installation_id) return mintInstallationToken(String(meta.installation_id));
+  if (secrets.token) return secrets.token;
+  throw new Error("This GitHub connection has no credentials — reconnect it.");
+}
+
 async function publishGitHub(meta: Meta, secrets: Secrets, a: Article): Promise<PublishResult> {
   const [owner, repo] = (meta.repo ?? "").split("/");
   if (!owner || !repo) throw new Error("Repository must be owner/repo");
+  const bearer = await githubBearer(meta, secrets);
   const branch = meta.branch || "main";
   const ext = meta.extension || "md";
   const path = `${(meta.content_path || "").replace(/\/+$/, "")}/${a.slug}.${ext}`.replace(/^\/+/, "");
@@ -75,7 +89,7 @@ async function publishGitHub(meta: Meta, secrets: Secrets, a: Article): Promise<
 
   const api = `https://api.github.com/repos/${owner}/${repo}/contents/${path.split("/").map(encodeURIComponent).join("/")}`;
   const headers = {
-    Authorization: `Bearer ${secrets.token}`,
+    Authorization: `Bearer ${bearer}`,
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
     "User-Agent": "Kirei-SEO",
@@ -182,8 +196,16 @@ export async function testConnection(sb: any, businessId: string, connectionId: 
     switch (conn.provider) {
       case "git-github": {
         const [owner, repo] = (meta.repo ?? "").split("/");
-        const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers: { Authorization: `Bearer ${secrets.token}`, Accept: "application/vnd.github+json", "User-Agent": "Kirei-SEO" } });
-        return res.ok ? { ok: true, message: `Connected to ${owner}/${repo}` } : { ok: false, message: `GitHub ${res.status} — check the repo and token scope.` };
+        const viaApp = !!meta.installation_id;
+        const bearer = await githubBearer(meta, secrets);
+        const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers: { Authorization: `Bearer ${bearer}`, Accept: "application/vnd.github+json", "User-Agent": "Kirei-SEO" } });
+        if (res.ok) return { ok: true, message: `Connected to ${owner}/${repo}${viaApp ? " via the GitHub App" : ""}` };
+        return {
+          ok: false,
+          message: viaApp
+            ? `GitHub ${res.status} — the App may no longer have access to ${owner}/${repo}. Reconnect to re-grant it.`
+            : `GitHub ${res.status} — check the repo and token scope.`,
+        };
       }
       case "wordpress": {
         const base = (meta.site_url ?? "").replace(/\/+$/, "");


### PR DESCRIPTION
## Why

Connecting a repo to the SEO plugin meant hand-creating a Personal Access Token and pasting it into a form. Now it's the flow you'd expect: **Connect GitHub → pick repos on GitHub → done.** The manual token form stays as an advanced fallback.

## How it works

1. **Connect GitHub** → server mints `github.com/apps/<slug>/installations/new?state=<signed>`.
2. GitHub asks which repos to grant → redirects to the App's Setup URL (`/api/seo/github/callback`) with `installation_id` + our `state`.
3. Callback verifies the signed state (CSRF + binds user/site), mints an installation token, lists granted repos:
   - **1 repo** → connected instantly (the one-click case)
   - **several** → repo picker
4. **At publish time** a fresh 1-hour installation token is minted from the App private key. **No long-lived token is ever stored.**

## Security notes

- Signed HMAC state binds `{user, site, installation}` + 15-min expiry; the callback rejects a mismatched/expired state and confirms the logged-in user started the flow.
- `finalizeGithubConnection` re-lists the installation's repos and rejects any repo not in it — a forged repo string can't slip through.
- Callback is **not** middleware-whitelisted (cookie auth applies, same as the Stripe connect return).
- MCP unchanged — connecting stays web-UI-only per the standing rule; no token ever transits MCP/chat.
- App private key stored base64 (`GITHUB_APP_PRIVATE_KEY_BASE64`) to dodge the multiline-newline env trap.

## Notable

- `publishGitHub` gains one `githubBearer()` call — App token or PAT fallback. Publishing logic otherwise untouched.
- **No migration**: `meta` jsonb already carries `installation_id`/`repo`; the `(site_id, provider)` unique constraint was dropped earlier.
- **Bonus**: App-mode connections store no encrypted secret → GitHub connects work even without `APP_ENCRYPTION_KEY` (still needed for WordPress/Sanity/etc).
- Degrades gracefully: no App env → Connect button disabled with an explanation, manual form still works.

## Verification

tsc clean · 17/17 tests · production build OK (no client-side `node:crypto` leak) · bundle budget green · routes **152 → 153** (the new callback — an addition; nothing removed).

⚠️ **Needs a one-time GitHub App registration + 3 env vars before the button lights up** — walking @maltamimi96 through it; the manual token path is unaffected meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)