### PR TITLE
feat(seo): Google Search Console connector — OAuth + nightly sync + Search performance

### DIFF
--- a/src/app/(dashboard)/seo/[id]/page.tsx
+++ b/src/app/(dashboard)/seo/[id]/page.tsx
@@ -3,16 +3,20 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getSeoSite } from "@/lib/actions/seo";
 import { listContentPieces, getSeoBudget, listOpportunities } from "@/lib/actions/seo-pipeline";
-import { listConnections } from "@/lib/actions/seo-connections";
+import { listConnections, getSearchPerformance } from "@/lib/actions/seo-connections";
 import { listSeoReports } from "@/lib/actions/seo-reports";
 import { githubAppConfigured } from "@/lib/seo/github-app";
+import { gscConfigured } from "@/lib/seo/gsc";
+import { encryptionAvailable } from "@/lib/crypto";
 import { SeoSiteHub } from "@/components/seo/seo-site-hub";
 
 // The Opportunity Scout (opus + web search) runs as a server action from this
 // route — give it room so it isn't cut off mid-scan.
 export const maxDuration = 300;
 
-type Search = { tab?: string; github?: string; gh?: string };
+type Search = { tab?: string; github?: string; gh?: string; gsc?: string; g?: string; guess?: string };
+const TABS = ["overview", "content", "performance", "opportunities", "connections", "reports", "activity"] as const;
+type TabId = (typeof TABS)[number];
 
 export default async function SeoSiteHubPage(
   { params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<Search> },
@@ -28,12 +32,13 @@ export default async function SeoSiteHubPage(
   const site = await getSeoSite(id);
   if (!site) notFound();
 
-  const [pieces, budget, connections, opportunities, reports] = await Promise.all([
+  const [pieces, budget, connections, opportunities, reports, performance] = await Promise.all([
     listContentPieces(id),
     getSeoBudget(),
     listConnections(id),
     listOpportunities(id),
     listSeoReports(id),
+    getSearchPerformance(id).catch(() => ({ rows: [], totals: { clicks: 0, impressions: 0, keywords: 0 }, lastSynced: null })),
   ]);
 
   return (
@@ -48,10 +53,17 @@ export default async function SeoSiteHubPage(
       budget={budget}
       // The GitHub callback lands here with ?tab=connections&github=… — resolve
       // it server-side so the right tab opens with its outcome.
-      initialTab={sp.tab === "connections" ? "connections" : undefined}
+      initialTab={TABS.includes(sp.tab as TabId) ? (sp.tab as TabId) : undefined}
       githubAppReady={githubAppConfigured()}
       githubStatus={sp.github ?? null}
       ghToken={sp.gh ?? null}
+      // GSC needs BOTH a Google client and the encryption key (it persists a
+      // refresh token) — gate on both so the button can't fail after consent.
+      gscReady={gscConfigured() && encryptionAvailable()}
+      gscStatus={sp.gsc ?? null}
+      gscToken={sp.g ?? null}
+      gscGuess={sp.guess ?? null}
+      performance={performance}
     />
   );
 }

--- a/src/app/api/cron/seo-gsc-sync/route.ts
+++ b/src/app/api/cron/seo-gsc-sync/route.ts
@@ -1,0 +1,102 @@
+/**
+ * GET /api/cron/seo-gsc-sync — daily.
+ *
+ * Pulls Search Console query performance into seo_keyword_snapshots for every
+ * active site with a connected GSC connection. That table already feeds the
+ * client report PDFs (src/lib/seo/report.ts) — this is the producer that was
+ * missing.
+ *
+ * Costs nothing (no Claude call), so it deliberately does NOT go through the
+ * seoSpendStatus budget gate.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { decryptSecret } from "@/lib/crypto";
+import { accessTokenFor, querySearchAnalytics } from "@/lib/seo/gsc";
+
+export const maxDuration = 300;
+
+const isoDate = (d: Date) => d.toISOString().split("T")[0];
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get("authorization");
+  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: conns } = await (sb as any)
+    .from("seo_connections")
+    .select("id, business_id, site_id, meta, secret, seo_sites!inner(status)")
+    .eq("provider", "gsc").eq("status", "connected")
+    .eq("seo_sites.status", "active")
+    .limit(500);
+
+  // GSC lags ~2-3 days and RESTATES recent days — always re-pull a trailing
+  // window rather than just yesterday, and let the unique key upsert over it.
+  const end = new Date();
+  const start = new Date(Date.now() - 5 * 86_400_000);
+
+  let synced = 0, rows = 0;
+  const errors: string[] = [];
+
+  for (const c of (conns ?? []) as Array<{ id: string; business_id: string; site_id: string; meta: Record<string, string>; secret: string | null }>) {
+    try {
+      if (!c.secret) continue;
+      const siteUrl = c.meta?.site_url;
+      if (!siteUrl) continue;
+
+      const { refresh_token } = JSON.parse(decryptSecret(c.secret)) as { refresh_token?: string };
+      if (!refresh_token) continue;
+
+      const token = await accessTokenFor(refresh_token);
+      const result = await querySearchAnalytics(token, siteUrl, {
+        startDate: isoDate(start), endDate: isoDate(end),
+        dimensions: ["date", "query"], rowLimit: 500,
+      });
+
+      const payload = result
+        .filter((r) => r.keys?.length >= 2)
+        .map((r) => ({
+          business_id: c.business_id, site_id: c.site_id,
+          captured_at: r.keys[0], keyword: r.keys[1],
+          position: r.position ?? null,
+          clicks: Math.round(r.clicks ?? 0),
+          impressions: Math.round(r.impressions ?? 0),
+          ctr: r.ctr ?? null,
+        }));
+
+      if (payload.length > 0) {
+        // Upserts on the (site_id, keyword, captured_at) unique index, so a
+        // re-run over restated days corrects rather than duplicates.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { error } = await (sb as any).from("seo_keyword_snapshots")
+          .upsert(payload, { onConflict: "site_id,keyword,captured_at" });
+        if (error) throw error;
+        rows += payload.length;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any).from("seo_connections")
+        .update({ status: "connected", account_ref: siteUrl }).eq("id", c.id);
+      synced++;
+    } catch (e) {
+      // One bad connection (revoked token, 7-day Testing expiry) must not kill
+      // the run — flag it so the UI shows "error" and the user reconnects.
+      const msg = e instanceof Error ? e.message : String(e);
+      errors.push(`${c.site_id}: ${msg.slice(0, 120)}`);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (sb as any).from("seo_connections").update({ status: "error" }).eq("id", c.id);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (sb as any).from("seo_job_events").insert({
+          business_id: c.business_id, site_id: c.site_id, level: "error",
+          message: `Search Console sync failed — ${msg.slice(0, 200)}`,
+        });
+      } catch { /* best effort */ }
+    }
+  }
+
+  return NextResponse.json({ synced, rows, errors: errors.length ? errors : undefined });
+}

--- a/src/app/api/seo/gsc/callback/route.ts
+++ b/src/app/api/seo/gsc/callback/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getUserOrNull } from "@/lib/auth";
+import { getActiveBizId } from "@/lib/active-business";
+import { appUrl } from "@/lib/app-url";
+import { verifyState, signState } from "@/lib/seo/connect-state";
+import { gscConfigured, exchangeCode, listProperties, guessProperty } from "@/lib/seo/gsc";
+
+/**
+ * Google OAuth redirect URI — where Google sends the user back after consent.
+ * Same shape as the GitHub App callback: NOT middleware-whitelisted, because
+ * the user is logged in and cookie auth is exactly what we want here.
+ *
+ * Google appends: ?code=…&state=<ours>&scope=… (or ?error=access_denied)
+ *
+ * One property → connect it and land back done. Several → hand the browser a
+ * re-signed state carrying the refresh token and let the UI show a picker.
+ */
+function back(siteId: string | null, params: string): NextResponse {
+  const base = appUrl() || "https://www.kireihq.com";
+  const path = siteId ? `/seo/${siteId}` : "/seo";
+  return NextResponse.redirect(new URL(`${path}?tab=connections&${params}`, base));
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const code = searchParams.get("code");
+  const rawState = searchParams.get("state");
+  const oauthError = searchParams.get("error");
+
+  if (!gscConfigured()) return back(null, "gsc=unconfigured");
+
+  const state = verifyState(rawState);
+  if (!state) return back(null, "gsc=expired");
+
+  const user = await getUserOrNull();
+  if (!user || user.id !== state.u) return back(state.s, "gsc=auth");
+  if (oauthError || !code) return back(state.s, "gsc=cancelled");
+
+  try {
+    const supabase = await createClient();
+    const businessId = await getActiveBizId(supabase, user.id);
+
+    // The business cookie could have switched mid-flow — re-check the site.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: site } = await (supabase as any)
+      .from("seo_sites").select("id, domain").eq("id", state.s).eq("business_id", businessId).maybeSingle();
+    if (!site) return back(null, "gsc=site");
+
+    const { refreshToken } = await exchangeCode(code);
+    const accessToken = await (await import("@/lib/seo/gsc")).accessTokenFor(refreshToken);
+    const props = await listProperties(accessToken);
+    if (props.length === 0) return back(state.s, "gsc=noprops");
+
+    // Carry the refresh token forward in a signed state rather than persisting
+    // anything half-done. Short TTL — it's only alive for the picker round trip.
+    const token = signState({ u: user.id, s: state.s, i: refreshToken }, 600);
+    const { finalizeGscConnection } = await import("@/lib/actions/seo-connections");
+
+    if (props.length === 1) {
+      await finalizeGscConnection({ token, site_url: props[0].siteUrl });
+      return back(state.s, "gsc=connected");
+    }
+
+    const guess = guessProperty(String(site.domain ?? ""), props);
+    return back(state.s, `gsc=pick&g=${encodeURIComponent(token)}${guess ? `&guess=${encodeURIComponent(guess)}` : ""}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Search Console connect failed";
+    return back(state.s, `gsc=error&msg=${encodeURIComponent(msg.slice(0, 160))}`);
+  }
+}

--- a/src/components/seo/seo-connections.tsx
+++ b/src/components/seo/seo-connections.tsx
@@ -14,6 +14,7 @@ import { CONNECTORS, CONNECTORS_BY_ID, type ConnectorDef, type ConnectionView } 
 import {
   saveConnection, deleteConnection, testSeoConnection,
   getGithubConnectUrl, listGithubRepos, finalizeGithubConnection,
+  getGscConnectUrl, listGscProperties, finalizeGscConnection,
 } from "@/lib/actions/seo-connections";
 
 const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
@@ -27,6 +28,14 @@ interface Props {
   githubStatus?: string | null;
   /** Signed state carrying the installation, when a repo still needs picking. */
   ghToken?: string | null;
+  /** Server has a Google OAuth client + encryption key configured. */
+  gscReady?: boolean;
+  /** Outcome of a Google round trip, from the callback's query string. */
+  gscStatus?: string | null;
+  /** Signed state carrying the Google credentials, when a property needs picking. */
+  gscToken?: string | null;
+  /** Best-guess property to pre-select in the picker. */
+  gscGuess?: string | null;
 }
 
 const GH_MESSAGES: Record<string, { ok: boolean; msg: string }> = {
@@ -39,7 +48,20 @@ const GH_MESSAGES: Record<string, { ok: boolean; msg: string }> = {
   unconfigured: { ok: false, msg: "The GitHub App isn't set up on this server yet" },
 };
 
-export function SeoConnections({ siteId, connections, githubAppReady, githubStatus, ghToken }: Props) {
+const GSC_MESSAGES: Record<string, { ok: boolean; msg: string }> = {
+  connected: { ok: true, msg: "Search Console connected" },
+  cancelled: { ok: false, msg: "Google connect was cancelled" },
+  expired: { ok: false, msg: "That connect link expired — try again" },
+  auth: { ok: false, msg: "Sign in again to finish connecting Google" },
+  site: { ok: false, msg: "That site isn't in the active business" },
+  noprops: { ok: false, msg: "That Google account has no Search Console properties" },
+  unconfigured: { ok: false, msg: "Search Console isn't set up on this server yet" },
+};
+
+export function SeoConnections({
+  siteId, connections, githubAppReady, githubStatus, ghToken,
+  gscReady, gscStatus, gscToken, gscGuess,
+}: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing] = useState<{ def: ConnectorDef; conn?: ConnectionView } | null>(null);
@@ -124,6 +146,50 @@ export function SeoConnections({ siteId, connections, githubAppReady, githubStat
     });
   }
 
+  // ── Google Search Console (OAuth) ──────────────────────────────────────────
+  const [connectingGsc, setConnectingGsc] = useState(false);
+  const [gscPicker, setGscPicker] = useState<{ props: { siteUrl: string; permissionLevel: string }[]; siteUrl: string } | null>(null);
+  const gscHandled = useRef(false);
+
+  useEffect(() => {
+    if (!gscStatus || gscHandled.current) return;
+    gscHandled.current = true;
+    const known = GSC_MESSAGES[gscStatus];
+    if (known) (known.ok ? toast.success : toast.error)(known.msg);
+    else if (gscStatus === "error") toast.error("Search Console connect failed");
+
+    if (gscStatus === "pick" && gscToken) {
+      listGscProperties(gscToken)
+        .then((props) => setGscPicker({ props, siteUrl: gscGuess || props[0]?.siteUrl || "" }))
+        .catch((e) => toast.error(e instanceof Error ? e.message : "Couldn't list properties"));
+    } else {
+      router.replace(`/seo/${siteId}`, { scroll: false });
+      if (known?.ok) router.refresh();
+    }
+  }, [gscStatus, gscToken, gscGuess, router, siteId]);
+
+  function handleConnectGsc() {
+    setConnectingGsc(true);
+    getGscConnectUrl(siteId)
+      .then((url) => { window.location.href = url; })
+      .catch((e) => { toast.error(e instanceof Error ? e.message : "Couldn't start Google connect"); setConnectingGsc(false); });
+  }
+
+  function handlePickProperty() {
+    if (!gscPicker || !gscToken || !gscPicker.siteUrl) return;
+    startTransition(async () => {
+      try {
+        await finalizeGscConnection({ token: gscToken, site_url: gscPicker.siteUrl });
+        toast.success("Search Console connected");
+        setGscPicker(null);
+        router.replace(`/seo/${siteId}`, { scroll: false });
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't connect that property");
+      }
+    });
+  }
+
   const [testingId, setTestingId] = useState<string | null>(null);
   function handleTest(conn: ConnectionView) {
     setTestingId(conn.id);
@@ -161,7 +227,8 @@ export function SeoConnections({ siteId, connections, githubAppReady, githubStat
                     )}
                     <div className="flex gap-2 mt-2">
                       <button onClick={() => handleTest(conn)} disabled={testingId === conn.id} className="text-xs text-muted-foreground hover:text-foreground underline">{testingId === conn.id ? "Testing…" : "Test"}</button>
-                      {def && <button onClick={() => openConnect(def, conn)} className="text-xs text-muted-foreground hover:text-foreground underline">Edit</button>}
+                      {/* OAuth connectors have no editable fields — reconnect instead. */}
+                      {def && def.auth === "token" && <button onClick={() => openConnect(def, conn)} className="text-xs text-muted-foreground hover:text-foreground underline">Edit</button>}
                       <button onClick={() => handleDelete(conn)} disabled={isPending} className="text-xs text-muted-foreground hover:text-destructive underline">Remove</button>
                     </div>
                   </div>
@@ -218,18 +285,34 @@ export function SeoConnections({ siteId, connections, githubAppReady, githubStat
       <section>
         <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Data sources</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {data.map((def) => (
-            <div key={def.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
-              <div className="flex items-start gap-3">
-                <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-foreground/70" /></div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2"><p className="text-sm font-semibold">{def.name}</p><span className="text-[10px] font-medium text-muted-foreground bg-muted rounded-full px-1.5 py-0.5">OAuth soon</span></div>
-                  <p className="text-xs text-muted-foreground mt-0.5">{def.description}</p>
+          {data.map((def) => {
+            const isGsc = def.id === "gsc";
+            return (
+              <div key={def.id} className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3">
+                <div className="flex items-start gap-3">
+                  <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0"><Plug className="w-4.5 h-4.5 text-foreground/70" /></div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold">{def.name}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{def.description}</p>
+                  </div>
                 </div>
+                {isGsc ? (
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Button size="sm" className="text-xs h-7" onClick={handleConnectGsc} disabled={!gscReady || connectingGsc}>
+                      {connectingGsc ? "Opening Google…" : "Connect Google"}
+                    </Button>
+                    {!gscReady && (
+                      <p className="text-[11px] text-muted-foreground basis-full">
+                        Needs a Google OAuth client + APP_ENCRYPTION_KEY on the server.
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div><Button size="sm" variant="outline" className="text-xs h-7" disabled>Coming soon</Button></div>
+                )}
               </div>
-              <div><Button size="sm" variant="outline" className="text-xs h-7" disabled>Needs Google setup</Button></div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
 
@@ -256,6 +339,31 @@ export function SeoConnections({ siteId, connections, githubAppReady, githubStat
           <DialogFooter>
             <Button variant="ghost" onClick={() => { setPicker(null); router.replace(`/seo/${siteId}`, { scroll: false }); }} disabled={isPending}>Cancel</Button>
             <Button onClick={handlePickRepo} disabled={isPending || !picker?.repo}>Connect</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Property picker — when the Google account has several properties */}
+      <Dialog open={!!gscPicker} onOpenChange={(o) => { if (!o) { setGscPicker(null); router.replace(`/seo/${siteId}`, { scroll: false }); } }}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Pick a Search Console property</DialogTitle></DialogHeader>
+          {gscPicker && (
+            <div className="space-y-3">
+              <p className="text-xs text-muted-foreground">
+                That Google account has {gscPicker.props.length} properties. Choose the one for this site — domain
+                (<span className="ch-mono">sc-domain:</span>) and URL-prefix properties are different in Search Console.
+              </p>
+              <div className="space-y-1.5">
+                <Label htmlFor="gsc-prop">Property</Label>
+                <select id="gsc-prop" className={selectCls} value={gscPicker.siteUrl} onChange={(e) => setGscPicker((p) => p && { ...p, siteUrl: e.target.value })}>
+                  {gscPicker.props.map((p) => <option key={p.siteUrl} value={p.siteUrl}>{p.siteUrl}</option>)}
+                </select>
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => { setGscPicker(null); router.replace(`/seo/${siteId}`, { scroll: false }); }} disabled={isPending}>Cancel</Button>
+            <Button onClick={handlePickProperty} disabled={isPending || !gscPicker?.siteUrl}>Connect</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/components/seo/seo-performance.tsx
+++ b/src/components/seo/seo-performance.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Search performance — top queries from the nightly Search Console sync
+ * (seo_keyword_snapshots). Position is the latest snapshot in the window;
+ * clicks/impressions sum across it.
+ */
+import { TrendingUp, Plug } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+
+export interface PerformanceData {
+  rows: { keyword: string; position: number | null; clicks: number; impressions: number; ctr: number | null }[];
+  totals: { clicks: number; impressions: number; keywords: number };
+  lastSynced: string | null;
+}
+
+const pct = (n: number | null) => (n == null ? "—" : `${(n * 100).toFixed(1)}%`);
+const pos = (n: number | null) => (n == null ? "—" : n.toFixed(1));
+
+export function SeoPerformance({ data, hasGsc, onConnect }: { data: PerformanceData; hasGsc: boolean; onConnect: () => void }) {
+  if (!hasGsc) {
+    return (
+      <div className="ch-empty rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+        <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><Plug className="w-6 h-6 text-muted-foreground" /></div>
+        <h4 className="font-semibold">No Search Console connected</h4>
+        <p className="text-sm text-muted-foreground mt-1 mb-4">Connect Google Search Console to pull real keyword positions, clicks and impressions — and to fill the rankings table in client reports.</p>
+        <Button onClick={onConnect}>Go to Connections</Button>
+      </div>
+    );
+  }
+
+  if (data.rows.length === 0) {
+    return (
+      <div className="ch-empty rounded-xl border border-dashed border-border bg-card/50 p-12 text-center">
+        <div className="w-12 h-12 rounded-xl bg-muted mx-auto flex items-center justify-center mb-3"><TrendingUp className="w-6 h-6 text-muted-foreground" /></div>
+        <h4 className="font-semibold">No data synced yet</h4>
+        <p className="text-sm text-muted-foreground mt-1">
+          Search Console is connected — the sync runs nightly and Google&apos;s data lags 2–3 days, so the first rows land within a day.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+        <Tile label="Clicks" value={data.totals.clicks.toLocaleString()} sub="last 28 days" />
+        <Tile label="Impressions" value={data.totals.impressions.toLocaleString()} sub="last 28 days" />
+        <Tile label="Queries" value={data.totals.keywords.toLocaleString()} sub={data.lastSynced ? `synced ${data.lastSynced}` : undefined} />
+      </div>
+
+      <div className="ch-table-wrap">
+        <table className="ch-table w-full">
+          <thead>
+            <tr>
+              <th>Query</th>
+              <th className="num">Position</th>
+              <th className="num">Clicks</th>
+              <th className="num">Impressions</th>
+              <th className="num">CTR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.rows.map((r) => (
+              <tr key={r.keyword}>
+                <td className="break-words">{r.keyword}</td>
+                <td className="num tabular-nums">{pos(r.position)}</td>
+                <td className="num tabular-nums font-semibold">{r.clicks.toLocaleString()}</td>
+                <td className="num tabular-nums">{r.impressions.toLocaleString()}</td>
+                <td className="num tabular-nums">{pct(r.ctr)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        Top {data.rows.length} queries by clicks. Position is the most recent daily snapshot; clicks and impressions are summed over the window.
+      </p>
+    </div>
+  );
+}
+
+function Tile({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1 tabular-nums">{value}</p>
+      {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
-import { ArrowLeft, Plus, FileText, Search, Globe, Plug, Activity } from "@/components/ui/icons";
+import { ArrowLeft, Plus, FileText, Search, Globe, Plug, Activity, TrendingUp } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,6 +16,7 @@ import { SeoActivityTerminal } from "@/components/seo/seo-activity-terminal";
 import { SeoConnections } from "@/components/seo/seo-connections";
 import { SeoOpportunities } from "@/components/seo/seo-opportunities";
 import { SeoReports } from "@/components/seo/seo-reports";
+import { SeoPerformance, type PerformanceData } from "@/components/seo/seo-performance";
 import { CONNECTORS, type ConnectionView } from "@/lib/seo/connectors";
 import type { SeoSite, SeoContentType } from "@/types/database";
 
@@ -39,9 +40,14 @@ interface Props {
   githubAppReady?: boolean;
   githubStatus?: string | null;
   ghToken?: string | null;
+  gscReady?: boolean;
+  gscStatus?: string | null;
+  gscToken?: string | null;
+  gscGuess?: string | null;
+  performance: PerformanceData;
 }
 
-type Tab = "overview" | "content" | "opportunities" | "connections" | "reports" | "activity";
+type Tab = "overview" | "content" | "performance" | "opportunities" | "connections" | "reports" | "activity";
 
 const STATUS_TONE: Record<string, string> = {
   running: "bg-blue-100 text-blue-700",
@@ -54,7 +60,11 @@ const STATUS_TONE: Record<string, string> = {
 };
 const money = (c: number) => `$${(c / 100).toFixed(2)}`;
 
-export function SeoSiteHub({ site, pieces, connections, opportunities, reports, budget, initialTab, githubAppReady, githubStatus, ghToken }: Props) {
+export function SeoSiteHub({
+  site, pieces, connections, opportunities, reports, budget, initialTab,
+  githubAppReady, githubStatus, ghToken,
+  gscReady, gscStatus, gscToken, gscGuess, performance,
+}: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>(initialTab ?? "overview");
   const [isPending, startTransition] = useTransition();
@@ -81,6 +91,7 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, reports, 
   const tabs: { id: Tab; label: string; icon: typeof FileText }[] = [
     { id: "overview", label: "Overview", icon: Globe },
     { id: "content", label: "Content", icon: FileText },
+    { id: "performance", label: "Search performance", icon: TrendingUp },
     { id: "opportunities", label: "Opportunities", icon: Search },
     { id: "connections", label: "Connections", icon: Plug },
     { id: "reports", label: "Reports", icon: FileText },
@@ -128,9 +139,20 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, reports, 
       {tab === "overview" && (
         <div className="space-y-4">
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-            <Stat label="Content pieces" value={String(pieces.length)} />
-            <Stat label="Approved" value={String(approvedCount)} />
-            <Stat label="Connectors" value={`${connectedCount} / ${CONNECTORS.length}`} />
+            <Stat label="Content pieces" value={String(pieces.length)} sub={`${approvedCount} approved`} />
+            {/* Real search data once GSC is synced; falls back to the connector
+                count so the strip never looks broken pre-connection. */}
+            {performance.totals.impressions > 0 ? (
+              <>
+                <Stat label="Clicks" value={performance.totals.clicks.toLocaleString()} sub="last 28 days" />
+                <Stat label="Impressions" value={performance.totals.impressions.toLocaleString()} sub="last 28 days" />
+              </>
+            ) : (
+              <>
+                <Stat label="Connectors" value={`${connectedCount} / ${CONNECTORS.length}`} />
+                <Stat label="Search data" value="—" sub="connect Search Console" />
+              </>
+            )}
             <Stat label="Spend this month" value={money(budget.spentCents)} sub={budget.budgetCents === 0 ? "unlimited" : `of ${money(budget.budgetCents)}`} />
           </div>
           <div className="rounded-xl border border-border bg-card p-5">
@@ -168,6 +190,14 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, reports, 
       {tab === "opportunities" && <SeoOpportunities siteId={site.id} opportunities={opportunities} />}
 
       {/* ── Connections ── */}
+      {tab === "performance" && (
+        <SeoPerformance
+          data={performance}
+          hasGsc={connections.some((c) => c.provider === "gsc" && c.status === "connected")}
+          onConnect={() => setTab("connections")}
+        />
+      )}
+
       {tab === "connections" && (
         <SeoConnections
           siteId={site.id}
@@ -175,6 +205,10 @@ export function SeoSiteHub({ site, pieces, connections, opportunities, reports, 
           githubAppReady={githubAppReady}
           githubStatus={githubStatus}
           ghToken={ghToken}
+          gscReady={gscReady}
+          gscStatus={gscStatus}
+          gscToken={gscToken}
+          gscGuess={gscGuess}
         />
       )}
 

--- a/src/lib/actions/seo-connections.ts
+++ b/src/lib/actions/seo-connections.ts
@@ -16,8 +16,10 @@ import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
 import { testConnection } from "@/lib/seo/publish";
 import { CONNECTORS_BY_ID, secretFieldKeys, type ConnectionView } from "@/lib/seo/connectors";
 import {
-  githubAppConfigured, installUrl, signState, verifyState, listInstallationRepos,
+  githubAppConfigured, installUrl, listInstallationRepos,
 } from "@/lib/seo/github-app";
+import { signState, verifyState } from "@/lib/seo/connect-state";
+import { gscConfigured, gscAuthUrl, accessTokenFor, listProperties } from "@/lib/seo/gsc";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
@@ -32,6 +34,7 @@ async function biz(): Promise<string> {
 function accountRef(provider: string, meta: Record<string, string>): string | null {
   switch (provider) {
     case "git-github": return meta.repo ?? null;
+    case "gsc": return meta.site_url ?? null;
     case "wordpress": return meta.site_url ?? null;
     case "sanity": return meta.project_id ? `${meta.project_id}/${meta.dataset ?? ""}` : null;
     case "payload": return meta.base_url ?? null;
@@ -201,4 +204,117 @@ export async function finalizeGithubConnection(input: {
   if (error) throw error;
   revalidatePath(`/seo/${state.s}`);
   return { site_id: state.s };
+}
+
+// ── Google Search Console (OAuth) ────────────────────────────────────────────
+// Unlike GitHub (App-minted tokens), GSC gives us a refresh token we must
+// persist — so this path DOES need APP_ENCRYPTION_KEY. Connecting stays
+// web-UI-only: no MCP tool, and the token never reaches the client.
+
+/** True when the server has a Google OAuth client configured. */
+export async function isGscConfigured(): Promise<boolean> {
+  return gscConfigured();
+}
+
+export async function getGscConnectUrl(siteId: string): Promise<string> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data: site } = await tbl(supabase, "seo_sites")
+    .select("id").eq("id", siteId).eq("business_id", businessId).maybeSingle();
+  if (!site) throw new Error("Site not found");
+  if (!gscConfigured()) throw new Error("Google Search Console isn't set up on this server yet.");
+  // Fail loudly here rather than after the user has consented at Google.
+  if (!encryptionAvailable()) throw new Error("Credential storage needs APP_ENCRYPTION_KEY set on the server.");
+  return gscAuthUrl(signState({ u: user.id, s: siteId }));
+}
+
+/** Properties on the just-connected Google account (for the picker). The signed
+ *  state carries the refresh token, so a user can't enumerate someone else's. */
+export async function listGscProperties(token: string): Promise<{ siteUrl: string; permissionLevel: string }[]> {
+  const user = await getUser();
+  const state = verifyState(token);
+  if (!state || state.u !== user.id) throw new Error("This connect link has expired — start again.");
+  if (!state.i) throw new Error("Missing Google credentials");
+  return listProperties(await accessTokenFor(state.i));
+}
+
+/** Persist the chosen property + its refresh token (encrypted). */
+export async function finalizeGscConnection(input: { token: string; site_url: string }): Promise<{ site_id: string }> {
+  const businessId = await biz();
+  const user = await getUser();
+  const supabase = await createClient();
+
+  const state = verifyState(input.token);
+  if (!state || state.u !== user.id) throw new Error("This connect link has expired — start again.");
+  if (!state.i) throw new Error("Missing Google credentials");
+  if (!encryptionAvailable()) throw new Error("Credential storage needs APP_ENCRYPTION_KEY set on the server.");
+
+  // Only properties this Google account actually has — blocks a forged site_url.
+  const props = await listProperties(await accessTokenFor(state.i));
+  const chosen = props.find((p) => p.siteUrl === input.site_url);
+  if (!chosen) throw new Error("That property isn't available on the connected Google account.");
+
+  const def = CONNECTORS_BY_ID["gsc"];
+  const meta: Record<string, string> = { site_url: chosen.siteUrl, permission_level: chosen.permissionLevel };
+
+  // One GSC connection per site — replace rather than stack duplicates.
+  await tbl(supabase, "seo_connections")
+    .delete().eq("business_id", businessId).eq("site_id", state.s).eq("provider", "gsc");
+
+  const { error } = await tbl(supabase, "seo_connections").insert({
+    business_id: businessId, site_id: state.s, provider: "gsc",
+    label: def?.name ?? "Google Search Console", meta,
+    status: "connected", account_ref: chosen.siteUrl,
+    connected_at: new Date().toISOString(),
+    secret: encryptSecret(JSON.stringify({ refresh_token: state.i })),
+  });
+  if (error) throw error;
+  revalidatePath(`/seo/${state.s}`);
+  return { site_id: state.s };
+}
+
+/** Top queries for the Search performance tab, from synced snapshots. */
+export async function getSearchPerformance(siteId: string, days = 28): Promise<{
+  rows: { keyword: string; position: number | null; clicks: number; impressions: number; ctr: number | null }[];
+  totals: { clicks: number; impressions: number; keywords: number };
+  lastSynced: string | null;
+}> {
+  const businessId = await biz();
+  const supabase = await createClient();
+  const since = new Date(Date.now() - days * 86400_000).toISOString().split("T")[0];
+  const { data } = await tbl(supabase, "seo_keyword_snapshots")
+    .select("keyword, position, clicks, impressions, ctr, captured_at")
+    .eq("business_id", businessId).eq("site_id", siteId).gte("captured_at", since)
+    .order("captured_at", { ascending: false }).limit(5000);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const all = (data ?? []) as any[];
+  // Latest snapshot per keyword = "where it stands now"; clicks/impressions sum
+  // across the window.
+  const byKeyword = new Map<string, { keyword: string; position: number | null; clicks: number; impressions: number; ctr: number | null }>();
+  for (const r of all) {
+    const k = String(r.keyword);
+    const hit = byKeyword.get(k);
+    if (!hit) {
+      byKeyword.set(k, {
+        keyword: k, position: r.position == null ? null : Number(r.position),
+        clicks: Number(r.clicks ?? 0), impressions: Number(r.impressions ?? 0),
+        ctr: r.ctr == null ? null : Number(r.ctr),
+      });
+    } else {
+      hit.clicks += Number(r.clicks ?? 0);
+      hit.impressions += Number(r.impressions ?? 0);
+    }
+  }
+  const rows = [...byKeyword.values()].sort((a, b) => b.clicks - a.clicks || b.impressions - a.impressions).slice(0, 200);
+  return {
+    rows,
+    totals: {
+      clicks: rows.reduce((s, r) => s + r.clicks, 0),
+      impressions: rows.reduce((s, r) => s + r.impressions, 0),
+      keywords: byKeyword.size,
+    },
+    lastSynced: all[0]?.captured_at ?? null,
+  };
 }

--- a/src/lib/mcp/tools/seo-tools.ts
+++ b/src/lib/mcp/tools/seo-tools.ts
@@ -229,6 +229,31 @@ export function registerSeoTools(tool: ToolFn): void {
       return text({ deleted: true });
     });
 
+  tool("get_search_performance", "Google Search Console performance for a site — top queries with position, clicks, impressions and CTR, from the nightly sync. Needs a connected 'gsc' connection (connect it in the web UI).",
+    { site_id: UUID, days: z.number().int().min(1).max(180).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "seo:read");
+      const since = new Date(Date.now() - (args.days ?? 28) * 86_400_000).toISOString().split("T")[0];
+      const { data, error } = await t(ctx, "seo_keyword_snapshots")
+        .select("keyword, position, clicks, impressions, ctr, captured_at")
+        .eq("business_id", ctx.businessId).eq("site_id", args.site_id)
+        .gte("captured_at", since).order("captured_at", { ascending: false }).limit(2000);
+      if (error) throw error;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = (data ?? []) as any[];
+      if (rows.length === 0) return text({ rows: [], note: "No Search Console data — connect GSC in the web UI, or the nightly sync hasn't run yet (Google's data also lags 2-3 days)." });
+      // Latest position per keyword; clicks/impressions summed over the window.
+      const by = new Map<string, { keyword: string; position: number | null; clicks: number; impressions: number }>();
+      for (const r of rows) {
+        const k = String(r.keyword);
+        const hit = by.get(k);
+        if (!hit) by.set(k, { keyword: k, position: r.position == null ? null : Number(r.position), clicks: Number(r.clicks ?? 0), impressions: Number(r.impressions ?? 0) });
+        else { hit.clicks += Number(r.clicks ?? 0); hit.impressions += Number(r.impressions ?? 0); }
+      }
+      const out = [...by.values()].sort((a, b) => b.clicks - a.clicks || b.impressions - a.impressions).slice(0, 100);
+      return text({ days: args.days ?? 28, queries: out.length, rows: out });
+    });
+
   tool("test_seo_connection", "Verify a gateway connection's credentials against the provider (git/wordpress/sanity/payload/rest/graphql).",
     { connection_id: UUID },
     async (args, extra) => {

--- a/src/lib/seo/connect-state.ts
+++ b/src/lib/seo/connect-state.ts
@@ -1,0 +1,65 @@
+/**
+ * Signed, stateless "connect state" for outbound OAuth-ish connector flows
+ * (GitHub App install, Google Search Console OAuth).
+ *
+ * The provider bounces the user's browser back to our callback; the state
+ * proves the round trip belongs to a flow *we* started, binds it to the user
+ * who started it (CSRF), and carries the site id through a provider that has
+ * no idea what a Kirei site is. Stateless HMAC — nothing half-done is persisted.
+ *
+ * Server-only. Keyed by APP_ENCRYPTION_KEY, falling back to the GitHub App
+ * private key so the GitHub flow keeps working on servers where the encryption
+ * key isn't configured. States are short-lived (15 min), so re-keying only ever
+ * costs an in-flight connect a retry.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export interface ConnectState {
+  /** Kirei user who started the flow — the callback must match. */
+  u: string;
+  /** seo_sites.id the connection belongs to. */
+  s: string;
+  /** Provider handle picked up on the return leg (GitHub installation id,
+   *  Google refresh token) so a follow-up picker can be trusted. */
+  i?: string;
+  /** expiry (epoch seconds). */
+  e: number;
+}
+
+const b64url = (b: Buffer | string) =>
+  (Buffer.isBuffer(b) ? b : Buffer.from(b, "utf8"))
+    .toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+function stateKey(): string {
+  const k = process.env.APP_ENCRYPTION_KEY?.trim() || process.env.GITHUB_APP_PRIVATE_KEY_BASE64?.trim();
+  if (!k) throw new Error("Connector flows need APP_ENCRYPTION_KEY set on the server.");
+  return k;
+}
+
+export function signState(payload: Omit<ConnectState, "e">, ttlSeconds = 900): string {
+  const body: ConnectState = { ...payload, e: Math.floor(Date.now() / 1000) + ttlSeconds };
+  const data = b64url(JSON.stringify(body));
+  const sig = b64url(createHmac("sha256", stateKey()).update(data).digest());
+  return `${data}.${sig}`;
+}
+
+/** Verify signature + expiry. Returns null on any tamper/expiry. */
+export function verifyState(token: string | null | undefined): ConnectState | null {
+  if (!token) return null;
+  const [data, sig] = token.split(".");
+  if (!data || !sig) return null;
+  let expected: string;
+  try { expected = b64url(createHmac("sha256", stateKey()).update(data).digest()); }
+  catch { return null; }
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8")) as ConnectState;
+    if (!parsed.u || !parsed.s || !parsed.e) return null;
+    if (parsed.e < Math.floor(Date.now() / 1000)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/seo/connectors.ts
+++ b/src/lib/seo/connectors.ts
@@ -127,8 +127,10 @@ export const CONNECTORS: ConnectorDef[] = [
     name: "Google Search Console",
     category: "data",
     auth: "oauth",
-    description: "Pull real keyword positions, clicks and impressions to feed the opportunity scout.",
-    docsHint: "Requires a Google Cloud OAuth client (Search Console read-only). Coming with the OAuth flow.",
+    description: "Pull real keyword positions, clicks and impressions. Syncs nightly and fills the rankings table in client reports.",
+    docsHint: "Sign in with the Google account that has access to the property — read-only, and we never see your password.",
+    // No fields: this is a redirect-to-Google OAuth flow, not a form. The
+    // refresh token is stored encrypted by the callback.
     fields: [],
   },
 ];

--- a/src/lib/seo/github-app.ts
+++ b/src/lib/seo/github-app.ts
@@ -16,7 +16,7 @@
  *   GITHUB_APP_PRIVATE_KEY_BASE64  — base64 of the .pem (base64 avoids the
  *                                    multiline-newline mangling env vars suffer)
  */
-import { createHmac, createSign, timingSafeEqual } from "node:crypto";
+import { createSign } from "node:crypto";
 
 const GH_API = "https://api.github.com";
 const UA = "Kirei-SEO";
@@ -128,49 +128,6 @@ export function installUrl(state: string): string {
   return `https://github.com/apps/${encodeURIComponent(slug)}/installations/new?state=${encodeURIComponent(state)}`;
 }
 
-export interface ConnectState {
-  /** Kirei user who started the flow — the callback must match. */
-  u: string;
-  /** seo_sites.id the connection belongs to. */
-  s: string;
-  /** installation id — absent on the outbound leg, added by the callback when
-   *  it re-signs the state to hand a repo picker back to the browser. */
-  i?: string;
-  /** expiry (epoch seconds). */
-  e: number;
-}
-
-/** HMAC key: the App private key is server-only and high-entropy, so it doubles
- *  as the state-signing secret — no extra env var to configure. */
-function stateKey(): string {
-  const pem = privateKeyPem();
-  if (!pem) throw new Error("GitHub App is not configured on this server.");
-  return pem;
-}
-
-/** Stateless signed state — CSRF defence + carries the site through GitHub. */
-export function signState(payload: Omit<ConnectState, "e">, ttlSeconds = 900): string {
-  const body: ConnectState = { ...payload, e: Math.floor(Date.now() / 1000) + ttlSeconds };
-  const data = b64url(JSON.stringify(body));
-  const sig = b64url(createHmac("sha256", stateKey()).update(data).digest());
-  return `${data}.${sig}`;
-}
-
-/** Verify signature + expiry. Returns null on any tamper/expiry. */
-export function verifyState(token: string | null | undefined): ConnectState | null {
-  if (!token) return null;
-  const [data, sig] = token.split(".");
-  if (!data || !sig) return null;
-  const expected = b64url(createHmac("sha256", stateKey()).update(data).digest());
-  const a = Buffer.from(sig);
-  const b = Buffer.from(expected);
-  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
-  try {
-    const parsed = JSON.parse(Buffer.from(data.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8")) as ConnectState;
-    if (!parsed.u || !parsed.s || !parsed.e) return null;
-    if (parsed.e < Math.floor(Date.now() / 1000)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
+// Signed state lives in ./connect-state — shared with the Google Search
+// Console flow. Re-exported so existing importers don't have to change.
+export { signState, verifyState, type ConnectState } from "@/lib/seo/connect-state";

--- a/src/lib/seo/gsc.ts
+++ b/src/lib/seo/gsc.ts
@@ -1,0 +1,158 @@
+/**
+ * Google Search Console connector (docs/SEO_AGENCY_PLAN.md Phase 2.2).
+ *
+ * Standard 3-legged OAuth: the user clicks Connect → consents at Google →
+ * we exchange the code for a refresh token, store it encrypted, and mint
+ * short-lived access tokens whenever we pull data.
+ *
+ * Deliberately NOT using `googleapis` — it's tens of megabytes and drags in the
+ * whole discovery surface for what is three fetch calls. The repo already talks
+ * to GitHub/WordPress/Sanity with plain fetch; this matches.
+ *
+ * Server-only. Env:
+ *   GOOGLE_OAUTH_CLIENT_ID
+ *   GOOGLE_OAUTH_CLIENT_SECRET
+ * plus APP_ENCRYPTION_KEY (the refresh token is stored encrypted by the caller).
+ *
+ * ⚠️ Until the Google Cloud project passes sensitive-scope verification, the
+ * consent screen stays in Testing mode and refresh tokens expire after 7 days —
+ * users have to reconnect weekly. Verification removes that.
+ */
+import { appUrl } from "@/lib/app-url";
+
+const OAUTH_AUTH = "https://accounts.google.com/o/oauth2/v2/auth";
+const OAUTH_TOKEN = "https://oauth2.googleapis.com/token";
+const WMT = "https://www.googleapis.com/webmasters/v3";
+/** Read-only Search Console. Sensitive scope — see the verification note above. */
+const SCOPE = "https://www.googleapis.com/auth/webmasters.readonly";
+
+const clientId = () => process.env.GOOGLE_OAUTH_CLIENT_ID?.trim();
+const clientSecret = () => process.env.GOOGLE_OAUTH_CLIENT_SECRET?.trim();
+
+/** True when the Google OAuth client is configured — gates the Connect button. */
+export function gscConfigured(): boolean {
+  return Boolean(clientId() && clientSecret());
+}
+
+/** Must exactly match an Authorized redirect URI on the OAuth client. */
+export function gscRedirectUri(): string {
+  return `${appUrl() || "https://www.kireihq.com"}/api/seo/gsc/callback`;
+}
+
+export function gscAuthUrl(state: string): string {
+  const id = clientId();
+  if (!id) throw new Error("Google Search Console isn't set up on this server.");
+  const p = new URLSearchParams({
+    client_id: id,
+    redirect_uri: gscRedirectUri(),
+    response_type: "code",
+    scope: SCOPE,
+    // offline + consent: Google only returns a refresh_token on the FIRST
+    // consent unless we force the prompt — without this a reconnect silently
+    // yields no refresh token and the connection dies at the next sync.
+    access_type: "offline",
+    prompt: "consent",
+    include_granted_scopes: "true",
+    state,
+  });
+  return `${OAUTH_AUTH}?${p.toString()}`;
+}
+
+/** Swap the one-time code for tokens. Returns the refresh token we persist. */
+export async function exchangeCode(code: string): Promise<{ refreshToken: string; accessToken: string }> {
+  const id = clientId(), secret = clientSecret();
+  if (!id || !secret) throw new Error("Google Search Console isn't set up on this server.");
+  const res = await fetch(OAUTH_TOKEN, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code, client_id: id, client_secret: secret,
+      redirect_uri: gscRedirectUri(), grant_type: "authorization_code",
+    }),
+  });
+  if (!res.ok) throw new Error(`Google token exchange ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const j = (await res.json()) as { refresh_token?: string; access_token?: string };
+  if (!j.refresh_token) {
+    throw new Error("Google didn't return a refresh token — revoke Kirei's access in your Google account and connect again.");
+  }
+  return { refreshToken: j.refresh_token, accessToken: j.access_token ?? "" };
+}
+
+/** Access tokens last ~1h — cache per refresh token, refresh 5 min early. */
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+export async function accessTokenFor(refreshToken: string): Promise<string> {
+  const hit = tokenCache.get(refreshToken);
+  if (hit && hit.expiresAt - 5 * 60_000 > Date.now()) return hit.token;
+
+  const id = clientId(), secret = clientSecret();
+  if (!id || !secret) throw new Error("Google Search Console isn't set up on this server.");
+  const res = await fetch(OAUTH_TOKEN, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ refresh_token: refreshToken, client_id: id, client_secret: secret, grant_type: "refresh_token" }),
+  });
+  if (!res.ok) {
+    const body = (await res.text()).slice(0, 200);
+    // invalid_grant = revoked, or the 7-day Testing-mode expiry bit us.
+    if (res.status === 400 && body.includes("invalid_grant")) {
+      throw new Error("Google access expired or was revoked — reconnect Search Console. (Unverified apps expire access every 7 days.)");
+    }
+    throw new Error(`Google token refresh ${res.status}: ${body}`);
+  }
+  const j = (await res.json()) as { access_token: string; expires_in?: number };
+  tokenCache.set(refreshToken, { token: j.access_token, expiresAt: Date.now() + (j.expires_in ?? 3600) * 1000 });
+  return j.access_token;
+}
+
+export interface GscProperty {
+  siteUrl: string;          // "sc-domain:example.com" or "https://example.com/"
+  permissionLevel: string;
+}
+
+/** Properties this Google account can see. */
+export async function listProperties(accessToken: string): Promise<GscProperty[]> {
+  const res = await fetch(`${WMT}/sites`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  if (!res.ok) throw new Error(`Search Console sites ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const j = (await res.json()) as { siteEntry?: { siteUrl: string; permissionLevel: string }[] };
+  return (j.siteEntry ?? [])
+    // siteUnverifiedUser can't query analytics — don't offer it.
+    .filter((s) => s.permissionLevel !== "siteUnverifiedUser")
+    .map((s) => ({ siteUrl: s.siteUrl, permissionLevel: s.permissionLevel }));
+}
+
+export interface SearchRow {
+  keys: string[];
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+/** searchAnalytics.query. `dimensions` e.g. ["date","query"]. Dates YYYY-MM-DD. */
+export async function querySearchAnalytics(
+  accessToken: string, siteUrl: string,
+  args: { startDate: string; endDate: string; dimensions: string[]; rowLimit?: number },
+): Promise<SearchRow[]> {
+  const res = await fetch(`${WMT}/sites/${encodeURIComponent(siteUrl)}/searchAnalytics/query`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      startDate: args.startDate, endDate: args.endDate,
+      dimensions: args.dimensions, rowLimit: args.rowLimit ?? 500, type: "web",
+    }),
+  });
+  if (!res.ok) throw new Error(`Search Console query ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const j = (await res.json()) as { rows?: SearchRow[] };
+  return j.rows ?? [];
+}
+
+/** Best-guess match between a seo_sites.domain and the account's properties.
+ *  domain is free-text and GSC has two property kinds, so this only pre-selects
+ *  the picker — the user confirms, and we store the exact siteUrl they chose. */
+export function guessProperty(domain: string, props: GscProperty[]): string | undefined {
+  const host = domain.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/.*$/, "").replace(/^www\./, "");
+  if (!host) return props[0]?.siteUrl;
+  const norm = (s: string) => s.toLowerCase().replace(/^sc-domain:/, "").replace(/^https?:\/\//, "").replace(/\/$/, "").replace(/^www\./, "");
+  return props.find((p) => norm(p.siteUrl) === host)?.siteUrl ?? props[0]?.siteUrl;
+}

--- a/src/lib/seo/publish.ts
+++ b/src/lib/seo/publish.ts
@@ -223,6 +223,16 @@ export async function testConnection(sb: any, businessId: string, connectionId: 
         const res = await fetch(`${base}/${meta.collection}?limit=1`, { headers: { Authorization: `users API-Key ${secrets.api_key}` } });
         return res.ok ? { ok: true, message: "Payload authentication OK" } : { ok: false, message: `Payload ${res.status} — check the base URL, collection and key.` };
       }
+      case "gsc": {
+        // Data connector, not a publish gateway — probe by listing properties.
+        if (!secrets.refresh_token) return { ok: false, message: "No Google credentials — reconnect Search Console." };
+        const { accessTokenFor, listProperties } = await import("@/lib/seo/gsc");
+        const props = await listProperties(await accessTokenFor(secrets.refresh_token));
+        const has = props.some((p) => p.siteUrl === meta.site_url);
+        return has
+          ? { ok: true, message: `Connected to ${meta.site_url}` }
+          : { ok: false, message: `The Google account can no longer see ${meta.site_url} — reconnect.` };
+      }
       case "rest":
       case "graphql": {
         try { const res = await fetch(meta.endpoint, { method: "OPTIONS" }); return { ok: true, message: `Endpoint reachable (${res.status}). Credentials are verified on the first real publish.` }; }

--- a/supabase/migrations/20260716180000_gsc_snapshots_idempotent.sql
+++ b/supabase/migrations/20260716180000_gsc_snapshots_idempotent.sql
@@ -1,0 +1,16 @@
+-- Make seo_keyword_snapshots safe for a repeating GSC sync.
+--
+-- Search Console restates the last ~3 days of data, so the nightly sync pulls a
+-- trailing window and re-writes rows it has already seen. Without a unique key
+-- that duplicates every keyword every night. With it, the sync upserts.
+--
+-- Safe as a plain (non-concurrent) index: the table has never had a producer —
+-- verified 0 rows before applying.
+CREATE UNIQUE INDEX IF NOT EXISTS seo_keyword_snapshots_unique_daily
+  ON public.seo_keyword_snapshots (site_id, keyword, captured_at);
+
+-- Page-level dimension. Nullable + additive: the query-only sync leaves it
+-- NULL. The Opportunity Scout follow-up needs it to say "rewrite THIS page's
+-- title" for high-impression/low-CTR pages.
+ALTER TABLE public.seo_keyword_snapshots
+  ADD COLUMN IF NOT EXISTS page TEXT;

--- a/vercel.json
+++ b/vercel.json
@@ -52,6 +52,10 @@
     {
       "path": "/api/cron/seo-audits",
       "schedule": "*/3 * * * *"
+    },
+    {
+      "path": "/api/cron/seo-gsc-sync",
+      "schedule": "0 4 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Why

GSC was the last stub in the connector registry and the one Phase-2 item that needed a Google Cloud OAuth client from you (`SEO_AGENCY_PLAN.md:97`).

**The find that shaped this PR:** `seo_keyword_snapshots` already existed, and `src/lib/seo/report.ts` + the report PDF **already read it** — two consumers sitting on a permanently empty table (the PDF even renders *"Connect Google Search Console to track keyword positions…"*). This PR is the missing **producer**, so **client report rankings light up with zero code changes to either.**

## What it does

**Connect Google** → consent → property picker (or auto-connect if there's one) → nightly sync pulls query performance into `seo_keyword_snapshots` → **Search performance** tab + overview tiles + report PDFs.

## Notable decisions

- **No `googleapis` dep** — it's ~50MB and would threaten the bundle budget. This is three plain `fetch`es, matching how the repo already talks to GitHub/WordPress/Sanity.
- **`access_type=offline` + `prompt=consent`** — Google only returns a refresh token on *first* consent otherwise, so a reconnect would silently produce a dead connection.
- **Property matching is never derived from `seo_sites.domain`** (free text, and `sc-domain:` vs URL-prefix are genuinely different properties). The user picks; we store the exact `siteUrl` in `account_ref` — which the schema comment already reserved for this.
- **`getGscConnectUrl` fails *before* the redirect** if `APP_ENCRYPTION_KEY` is missing, rather than stranding the user after they've consented at Google.
- **`finalizeGscConnection` re-lists the account's properties** and rejects anything not in it — a forged `site_url` can't be stored.
- **Sync pulls a trailing 5-day window**, because GSC lags 2-3 days *and restates* recent days. The new `UNIQUE (site_id, keyword, captured_at)` makes that an upsert instead of nightly duplication.
- A revoked/expired token flags **that one connection** `status=error` + logs a job event — it never kills the run for other sites.
- `signState`/`verifyState` extracted to `connect-state.ts`, now shared with the GitHub flow (states are 15-min ephemeral, so re-keying is safe).

## Security

Refresh token stored **encrypted** (`encryptSecret`), never returned to client or MCP. Callback is cookie-authed and **not** middleware-whitelisted. Connecting stays **web-UI-only** per the standing rule — the only new MCP tool is read-only `get_search_performance`.

## ⚠️ Needs from you before it lights up

1. **`APP_ENCRYPTION_KEY`** (64 hex) — **currently unset**, which is *also* silently breaking every manual-token connector (WordPress/Sanity/PAT). GitHub App only works because it stores no secret.
2. Google Cloud project → Search Console API → OAuth consent screen (External, `webmasters.readonly`, add yourself as test user) → OAuth client with redirect `https://www.kireihq.com/api/seo/gsc/callback` → `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`.
3. **Start Google's sensitive-scope verification.** Until approved, the consent screen is in Testing mode and **refresh tokens expire every 7 days** (you'll reconnect weekly). The code surfaces that as a plain "reconnect" message rather than a cryptic 400.

Degrades cleanly: no env → Connect disabled with the reason; the rest of the app is untouched.

## Verification

tsc · 17/17 tests · build (both new routes registered) · bundle budget green · routes **153 → 155** (additions only) · migration applied + recorded (table verified 0 rows first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)