### PR TITLE
refactor(mcp): one tool registry behind both MCP and the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,8 @@
         "twilio": "^5.13.1",
         "uuid": "^13.0.0",
         "vaul": "^1.1.2",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.25.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -4725,6 +4726,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
@@ -13945,7 +14010,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "twilio": "^5.13.1",
     "uuid": "^13.0.0",
     "vaul": "^1.1.2",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -20,7 +20,19 @@ export const maxDuration = 120;
 
 const handler = createMcpHandler(
   (server) => {
-    registerTools(server);
+    // registerTools takes a ToolFn, not a server, so the same definitions can
+    // also back the in-app assistant (see lib/mcp/collect.ts). Adapt onto the
+    // real server here — this is the only place that knows about MCP.
+    //
+    // The cast covers the handler's `Promise<unknown>` vs the SDK's
+    // `Promise<CallToolResult>`: handlers return text()/errorText(), which are
+    // CallToolResult-shaped but typed loosely across ~200 tools. This used to
+    // be a blanket `type McpServer = any` on the whole server, so narrowing it
+    // to this one callback is a strict improvement in coverage.
+    registerTools((name, description, shape, handler) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      server.tool(name, description, shape, handler as any)
+    );
   },
   {
     serverInfo: { name: "kirei", version: "1.0.0" },

--- a/src/lib/mcp/__tests__/collect.test.ts
+++ b/src/lib/mcp/__tests__/collect.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { TOOL_SPECS, TOOL_SPECS_BY_NAME } from "../collect";
+import { ANTHROPIC_TOOLS } from "../anthropic-tools";
+
+/**
+ * These lock the shared registry's contract. `/api/mcp` and the in-app
+ * assistant both read from it, so a regression here silently changes what
+ * Claude Code, the claude.ai connector, and the assistant can all do.
+ */
+describe("tool registry", () => {
+  it("collects the full tool surface", () => {
+    // Guards against a sub-registrar being dropped in a refactor. Deliberately
+    // a floor, not an exact count — adding tools is normal and shouldn't fail.
+    expect(TOOL_SPECS.length).toBeGreaterThan(150);
+  });
+
+  it("has no duplicate tool names", () => {
+    const names = TOOL_SPECS.map((s) => s.name);
+    expect(names.length).toBe(new Set(names).size);
+  });
+
+  it("indexes every spec by name", () => {
+    expect(Object.keys(TOOL_SPECS_BY_NAME).length).toBe(TOOL_SPECS.length);
+  });
+
+  it("still registers known tools from every sub-registrar", () => {
+    // One per registrar: core, plugin-forms, seo, expenses, inventory,
+    // timesheets, assets, prospects.
+    for (const name of [
+      "list_customers",
+      "list_public_forms",
+      "list_seo_sites",
+      "list_expenses",
+      "list_inventory",
+      "get_timesheet",
+      "list_assets",
+      "list_prospects",
+    ]) {
+      expect(TOOL_SPECS_BY_NAME[name], `missing tool: ${name}`).toBeDefined();
+    }
+  });
+
+  it("exposes each tool to Anthropic with a valid input_schema", () => {
+    expect(ANTHROPIC_TOOLS.length).toBe(TOOL_SPECS.length);
+    for (const tool of ANTHROPIC_TOOLS) {
+      expect(tool.name, "tool needs a name").toBeTruthy();
+      expect(tool.description, `${tool.name} needs a description`).toBeTruthy();
+      expect(tool.input_schema.type).toBe("object");
+      // $schema is stripped: it's dead weight in the prompt-cache prefix.
+      expect(tool.input_schema).not.toHaveProperty("$schema");
+      // A $ref would be unresolvable — we send no definitions block.
+      expect(JSON.stringify(tool.input_schema)).not.toContain('"$ref"');
+    }
+  });
+
+  it("converts zod shapes to JSON Schema faithfully", () => {
+    const listCustomers = ANTHROPIC_TOOLS.find((t) => t.name === "list_customers");
+    const schema = listCustomers?.input_schema as {
+      properties?: Record<string, { type?: string }>;
+    };
+    expect(schema.properties?.search?.type).toBe("string");
+    expect(schema.properties?.limit?.type).toBe("integer");
+  });
+});

--- a/src/lib/mcp/anthropic-tools.ts
+++ b/src/lib/mcp/anthropic-tools.ts
@@ -1,0 +1,38 @@
+/**
+ * Present the shared tool registry to the Anthropic Messages API.
+ *
+ * The registry stores each tool's params as a zod raw shape (that's what the
+ * MCP server wants); Anthropic wants JSON Schema. This converts once at module
+ * scope and hands back a frozen `Anthropic.Tool[]`.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { TOOL_SPECS, type ToolSpec } from "./collect";
+
+function toAnthropicTool(spec: ToolSpec): Anthropic.Tool {
+  const schema = zodToJsonSchema(z.object(spec.shape), {
+    target: "jsonSchema7",
+    // Inline everything: Anthropic reads input_schema standalone, and a $ref
+    // pointing at a definitions block we don't send would be unresolvable.
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+
+  // Drop the JSON Schema dialect marker — it's meaningless to the tool-use API
+  // and only adds bytes to a payload that sits in the prompt cache prefix.
+  delete schema.$schema;
+
+  return {
+    name: spec.name,
+    description: spec.description,
+    input_schema: schema as Anthropic.Tool.InputSchema,
+  };
+}
+
+/**
+ * Built once at module scope — same reasoning as TOOL_SPECS. These render at
+ * the head of every request, so a stable serialization is what keeps the prompt
+ * cache warm across turns.
+ */
+export const ANTHROPIC_TOOLS: Anthropic.Tool[] = TOOL_SPECS.map(toAnthropicTool);

--- a/src/lib/mcp/collect.ts
+++ b/src/lib/mcp/collect.ts
@@ -1,0 +1,42 @@
+/**
+ * Collect every registered tool as plain data.
+ *
+ * `registerTools` is written against a `ToolFn` callback rather than an MCP
+ * server, so passing a collector here yields the same ~200 tools `/api/mcp`
+ * exposes — without an MCP server, an HTTP hop, or an API key. This is what
+ * lets the in-app assistant share one tool surface with the MCP server instead
+ * of maintaining a second, drifting copy.
+ */
+
+import type { z } from "zod";
+import { registerTools } from "./register-tools";
+
+export interface ToolSpec {
+  name: string;
+  description: string;
+  shape: z.ZodRawShape;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (args: any, extra: any) => Promise<unknown>;
+}
+
+function collect(): ToolSpec[] {
+  const specs: ToolSpec[] = [];
+  registerTools((name, description, shape, handler) => {
+    specs.push({ name, description, shape, handler });
+  });
+  return specs;
+}
+
+/**
+ * Built once at module scope, deliberately.
+ *
+ * Tool definitions are static, so re-collecting per request would burn CPU for
+ * an identical result — and worse, the tool list is the head of the prompt
+ * cache prefix, so any per-request rebuild risks changing its serialization and
+ * silently invalidating the cache on every turn.
+ */
+export const TOOL_SPECS: ToolSpec[] = collect();
+
+export const TOOL_SPECS_BY_NAME: Record<string, ToolSpec> = Object.fromEntries(
+  TOOL_SPECS.map((s) => [s.name, s])
+);

--- a/src/lib/mcp/invoke.ts
+++ b/src/lib/mcp/invoke.ts
@@ -1,0 +1,76 @@
+/**
+ * Run a registry tool in-process.
+ *
+ * The MCP server reaches these handlers through `server.tool(...)`, which
+ * authenticates via an `inv_*` API key and validates arguments against the
+ * tool's zod shape before dispatching. Callers here have neither, so this
+ * module supplies both: it validates the arguments and synthesises the auth
+ * context the handlers expect.
+ */
+
+import { z } from "zod";
+import type { ApiScope } from "@/types/database";
+import { TOOL_SPECS_BY_NAME } from "./collect";
+
+export interface InvokeContext {
+  /** Resolved server-side from the session — never accepted from a client. */
+  businessId: string;
+  userId: string;
+  /** Derived from the caller's role, not assumed. */
+  scopes: ApiScope[];
+}
+
+export interface ToolOutcome {
+  /** Text handed back to the model as the tool_result body. */
+  text: string;
+  isError: boolean;
+}
+
+/** Flatten an MCP tool result (`{content:[{type:"text",text}], isError?}`). */
+function toOutcome(raw: unknown): ToolOutcome {
+  if (raw && typeof raw === "object" && "content" in raw) {
+    const r = raw as { content?: Array<{ type?: string; text?: string }>; isError?: boolean };
+    const text = (r.content ?? [])
+      .filter((b) => b?.type === "text" && typeof b.text === "string")
+      .map((b) => b.text as string)
+      .join("\n");
+    return { text: text || "Done.", isError: r.isError === true };
+  }
+  return { text: typeof raw === "string" ? raw : JSON.stringify(raw), isError: false };
+}
+
+/**
+ * Validate + run one tool. Never throws: a failure comes back as an error
+ * outcome so the model can read it and correct itself, which is what the MCP
+ * server's own wrapper does.
+ */
+export async function invokeTool(
+  name: string,
+  input: unknown,
+  ctx: InvokeContext
+): Promise<ToolOutcome> {
+  const spec = TOOL_SPECS_BY_NAME[name];
+  if (!spec) return { text: `Error: no such tool "${name}"`, isError: true };
+
+  // The MCP server validates against the shape before dispatch; nothing else
+  // does, so handlers would otherwise receive raw model output.
+  const parsed = z.object(spec.shape).safeParse(input ?? {});
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    return { text: `Error: invalid arguments for ${name} — ${detail}`, isError: true };
+  }
+
+  // ctxFrom() reads auth off `extra.authInfo.extra` (see tools/shared.ts).
+  const extra = { authInfo: { extra: { businessId: ctx.businessId, userId: ctx.userId, scopes: ctx.scopes } } };
+
+  // Handlers are already wrapped in registerTools' try/catch, which converts a
+  // throw into an errorText result — so a rejection here would be unexpected.
+  // Catch anyway: one bad tool must not take down the whole turn.
+  try {
+    return toOutcome(await spec.handler(parsed.data, extra));
+  } catch (e) {
+    return { text: `Error: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+  }
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -12,8 +12,6 @@
  */
 
 import { z } from "zod";
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type McpServer = any;
 import { v4 as uuidv4 } from "uuid";
 import { randomBytes } from "crypto";
 import { assertScope, t, text, errorText, type McpContext } from "./context";
@@ -29,7 +27,7 @@ import {
 } from "@/lib/emails/templates";
 import { customerAllowsCard } from "@/lib/payment-methods";
 import type { LineItem } from "@/types/database";
-import { ctxFrom, appBase, UUID, getOrMintPortalToken } from "./tools/shared";
+import { ctxFrom, appBase, UUID, getOrMintPortalToken, type ToolFn } from "./tools/shared";
 import { registerPluginFormTools } from "./tools/plugin-form-tools";
 import { registerSeoTools } from "./tools/seo-tools";
 import { registerExpenseTools } from "./tools/expenses-tools";
@@ -125,10 +123,20 @@ async function renderPdf(kind: "quote" | "invoice", doc: unknown, customer: unkn
 
 // ── registration ─────────────────────────────────────────────────────────────
 
-export function registerTools(server: McpServer): void {
+/**
+ * Register every Kirei tool against `register`.
+ *
+ * Takes a `ToolFn` rather than an MCP server so the same definitions can back
+ * more than one surface: `/api/mcp` passes an adapter onto the real server,
+ * while `collect.ts` passes a collector that just gathers the specs (which is
+ * how the in-app assistant gets the identical tool set instead of maintaining
+ * its own copy). The sub-registrars below already took a `ToolFn`; this makes
+ * the top-level match them.
+ */
+export function registerTools(register: ToolFn): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tool = (name: string, description: string, shape: z.ZodRawShape, handler: (args: any, extra: any) => Promise<unknown>) =>
-    server.tool(name, description, shape, async (args: unknown, extra: unknown) => {
+    register(name, description, shape, async (args: unknown, extra: unknown) => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return await handler(args as any, extra as any);


### PR DESCRIPTION
**Stacked on #398** — retarget to `main` after that merges.

Groundwork for the assistant rebuild: make the MCP registry the single source of truth for tools.

## Why

Three parallel tool implementations that drift:

| Impl | Tools | Backend |
|---|---|---|
| `src/lib/actions/*` | — | canonical server actions |
| `src/lib/mcp/` | **196** | raw Supabase (0 imports from `lib/actions`) |
| `api/agent/route.ts` | **79** | hybrid |

The standing rule is *every feature gets an MCP tool* — so MCP is the real surface and the chat agent is permanently 117 tools behind it. Rather than write a fourth copy for the new assistant, this makes one registry back both.

## Why it's small

The abstraction was already there. `registerTools` built a local `ToolFn` closure and passed *that* to every sub-registrar (`registerSeoTools(tool: ToolFn)`, …) — nothing was written against a real MCP server object. Only the top-level signature needed to match what its own children already used.

- `registerTools(server)` → `registerTools(register: ToolFn)`; the try/catch + `errorText` wrapper moves inside, unchanged.
- `/api/mcp` adapts onto the real server — now the **only** file that knows MCP exists.
- **`collect.ts`** — gathers specs via a collector `ToolFn`. 196 tools, no server, no HTTP hop, no API key.
- **`anthropic-tools.ts`** — zod shape → JSON Schema for the Messages API (`$schema` stripped, refs inlined).
- **`invoke.ts`** — runs one in-process, synthesising the auth context `ctxFrom` expects.

## Two things worth reviewing

1. **`invoke.ts` validates arguments.** `server.tool()` validates against the zod shape before dispatch; nothing else does. Without this, handlers would receive raw unvalidated model output. This is the subtle part of not going through MCP.
2. **Both registries build once at module scope.** Tool defs are static, and the tool list heads the prompt-cache prefix — a per-request rebuild would risk invalidating the cache on every turn.

Also: dropping `type McpServer = any` exposed a real type error the blanket `any` was hiding (handlers return `Promise<unknown>`; `server.tool` wants `Promise<CallToolResult>`). Narrowed to a cast on that one callback — strictly better coverage than before.

`zod-to-json-schema` added as a **direct dependency** — it was transitive-only, so importing it undeclared was a build landmine.

## Verification

Behaviour-neutral by design — `/api/mcp` should be byte-identical.

- `tsc` clean · **29/29** tests (6 new: 196 tools, no duplicates, one known tool per sub-registrar, valid schemas, no `$ref`/`$schema`) · build compiles · within bundle budget · no route changes.
- 🔴 **Risk gate before merging:** this is the tool surface Claude Code and the claude.ai connector both use. Please confirm against the preview that `/api/mcp` still lists tools and can run a read + a write. A regression here breaks both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)