### PR TITLE
feat(assistant): new agent loop with real cross-turn memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kirei",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.80.0",
+        "@anthropic-ai/sdk": "^0.111.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -91,12 +91,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
+      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "env:pull": "vercel env pull .env.local --environment=production --yes"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.80.0",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -168,6 +168,29 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "No messages provided" }, { status: 400 });
   }
 
+  // Say plainly when the environment can't run the assistant, rather than
+  // throwing somewhere downstream and surfacing as an opaque 500.
+  //
+  // Both of these are Production-only on Vercel today, so every preview
+  // deployment hits this. The service-role key matters as much as the API key:
+  // the shared tool registry runs entirely through the admin client, so without
+  // it there is no assistant, just a chatbot that can't touch anything.
+  const missing = [
+    !process.env.ANTHROPIC_API_KEY && "ANTHROPIC_API_KEY",
+    !process.env.SUPABASE_SERVICE_ROLE_KEY && "SUPABASE_SERVICE_ROLE_KEY",
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    return Response.json(
+      {
+        error:
+          `The assistant isn't configured in this environment — ${missing.join(" and ")} ` +
+          `${missing.length > 1 ? "are" : "is"} missing. On Vercel these are set for Production only; ` +
+          `add them to Preview to use the assistant here.`,
+      },
+      { status: 503 }
+    );
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: business } = await (supabase as any)
     .from("businesses")

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -1,0 +1,333 @@
+/**
+ * The Kirei assistant.
+ *
+ * Replaces /api/agent's hand-rolled loop. Three things are different, and each
+ * fixes a specific defect in the old one:
+ *
+ *  1. **Memory.** The wire format is Anthropic.MessageParam[] with content
+ *     blocks preserved, and the route returns the updated history for the
+ *     client to send back. The old panel typed content as a plain string and
+ *     kept only the final text, so every tool_use/tool_result block was thrown
+ *     away between turns — the agent could not remember an ID it had just
+ *     looked up. This is the contract CLAUDE.md documents for the mobile agent.
+ *
+ *  2. **Tools.** It reads the shared registry (lib/mcp/collect.ts) — the same
+ *     ~196 tools /api/mcp exposes — instead of a hand-maintained 79 that drift.
+ *
+ *  3. **Truth about stopping.** Tools run only on stop_reason === "tool_use";
+ *     truncation, refusal and the iteration cap are reported rather than
+ *     silently swallowed.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { getMyRoleCached } from "@/lib/role";
+import { ANTHROPIC_TOOLS } from "@/lib/mcp/anthropic-tools";
+import { invokeTool } from "@/lib/mcp/invoke";
+import { assistantScopesForRole } from "@/lib/assistant/scopes";
+import { resolveModel, resolveEffort } from "@/lib/assistant/models";
+import { dispatchToolWebhook } from "@/lib/assistant/tool-webhooks";
+import type { AgentContextPacket } from "@/lib/actions/agent-context";
+
+const anthropic = new Anthropic();
+
+/** Each iteration is a model round-trip plus its tool calls. Without this the
+ *  platform default applies and the function dies mid-chain. */
+export const maxDuration = 300;
+
+const MAX_ITERATIONS = 15;
+
+/** 4096 (the old value) truncates real tool chains — which is how truncated
+ *  tool calls reached live write actions in the first place. */
+const MAX_TOKENS = 16000;
+
+// ── system prompt ────────────────────────────────────────────────────────────
+
+/**
+ * The stable half of the prompt. Everything here is byte-identical across
+ * turns and across users of the same business, so it can carry the cache
+ * breakpoint. Anything volatile (the live snapshot, today's date) goes in the
+ * conversation instead — putting it here would invalidate the cached prefix on
+ * every single turn.
+ */
+function stableSystemPrompt(businessName: string): string {
+  return `You are the AI assistant inside Kirei, the field-services and CRM app ${businessName} runs their business on.
+
+You have real tools covering the whole app — customers, sites, contacts, leads,
+quotes, invoices, payments, work orders, scheduling, products, tasks, team,
+expenses, inventory, timesheets, assets, prospects, forms, contracts and SEO.
+Use them. Never claim you can't do something that a tool covers.
+
+How to work:
+- Search before you create. Duplicate customers are a real and costly problem.
+- When the user says "this invoice", "that customer", "today's jobs" — resolve
+  it from the conversation and the context snapshot rather than asking.
+- You can see what you did earlier in this conversation, including every tool
+  call and its result. If you already have an ID, use it; don't search again.
+- Prefer one clear action over a long plan. Do the thing, then say what you did.
+- Some requests are read-only ("how many overdue invoices?"). Answer those
+  directly — don't mutate anything you weren't asked to.
+- Before anything destructive or irreversible (deleting records, sending email
+  to a customer, charging a card), make sure that is actually what was asked.
+- Voice input is transcribed and may contain small errors. Read for intent, but
+  if a misheard word would change *what gets deleted or sent*, ask first.
+- Report honestly. If a tool failed, say so and what you'll do about it. Never
+  claim something was done when it wasn't.
+
+Answer in plain prose. Lead with the outcome — what happened or what you found —
+then any detail that changes what the user would do next.`;
+}
+
+/** Render the live snapshot. Volatile, so it never touches the cached prefix. */
+function renderContext(ctx: AgentContextPacket | null): string {
+  if (!ctx) return "";
+  const lines: string[] = [];
+  const money = (n: number) => `${ctx.business.currency ?? "$"}${Number(n ?? 0).toFixed(2)}`;
+
+  lines.push(`Current page: ${ctx.current_page}`);
+  lines.push(
+    `Stats: ${money(ctx.stats.outstanding)} outstanding, ${money(ctx.stats.overdue)} overdue, ` +
+      `${ctx.stats.jobs_today} jobs today, ${ctx.stats.jobs_this_week} this week, ` +
+      `${ctx.stats.draft_quotes} draft quotes, ${ctx.stats.new_leads_7d} new leads (7d).`
+  );
+
+  const section = <T,>(title: string, rows: T[], fmt: (r: T) => string) => {
+    if (!rows?.length) return;
+    lines.push(`\n${title}:`);
+    for (const r of rows) lines.push(`  ${fmt(r)}`);
+  };
+
+  section(
+    "Recent customers",
+    ctx.recent_customers,
+    (c) => `${c.name}${c.company ? ` (${c.company})` : ""} — id ${c.id}`
+  );
+  section(
+    "Recent invoices",
+    ctx.recent_invoices,
+    (i) =>
+      `${i.number} — ${i.customer_name ?? "no customer"} — ${i.status} — ` +
+      `${money(i.total)} (balance ${money(i.balance)}) — id ${i.id}`
+  );
+  section(
+    "Recent quotes",
+    ctx.recent_quotes,
+    (q) => `${q.number} — ${q.customer_name ?? "no customer"} — ${q.status} — ${money(q.total)} — id ${q.id}`
+  );
+  section(
+    "Today's jobs",
+    ctx.todays_jobs,
+    (j) => `${j.number} — ${j.title} — ${j.status} — ${j.customer_name ?? "no customer"} — id ${j.id}`
+  );
+  section("Open leads", ctx.open_leads, (l) => `${l.name} — ${l.status} — id ${l.id}`);
+
+  return lines.join("\n");
+}
+
+// ── route ────────────────────────────────────────────────────────────────────
+
+interface AssistantRequest {
+  messages: Anthropic.MessageParam[];
+  context?: AgentContextPacket | null;
+  model?: string;
+  effort?: string;
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+
+  let user: Awaited<ReturnType<typeof getUser>>;
+  try {
+    user = await getUser();
+  } catch {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // The tools run as service-role, bypassing RLS — so the caller's role, not
+  // the database, decides what they can reach here. See lib/assistant/scopes.
+  const role = await getMyRoleCached();
+  const scopes = assistantScopesForRole(role);
+  if (!scopes) {
+    return Response.json(
+      { error: "The assistant isn't available for your access level." },
+      { status: 403 }
+    );
+  }
+
+  const body = (await request.json()) as AssistantRequest;
+  const model = resolveModel(body.model);
+  const effort = resolveEffort(body.effort);
+  const snapshot = body.context ?? null;
+
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    return Response.json({ error: "No messages provided" }, { status: 400 });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: business } = await (supabase as any)
+    .from("businesses")
+    .select("name")
+    .eq("id", businessId)
+    .single();
+
+  const invokeCtx = { businessId, userId: user.id, scopes };
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const send = (event: object) => controller.enqueue(enc.encode(JSON.stringify(event) + "\n"));
+
+      // Local working copy. Returned to the client at the end so the next turn
+      // carries the full block history — the whole point of this route.
+      const messages: Anthropic.MessageParam[] = [...body.messages];
+
+      try {
+        // Caching is a prefix match, so ordering is load-bearing. Render order
+        // is tools -> system -> messages. The breakpoint sits on the *first*
+        // system block, which caches the ~196 tool schemas plus the stable
+        // prompt — by far the largest fixed cost. The live snapshot and today's
+        // date change every turn, so they go in a second system block *after*
+        // the breakpoint, where they cost nothing to re-send and cannot
+        // invalidate what precedes them.
+        const contextText = renderContext(snapshot);
+        const system: Anthropic.TextBlockParam[] = [
+          {
+            type: "text",
+            text: stableSystemPrompt(business?.name ?? "your business"),
+            cache_control: { type: "ephemeral" },
+          },
+        ];
+        if (contextText) {
+          system.push({
+            type: "text",
+            text:
+              `Live data for ${business?.name ?? "this business"}, as of ` +
+              `${new Date().toISOString().split("T")[0]}. Prefer these IDs over searching again.\n\n${contextText}`,
+          });
+        }
+
+        for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+          const response = await anthropic.messages
+            .stream({
+              model,
+              max_tokens: MAX_TOKENS,
+              system,
+              tools: ANTHROPIC_TOOLS,
+              // Claude decides how much to think per request. budget_tokens and
+              // temperature are 400s on this generation — don't reintroduce them.
+              thinking: { type: "adaptive" },
+              output_config: { effort },
+              messages,
+              // Second breakpoint, auto-placed on the last message block, so a
+              // growing conversation reuses its own prefix turn over turn
+              // instead of re-reading the whole history at full price.
+              cache_control: { type: "ephemeral" },
+            })
+            .on("text", (delta) => send({ type: "text", content: delta }))
+            .on("thinking", (delta) => send({ type: "thinking", content: delta }));
+
+          const message = await response.finalMessage();
+
+          // Only run tools when the model actually finished asking for them: a
+          // reply cut off at max_tokens can end inside a tool_use block with
+          // partial JSON, and these tools write to real records.
+          const canRunTools = message.stop_reason === "tool_use";
+
+          if (!canRunTools) {
+            // Drop unanswered tool_use blocks before persisting: the client
+            // sends this history back, and a tool_use with no tool_result is a
+            // 400 that would wedge the conversation for good.
+            const keep = message.content.filter((b) => b.type !== "tool_use");
+            if (keep.length > 0) messages.push({ role: "assistant", content: keep });
+
+            if (message.stop_reason === "max_tokens") {
+              send({
+                type: "error",
+                message:
+                  "That reply was cut off because it hit the length limit. Nothing was run — try a narrower request.",
+              });
+            } else if (message.stop_reason === "refusal") {
+              send({ type: "error", message: "I can't help with that request." });
+            }
+            break;
+          }
+
+          messages.push({ role: "assistant", content: message.content });
+
+          const toolUses = message.content.filter(
+            (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+          );
+
+          for (const block of toolUses) {
+            send({ type: "tool_start", id: block.id, name: block.name, input: block.input });
+          }
+
+          // Claude emits parallel tool_use blocks readily; the old loop awaited
+          // them one at a time. All results must come back in a single user
+          // message or the model learns to stop calling tools in parallel.
+          const results = await Promise.all(
+            toolUses.map(async (block) => {
+              const args = (block.input ?? {}) as Record<string, unknown>;
+              const outcome = await invokeTool(block.name, args, invokeCtx);
+
+              if (!outcome.isError) {
+                dispatchToolWebhook(block.name, businessId, args, outcome.text);
+              }
+
+              send({
+                type: outcome.isError ? "tool_error" : "tool_done",
+                id: block.id,
+                name: block.name,
+                result: outcome.text,
+              });
+
+              return {
+                type: "tool_result" as const,
+                tool_use_id: block.id,
+                content: outcome.text,
+                ...(outcome.isError ? { is_error: true } : {}),
+              };
+            })
+          );
+
+          messages.push({ role: "user", content: results });
+
+          if (iteration === MAX_ITERATIONS) {
+            // Previously this exited silently: every tool card green, no text,
+            // indistinguishable from a hang.
+            send({
+              type: "error",
+              message:
+                "I ran out of steps on this one. The actions above did run — ask me to continue if there's more to do.",
+            });
+          }
+        }
+
+        // The updated history is the payload that fixes cross-turn memory.
+        send({ type: "done", messages });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Something went wrong";
+        console.error("[assistant]", msg);
+        send({ type: "error", message: msg });
+        // Still hand back history, so a mid-turn failure doesn't silently
+        // desync the client's copy from what actually ran.
+        send({ type: "done", messages });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "application/x-ndjson",
+      "Cache-Control": "no-cache",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/src/lib/assistant/models.ts
+++ b/src/lib/assistant/models.ts
@@ -1,0 +1,63 @@
+/**
+ * The models and effort levels the assistant may run.
+ *
+ * Plain module — the picker (client) and the route (server) share it, so the
+ * options a user sees are the options the server accepts. The server still
+ * validates: an allow-list is only a boundary if the boundary enforces it.
+ */
+
+export const ASSISTANT_MODELS = [
+  {
+    id: "claude-opus-4-8",
+    label: "Opus 4.8",
+    blurb: "Most capable. Best for multi-step work and anything you'd rather get right first time.",
+  },
+  {
+    id: "claude-sonnet-5",
+    label: "Sonnet 5",
+    blurb: "Near-Opus quality, faster and cheaper. A good everyday default.",
+  },
+  {
+    id: "claude-haiku-4-5",
+    label: "Haiku 4.5",
+    blurb: "Fastest and cheapest. Good for quick lookups and simple edits.",
+  },
+] as const;
+
+export type AssistantModel = (typeof ASSISTANT_MODELS)[number]["id"];
+
+export const DEFAULT_MODEL: AssistantModel = "claude-opus-4-8";
+
+/**
+ * Effort moves the intelligence/latency/cost tradeoff more than the model
+ * choice does on this generation, so it's a first-class control rather than a
+ * hidden constant.
+ */
+export const ASSISTANT_EFFORTS = [
+  { id: "low", label: "Quick", blurb: "Short, scoped tasks. Least thinking." },
+  { id: "medium", label: "Balanced", blurb: "Cheaper, still capable." },
+  { id: "high", label: "Thorough", blurb: "The default. Best balance for most work." },
+  { id: "xhigh", label: "Maximum", blurb: "Hardest multi-step jobs. Slowest." },
+] as const;
+
+export type AssistantEffort = (typeof ASSISTANT_EFFORTS)[number]["id"];
+
+/** `high` is also the API default; naming it keeps intent explicit. */
+export const DEFAULT_EFFORT: AssistantEffort = "high";
+
+const MODEL_IDS = new Set<string>(ASSISTANT_MODELS.map((m) => m.id));
+const EFFORT_IDS = new Set<string>(ASSISTANT_EFFORTS.map((e) => e.id));
+
+/** Coerce untrusted input to an allowed model, falling back to the default. */
+export function resolveModel(value: unknown): AssistantModel {
+  return typeof value === "string" && MODEL_IDS.has(value)
+    ? (value as AssistantModel)
+    : DEFAULT_MODEL;
+}
+
+/** Coerce untrusted input to an allowed effort, falling back to the default. */
+export function resolveEffort(value: unknown): AssistantEffort {
+  return typeof value === "string" && EFFORT_IDS.has(value)
+    ? (value as AssistantEffort)
+    : DEFAULT_EFFORT;
+}

--- a/src/lib/assistant/scopes.ts
+++ b/src/lib/assistant/scopes.ts
@@ -1,0 +1,64 @@
+/**
+ * Translate a member's role into the API scopes the assistant may use.
+ *
+ * ⚠️ This is a real security boundary, not a formality.
+ *
+ * The shared tool registry runs against the **admin Supabase client**, which
+ * bypasses RLS and is scoped only by a manually-passed business_id (see
+ * lib/mcp/context.ts). Everywhere else in Kirei, RLS is the only gate; on this
+ * path the gate is this file. Two rules follow:
+ *
+ *  1. Never hand the assistant a blanket "admin" scope just because the tools
+ *     accept one. Scopes must track what the person is actually allowed to do.
+ *  2. Workers get nothing. The worker role is enforced *in the database* via
+ *     is_business_worker() / my_member_profile_ids() — precisely the layer the
+ *     admin client steps around. A worker with assistant access could read
+ *     every customer and invoice in the business, which is the exact isolation
+ *     the schema exists to guarantee.
+ */
+
+import { ALL_API_SCOPES, type ApiScope } from "@/types/database";
+import type { Role } from "@/lib/permissions";
+
+const EVERY_SCOPE = ALL_API_SCOPES.map((s) => s.value).filter((s) => s !== "admin");
+
+const READ_SCOPES = EVERY_SCOPE.filter((s) => s.endsWith(":read"));
+const WRITE_SCOPES = EVERY_SCOPE.filter((s) => s.endsWith(":write"));
+
+/**
+ * Scopes for a role, or `null` if the role may not use the assistant at all.
+ * `null` is deliberately distinct from `[]` — "denied" and "granted nothing"
+ * should not be conflated by callers.
+ */
+export function assistantScopesForRole(role: Role): ApiScope[] | null {
+  switch (role) {
+    case "worker":
+      // See the note above: RLS-enforced isolation, admin client bypasses it.
+      return null;
+
+    case "owner":
+    case "admin":
+      return ["admin"];
+
+    case "editor":
+      // Everything except changing the business's own configuration.
+      return [
+        ...READ_SCOPES,
+        ...WRITE_SCOPES.filter((s) => s !== "settings:write"),
+        "email:send",
+        "agent:access",
+      ];
+
+    case "viewer":
+      return [...READ_SCOPES, "agent:access"];
+
+    default: {
+      // Fail closed on an unrecognised role rather than defaulting to access.
+      // Mirrors mobile's fetchRoleForBusiness, which returns the most
+      // restricted role on an unknown value instead of the least.
+      const _exhaustive: never = role;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/src/lib/assistant/tool-webhooks.ts
+++ b/src/lib/assistant/tool-webhooks.ts
@@ -1,0 +1,90 @@
+/**
+ * Fire business webhooks for assistant-initiated mutations.
+ *
+ * The MCP tool registry is a parallel implementation against raw Supabase and
+ * does **not** call dispatchWebhook — only the server actions in lib/actions do.
+ * So routing the assistant through the shared registry would silently stop a
+ * customer's webhooks firing for anything the assistant did. This bridges that
+ * gap in one place rather than touching ~200 tools.
+ *
+ * Deliberately conservative: only events that already exist in the
+ * WebhookEvent union and only tools whose meaning is unambiguous. Events that
+ * are subscribable but never fired anywhere (invoice.overdue, quote.rejected,
+ * booking.confirmed, booking.no_show) are left alone — wiring them up here
+ * would make the assistant the only source of an event the rest of the app
+ * never emits, which is worse than the current honest gap.
+ */
+
+import { dispatchWebhook } from "@/lib/webhooks";
+import type { WebhookEvent } from "@/types/database";
+
+/** tool name -> event it means. */
+const TOOL_EVENTS: Record<string, WebhookEvent> = {
+  create_customer: "customer.created",
+  update_customer: "customer.updated",
+  create_lead: "lead.created",
+  update_lead: "lead.updated",
+  set_lead_status: "lead.updated",
+  create_invoice: "invoice.created",
+  send_invoice_email: "invoice.sent",
+  mark_invoice_paid: "invoice.paid",
+  add_invoice_payment: "payment.received",
+  create_quote: "quote.created",
+  send_quote_email: "quote.sent",
+  create_work_order: "work_order.created",
+};
+
+/**
+ * Pull an id out of a tool's result text.
+ *
+ * Tools return `text(row)` / `text({id, ...})`, so the JSON usually carries the
+ * id — but the shape isn't guaranteed across ~200 hand-written tools. Returning
+ * null (and sending the args instead) is fine: webhook payloads are already
+ * inconsistent across the existing 21 dispatch sites, so consumers cannot rely
+ * on a fixed shape anyway.
+ */
+function idFromResult(text: string): string | null {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && "id" in parsed) {
+      const id = (parsed as { id: unknown }).id;
+      return typeof id === "string" ? id : null;
+    }
+  } catch {
+    // Not JSON — plenty of tools return prose. Nothing to extract.
+  }
+  return null;
+}
+
+/**
+ * Best-effort dispatch after a successful tool call.
+ *
+ * dispatchWebhook is already fire-and-forget (an unawaited promise with no
+ * waitUntil), so this never blocks the turn and never throws into it.
+ */
+export function dispatchToolWebhook(
+  toolName: string,
+  businessId: string,
+  args: Record<string, unknown>,
+  resultText: string
+): void {
+  const event = TOOL_EVENTS[toolName];
+  if (!event) return;
+
+  const id = idFromResult(resultText) ?? (typeof args.id === "string" ? args.id : null);
+
+  try {
+    dispatchWebhook(businessId, event, {
+      ...(id ? { id } : {}),
+      source: "assistant",
+      tool: toolName,
+    });
+  } catch {
+    // A webhook must never break the user's turn.
+  }
+}
+
+/** Whether a tool is one we consider a mutation for webhook purposes. */
+export function isWebhookTool(toolName: string): boolean {
+  return toolName in TOOL_EVENTS;
+}

--- a/src/lib/mcp/__tests__/live-api.test.ts
+++ b/src/lib/mcp/__tests__/live-api.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+import { ANTHROPIC_TOOLS } from "../anthropic-tools";
+
+/**
+ * Live API probe — costs money, so it's opt-in:
+ *
+ *   RUN_LIVE_API=1 npx vitest run src/lib/mcp/__tests__/live-api.test.ts
+ *
+ * It exists because there is no offline validator for tool schemas. The only
+ * way to know all ~196 generated schemas are well-formed is to send them: a
+ * schema the API rejects is a 400 at runtime, in the user's face. It also
+ * pins the exact request shape the assistant uses (adaptive thinking + effort
+ * + prompt caching on Opus 4.8), which is where the 400s on this generation
+ * live (budget_tokens and temperature are both rejected).
+ */
+const live = process.env.RUN_LIVE_API === "1" && !!process.env.ANTHROPIC_API_KEY;
+
+describe.skipIf(!live)("live API contract", () => {
+  const client = new Anthropic();
+
+  const system: Anthropic.TextBlockParam[] = [
+    {
+      type: "text",
+      // Padded: the cacheable prefix has a minimum size, but the 196 tool
+      // schemas render before system and carry it well past that on their own.
+      text: "You are a test harness for Kirei's assistant. Answer in one short sentence.",
+      cache_control: { type: "ephemeral" },
+    },
+  ];
+
+  const ask = () =>
+    client.messages.create({
+      model: "claude-opus-4-8",
+      max_tokens: 1024,
+      system,
+      tools: ANTHROPIC_TOOLS,
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+      messages: [{ role: "user", content: "Reply with the single word: ok" }],
+    });
+
+  it("accepts all generated tool schemas", async () => {
+    const res = await ask();
+    // Reaching here at all means the API accepted every schema.
+    expect(res.stop_reason).not.toBe("refusal");
+    expect(res.usage.input_tokens).toBeGreaterThan(0);
+  }, 120_000);
+
+  it("caches the tools+system prefix across calls", async () => {
+    await ask();
+    const second = await ask();
+    // If this is 0, the prefix isn't stable and every turn re-reads ~196 tool
+    // schemas at full price — the single largest cost in the old agent.
+    expect(second.usage.cache_read_input_tokens ?? 0).toBeGreaterThan(0);
+  }, 120_000);
+
+  it("lets the model find the right tool among ~196", async () => {
+    const res = await client.messages.create({
+      model: "claude-opus-4-8",
+      max_tokens: 2048,
+      system: [{ type: "text", text: "You are the Kirei assistant. Use tools when asked." }],
+      tools: ANTHROPIC_TOOLS,
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+      messages: [{ role: "user", content: "List my customers." }],
+    });
+    const picked = res.content.find((b) => b.type === "tool_use");
+    expect(picked?.type === "tool_use" ? picked.name : null).toBe("list_customers");
+  }, 120_000);
+});


### PR DESCRIPTION
**Stacked on #399** (which is stacked on #398). Retarget down the chain as each merges.

This is the PR that actually fixes *"very very buggy"*.

## The headline fix: the agent was amnesiac

`agent-panel.tsx:41-44` typed the wire format as `{role, content: string}` and `:353` appended only `finalText`. **Every `tool_use`/`tool_result` block was discarded between turns.** So "create an invoice" → "now send it" made the model re-search or invent an ID, because the server rebuilt the conversation from bare text.

This is the exact trap `CLAUDE.md` documents for the mobile agent — *"sending plain `{role, content: string}` would amputate the cross-turn memory"* — and the web panel was on the wrong side of the rule the repo already wrote down. Mobile had it right.

`/api/assistant` uses `Anthropic.MessageParam[]` with blocks preserved and returns the updated history for the client to send back. Same contract as mobile.

## Everything else that was wrong with the old loop

| Was | Now |
|---|---|
| **Never actually streamed** — `stream:true` was never passed; text emitted per *iteration*. The blinking cursor was theater. | Real token streaming. |
| **79 hand-written tools**, drifting from MCP's 196 | The shared registry — **196**. New tools reach chat for free. |
| **`claude-opus-4-6` hardcoded**, no picker | opus-4-8 (default) / sonnet-5 / haiku-4-5 + effort, allow-listed **server-side** |
| `max_tokens: 4096` — truncates real chains | 16000 |
| **No `maxDuration`** | 300 |
| **No `cache_control` at all** — ~150k tokens/turn | Cached (see below) |
| Tools ran **serially** despite parallel `tool_use` | `Promise.all`, results in one user message |
| Iteration cap exited **silently** — looked like a hang | Reported |

## Prompt caching

Ordering is load-bearing here. Breakpoint on the **first** system block, so the ~196 tool schemas + stable prompt cache together. The live snapshot goes in a **second system block after it**, where it can't invalidate the prefix. A second auto-placed breakpoint caches the growing history.

(I initially put the snapshot *before* the history — which would have invalidated the cache every single turn, exactly backwards. Caught and fixed.)

## 🔴 Security — please review this specifically

The registry runs as **service-role and bypasses RLS**, scoped only by a passed `business_id`. `CLAUDE.md` calls RLS *"the only security gate"* — on this path, the gate is `src/lib/assistant/scopes.ts`.

- **Workers are denied outright (403).** Worker isolation is enforced *in the database* by `is_business_worker()` / `my_member_profile_ids()` — precisely the layer the admin client steps around. A worker with assistant access could read every customer and invoice in the business.
- Scopes derive from the role; never a blanket `admin`. Editor loses `settings:write`; viewer is read-only.
- `businessId` comes from `getActiveBizId` — never the client, never the model.

## Webhook regression, closed

MCP tools don't call `dispatchWebhook`; `lib/actions` do. Routing chat through the registry would have **silently stopped customers' webhooks firing**. Bridged centrally in the tool loop rather than across ~200 tools. Deliberately only events the rest of the app already emits — inventing events here would make the assistant the sole source of something nothing else fires.

## SDK bump: 0.80.0 → 0.111.0

0.80 predates `xhigh` effort and mid-conversation system messages. Whole repo typechecks clean on 0.111.

## ✅ Verified against the LIVE API

There is **no offline validator for tool schemas** — a bad one is a 400 in the user's face. So I sent them (opt-in test, `RUN_LIVE_API=1`, skipped in CI):

- ✅ **All 196 generated schemas accepted**
- ✅ **Prompt caching engages** — `cache_read > 0` on the second call
- ✅ **Model picks `list_customers`** correctly out of 196 tools

Plus: `tsc` clean · 29 passed / 3 skipped · build compiles · within bundle budget · adds one route.

## Not in this PR

Undo moved to PR3 — it logs a `change_log`, and the table that stores it lands with persistence. Logging with nowhere to store it would be dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)