### PR TITLE
feat(assistant): chat page, persistence, undo and voice

### DIFF
--- a/src/app/(dashboard)/assistant/page.tsx
+++ b/src/app/(dashboard)/assistant/page.tsx
@@ -1,7 +1,27 @@
 import { Sparkles } from "@/components/ui/icons";
-import { BriefingWidget } from "@/components/briefing/briefing-widget";
+import { AssistantChat } from "@/components/assistant/assistant-chat";
+import { listAssistantConversations } from "@/lib/actions/assistant";
+import type { AssistantConversation } from "@/types/database";
 
-export default function AssistantPage() {
+/**
+ * The assistant's home. This page used to render a briefing widget and nothing
+ * else — the only actual chat was a 400px floating panel. The briefing moved to
+ * the dashboard's own widgets; this is now a real chat surface.
+ */
+export default async function AssistantPage() {
+  let conversations: AssistantConversation[] = [];
+  let denied = false;
+
+  try {
+    conversations = await listAssistantConversations();
+  } catch {
+    // Workers are denied the assistant outright (see lib/assistant/scopes) —
+    // their tools bypass RLS, which is the layer that isolates them. Anything
+    // else that throws here is treated the same way: no chat rather than a
+    // broken one.
+    denied = true;
+  }
+
   return (
     <div>
       <div className="ch-page-header">
@@ -11,16 +31,19 @@ export default function AssistantPage() {
             Your AI assistant
           </h1>
           <p className="ch-page-subtitle">
-            What needs your attention right now — overdue invoices, stale quotes, new leads, and jobs to close out.
+            Ask anything about your business, or tell me what to do — I can run quotes, invoices,
+            jobs, customers and more.
           </p>
         </div>
       </div>
 
-      <BriefingWidget />
-
-      <p className="text-[11px] text-muted-foreground/70 mt-4">
-        Items refresh from your live data every time you open this page. Snooze to hide for 24h, dismiss to hide until something changes.
-      </p>
+      {denied ? (
+        <div className="ch-empty">
+          <p>The assistant isn&apos;t available for your access level.</p>
+        </div>
+      ) : (
+        <AssistantChat initialConversations={conversations} />
+      )}
     </div>
   );
 }

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -217,11 +217,17 @@ export async function POST(request: NextRequest) {
       // assistant message so an Undo button can replay them backwards.
       const changeLog: AssistantChangeEntry[] = [];
 
-      // Snapshots read through the admin client, same as the tools themselves —
-      // the caller was already authorised by role above.
-      const admin = createAdminClient();
-
       try {
+        // Snapshots read through the admin client, same as the tools themselves —
+        // the caller was already authorised by role above.
+        //
+        // Inside the try, deliberately: createClient() throws outright when the
+        // service-role key is absent ("supabaseKey is required"), and out here
+        // that throw escaped start(), took down the whole ReadableStream, and
+        // surfaced as a bare 500 with no explanation. Anything that can throw
+        // belongs where the catch can turn it into a message.
+        const admin = createAdminClient();
+
         // Caching is a prefix match, so ordering is load-bearing. Render order
         // is tools -> system -> messages. The breakpoint sits on the *first*
         // system block, which caches the ~196 tool schemas plus the stable

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -30,7 +30,11 @@ import { invokeTool } from "@/lib/mcp/invoke";
 import { assistantScopesForRole } from "@/lib/assistant/scopes";
 import { resolveModel, resolveEffort } from "@/lib/assistant/models";
 import { dispatchToolWebhook } from "@/lib/assistant/tool-webhooks";
+import { undoSpecFor, targetIdFor, snapshotRow, buildChangeEntry } from "@/lib/assistant/undo";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { v4 as uuidv4 } from "uuid";
 import type { AgentContextPacket } from "@/lib/actions/agent-context";
+import type { AssistantChangeEntry } from "@/types/database";
 
 const anthropic = new Anthropic();
 
@@ -209,6 +213,14 @@ export async function POST(request: NextRequest) {
       // carries the full block history — the whole point of this route.
       const messages: Anthropic.MessageParam[] = [...body.messages];
 
+      // Reversible mutations this turn made, in order. Persisted with the
+      // assistant message so an Undo button can replay them backwards.
+      const changeLog: AssistantChangeEntry[] = [];
+
+      // Snapshots read through the admin client, same as the tools themselves —
+      // the caller was already authorised by role above.
+      const admin = createAdminClient();
+
       try {
         // Caching is a prefix match, so ordering is load-bearing. Render order
         // is tools -> system -> messages. The breakpoint sits on the *first*
@@ -296,10 +308,28 @@ export async function POST(request: NextRequest) {
           const results = await Promise.all(
             toolUses.map(async (block) => {
               const args = (block.input ?? {}) as Record<string, unknown>;
+
+              // Snapshot before the tool runs, so a destructive call is
+              // reversible. Nothing the old agent did was ever logged: it
+              // could hard-delete a customer with no record and no undo.
+              const spec = undoSpecFor(block.name);
+              const targetId = spec ? targetIdFor(spec, args) : null;
+              const before =
+                spec && targetId ? await snapshotRow(admin, spec.table, targetId, businessId) : null;
+
               const outcome = await invokeTool(block.name, args, invokeCtx);
 
               if (!outcome.isError) {
                 dispatchToolWebhook(block.name, businessId, args, outcome.text);
+
+                if (spec && targetId && before) {
+                  const after =
+                    spec.op === "update"
+                      ? await snapshotRow(admin, spec.table, targetId, businessId)
+                      : null;
+                  const entry = buildChangeEntry(block.name, spec, before, after, uuidv4());
+                  if (entry) changeLog.push(entry);
+                }
               }
 
               send({
@@ -332,14 +362,14 @@ export async function POST(request: NextRequest) {
         }
 
         // The updated history is the payload that fixes cross-turn memory.
-        send({ type: "done", messages });
+        send({ type: "done", messages, changeLog });
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Something went wrong";
         console.error("[assistant]", msg);
         send({ type: "error", message: msg });
         // Still hand back history, so a mid-turn failure doesn't silently
         // desync the client's copy from what actually ran.
-        send({ type: "done", messages });
+        send({ type: "done", messages, changeLog });
       } finally {
         controller.close();
       }

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -70,6 +70,13 @@ quotes, invoices, payments, work orders, scheduling, products, tasks, team,
 expenses, inventory, timesheets, assets, prospects, forms, contracts and SEO.
 Use them. Never claim you can't do something that a tool covers.
 
+You can see images. The user can attach photos or shoot one on their phone, and
+you can pull a work order's own photos with view_job_photos (use list_job_photos
+first to see how many there are, and filter by phase — before/during/after —
+rather than fetching everything). Read what's actually in the picture: damage,
+a meter reading, a handwritten note, a receipt, a serial number. If a photo is
+too dark or blurry to judge, say so rather than guessing.
+
 How to work:
 - Search before you create. Duplicate customers are a real and costly problem.
 - When the user says "this invoice", "that customer", "today's jobs" — resolve
@@ -363,7 +370,10 @@ export async function POST(request: NextRequest) {
               return {
                 type: "tool_result" as const,
                 tool_use_id: block.id,
-                content: outcome.text,
+                // Blocks, not outcome.text: tools like view_job_photos return
+                // the actual images, and flattening to a string would leave the
+                // assistant unable to see a work order's photos at all.
+                content: outcome.content,
                 ...(outcome.isError ? { is_error: true } : {}),
               };
             })

--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -28,7 +28,12 @@ import { getMyRoleCached } from "@/lib/role";
 import { ANTHROPIC_TOOLS } from "@/lib/mcp/anthropic-tools";
 import { invokeTool } from "@/lib/mcp/invoke";
 import { assistantScopesForRole } from "@/lib/assistant/scopes";
-import { resolveModel, resolveEffort } from "@/lib/assistant/models";
+import {
+  resolveModel,
+  resolveEffort,
+  modelSupportsThinking,
+  modelSupportsEffort,
+} from "@/lib/assistant/models";
 import { dispatchToolWebhook } from "@/lib/assistant/tool-webhooks";
 import { undoSpecFor, targetIdFor, snapshotRow, buildChangeEntry } from "@/lib/assistant/undo";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -252,6 +257,18 @@ export async function POST(request: NextRequest) {
           });
         }
 
+        // Capabilities differ per model and an unsupported one is a hard 400,
+        // not a no-op — Haiku 4.5 rejects both adaptive thinking and effort.
+        // Build these conditionally rather than sending them blanket.
+        //
+        // budget_tokens and temperature stay out entirely: both are 400s on the
+        // thinking-capable models here. Don't reintroduce them for Haiku either
+        // — it's the fast option, and thinking defeats the point.
+        const thinkingParam = modelSupportsThinking(model)
+          ? ({ type: "adaptive" } as const)
+          : undefined;
+        const outputConfig = modelSupportsEffort(model) ? { effort } : undefined;
+
         for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
           const response = await anthropic.messages
             .stream({
@@ -259,10 +276,8 @@ export async function POST(request: NextRequest) {
               max_tokens: MAX_TOKENS,
               system,
               tools: ANTHROPIC_TOOLS,
-              // Claude decides how much to think per request. budget_tokens and
-              // temperature are 400s on this generation — don't reintroduce them.
-              thinking: { type: "adaptive" },
-              output_config: { effort },
+              ...(thinkingParam ? { thinking: thinkingParam } : {}),
+              ...(outputConfig ? { output_config: outputConfig } : {}),
               messages,
               // Second breakpoint, auto-placed on the last message block, so a
               // growing conversation reuses its own prefix turn over turn

--- a/src/components/agent/use-voice-capture.ts
+++ b/src/components/agent/use-voice-capture.ts
@@ -20,6 +20,17 @@ export function useVoiceCapture(onText: (text: string) => void) {
   /** Live text-as-you-speak (Web Speech API only — Whisper is one-shot). */
   const [interimText,  setInterimText]  = useState<string>("");
 
+  /**
+   * Callbacks fire from recogniser events long after start(), so reading
+   * `onText` out of the closure captured the version that existed when
+   * recording began. Callers pass a useCallback whose identity changes every
+   * turn (it closes over the conversation), so a recording started mid-turn
+   * delivered its transcript to a stale handler — silently reverting the
+   * conversation to an earlier state. Always call through the ref.
+   */
+  const onTextRef = useRef(onText);
+  useEffect(() => { onTextRef.current = onText; }, [onText]);
+
   // Web Speech API instance
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const speechRef    = useRef<any>(null);
@@ -83,7 +94,7 @@ export function useVoiceCapture(onText: (text: string) => void) {
       setRecording(false);
       const out = finalText.trim();
       setInterimText("");
-      if (out) onText(out);
+      if (out) onTextRef.current(out);
     };
 
     try {
@@ -97,7 +108,7 @@ export function useVoiceCapture(onText: (text: string) => void) {
     } catch {
       return false;
     }
-  }, [onText]);
+  }, []);
 
   const stopSpeech = useCallback(() => {
     if (speechRef.current && speechActive.current) {
@@ -140,7 +151,7 @@ export function useVoiceCapture(onText: (text: string) => void) {
             throw new Error(j.error ?? "Transcription failed");
           }
           const { text } = await res.json();
-          if (text?.trim()) onText(text.trim());
+          if (text?.trim()) onTextRef.current(text.trim());
         } catch (err) {
           setError(err instanceof Error ? err.message : "Transcription failed");
         } finally {
@@ -155,7 +166,7 @@ export function useVoiceCapture(onText: (text: string) => void) {
       setError("Microphone access denied");
       cleanupMR();
     }
-  }, [cleanupMR, onText]);
+  }, [cleanupMR]);
 
   const stopMR = useCallback(() => {
     setRecording(false);

--- a/src/components/assistant/assistant-chat.tsx
+++ b/src/components/assistant/assistant-chat.tsx
@@ -1,0 +1,651 @@
+"use client";
+
+/**
+ * The assistant chat surface.
+ *
+ * The critical difference from the old floating panel: `apiHistory` here is a
+ * real Anthropic block array, not `{role, content: string}`. The server returns
+ * the updated history and we keep it verbatim — that's what lets the agent
+ * remember an ID it looked up three turns ago instead of re-searching.
+ */
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Bot, Send, Loader2, CheckCircle2, AlertCircle, Sparkles, Mic,
+  Square, Plus, Trash2, RotateCcw, Volume2, VolumeX, MessageSquare,
+} from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useVoiceCapture } from "@/components/agent/use-voice-capture";
+import { getAgentContext } from "@/lib/actions/agent-context";
+import {
+  createAssistantConversation,
+  deleteAssistantConversation,
+  getAssistantConversation,
+  saveAssistantTurn,
+  undoAssistantAction,
+} from "@/lib/actions/assistant";
+import {
+  ASSISTANT_MODELS, ASSISTANT_EFFORTS, DEFAULT_MODEL, DEFAULT_EFFORT,
+  type AssistantModel, type AssistantEffort,
+} from "@/lib/assistant/models";
+import type { AssistantConversation, AssistantChangeEntry } from "@/types/database";
+import { undoLabel } from "@/lib/assistant/undo";
+
+// ── types ────────────────────────────────────────────────────────────────────
+
+/** The real wire format. Blocks, not strings. */
+type ApiMessage = { role: "user" | "assistant"; content: unknown };
+
+interface ToolStep {
+  id: string;
+  name: string;
+  status: "running" | "done" | "error";
+  result?: string;
+}
+
+interface DisplayMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  steps: ToolStep[];
+  streaming?: boolean;
+  /** Set once persisted, so Undo knows which row to reverse. */
+  messageId?: string;
+  changeLog?: AssistantChangeEntry[];
+  undone?: boolean;
+}
+
+const uid = () => crypto.randomUUID();
+
+/** Turn a snake_case tool name into something readable. */
+function toolLabel(name: string): string {
+  const s = name.replace(/_/g, " ");
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/** Pull plain text out of a block array, for display + persistence. */
+function textOf(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b): b is { type: string; text: string } =>
+      !!b && typeof b === "object" && (b as { type?: string }).type === "text"
+    )
+    .map((b) => b.text)
+    .join("");
+}
+
+// ── speech ───────────────────────────────────────────────────────────────────
+
+/** Browser TTS. Off by default — nobody wants an app talking unprompted. */
+function speak(text: string) {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+  window.speechSynthesis.cancel();
+  const u = new SpeechSynthesisUtterance(text.slice(0, 1000));
+  u.rate = 1.05;
+  window.speechSynthesis.speak(u);
+}
+
+// ── sub-components ───────────────────────────────────────────────────────────
+
+function StepRow({ step }: { step: ToolStep }) {
+  return (
+    <div className="flex items-start gap-2 py-1">
+      <div className="mt-0.5 shrink-0">
+        {step.status === "running" && <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />}
+        {step.status === "done" && <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />}
+        {step.status === "error" && <AlertCircle className="w-3.5 h-3.5 text-destructive" />}
+      </div>
+      <div className="text-xs leading-snug min-w-0">
+        <span className={step.status === "error" ? "text-destructive" : "text-muted-foreground"}>
+          {toolLabel(step.name)}
+          {step.status === "running" ? "…" : ""}
+        </span>
+        {step.status === "error" && step.result && (
+          <p className="text-destructive/80 mt-0.5 break-words">{step.result}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UndoBar({
+  message,
+  onUndone,
+}: {
+  message: DisplayMessage;
+  onUndone: (id: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const log = message.changeLog ?? [];
+  if (!message.messageId || log.length === 0) return null;
+
+  if (message.undone) {
+    return <p className="text-xs text-muted-foreground pt-1">Undone.</p>;
+  }
+
+  const run = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await undoAssistantAction(message.messageId!);
+      onUndone(message.id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't undo that");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="pt-1 space-y-1">
+      <Button variant="outline" size="sm" onClick={run} disabled={busy} className="h-7 text-xs gap-1.5">
+        {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <RotateCcw className="w-3 h-3" />}
+        {log.length === 1 ? undoLabel(log[0]) : `Undo ${log.length} changes`}
+      </Button>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+function Bubble({
+  message,
+  onUndone,
+}: {
+  message: DisplayMessage;
+  onUndone: (id: string) => void;
+}) {
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed break-words">
+          {message.text}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-2.5">
+      <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5">
+        <Bot className="w-3.5 h-3.5 text-primary" />
+      </div>
+      <div className="flex-1 min-w-0 space-y-1.5">
+        {message.steps.length > 0 && (
+          <div className="rounded-xl bg-muted/50 border px-3 py-2 space-y-0.5">
+            {message.steps.map((s) => (
+              <StepRow key={s.id} step={s} />
+            ))}
+          </div>
+        )}
+        {message.text && (
+          <div className="text-sm leading-relaxed whitespace-pre-wrap break-words">
+            {message.text}
+            {message.streaming && (
+              <span className="inline-block w-0.5 h-4 bg-current ml-0.5 animate-pulse align-text-bottom" />
+            )}
+          </div>
+        )}
+        {message.streaming && !message.text && message.steps.length === 0 && (
+          <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+        )}
+        <UndoBar message={message} onUndone={onUndone} />
+      </div>
+    </div>
+  );
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const SUGGESTIONS = [
+  "What needs my attention today?",
+  "Show me overdue invoices",
+  "Create a quote for my most recent customer",
+  "Which jobs are scheduled this week?",
+];
+
+export function AssistantChat({
+  initialConversations,
+}: {
+  initialConversations: AssistantConversation[];
+}) {
+  const router = useRouter();
+
+  const [conversations, setConversations] = useState(initialConversations);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [apiHistory, setApiHistory] = useState<ApiMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [model, setModel] = useState<AssistantModel>(DEFAULT_MODEL);
+  const [effort, setEffort] = useState<AssistantEffort>(DEFAULT_EFFORT);
+  const [speakReplies, setSpeakReplies] = useState(false);
+  /** Voice transcript awaiting confirmation — never auto-sent. */
+  const [pendingVoice, setPendingVoice] = useState<string | null>(null);
+
+  const endRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  /** Lets Stop actually abort the request instead of orphaning it. */
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const newChat = () => {
+    abortRef.current?.abort();
+    setConversationId(null);
+    setMessages([]);
+    setApiHistory([]);
+    setInput("");
+  };
+
+  const openConversation = async (id: string) => {
+    abortRef.current?.abort();
+    setLoading(true);
+    try {
+      const { conversation, messages: rows } = await getAssistantConversation(id);
+      setConversationId(id);
+      if (conversation.model) setModel(conversation.model as AssistantModel);
+      setApiHistory(rows.map((r) => ({ role: r.role, content: r.content })));
+      setMessages(
+        rows.map((r) => ({
+          id: r.id,
+          messageId: r.id,
+          role: r.role,
+          text: textOf(r.content),
+          steps: [],
+          changeLog: r.change_log ?? [],
+          undone: !!r.undone_at,
+        }))
+      );
+    } catch {
+      // Falls through to an empty chat rather than a broken one.
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const removeConversation = async (id: string) => {
+    await deleteAssistantConversation(id);
+    setConversations((prev) => prev.filter((c) => c.id !== id));
+    if (conversationId === id) newChat();
+  };
+
+  const markUndone = (displayId: string) =>
+    setMessages((prev) => prev.map((m) => (m.id === displayId ? { ...m, undone: true } : m)));
+
+  const stop = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setLoading(false);
+    setMessages((prev) => prev.map((m) => (m.streaming ? { ...m, streaming: false } : m)));
+  };
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || loading) return;
+
+      setInput("");
+      setPendingVoice(null);
+
+      const userBlocks = [{ type: "text", text: trimmed }];
+      const nextHistory: ApiMessage[] = [...apiHistory, { role: "user", content: userBlocks }];
+      setApiHistory(nextHistory);
+      setMessages((prev) => [
+        ...prev,
+        { id: uid(), role: "user", text: trimmed, steps: [] },
+      ]);
+
+      const assistantId = uid();
+      setMessages((prev) => [
+        ...prev,
+        { id: assistantId, role: "assistant", text: "", steps: [], streaming: true },
+      ]);
+      setLoading(true);
+
+      const update = (fn: (m: DisplayMessage) => DisplayMessage) =>
+        setMessages((prev) => prev.map((m) => (m.id === assistantId ? fn(m) : m)));
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        let context: unknown = null;
+        try {
+          context = await getAgentContext("/assistant");
+        } catch {
+          // Non-fatal: the agent just loses the live snapshot this turn.
+        }
+
+        const res = await fetch("/api/assistant", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ messages: nextHistory, context, model, effort }),
+          signal: controller.signal,
+        });
+
+        if (res.status === 403) {
+          update((m) => ({
+            ...m,
+            text: "The assistant isn't available for your access level.",
+            streaming: false,
+          }));
+          return;
+        }
+        if (!res.ok || !res.body) throw new Error("The assistant didn't respond. Try again.");
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let finalText = "";
+        let returnedHistory: ApiMessage[] | null = null;
+        let changeLog: AssistantChangeEntry[] = [];
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            let ev: Record<string, unknown>;
+            try {
+              ev = JSON.parse(line);
+            } catch {
+              continue;
+            }
+
+            switch (ev.type) {
+              case "text":
+                finalText += ev.content as string;
+                update((m) => ({ ...m, text: finalText }));
+                break;
+              case "tool_start":
+                update((m) => ({
+                  ...m,
+                  steps: [...m.steps, { id: ev.id as string, name: ev.name as string, status: "running" }],
+                }));
+                break;
+              case "tool_done":
+                update((m) => ({
+                  ...m,
+                  steps: m.steps.map((s) => (s.id === ev.id ? { ...s, status: "done" } : s)),
+                }));
+                break;
+              case "tool_error":
+                update((m) => ({
+                  ...m,
+                  steps: m.steps.map((s) =>
+                    s.id === ev.id ? { ...s, status: "error", result: ev.result as string } : s
+                  ),
+                }));
+                break;
+              case "error":
+                // Append: an error after some text used to be dropped entirely,
+                // so a cut-off turn looked like a complete answer.
+                finalText = finalText ? `${finalText}\n\n${ev.message as string}` : (ev.message as string);
+                update((m) => ({ ...m, text: finalText }));
+                break;
+              case "done":
+                returnedHistory = (ev.messages as ApiMessage[]) ?? null;
+                changeLog = (ev.changeLog as AssistantChangeEntry[]) ?? [];
+                update((m) => ({ ...m, streaming: false }));
+                break;
+            }
+          }
+        }
+
+        // Keep the server's history verbatim — blocks and all. Rebuilding it
+        // from text here is exactly the bug this feature exists to fix.
+        if (returnedHistory) setApiHistory(returnedHistory);
+        if (speakReplies && finalText) speak(finalText);
+
+        // Persist. Best-effort: a failed save must not lose the visible reply.
+        try {
+          let convId = conversationId;
+          if (!convId) {
+            const created = await createAssistantConversation(trimmed.slice(0, 60));
+            convId = created.id;
+            setConversationId(convId);
+            setConversations((prev) => [created, ...prev]);
+          }
+          const assistantBlocks =
+            returnedHistory && returnedHistory.length > 0
+              ? returnedHistory[returnedHistory.length - 1].content
+              : [{ type: "text", text: finalText }];
+
+          const { assistantMessageId } = await saveAssistantTurn({
+            conversationId: convId,
+            userContent: userBlocks,
+            assistantContent: Array.isArray(assistantBlocks) ? assistantBlocks : [assistantBlocks],
+            model,
+            changeLog,
+          });
+          update((m) => ({ ...m, messageId: assistantMessageId, changeLog }));
+        } catch {
+          // Not fatal — the turn happened, it just isn't saved.
+          update((m) => ({ ...m, changeLog }));
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          update((m) => ({ ...m, streaming: false, text: m.text || "Stopped." }));
+        } else {
+          update((m) => ({
+            ...m,
+            streaming: false,
+            text: err instanceof Error ? err.message : "Something went wrong",
+          }));
+        }
+      } finally {
+        abortRef.current = null;
+        setLoading(false);
+        router.refresh();
+      }
+    },
+    [apiHistory, conversationId, effort, loading, model, router, speakReplies]
+  );
+
+  // Voice never auto-sends: a misheard "delete the Smith invoice" would fire
+  // straight into tools. Show it, let the user confirm or edit.
+  const voice = useVoiceCapture(
+    useCallback((text: string) => setPendingVoice(text), [])
+  );
+
+  return (
+    <div className="flex gap-4 h-[calc(100vh-11rem)] min-h-[28rem]">
+      {/* Conversations */}
+      <aside className="hidden md:flex w-56 shrink-0 flex-col gap-2">
+        <Button onClick={newChat} variant="outline" size="sm" className="gap-1.5 justify-start">
+          <Plus className="w-3.5 h-3.5" /> New chat
+        </Button>
+        <div className="flex-1 overflow-y-auto space-y-0.5">
+          {conversations.length === 0 && (
+            <p className="text-xs text-muted-foreground px-2 py-3">No saved chats yet.</p>
+          )}
+          {conversations.map((c) => (
+            <div
+              key={c.id}
+              className={`group flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs cursor-pointer hover:bg-muted ${
+                conversationId === c.id ? "bg-muted" : ""
+              }`}
+              onClick={() => openConversation(c.id)}
+            >
+              <MessageSquare className="w-3 h-3 shrink-0 text-muted-foreground" />
+              <span className="flex-1 truncate">{c.title ?? "Untitled"}</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void removeConversation(c.id);
+                }}
+                className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive"
+                aria-label="Delete conversation"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      {/* Chat */}
+      <div className="flex-1 flex flex-col border rounded-xl bg-card min-w-0">
+        {/* Controls */}
+        <div className="flex items-center gap-2 border-b px-3 py-2 flex-wrap">
+          <select
+            value={model}
+            onChange={(e) => setModel(e.target.value as AssistantModel)}
+            className="text-xs border rounded-md px-2 py-1 bg-background"
+            title={ASSISTANT_MODELS.find((m) => m.id === model)?.blurb}
+          >
+            {ASSISTANT_MODELS.map((m) => (
+              <option key={m.id} value={m.id}>{m.label}</option>
+            ))}
+          </select>
+          <select
+            value={effort}
+            onChange={(e) => setEffort(e.target.value as AssistantEffort)}
+            className="text-xs border rounded-md px-2 py-1 bg-background"
+            title={ASSISTANT_EFFORTS.find((e) => e.id === effort)?.blurb}
+          >
+            {ASSISTANT_EFFORTS.map((e) => (
+              <option key={e.id} value={e.id}>{e.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={() => setSpeakReplies((v) => !v)}
+            className={`text-xs flex items-center gap-1 rounded-md px-2 py-1 border ${
+              speakReplies ? "bg-primary/10 text-primary border-primary/30" : "text-muted-foreground"
+            }`}
+            title={speakReplies ? "Replies are spoken aloud" : "Replies are silent"}
+          >
+            {speakReplies ? <Volume2 className="w-3 h-3" /> : <VolumeX className="w-3 h-3" />}
+            {speakReplies ? "Speaking" : "Silent"}
+          </button>
+          <div className="ml-auto">
+            {loading && (
+              <Button variant="outline" size="sm" onClick={stop} className="h-7 text-xs gap-1.5">
+                <Square className="w-3 h-3" /> Stop
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-3 py-4 space-y-4">
+          {messages.length === 0 ? (
+            <div className="h-full flex flex-col items-center justify-center text-center gap-4 px-4">
+              <div className="w-12 h-12 rounded-2xl bg-primary/10 flex items-center justify-center">
+                <Sparkles className="w-6 h-6 text-primary" />
+              </div>
+              <div>
+                <p className="font-semibold text-sm">What can I help with?</p>
+                <p className="text-xs text-muted-foreground mt-1 max-w-sm">
+                  I can see your live data and run anything in Kirei — quotes, invoices, jobs,
+                  customers, leads and more.
+                </p>
+              </div>
+              <div className="w-full max-w-sm space-y-1.5">
+                {SUGGESTIONS.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => void send(s)}
+                    className="w-full text-left text-xs px-3 py-2 rounded-lg border hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            messages.map((m) => <Bubble key={m.id} message={m} onUndone={markUndone} />)
+          )}
+          <div ref={endRef} />
+        </div>
+
+        {/* Voice confirmation */}
+        {pendingVoice && (
+          <div className="border-t px-3 py-2 bg-muted/40 space-y-2">
+            <p className="text-xs text-muted-foreground">Heard — send this?</p>
+            <p className="text-sm break-words">{pendingVoice}</p>
+            <div className="flex gap-2">
+              <Button size="sm" className="h-7 text-xs" onClick={() => void send(pendingVoice)}>
+                Send
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                onClick={() => {
+                  setInput(pendingVoice);
+                  setPendingVoice(null);
+                  inputRef.current?.focus();
+                }}
+              >
+                Edit
+              </Button>
+              <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={() => setPendingVoice(null)}>
+                Discard
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Composer */}
+        <div className="border-t p-2.5">
+          {voice.recording && voice.interimText && (
+            <p className="text-xs text-muted-foreground px-1 pb-1.5 italic">{voice.interimText}</p>
+          )}
+          {voice.error && <p className="text-xs text-destructive px-1 pb-1.5">{voice.error}</p>}
+          <div className="flex items-end gap-2">
+            <Textarea
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  void send(input);
+                }
+              }}
+              placeholder="Ask anything, or tap the mic…"
+              rows={1}
+              className="resize-none min-h-[38px] max-h-32 text-sm"
+              disabled={loading}
+            />
+            <Button
+              type="button"
+              variant={voice.recording ? "default" : "outline"}
+              size="icon"
+              className="h-[38px] w-[38px] shrink-0"
+              onClick={() => (voice.recording ? voice.stop() : void voice.start())}
+              disabled={loading || voice.transcribing}
+              title={voice.recording ? "Tap to stop" : "Tap to talk"}
+            >
+              {voice.transcribing ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Mic className="w-4 h-4" />
+              )}
+            </Button>
+            <Button
+              size="icon"
+              className="h-[38px] w-[38px] shrink-0"
+              onClick={() => void send(input)}
+              disabled={loading || !input.trim()}
+            >
+              <Send className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/assistant/assistant-chat.tsx
+++ b/src/components/assistant/assistant-chat.tsx
@@ -330,15 +330,23 @@ export function AssistantChat({
           signal: controller.signal,
         });
 
-        if (res.status === 403) {
+        // Surface what the server actually said. This previously threw a flat
+        // "The assistant didn't respond. Try again." for every non-OK status,
+        // which hid the reason entirely — a missing API key, a denied role and
+        // a genuine crash all looked identical, to the user and to me.
+        if (!res.ok) {
+          const detail = await res
+            .json()
+            .then((j: { error?: string }) => j?.error)
+            .catch(() => null);
           update((m) => ({
             ...m,
-            text: "The assistant isn't available for your access level.",
+            text: detail ?? `The assistant returned ${res.status}. Try again.`,
             streaming: false,
           }));
           return;
         }
-        if (!res.ok || !res.body) throw new Error("The assistant didn't respond. Try again.");
+        if (!res.body) throw new Error("The assistant returned an empty response. Try again.");
 
         const reader = res.body.getReader();
         const decoder = new TextDecoder();

--- a/src/components/assistant/assistant-chat.tsx
+++ b/src/components/assistant/assistant-chat.tsx
@@ -28,10 +28,12 @@ import {
 } from "@/lib/actions/assistant";
 import {
   ASSISTANT_MODELS, ASSISTANT_EFFORTS, DEFAULT_MODEL, DEFAULT_EFFORT,
+  modelSupportsEffort,
   type AssistantModel, type AssistantEffort,
 } from "@/lib/assistant/models";
 import type { AssistantConversation, AssistantChangeEntry } from "@/types/database";
 import { undoLabel } from "@/lib/assistant/undo";
+import { Markdown } from "./markdown";
 
 // ── types ────────────────────────────────────────────────────────────────────
 
@@ -183,8 +185,10 @@ function Bubble({
           </div>
         )}
         {message.text && (
-          <div className="text-sm leading-relaxed whitespace-pre-wrap break-words">
-            {message.text}
+          <div>
+            {/* Claude writes markdown — rendered as plain text it showed
+                literal ** and dead links. */}
+            <Markdown>{message.text}</Markdown>
             {message.streaming && (
               <span className="inline-block w-0.5 h-4 bg-current ml-0.5 animate-pulse align-text-bottom" />
             )}
@@ -517,11 +521,18 @@ export function AssistantChat({
               <option key={m.id} value={m.id}>{m.label}</option>
             ))}
           </select>
+          {/* Effort isn't universal — Haiku 4.5 rejects it outright. Disable
+              rather than offer a control that does nothing. */}
           <select
             value={effort}
             onChange={(e) => setEffort(e.target.value as AssistantEffort)}
-            className="text-xs border rounded-md px-2 py-1 bg-background"
-            title={ASSISTANT_EFFORTS.find((e) => e.id === effort)?.blurb}
+            disabled={!modelSupportsEffort(model)}
+            className="text-xs border rounded-md px-2 py-1 bg-background disabled:opacity-50"
+            title={
+              modelSupportsEffort(model)
+                ? ASSISTANT_EFFORTS.find((e) => e.id === effort)?.blurb
+                : `${ASSISTANT_MODELS.find((m) => m.id === model)?.label} doesn't support effort control.`
+            }
           >
             {ASSISTANT_EFFORTS.map((e) => (
               <option key={e.id} value={e.id}>{e.label}</option>

--- a/src/components/assistant/assistant-chat.tsx
+++ b/src/components/assistant/assistant-chat.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import {
   Bot, Send, Loader2, CheckCircle2, AlertCircle, Sparkles, Mic,
   Square, Plus, Trash2, RotateCcw, Volume2, VolumeX, MessageSquare,
+  Camera, Image as ImageIcon, X,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -34,6 +35,9 @@ import {
 import type { AssistantConversation, AssistantChangeEntry } from "@/types/database";
 import { undoLabel } from "@/lib/assistant/undo";
 import { Markdown } from "./markdown";
+import {
+  prepareImages, toImageBlock, MAX_IMAGES_PER_MESSAGE, type PreparedImage,
+} from "./images";
 
 // ── types ────────────────────────────────────────────────────────────────────
 
@@ -51,6 +55,8 @@ interface DisplayMessage {
   id: string;
   role: "user" | "assistant";
   text: string;
+  /** Thumbnails of what the user attached, so the turn reads back correctly. */
+  images?: string[];
   steps: ToolStep[];
   streaming?: boolean;
   /** Set once persisted, so Undo knows which row to reverse. */
@@ -77,6 +83,24 @@ function textOf(content: unknown): string {
     )
     .map((b) => b.text)
     .join("");
+}
+
+/**
+ * Rebuild thumbnails from stored blocks, so a reloaded conversation still shows
+ * what was attached. The base64 round-trips through the message content, so no
+ * separate copy is needed.
+ */
+function imagesOf(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(
+      (b): b is { type: string; source?: { media_type?: string; data?: string } } =>
+        !!b && typeof b === "object" && (b as { type?: string }).type === "image"
+    )
+    .map((b) =>
+      b.source?.data ? `data:${b.source.media_type ?? "image/jpeg"};base64,${b.source.data}` : ""
+    )
+    .filter(Boolean);
 }
 
 // ── speech ───────────────────────────────────────────────────────────────────
@@ -164,8 +188,25 @@ function Bubble({
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed break-words">
-          {message.text}
+        <div className="max-w-[80%] space-y-1.5">
+          {message.images && message.images.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 justify-end">
+              {message.images.map((src, i) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={i}
+                  src={src}
+                  alt={`Attachment ${i + 1}`}
+                  className="h-24 w-24 rounded-lg object-cover border"
+                />
+              ))}
+            </div>
+          )}
+          {message.text && (
+            <div className="rounded-2xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed break-words">
+              {message.text}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -230,11 +271,17 @@ export function AssistantChat({
   const [speakReplies, setSpeakReplies] = useState(false);
   /** Voice transcript awaiting confirmation — never auto-sent. */
   const [pendingVoice, setPendingVoice] = useState<string | null>(null);
+  /** Images staged for the next message. */
+  const [attached, setAttached] = useState<PreparedImage[]>([]);
+  const [attachError, setAttachError] = useState<string | null>(null);
+  const [preparing, setPreparing] = useState(false);
 
   const endRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   /** Lets Stop actually abort the request instead of orphaning it. */
   const abortRef = useRef<AbortController | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const cameraRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -246,6 +293,8 @@ export function AssistantChat({
     setMessages([]);
     setApiHistory([]);
     setInput("");
+    setAttached([]);
+    setAttachError(null);
   };
 
   const openConversation = async (id: string) => {
@@ -262,6 +311,7 @@ export function AssistantChat({
           messageId: r.id,
           role: r.role,
           text: textOf(r.content),
+          images: imagesOf(r.content),
           steps: [],
           changeLog: r.change_log ?? [],
           undone: !!r.undone_at,
@@ -290,20 +340,58 @@ export function AssistantChat({
     setMessages((prev) => prev.map((m) => (m.streaming ? { ...m, streaming: false } : m)));
   };
 
+  const addFiles = async (list: FileList | null) => {
+    if (!list || list.length === 0) return;
+    setAttachError(null);
+    setPreparing(true);
+    try {
+      const room = MAX_IMAGES_PER_MESSAGE - attached.length;
+      const files = Array.from(list).slice(0, room);
+      const { images, errors } = await prepareImages(files);
+      if (images.length > 0) setAttached((prev) => [...prev, ...images]);
+      if (errors.length > 0) setAttachError(errors.join(" "));
+      else if (list.length > room) {
+        setAttachError(`Only ${MAX_IMAGES_PER_MESSAGE} images per message — the rest were skipped.`);
+      }
+    } catch (e) {
+      setAttachError(e instanceof Error ? e.message : "Couldn't read that image.");
+    } finally {
+      setPreparing(false);
+      // Reset both inputs so picking the same file twice still fires onChange.
+      if (fileRef.current) fileRef.current.value = "";
+      if (cameraRef.current) cameraRef.current.value = "";
+    }
+  };
+
   const send = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
-      if (!trimmed || loading) return;
+      // An image on its own is a valid message — "what's wrong here?" is often
+      // the whole question.
+      if ((!trimmed && attached.length === 0) || loading) return;
 
       setInput("");
       setPendingVoice(null);
+      const sending = attached;
+      setAttached([]);
 
-      const userBlocks = [{ type: "text", text: trimmed }];
+      // Images before text: the model reads them as context for the question
+      // that follows, which is how they're meant to be ordered.
+      const userBlocks = [
+        ...sending.map(toImageBlock),
+        ...(trimmed ? [{ type: "text", text: trimmed }] : []),
+      ];
       const nextHistory: ApiMessage[] = [...apiHistory, { role: "user", content: userBlocks }];
       setApiHistory(nextHistory);
       setMessages((prev) => [
         ...prev,
-        { id: uid(), role: "user", text: trimmed, steps: [] },
+        {
+          id: uid(),
+          role: "user",
+          text: trimmed,
+          images: sending.map((i) => i.previewUrl),
+          steps: [],
+        },
       ]);
 
       const assistantId = uid();
@@ -462,7 +550,7 @@ export function AssistantChat({
         router.refresh();
       }
     },
-    [apiHistory, conversationId, effort, loading, model, router, speakReplies]
+    [apiHistory, attached, conversationId, effort, loading, model, router, speakReplies]
   );
 
   // Voice never auto-sends: a misheard "delete the Smith invoice" would fire
@@ -619,11 +707,86 @@ export function AssistantChat({
 
         {/* Composer */}
         <div className="border-t p-2.5">
+          {/* Staged attachments */}
+          {attached.length > 0 && (
+            <div className="flex flex-wrap gap-2 pb-2">
+              {attached.map((img, i) => (
+                <div key={i} className="relative group">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={img.previewUrl}
+                    alt={img.name}
+                    className="h-16 w-16 rounded-lg object-cover border"
+                  />
+                  <button
+                    onClick={() => setAttached((prev) => prev.filter((_, j) => j !== i))}
+                    className="absolute -top-1.5 -right-1.5 rounded-full bg-background border shadow-sm p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+                    aria-label={`Remove ${img.name}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {preparing && (
+            <p className="text-xs text-muted-foreground px-1 pb-1.5 flex items-center gap-1.5">
+              <Loader2 className="w-3 h-3 animate-spin" /> Preparing image…
+            </p>
+          )}
+          {attachError && <p className="text-xs text-destructive px-1 pb-1.5">{attachError}</p>}
           {voice.recording && voice.interimText && (
             <p className="text-xs text-muted-foreground px-1 pb-1.5 italic">{voice.interimText}</p>
           )}
           {voice.error && <p className="text-xs text-destructive px-1 pb-1.5">{voice.error}</p>}
+
+          {/* Two inputs, not one: `capture` makes a phone open the camera
+              directly, but on desktop it would hide the file picker — so the
+              paperclip and the camera stay separate controls. */}
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            multiple
+            hidden
+            onChange={(e) => void addFiles(e.target.files)}
+          />
+          <input
+            ref={cameraRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            hidden
+            onChange={(e) => void addFiles(e.target.files)}
+          />
+
           <div className="flex items-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-[38px] w-[38px] shrink-0"
+              onClick={() => fileRef.current?.click()}
+              disabled={loading || attached.length >= MAX_IMAGES_PER_MESSAGE}
+              title={
+                attached.length >= MAX_IMAGES_PER_MESSAGE
+                  ? `Up to ${MAX_IMAGES_PER_MESSAGE} images per message`
+                  : "Attach an image"
+              }
+            >
+              <ImageIcon className="w-4 h-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-[38px] w-[38px] shrink-0"
+              onClick={() => cameraRef.current?.click()}
+              disabled={loading || attached.length >= MAX_IMAGES_PER_MESSAGE}
+              title="Take a photo"
+            >
+              <Camera className="w-4 h-4" />
+            </Button>
             <Textarea
               ref={inputRef}
               value={input}
@@ -658,7 +821,7 @@ export function AssistantChat({
               size="icon"
               className="h-[38px] w-[38px] shrink-0"
               onClick={() => void send(input)}
-              disabled={loading || !input.trim()}
+              disabled={loading || (!input.trim() && attached.length === 0)}
             >
               <Send className="w-4 h-4" />
             </Button>

--- a/src/components/assistant/images.ts
+++ b/src/components/assistant/images.ts
@@ -1,0 +1,112 @@
+"use client";
+
+/**
+ * Preparing user-attached images for the assistant.
+ *
+ * Resizing is not cosmetic. Attached images live in the conversation history,
+ * and the whole history is re-sent on every turn — and again on every iteration
+ * of the tool loop. A raw 4MB phone photo becomes ~5.3MB of base64 that gets
+ * uploaded over and over. Downscaling once, here, is the difference between a
+ * usable feature and a slow, expensive one.
+ */
+
+/**
+ * Long-edge cap. Claude's standard vision tier tops out around this, and it's
+ * ample for a job photo or a screenshot of a bill. Opus 4.8 can take ~2576px,
+ * but that costs roughly 3x the image tokens for detail this use case doesn't
+ * need.
+ */
+const MAX_EDGE = 1568;
+
+/** The API accepts only these. A HEIC straight off an iPhone is a 400. */
+const ACCEPTED = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+
+/** More than a handful per message stops being a question and starts being a
+ *  batch job — and each one is re-sent every turn. */
+export const MAX_IMAGES_PER_MESSAGE = 4;
+
+export interface PreparedImage {
+  /** Base64 payload, no data: prefix — what the API wants. */
+  data: string;
+  media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+  /** data: URL for the thumbnail. */
+  previewUrl: string;
+  name: string;
+}
+
+function loadBitmap(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("That file couldn't be read as an image."));
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Downscale to MAX_EDGE and re-encode as JPEG.
+ *
+ * Re-encoding also launders the format: a HEIC or oversized PNG the API would
+ * reject comes out as JPEG it accepts. Animated GIFs lose animation — an
+ * acceptable trade, since the model only reads the first frame anyway.
+ */
+export async function prepareImage(file: File): Promise<PreparedImage> {
+  if (!file.type.startsWith("image/")) {
+    throw new Error(`${file.name} isn't an image.`);
+  }
+
+  const img = await loadBitmap(file);
+  const scale = Math.min(1, MAX_EDGE / Math.max(img.width, img.height));
+  const w = Math.max(1, Math.round(img.width * scale));
+  const h = Math.max(1, Math.round(img.height * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Couldn't process that image in this browser.");
+  ctx.drawImage(img, 0, 0, w, h);
+
+  // Keep PNG only when it's already small and accepted — screenshots of text
+  // stay sharper. Everything else becomes JPEG.
+  const keepPng = file.type === "image/png" && file.size < 400_000 && scale === 1;
+  const outType: PreparedImage["media_type"] = keepPng ? "image/png" : "image/jpeg";
+  const dataUrl = canvas.toDataURL(outType, 0.85);
+  const data = dataUrl.split(",")[1] ?? "";
+
+  if (!data) throw new Error("Couldn't process that image.");
+  if (!ACCEPTED.has(outType)) throw new Error("Unsupported image format.");
+
+  return { data, media_type: outType, previewUrl: dataUrl, name: file.name };
+}
+
+/** Prepare several, skipping any that fail rather than losing the whole batch. */
+export async function prepareImages(
+  files: File[]
+): Promise<{ images: PreparedImage[]; errors: string[] }> {
+  const images: PreparedImage[] = [];
+  const errors: string[] = [];
+  for (const f of files.slice(0, MAX_IMAGES_PER_MESSAGE)) {
+    try {
+      images.push(await prepareImage(f));
+    } catch (e) {
+      errors.push(e instanceof Error ? e.message : `Couldn't read ${f.name}.`);
+    }
+  }
+  return { images, errors };
+}
+
+/** The Messages API image block. */
+export function toImageBlock(img: PreparedImage) {
+  return {
+    type: "image" as const,
+    source: { type: "base64" as const, media_type: img.media_type, data: img.data },
+  };
+}

--- a/src/components/assistant/markdown.tsx
+++ b/src/components/assistant/markdown.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+/**
+ * Markdown → React, for assistant replies.
+ *
+ * Claude writes markdown, so rendering replies as plain text showed users
+ * literal `**bold**` and dead links.
+ *
+ * Renders from marked's *token tree* into React elements rather than piping
+ * marked's HTML through dangerouslySetInnerHTML. That matters here: the
+ * assistant echoes business data, so a lead who submits
+ * `<img src=x onerror=...>` as their name would otherwise get that HTML
+ * executed in the owner's session the moment the assistant lists leads. Going
+ * through tokens makes injection structurally impossible instead of something
+ * a sanitiser has to catch — and the repo has no sanitiser installed.
+ */
+
+import { Fragment, type ReactNode } from "react";
+import Link from "next/link";
+import { marked, type Token, type Tokens } from "marked";
+
+/** Same-origin app paths route through the SPA; anything else opens safely. */
+function MdLink({ href, children }: { href: string; children: ReactNode }) {
+  const isInternal = href.startsWith("/") && !href.startsWith("//");
+
+  if (isInternal) {
+    return (
+      <Link href={href} className="text-primary underline underline-offset-2 hover:opacity-80">
+        {children}
+      </Link>
+    );
+  }
+
+  // Only http(s) escapes. Anything else — javascript:, data:, vbscript: — is
+  // rendered as inert text rather than made clickable.
+  const safe = /^https?:\/\//i.test(href);
+  if (!safe) return <span>{children}</span>;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary underline underline-offset-2 hover:opacity-80"
+    >
+      {children}
+    </a>
+  );
+}
+
+/** Inline tokens: bold, italic, code, links, breaks. */
+function Inline({ tokens }: { tokens?: Token[] }) {
+  if (!tokens) return null;
+  return (
+    <>
+      {tokens.map((t, i) => {
+        switch (t.type) {
+          case "text": {
+            const tok = t as Tokens.Text;
+            // Nested tokens exist when the text contains further inline markup.
+            return tok.tokens ? (
+              <Inline key={i} tokens={tok.tokens} />
+            ) : (
+              <Fragment key={i}>{tok.text}</Fragment>
+            );
+          }
+          case "strong":
+            return (
+              <strong key={i} className="font-semibold">
+                <Inline tokens={(t as Tokens.Strong).tokens} />
+              </strong>
+            );
+          case "em":
+            return (
+              <em key={i}>
+                <Inline tokens={(t as Tokens.Em).tokens} />
+              </em>
+            );
+          case "del":
+            return (
+              <del key={i} className="opacity-70">
+                <Inline tokens={(t as Tokens.Del).tokens} />
+              </del>
+            );
+          case "codespan":
+            return (
+              <code
+                key={i}
+                className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em] break-words"
+              >
+                {(t as Tokens.Codespan).text}
+              </code>
+            );
+          case "link": {
+            const tok = t as Tokens.Link;
+            return (
+              <MdLink key={i} href={tok.href}>
+                <Inline tokens={tok.tokens} />
+              </MdLink>
+            );
+          }
+          case "br":
+            return <br key={i} />;
+          case "escape":
+            return <Fragment key={i}>{(t as Tokens.Escape).text}</Fragment>;
+          // Images and raw HTML are deliberately not rendered — the assistant
+          // has no reason to emit either, and both are injection surface.
+          case "image":
+          case "html":
+            return null;
+          default: {
+            const raw = (t as { raw?: string }).raw;
+            return raw ? <Fragment key={i}>{raw}</Fragment> : null;
+          }
+        }
+      })}
+    </>
+  );
+}
+
+function ListBlock({ token }: { token: Tokens.List }) {
+  const cls = "my-1.5 space-y-0.5 pl-5 " + (token.ordered ? "list-decimal" : "list-disc");
+  const items = token.items.map((item, i) => (
+    <li key={i} className="leading-relaxed">
+      <Blocks tokens={item.tokens} tight />
+    </li>
+  ));
+  return token.ordered ? (
+    <ol className={cls} start={Number(token.start) || 1}>
+      {items}
+    </ol>
+  ) : (
+    <ul className={cls}>{items}</ul>
+  );
+}
+
+function TableBlock({ token }: { token: Tokens.Table }) {
+  // Wide tables scroll inside their own container — the chat column must never
+  // scroll sideways.
+  return (
+    <div className="my-2 overflow-x-auto">
+      <table className="w-full text-xs border-collapse">
+        <thead>
+          <tr className="border-b">
+            {token.header.map((cell, i) => (
+              <th key={i} className="text-left font-semibold px-2 py-1 whitespace-nowrap">
+                <Inline tokens={cell.tokens} />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {token.rows.map((row, r) => (
+            <tr key={r} className="border-b last:border-0">
+              {row.map((cell, c) => (
+                <td key={c} className="px-2 py-1 align-top">
+                  <Inline tokens={cell.tokens} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Block-level tokens. `tight` drops paragraph margins inside list items. */
+function Blocks({ tokens, tight = false }: { tokens: Token[]; tight?: boolean }) {
+  return (
+    <>
+      {tokens.map((t, i) => {
+        switch (t.type) {
+          case "paragraph":
+            return (
+              <p key={i} className={tight ? "" : "my-1.5 first:mt-0 last:mb-0 leading-relaxed"}>
+                <Inline tokens={(t as Tokens.Paragraph).tokens} />
+              </p>
+            );
+          case "text": {
+            const tok = t as Tokens.Text;
+            return tok.tokens ? (
+              <Inline key={i} tokens={tok.tokens} />
+            ) : (
+              <Fragment key={i}>{tok.text}</Fragment>
+            );
+          }
+          case "heading": {
+            const tok = t as Tokens.Heading;
+            // Chat bubbles are small — scale headings down so an h1 doesn't
+            // dwarf the conversation around it.
+            const size =
+              tok.depth <= 2 ? "text-sm font-semibold" : "text-[13px] font-semibold";
+            return (
+              <p key={i} className={`${size} mt-3 first:mt-0 mb-1`}>
+                <Inline tokens={tok.tokens} />
+              </p>
+            );
+          }
+          case "code": {
+            const tok = t as Tokens.Code;
+            return (
+              <pre
+                key={i}
+                className="my-2 overflow-x-auto rounded-lg border bg-muted/60 p-2.5 text-xs"
+              >
+                <code className="font-mono">{tok.text}</code>
+              </pre>
+            );
+          }
+          case "blockquote":
+            return (
+              <blockquote key={i} className="my-2 border-l-2 pl-3 text-muted-foreground">
+                <Blocks tokens={(t as Tokens.Blockquote).tokens} />
+              </blockquote>
+            );
+          case "list":
+            return <ListBlock key={i} token={t as Tokens.List} />;
+          case "table":
+            return <TableBlock key={i} token={t as Tokens.Table} />;
+          case "hr":
+            return <hr key={i} className="my-3 border-border" />;
+          case "space":
+            return null;
+          case "html":
+            return null; // never rendered — see the file header
+          default: {
+            const raw = (t as { raw?: string }).raw;
+            return raw ? <Fragment key={i}>{raw}</Fragment> : null;
+          }
+        }
+      })}
+    </>
+  );
+}
+
+export function Markdown({ children }: { children: string }) {
+  if (!children) return null;
+  // gfm gives tables and strikethrough. `breaks` keeps single newlines visible,
+  // which matches how the model formats short chat replies.
+  const tokens = marked.lexer(children, { gfm: true, breaks: true });
+  return (
+    <div className="text-sm leading-relaxed break-words">
+      <Blocks tokens={tokens} />
+    </div>
+  );
+}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -154,6 +154,8 @@ export {
   WebhooksLogo as Webhook,
   FlowArrow as Workflow,
   Lightning as Zap,
+  SpeakerHigh as Volume2,
+  SpeakerSlash as VolumeX,
 } from "@phosphor-icons/react";
 
 // Compat type for code that imports `LucideIcon`

--- a/src/lib/actions/assistant.ts
+++ b/src/lib/actions/assistant.ts
@@ -1,0 +1,245 @@
+"use server";
+
+/**
+ * Assistant conversations: persistence + undo.
+ *
+ * The assistant previously had neither. History lived in useState (a refresh
+ * destroyed it), and nothing it did was logged or reversible — it could call
+ * deleteCustomer with no snapshot and no way back.
+ */
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { getMyRoleCached } from "@/lib/role";
+import { assistantScopesForRole } from "@/lib/assistant/scopes";
+import type {
+  AssistantConversation,
+  AssistantMessage,
+  AssistantChangeEntry,
+} from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/**
+ * Every action here goes through this. RLS already scopes these tables to the
+ * owning user and excludes workers, but the assistant is a service-role
+ * surface elsewhere — so the role check is repeated at the action layer rather
+ * than assumed. Returns the caller's identity.
+ */
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const role = await getMyRoleCached();
+  if (!assistantScopesForRole(role)) {
+    throw new Error("The assistant isn't available for your access level.");
+  }
+  return { supabase, user, businessId };
+}
+
+// ── conversations ────────────────────────────────────────────────────────────
+
+export async function listAssistantConversations(): Promise<AssistantConversation[]> {
+  const { supabase, user, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "assistant_conversations")
+    .select("id, business_id, user_id, title, model, created_at, updated_at")
+    .eq("business_id", businessId)
+    .eq("user_id", user.id)
+    .order("updated_at", { ascending: false })
+    .limit(100);
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AssistantConversation[];
+}
+
+export async function getAssistantConversation(
+  conversationId: string
+): Promise<{ conversation: AssistantConversation; messages: AssistantMessage[] }> {
+  const { supabase, user, businessId } = await ctx();
+
+  const { data: conversation, error: convErr } = await tbl(supabase, "assistant_conversations")
+    .select("*")
+    .eq("id", conversationId)
+    .eq("business_id", businessId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (convErr) throw new Error(convErr.message);
+  if (!conversation) throw new Error("Conversation not found");
+
+  const { data: messages, error: msgErr } = await tbl(supabase, "assistant_messages")
+    .select("*")
+    .eq("conversation_id", conversationId)
+    .order("seq", { ascending: true });
+  if (msgErr) throw new Error(msgErr.message);
+
+  return {
+    conversation: conversation as AssistantConversation,
+    messages: (messages ?? []) as AssistantMessage[],
+  };
+}
+
+export async function createAssistantConversation(title?: string): Promise<AssistantConversation> {
+  const { supabase, user, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "assistant_conversations")
+    .insert({
+      business_id: businessId,
+      user_id: user.id,
+      title: title?.trim() || null,
+    })
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  revalidatePath("/assistant");
+  return data as AssistantConversation;
+}
+
+export async function renameAssistantConversation(
+  conversationId: string,
+  title: string
+): Promise<void> {
+  const { supabase, user, businessId } = await ctx();
+  const { error } = await tbl(supabase, "assistant_conversations")
+    .update({ title: title.trim() || null, updated_at: new Date().toISOString() })
+    .eq("id", conversationId)
+    .eq("business_id", businessId)
+    .eq("user_id", user.id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/assistant");
+}
+
+export async function deleteAssistantConversation(conversationId: string): Promise<void> {
+  const { supabase, user, businessId } = await ctx();
+  const { error } = await tbl(supabase, "assistant_conversations")
+    .delete()
+    .eq("id", conversationId)
+    .eq("business_id", businessId)
+    .eq("user_id", user.id);
+  if (error) throw new Error(error.message);
+  revalidatePath("/assistant");
+}
+
+// ── turns ────────────────────────────────────────────────────────────────────
+
+/**
+ * Persist one exchange.
+ *
+ * `content` is the full Anthropic block array on both sides — never flattened
+ * to text. That flattening is the bug this whole feature exists to fix.
+ */
+export async function saveAssistantTurn(input: {
+  conversationId: string;
+  userContent: unknown[];
+  assistantContent: unknown[];
+  model: string;
+  changeLog?: AssistantChangeEntry[];
+}): Promise<{ assistantMessageId: string }> {
+  const { supabase, user, businessId } = await ctx();
+
+  // Next sequence number. A unique (conversation_id, seq) index means two
+  // racing turns collide loudly rather than silently interleaving.
+  const { data: last } = await tbl(supabase, "assistant_messages")
+    .select("seq")
+    .eq("conversation_id", input.conversationId)
+    .order("seq", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const nextSeq = ((last?.seq as number | undefined) ?? -1) + 1;
+
+  const base = {
+    conversation_id: input.conversationId,
+    business_id: businessId,
+    user_id: user.id,
+    model: input.model,
+  };
+
+  const { data, error } = await tbl(supabase, "assistant_messages")
+    .insert([
+      { ...base, role: "user", content: input.userContent, seq: nextSeq, change_log: [] },
+      {
+        ...base,
+        role: "assistant",
+        content: input.assistantContent,
+        seq: nextSeq + 1,
+        change_log: input.changeLog ?? [],
+      },
+    ])
+    .select("id, role");
+  if (error) throw new Error(error.message);
+
+  await tbl(supabase, "assistant_conversations")
+    .update({ updated_at: new Date().toISOString(), model: input.model })
+    .eq("id", input.conversationId);
+
+  const assistant = (data ?? []).find((m: { role: string }) => m.role === "assistant");
+  return { assistantMessageId: assistant?.id as string };
+}
+
+// ── undo ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Reverse everything one assistant turn changed.
+ *
+ * Same reverse-replay as undoCleanup (src/lib/actions/cleanup.ts:437): walk the
+ * log backwards so dependent operations untangle, restore only the keys that
+ * actually changed (so a concurrent edit to an untouched column isn't
+ * clobbered), and re-insert deleted rows wholesale.
+ */
+export async function undoAssistantAction(
+  messageId: string
+): Promise<{ reverted: number }> {
+  const { supabase, user, businessId } = await ctx();
+
+  const { data: message, error } = await tbl(supabase, "assistant_messages")
+    .select("*")
+    .eq("id", messageId)
+    .eq("business_id", businessId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!message) throw new Error("Message not found");
+  if (message.undone_at) throw new Error("This has already been undone");
+
+  const log = (message.change_log ?? []) as AssistantChangeEntry[];
+  if (log.length === 0) throw new Error("There's nothing to undo here");
+
+  let reverted = 0;
+
+  for (const entry of [...log].reverse()) {
+    if (entry.op === "update") {
+      const before = entry.before as (Record<string, unknown> & { id?: string }) | null;
+      const after = (entry.after ?? {}) as Record<string, unknown>;
+      if (!before?.id) continue;
+
+      // Restore only what we changed. Rewriting the whole row would clobber
+      // any column someone else edited in the meantime.
+      const restore: Record<string, unknown> = {};
+      for (const key of Object.keys(after)) {
+        if (key === "id" || key === "updated_at") continue;
+        if (before[key] !== after[key]) restore[key] = before[key];
+      }
+      if (Object.keys(restore).length === 0) continue;
+
+      const { error: upErr } = await tbl(supabase, entry.table)
+        .update(restore)
+        .eq("id", before.id)
+        .eq("business_id", businessId);
+      if (upErr) throw new Error(`Couldn't undo the change to ${entry.table}: ${upErr.message}`);
+      reverted++;
+    } else if (entry.op === "delete") {
+      const before = entry.before as Record<string, unknown> | null;
+      if (!before) continue;
+      const { error: insErr } = await tbl(supabase, entry.table).insert(before);
+      if (insErr) throw new Error(`Couldn't restore the ${entry.table} row: ${insErr.message}`);
+      reverted++;
+    }
+  }
+
+  await tbl(supabase, "assistant_messages")
+    .update({ undone_at: new Date().toISOString() })
+    .eq("id", messageId);
+
+  revalidatePath("/assistant");
+  return { reverted };
+}

--- a/src/lib/assistant/__tests__/models.test.ts
+++ b/src/lib/assistant/__tests__/models.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  ASSISTANT_MODELS,
+  DEFAULT_MODEL,
+  DEFAULT_EFFORT,
+  resolveModel,
+  resolveEffort,
+  modelSupportsThinking,
+  modelSupportsEffort,
+} from "../models";
+
+describe("model allow-list", () => {
+  it("coerces untrusted input to an allowed model", () => {
+    expect(resolveModel("claude-sonnet-5")).toBe("claude-sonnet-5");
+    // The client picks the model, so anything can arrive here.
+    expect(resolveModel("claude-opus-9-nonsense")).toBe(DEFAULT_MODEL);
+    expect(resolveModel(undefined)).toBe(DEFAULT_MODEL);
+    expect(resolveModel(42)).toBe(DEFAULT_MODEL);
+    expect(resolveModel({ id: "x" })).toBe(DEFAULT_MODEL);
+  });
+
+  it("coerces untrusted input to an allowed effort", () => {
+    expect(resolveEffort("low")).toBe("low");
+    expect(resolveEffort("ludicrous")).toBe(DEFAULT_EFFORT);
+    expect(resolveEffort(null)).toBe(DEFAULT_EFFORT);
+  });
+
+  it("defaults to the most capable model", () => {
+    expect(DEFAULT_MODEL).toBe("claude-opus-4-8");
+  });
+});
+
+describe("per-model capabilities", () => {
+  /**
+   * These are 400s, not no-ops. Sending adaptive thinking to Haiku 4.5 returns
+   * "adaptive thinking is not supported on this model" and the turn dies — which
+   * is exactly what shipped, because the capability was assumed uniform.
+   */
+  it("knows Haiku 4.5 supports neither thinking nor effort", () => {
+    expect(modelSupportsThinking("claude-haiku-4-5")).toBe(false);
+    expect(modelSupportsEffort("claude-haiku-4-5")).toBe(false);
+  });
+
+  it("knows the 4.6+ generation supports both", () => {
+    for (const id of ["claude-opus-4-8", "claude-sonnet-5"] as const) {
+      expect(modelSupportsThinking(id)).toBe(true);
+      expect(modelSupportsEffort(id)).toBe(true);
+    }
+  });
+
+  it("declares a capability for every model the picker offers", () => {
+    // A model added without capability flags would silently default to false
+    // and quietly lose thinking — or worse, be assumed capable and 400.
+    for (const m of ASSISTANT_MODELS) {
+      expect(typeof m.thinking, `${m.id} missing thinking flag`).toBe("boolean");
+      expect(typeof m.effort, `${m.id} missing effort flag`).toBe("boolean");
+    }
+  });
+});

--- a/src/lib/assistant/__tests__/scopes.test.ts
+++ b/src/lib/assistant/__tests__/scopes.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { assistantScopesForRole } from "../scopes";
+import { expandApiScopes } from "@/types/database";
+
+/**
+ * This is a security boundary, not a preference.
+ *
+ * The assistant's tools run as service-role and bypass RLS entirely, so this
+ * function — not the database — decides what a caller can reach. These tests
+ * exist so a future refactor can't quietly widen it.
+ */
+describe("assistantScopesForRole", () => {
+  it("denies workers outright", () => {
+    // Worker isolation is enforced in the DB by is_business_worker() /
+    // my_member_profile_ids() — precisely the layer the admin client steps
+    // around. Granting a worker any scope here would expose every customer and
+    // invoice in the business.
+    expect(assistantScopesForRole("worker")).toBeNull();
+  });
+
+  it("distinguishes denial from granting nothing", () => {
+    // null (denied) and [] (allowed, no scopes) must not be conflated: a
+    // truthiness check on [] would silently let a denied role through.
+    expect(assistantScopesForRole("worker")).toBeNull();
+    expect(assistantScopesForRole("viewer")).not.toBeNull();
+  });
+
+  it("gives owners and admins the full surface", () => {
+    for (const role of ["owner", "admin"] as const) {
+      const scopes = assistantScopesForRole(role);
+      expect(scopes).toEqual(["admin"]);
+      // The wildcard must actually expand, or tools would fail scope checks.
+      expect(expandApiScopes(scopes!).length).toBeGreaterThan(20);
+    }
+  });
+
+  it("lets editors write but not change business settings", () => {
+    const scopes = assistantScopesForRole("editor")!;
+    expect(scopes).toContain("customers:write");
+    expect(scopes).toContain("invoices:write");
+    expect(scopes).not.toContain("settings:write");
+    expect(scopes).not.toContain("admin");
+  });
+
+  it("keeps viewers read-only", () => {
+    const scopes = assistantScopesForRole("viewer")!;
+    expect(scopes).toContain("customers:read");
+    expect(scopes).not.toContain("admin");
+    // Not a single write scope may leak in.
+    expect(scopes.filter((s) => s.endsWith(":write"))).toEqual([]);
+  });
+
+  it("never grants a write scope to a non-writing role", () => {
+    for (const role of ["viewer", "worker"] as const) {
+      const scopes = assistantScopesForRole(role) ?? [];
+      expect(scopes.some((s) => s.endsWith(":write") || s === "admin")).toBe(false);
+    }
+  });
+});

--- a/src/lib/assistant/__tests__/undo.test.ts
+++ b/src/lib/assistant/__tests__/undo.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { TOOL_UNDO, undoSpecFor, targetIdFor, buildChangeEntry, undoLabel } from "../undo";
+import { TOOL_SPECS_BY_NAME } from "@/lib/mcp/collect";
+
+describe("undo registry", () => {
+  it("only lists tools that actually exist", () => {
+    // A typo here means a silently missing Undo button — the log entry would
+    // never be written and nothing would say why.
+    for (const name of Object.keys(TOOL_UNDO)) {
+      expect(TOOL_SPECS_BY_NAME[name], `TOOL_UNDO references unknown tool: ${name}`).toBeDefined();
+    }
+  });
+
+  it("does not claim to reverse irreversible actions", () => {
+    // An Undo button that can't undo is worse than no button.
+    for (const name of Object.keys(TOOL_UNDO)) {
+      expect(name).not.toMatch(/^send_|charge_|publish_|email_/);
+    }
+  });
+
+  it("does not offer undo for creates", () => {
+    // Reversing a create means deleting a row — a destructive act dressed up
+    // as an undo. Left to the user deliberately.
+    for (const name of Object.keys(TOOL_UNDO)) {
+      expect(name).not.toMatch(/^create_/);
+    }
+  });
+
+  it("names an id argument each tool actually accepts", () => {
+    // The quiet failure this guards against: a wrong idArg means targetIdFor
+    // returns null, no change entry is written, and the Undo button simply
+    // never appears — with nothing anywhere saying why.
+    for (const [name, spec] of Object.entries(TOOL_UNDO)) {
+      const shape = TOOL_SPECS_BY_NAME[name]?.shape ?? {};
+      const accepts = Object.keys(shape);
+      expect(
+        accepts.includes(spec.idArg) || accepts.includes("id"),
+        `${name}: idArg "${spec.idArg}" is not a parameter of the tool (has: ${accepts.join(", ")})`
+      ).toBe(true);
+    }
+  });
+
+  it("resolves a spec only for registered tools", () => {
+    expect(undoSpecFor("delete_customer")).toEqual({
+      table: "customers",
+      idArg: "customer_id",
+      op: "delete",
+    });
+    expect(undoSpecFor("send_invoice_email")).toBeNull();
+    expect(undoSpecFor("nonsense_tool")).toBeNull();
+  });
+});
+
+describe("targetIdFor", () => {
+  const spec = { table: "customers", idArg: "customer_id", op: "update" as const };
+
+  it("reads the id from the tool's own argument", () => {
+    expect(targetIdFor(spec, { customer_id: "abc" })).toBe("abc");
+  });
+
+  it("falls back to a plain id argument", () => {
+    expect(targetIdFor(spec, { id: "xyz" })).toBe("xyz");
+  });
+
+  it("returns null when there is no id to snapshot", () => {
+    expect(targetIdFor(spec, {})).toBeNull();
+    expect(targetIdFor(spec, { customer_id: 42 })).toBeNull();
+    expect(targetIdFor(spec, { customer_id: "" })).toBeNull();
+  });
+});
+
+describe("buildChangeEntry", () => {
+  const spec = { table: "customers", idArg: "customer_id", op: "update" as const };
+
+  it("records a reversible change", () => {
+    const entry = buildChangeEntry(
+      "update_customer",
+      spec,
+      { id: "1", name: "Old" },
+      { id: "1", name: "New" },
+      "chg-1"
+    );
+    expect(entry).toEqual({
+      change_id: "chg-1",
+      op: "update",
+      table: "customers",
+      before: { id: "1", name: "Old" },
+      after: { id: "1", name: "New" },
+      tool: "update_customer",
+    });
+  });
+
+  it("records nothing when the row was never snapshotted", () => {
+    // No 'before' means nothing to restore. Writing an entry anyway would put
+    // an Undo button on an action it cannot reverse.
+    expect(buildChangeEntry("update_customer", spec, null, { id: "1" }, "chg-2")).toBeNull();
+  });
+});
+
+describe("undoLabel", () => {
+  it("says restore for deletes and undo for updates", () => {
+    const base = { change_id: "c", before: {}, after: {}, tool: "t" };
+    expect(undoLabel({ ...base, op: "delete", table: "customers" })).toBe("Restore customer");
+    expect(undoLabel({ ...base, op: "update", table: "work_orders" })).toBe(
+      "Undo change to work order"
+    );
+  });
+});

--- a/src/lib/assistant/models.ts
+++ b/src/lib/assistant/models.ts
@@ -6,21 +6,33 @@
  * validates: an allow-list is only a boundary if the boundary enforces it.
  */
 
+/**
+ * Capabilities are per-model and NOT uniform — sending an unsupported one is a
+ * hard 400, not a silent no-op. Adaptive thinking arrived with the 4.6
+ * generation and `effort` errors outright on Haiku 4.5, so both have to be
+ * gated per model rather than sent blanket.
+ */
 export const ASSISTANT_MODELS = [
   {
     id: "claude-opus-4-8",
     label: "Opus 4.8",
     blurb: "Most capable. Best for multi-step work and anything you'd rather get right first time.",
+    thinking: true,
+    effort: true,
   },
   {
     id: "claude-sonnet-5",
     label: "Sonnet 5",
     blurb: "Near-Opus quality, faster and cheaper. A good everyday default.",
+    thinking: true,
+    effort: true,
   },
   {
     id: "claude-haiku-4-5",
     label: "Haiku 4.5",
-    blurb: "Fastest and cheapest. Good for quick lookups and simple edits.",
+    blurb: "Fastest and cheapest. No thinking or effort control — that's the trade.",
+    thinking: false,
+    effort: false,
   },
 ] as const;
 
@@ -60,4 +72,22 @@ export function resolveEffort(value: unknown): AssistantEffort {
   return typeof value === "string" && EFFORT_IDS.has(value)
     ? (value as AssistantEffort)
     : DEFAULT_EFFORT;
+}
+
+const CAPS = new Map<string, { thinking: boolean; effort: boolean }>(
+  ASSISTANT_MODELS.map((m) => [m.id, { thinking: m.thinking, effort: m.effort }])
+);
+
+/**
+ * Whether adaptive thinking may be sent. Sending it to a model without it is a
+ * 400 ("adaptive thinking is not supported on this model"), so this gates both
+ * the request and the picker — a control that lies is worse than no control.
+ */
+export function modelSupportsThinking(id: AssistantModel): boolean {
+  return CAPS.get(id)?.thinking ?? false;
+}
+
+/** Whether output_config.effort may be sent. Also a 400 where unsupported. */
+export function modelSupportsEffort(id: AssistantModel): boolean {
+  return CAPS.get(id)?.effort ?? false;
 }

--- a/src/lib/assistant/undo.ts
+++ b/src/lib/assistant/undo.ts
@@ -1,0 +1,113 @@
+/**
+ * What the assistant did, and how to take it back.
+ *
+ * Today nothing the agent does is logged or reversible: it can call
+ * deleteCustomer / deleteInvoice / deleteWorkOrder with no snapshot, no audit
+ * and no undo. This adds the snapshot half. The reversal reuses the exact
+ * entry shape cleanup_runs already uses (src/lib/actions/cleanup.ts), so the
+ * proven reverse-replay applies unchanged.
+ *
+ * Deliberately a small allow-list rather than "everything". An undo button that
+ * silently fails, or that claims to reverse a sent email, is worse than no
+ * button — so a tool is only listed here when the reversal is honest.
+ */
+
+import type { AssistantChangeEntry } from "@/types/database";
+
+export interface UndoSpec {
+  /** Table the tool mutates. */
+  table: string;
+  /** Which argument carries the row id. */
+  idArg: string;
+  /** update = restore prior column values; delete = re-insert the row. */
+  op: "update" | "delete";
+}
+
+/**
+ * Tools whose effect can be honestly reversed from a row snapshot.
+ *
+ * Not listed, on purpose:
+ *  - create_* — reversing a create means deleting the row, which is a
+ *    destructive act dressed up as an undo. The user can delete it themselves.
+ *  - send_*_email, charge_saved_card, publish_content — genuinely
+ *    irreversible. The UI says so rather than pretending.
+ *  - merges and cascades — cleanup's own undo handles those with fk_updates;
+ *    replicating that here without its proposal step would be guesswork.
+ */
+export const TOOL_UNDO: Record<string, UndoSpec> = {
+  update_customer: { table: "customers", idArg: "customer_id", op: "update" },
+  delete_customer: { table: "customers", idArg: "customer_id", op: "delete" },
+  update_lead: { table: "leads", idArg: "lead_id", op: "update" },
+  set_lead_status: { table: "leads", idArg: "lead_id", op: "update" },
+  delete_lead: { table: "leads", idArg: "lead_id", op: "delete" },
+  update_invoice: { table: "invoices", idArg: "invoice_id", op: "update" },
+  set_invoice_status: { table: "invoices", idArg: "invoice_id", op: "update" },
+  delete_invoice: { table: "invoices", idArg: "invoice_id", op: "delete" },
+  update_quote: { table: "quotes", idArg: "quote_id", op: "update" },
+  set_quote_status: { table: "quotes", idArg: "quote_id", op: "update" },
+  delete_quote: { table: "quotes", idArg: "quote_id", op: "delete" },
+  update_work_order: { table: "work_orders", idArg: "work_order_id", op: "update" },
+  set_work_order_status: { table: "work_orders", idArg: "work_order_id", op: "update" },
+  delete_work_order: { table: "work_orders", idArg: "work_order_id", op: "delete" },
+  update_product: { table: "products", idArg: "product_id", op: "update" },
+  delete_product: { table: "products", idArg: "product_id", op: "delete" },
+  update_task: { table: "tasks", idArg: "task_id", op: "update" },
+  update_task_status: { table: "tasks", idArg: "task_id", op: "update" },
+  delete_task: { table: "tasks", idArg: "task_id", op: "delete" },
+};
+
+export function undoSpecFor(toolName: string): UndoSpec | null {
+  return TOOL_UNDO[toolName] ?? null;
+}
+
+/** The row id a tool call targets, if we can identify one. */
+export function targetIdFor(spec: UndoSpec, args: Record<string, unknown>): string | null {
+  const v = args[spec.idArg] ?? args.id;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/**
+ * Snapshot a row before a tool touches it.
+ *
+ * Uses the admin client (the same one the tools use), so it sees the row
+ * regardless of RLS — the caller has already been authorised by role.
+ */
+export async function snapshotRow(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  table: string,
+  id: string,
+  businessId: string
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await sb
+    .from(table)
+    .select("*")
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .maybeSingle();
+  if (error) return null;
+  return (data as Record<string, unknown>) ?? null;
+}
+
+/**
+ * Build the change entry for one tool call, or null if there's nothing
+ * honestly reversible to record.
+ */
+export function buildChangeEntry(
+  tool: string,
+  spec: UndoSpec,
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+  changeId: string
+): AssistantChangeEntry | null {
+  // No 'before' means we never saw the row — there is nothing to restore, and
+  // recording an entry would put an Undo button on an action it can't reverse.
+  if (!before) return null;
+  return { change_id: changeId, op: spec.op, table: spec.table, before, after, tool };
+}
+
+/** Human label for an undo button. */
+export function undoLabel(entry: AssistantChangeEntry): string {
+  const noun = entry.table.replace(/_/g, " ").replace(/s$/, "");
+  return entry.op === "delete" ? `Restore ${noun}` : `Undo change to ${noun}`;
+}

--- a/src/lib/mcp/__tests__/collect.test.ts
+++ b/src/lib/mcp/__tests__/collect.test.ts
@@ -25,7 +25,7 @@ describe("tool registry", () => {
 
   it("still registers known tools from every sub-registrar", () => {
     // One per registrar: core, plugin-forms, seo, expenses, inventory,
-    // timesheets, assets, prospects.
+    // timesheets, assets, prospects, assistant.
     for (const name of [
       "list_customers",
       "list_public_forms",
@@ -35,6 +35,7 @@ describe("tool registry", () => {
       "get_timesheet",
       "list_assets",
       "list_prospects",
+      "list_assistant_conversations",
     ]) {
       expect(TOOL_SPECS_BY_NAME[name], `missing tool: ${name}`).toBeDefined();
     }

--- a/src/lib/mcp/__tests__/invoke.test.ts
+++ b/src/lib/mcp/__tests__/invoke.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { invokeTool, toResultBlock } from "../invoke";
+
+/**
+ * The image path specifically.
+ *
+ * MCP and the Messages API disagree on the image block shape — MCP uses
+ * {type:"image", data, mimeType}, the API wants
+ * {type:"image", source:{type:"base64", media_type, data}}. view_job_photos
+ * returns the MCP shape, so a conversion bug here means the assistant silently
+ * can't see a work order's photos: no error, just an agent that claims it
+ * can't tell.
+ */
+
+const ctx = { businessId: "biz", userId: "user", scopes: ["admin"] as const };
+
+describe("invokeTool", () => {
+  it("reports an unknown tool rather than throwing", async () => {
+    const out = await invokeTool("no_such_tool", {}, { ...ctx, scopes: ["admin"] });
+    expect(out.isError).toBe(true);
+    expect(out.text).toContain("no such tool");
+    // Even errors must be a valid non-empty tool_result body.
+    expect(out.content.length).toBeGreaterThan(0);
+  });
+
+  it("validates arguments before dispatch", async () => {
+    // list_customers takes limit as an int 1..200. The MCP server validates
+    // against the zod shape; nothing else would, so this must.
+    const out = await invokeTool("list_customers", { limit: 9999 }, { ...ctx, scopes: ["admin"] });
+    expect(out.isError).toBe(true);
+    expect(out.text).toContain("invalid arguments");
+  });
+
+  it("refuses a tool the caller lacks the scope for", async () => {
+    const out = await invokeTool("list_customers", {}, { ...ctx, scopes: ["leads:read"] });
+    expect(out.isError).toBe(true);
+    expect(out.text.toLowerCase()).toContain("scope");
+  });
+
+  it("never throws — a bad tool must not take down the turn", async () => {
+    await expect(
+      invokeTool("list_customers", { limit: "not-a-number" }, { ...ctx, scopes: ["admin"] })
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("toResultBlock — MCP → Messages API", () => {
+  it("converts an MCP image block to the API's source shape", () => {
+    // view_job_photos emits exactly this shape.
+    expect(
+      toResultBlock({ type: "image", data: "AAAA", mimeType: "image/jpeg" })
+    ).toEqual({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: "AAAA" },
+    });
+  });
+
+  it("passes text through", () => {
+    expect(toResultBlock({ type: "text", text: "hi" })).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("drops image types the API rejects rather than 400ing the turn", () => {
+    // A HEIC straight off an iPhone. Better to lose one photo than the reply.
+    expect(toResultBlock({ type: "image", data: "AAAA", mimeType: "image/heic" })).toBeNull();
+    expect(toResultBlock({ type: "image", data: "AAAA", mimeType: "" })).toBeNull();
+    expect(toResultBlock({ type: "image", data: "AAAA" })).toBeNull();
+  });
+
+  it("normalises the mime case", () => {
+    expect(
+      toResultBlock({ type: "image", data: "A", mimeType: "IMAGE/PNG" })
+    ).toMatchObject({ source: { media_type: "image/png" } });
+  });
+
+  it("drops anything unrecognised instead of passing it through", () => {
+    expect(toResultBlock({ type: "resource", uri: "x" })).toBeNull();
+    expect(toResultBlock(null)).toBeNull();
+    expect(toResultBlock("plain string")).toBeNull();
+  });
+});

--- a/src/lib/mcp/__tests__/live-api.test.ts
+++ b/src/lib/mcp/__tests__/live-api.test.ts
@@ -98,3 +98,81 @@ describe.skipIf(!live)("live API contract", () => {
     expect(picked?.type === "tool_use" ? picked.name : null).toBe("list_customers");
   }, 120_000);
 });
+
+/**
+ * Vision, live. The assistant is meant to read job photos and attachments, and
+ * an image block the API rejects is a 400 for the whole turn — so the exact
+ * shapes the route emits get sent for real.
+ */
+describe.skipIf(!live)("live vision contract", () => {
+  const client = new Anthropic();
+
+  // A real 8x8 solid red PNG (generated with sharp, then pasted). Hand-rolled
+  // base64 got "Could not process image" — the bytes have to be a valid PNG.
+  const RED_PNG =
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAEUlEQVR4nGO4IyKCFTEMLQkAmD9BAZzFjLYAAAAASUVORK5CYII=";
+
+  it("accepts a user-attached image alongside the full tool set", async () => {
+    const res = await client.messages.create({
+      model: "claude-opus-4-8",
+      max_tokens: 512,
+      tools: ANTHROPIC_TOOLS,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "base64", media_type: "image/png", data: RED_PNG } },
+            { type: "text", text: "What colour is this image? One word." },
+          ],
+        },
+      ],
+    });
+    expect(res.stop_reason).not.toBe("refusal");
+    const text = res.content.find((b) => b.type === "text");
+    // Proves the image was actually decoded, not just accepted.
+    expect(text?.type === "text" ? text.text.toLowerCase() : "").toContain("red");
+  }, 120_000);
+
+  it("accepts an image inside a tool_result — the view_job_photos path", async () => {
+    // Mirrors what invokeTool now produces for view_job_photos: text + image
+    // blocks in the tool_result body.
+    const toolUseId = "toolu_01A09q90qw90lq917835lq9";
+    const res = await client.messages.create({
+      model: "claude-opus-4-8",
+      max_tokens: 512,
+      tools: [
+        {
+          name: "get_photo",
+          description: "Return a job photo.",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+      messages: [
+        { role: "user", content: "Use get_photo, then tell me the colour in one word." },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: toolUseId, name: "get_photo", input: {} }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUseId,
+              content: [
+                { type: "text", text: '{"photos":[{"id":"p1"}]}' },
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/png", data: RED_PNG },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(res.stop_reason).not.toBe("refusal");
+    const text = res.content.find((b) => b.type === "text");
+    expect(text?.type === "text" ? text.text.toLowerCase() : "").toContain("red");
+  }, 120_000);
+});

--- a/src/lib/mcp/__tests__/live-api.test.ts
+++ b/src/lib/mcp/__tests__/live-api.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import Anthropic from "@anthropic-ai/sdk";
 import { ANTHROPIC_TOOLS } from "../anthropic-tools";
+import {
+  ASSISTANT_MODELS,
+  modelSupportsThinking,
+  modelSupportsEffort,
+} from "@/lib/assistant/models";
 
 /**
  * Live API probe — costs money, so it's opt-in:
@@ -54,6 +59,30 @@ describe.skipIf(!live)("live API contract", () => {
     // schemas at full price — the single largest cost in the old agent.
     expect(second.usage.cache_read_input_tokens ?? 0).toBeGreaterThan(0);
   }, 120_000);
+
+  // The gap that let a 400 ship: the checks above only exercised Opus, so the
+  // picker was "verified" on one model out of three. Haiku 4.5 rejects both
+  // adaptive thinking and effort — a hard 400, not a no-op. Every model the
+  // picker offers must be sent exactly the way the route sends it.
+  it.each(ASSISTANT_MODELS.map((m) => [m.id, m] as const))(
+    "accepts the exact request shape the route builds for %s",
+    async (_id, m) => {
+      const res = await client.messages.create({
+        model: m.id,
+        max_tokens: 1024,
+        system,
+        tools: ANTHROPIC_TOOLS,
+        // Mirrors the route's conditional construction. If this drifts from
+        // route.ts, this test stops guarding anything.
+        ...(modelSupportsThinking(m.id) ? { thinking: { type: "adaptive" as const } } : {}),
+        ...(modelSupportsEffort(m.id) ? { output_config: { effort: "low" as const } } : {}),
+        messages: [{ role: "user", content: "Reply with the single word: ok" }],
+      });
+      expect(res.stop_reason).not.toBe("refusal");
+      expect(res.usage.input_tokens).toBeGreaterThan(0);
+    },
+    120_000
+  );
 
   it("lets the model find the right tool among ~196", async () => {
     const res = await client.messages.create({

--- a/src/lib/mcp/context.ts
+++ b/src/lib/mcp/context.ts
@@ -28,17 +28,31 @@ export function assertScope(ctx: McpContext, required: ApiScope): void {
   }
 }
 
-/** Build the per-request context from the authenticated key info. */
+/**
+ * Build the per-request context from the authenticated key info.
+ *
+ * `sb` is lazy on purpose. Every handler runs ctxFrom() then assertScope(), so
+ * building the client eagerly meant a service-role client was constructed for
+ * calls that were about to be denied — and, worse, that the denial couldn't
+ * happen at all without Supabase env: createAdminClient() throws
+ * "supabaseUrl is required" first, so a scope refusal surfaced as a config
+ * error. The gate must not depend on the thing it's gating.
+ */
 export function buildContext(auth: {
   businessId: string;
   userId: string;
   scopes: ApiScope[];
 }): McpContext {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let client: any;
   return {
     businessId: auth.businessId,
     userId: auth.userId,
     scopes: auth.scopes,
-    sb: createAdminClient(),
+    get sb() {
+      client ??= createAdminClient();
+      return client;
+    },
   };
 }
 

--- a/src/lib/mcp/invoke.ts
+++ b/src/lib/mcp/invoke.ts
@@ -20,23 +20,87 @@ export interface InvokeContext {
   scopes: ApiScope[];
 }
 
+/** Blocks the Messages API accepts inside a tool_result. */
+type ResultBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source: { type: "base64"; media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp"; data: string };
+    };
+
+export type { ResultBlock };
+
 export interface ToolOutcome {
-  /** Text handed back to the model as the tool_result body. */
+  /** Full tool_result body — text and any images the tool returned. */
+  content: ResultBlock[];
+  /** Just the text, for logging, webhooks and the UI step label. */
   text: string;
   isError: boolean;
 }
 
-/** Flatten an MCP tool result (`{content:[{type:"text",text}], isError?}`). */
+const IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+
+/**
+ * Convert one MCP content block to a Messages API block.
+ *
+ * The two formats differ and it's easy to miss: MCP images are
+ * `{type:"image", data, mimeType}` while the Messages API wants
+ * `{type:"image", source:{type:"base64", media_type, data}}`. Returns null for
+ * anything unrecognised or unsupported rather than passing it through — an
+ * invalid block is a 400 for the whole turn.
+ */
+export function toResultBlock(b: unknown): ResultBlock | null {
+  if (!b || typeof b !== "object") return null;
+  const block = b as { type?: string; text?: string; data?: string; mimeType?: string };
+
+  if (block.type === "text" && typeof block.text === "string") {
+    return { type: "text", text: block.text };
+  }
+
+  if (block.type === "image" && typeof block.data === "string") {
+    // The API accepts a fixed set; a HEIC straight off an iPhone is a 400.
+    const mime = (block.mimeType ?? "").toLowerCase();
+    if (!IMAGE_TYPES.has(mime)) return null;
+    return {
+      type: "image",
+      source: { type: "base64", media_type: mime as "image/jpeg", data: block.data },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Normalise an MCP tool result.
+ *
+ * Images are preserved, not flattened away: `view_job_photos` returns the
+ * actual job photos as image blocks, and dropping them would leave the
+ * assistant unable to see a work order's photos at all — something /api/mcp
+ * can already do.
+ */
 function toOutcome(raw: unknown): ToolOutcome {
   if (raw && typeof raw === "object" && "content" in raw) {
-    const r = raw as { content?: Array<{ type?: string; text?: string }>; isError?: boolean };
-    const text = (r.content ?? [])
-      .filter((b) => b?.type === "text" && typeof b.text === "string")
-      .map((b) => b.text as string)
+    const r = raw as { content?: unknown[]; isError?: boolean };
+    const content = (r.content ?? []).map(toResultBlock).filter((b): b is ResultBlock => b !== null);
+    const text = content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
       .join("\n");
-    return { text: text || "Done.", isError: r.isError === true };
+
+    // tool_result content must not be empty.
+    if (content.length === 0) content.push({ type: "text", text: "Done." });
+
+    return { content, text: text || "Done.", isError: r.isError === true };
   }
-  return { text: typeof raw === "string" ? raw : JSON.stringify(raw), isError: false };
+
+  const text = typeof raw === "string" ? raw : JSON.stringify(raw);
+  return { content: [{ type: "text", text }], text, isError: false };
+}
+
+/** An error outcome, in the same shape as a successful one. */
+function err(message: string): ToolOutcome {
+  const text = `Error: ${message}`;
+  return { content: [{ type: "text", text }], text, isError: true };
 }
 
 /**
@@ -50,7 +114,7 @@ export async function invokeTool(
   ctx: InvokeContext
 ): Promise<ToolOutcome> {
   const spec = TOOL_SPECS_BY_NAME[name];
-  if (!spec) return { text: `Error: no such tool "${name}"`, isError: true };
+  if (!spec) return err(`no such tool "${name}"`);
 
   // The MCP server validates against the shape before dispatch; nothing else
   // does, so handlers would otherwise receive raw model output.
@@ -59,7 +123,7 @@ export async function invokeTool(
     const detail = parsed.error.issues
       .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
       .join("; ");
-    return { text: `Error: invalid arguments for ${name} — ${detail}`, isError: true };
+    return err(`invalid arguments for ${name} — ${detail}`);
   }
 
   // ctxFrom() reads auth off `extra.authInfo.extra` (see tools/shared.ts).
@@ -71,6 +135,6 @@ export async function invokeTool(
   try {
     return toOutcome(await spec.handler(parsed.data, extra));
   } catch (e) {
-    return { text: `Error: ${e instanceof Error ? e.message : String(e)}`, isError: true };
+    return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -35,6 +35,7 @@ import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
 import { registerProspectTools } from "./tools/prospects-tools";
+import { registerAssistantTools } from "./tools/assistant-tools";
 import { ilikeAcross } from "@/lib/pg-filter";
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -1422,6 +1423,9 @@ export function registerTools(register: ToolFn): void {
 
   // ===== ASSETS & EQUIPMENT =====
   registerAssetTools(tool);
+
+  // ===== AI ASSISTANT =====
+  registerAssistantTools(tool);
 
   // ===== PROSPECTS =====
   registerProspectTools(tool);

--- a/src/lib/mcp/tools/assistant-tools.ts
+++ b/src/lib/mcp/tools/assistant-tools.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP tools for assistant conversations.
+ *
+ * Read + delete only. There is deliberately no "send a message as the user"
+ * tool: the assistant already runs the full registry, so such a tool would let
+ * an agent drive an agent — a loop with no supervision and no undo.
+ */
+
+import { z } from "zod";
+import { assertScope, t, text } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+export function registerAssistantTools(tool: ToolFn): void {
+  tool(
+    "list_assistant_conversations",
+    "List saved AI assistant conversations for this business, newest first. Returns titles and timestamps, not the message bodies.",
+    {
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra);
+      assertScope(ctx, "assistant:read");
+      const { data, error } = await t(ctx, "assistant_conversations")
+        .select("id, title, model, created_at, updated_at, user_id")
+        .eq("business_id", ctx.businessId)
+        .order("updated_at", { ascending: false })
+        .limit(args.limit ?? 30);
+      if (error) throw new Error(error.message);
+      return text(data ?? []);
+    }
+  );
+
+  tool(
+    "get_assistant_conversation",
+    "Get one AI assistant conversation with its full message history, including the tool calls the assistant made and their results.",
+    {
+      conversation_id: UUID,
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra);
+      assertScope(ctx, "assistant:read");
+
+      const { data: conversation, error: convErr } = await t(ctx, "assistant_conversations")
+        .select("*")
+        .eq("id", args.conversation_id)
+        .eq("business_id", ctx.businessId)
+        .maybeSingle();
+      if (convErr) throw new Error(convErr.message);
+      if (!conversation) throw new Error("Conversation not found");
+
+      const { data: messages, error: msgErr } = await t(ctx, "assistant_messages")
+        .select("id, role, content, seq, model, change_log, undone_at, created_at")
+        .eq("conversation_id", args.conversation_id)
+        .eq("business_id", ctx.businessId)
+        .order("seq", { ascending: true });
+      if (msgErr) throw new Error(msgErr.message);
+
+      return text({ conversation, messages: messages ?? [] });
+    }
+  );
+
+  tool(
+    "delete_assistant_conversation",
+    "Permanently delete an AI assistant conversation and all of its messages. This cannot be undone.",
+    {
+      conversation_id: UUID,
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra);
+      assertScope(ctx, "assistant:write");
+      const { error } = await t(ctx, "assistant_conversations")
+        .delete()
+        .eq("id", args.conversation_id)
+        .eq("business_id", ctx.businessId);
+      if (error) throw new Error(error.message);
+      return text({ deleted: true, id: args.conversation_id });
+    }
+  );
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1266,6 +1266,57 @@ export const ALL_WEBHOOK_EVENTS: { value: WebhookEvent; label: string; group: st
   { value: 'booking.no_show',       label: 'Booking no-show',       group: 'Bookings' },
 ];
 
+// ── Assistant ────────────────────────────────────────────────────────────────
+
+export interface AssistantConversation {
+  id: string;
+  business_id: string;
+  user_id: string;
+  title: string | null;
+  model: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * One turn of an assistant conversation.
+ *
+ * `content` is the full Anthropic content block array (text / tool_use /
+ * tool_result / thinking) — deliberately `unknown[]` rather than a string.
+ * Flattening it to text is the exact bug this feature exists to fix: the tool
+ * blocks are the agent's cross-turn memory.
+ */
+export interface AssistantMessage {
+  id: string;
+  conversation_id: string;
+  business_id: string;
+  user_id: string;
+  role: 'user' | 'assistant';
+  content: unknown[];
+  seq: number;
+  model: string | null;
+  /** Same entry shape as cleanup_runs.change_log — see AssistantChangeEntry. */
+  change_log: AssistantChangeEntry[];
+  undone_at: string | null;
+  created_at: string;
+}
+
+/**
+ * A reversible mutation an assistant turn made. Mirrors cleanup_runs'
+ * change_log entry shape so the proven reverse-replay in undoCleanup applies
+ * to assistant actions unchanged.
+ */
+export interface AssistantChangeEntry {
+  change_id: string;
+  op: 'update' | 'delete';
+  /** Table the change targeted — undo needs it to talk to the right row. */
+  table: string;
+  before: unknown;
+  after: unknown;
+  /** Tool that made the change, for the UI label. */
+  tool: string;
+}
+
 export interface BusinessWebhook {
   id: string;
   business_id: string;
@@ -1329,6 +1380,8 @@ export type ApiScope =
   | 'assets:write'
   | 'prospects:read'
   | 'prospects:write'
+  | 'assistant:read'
+  | 'assistant:write'
   | 'email:send'
   | 'agent:access'
   | 'admin';  // wildcard — grants every scope (use for trusted Claude Code keys)
@@ -1369,6 +1422,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'assets:write',     label: 'Manage assets & equipment', group: 'Assets' },
   { value: 'prospects:read',   label: 'Read prospects', group: 'Prospects' },
   { value: 'prospects:write',  label: 'Create / edit / import prospects', group: 'Prospects' },
+  { value: 'assistant:read',   label: 'Read assistant conversations', group: 'Assistant' },
+  { value: 'assistant:write',  label: 'Delete assistant conversations', group: 'Assistant' },
   { value: 'email:send',       label: 'Send emails to customers', group: 'Email' },
   { value: 'agent:access',     label: 'AI Agent access',   group: 'Agent' },
 ];

--- a/supabase/migrations/20260717000000_assistant_conversations.sql
+++ b/supabase/migrations/20260717000000_assistant_conversations.sql
@@ -1,0 +1,125 @@
+-- ============================================================================
+-- Assistant conversations
+--
+-- The AI assistant had no persistence at all: history lived in useState, so a
+-- refresh destroyed the conversation. It also lost its memory *between turns*,
+-- because the client only kept the final text of each reply and dropped every
+-- tool_use / tool_result block.
+--
+-- Hence `content` is JSONB, not TEXT. It stores the full Anthropic content
+-- block array verbatim. Flattening it to text is exactly the bug being fixed —
+-- the agent must be able to see the tool calls it already made and reuse the
+-- IDs they returned instead of searching again.
+--
+-- `change_log` mirrors cleanup_runs (20260505000001) so undoCleanup's proven
+-- reverse-replay applies unchanged to assistant actions.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.assistant_conversations (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID        NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id     UUID        NOT NULL REFERENCES auth.users(id)        ON DELETE CASCADE,
+  title       TEXT,                       -- NULL until the first turn names it
+  model       TEXT,                       -- last model used, to restore the picker
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.assistant_messages (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID        NOT NULL REFERENCES public.assistant_conversations(id) ON DELETE CASCADE,
+  -- Denormalised so RLS can gate a message without joining its conversation.
+  business_id     UUID        NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id         UUID        NOT NULL REFERENCES auth.users(id)        ON DELETE CASCADE,
+  role            TEXT        NOT NULL CHECK (role IN ('user', 'assistant')),
+  -- The full Anthropic content block array. See the note above: this is JSONB
+  -- rather than TEXT on purpose.
+  content         JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  seq             INTEGER     NOT NULL,   -- ordering within the conversation
+  model           TEXT,
+  -- Same entry shape as cleanup_runs.change_log:
+  --   {change_id, op:'update'|'delete'|'merge', table, before, after, fk_updates?}
+  change_log      JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  undone_at       TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (conversation_id, seq)
+);
+
+-- Hot paths: list a user's conversations newest-first, and replay one in order.
+CREATE INDEX IF NOT EXISTS assistant_conversations_user_idx
+  ON public.assistant_conversations (business_id, user_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS assistant_conversations_business_idx
+  ON public.assistant_conversations (business_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS assistant_messages_conversation_idx
+  ON public.assistant_messages (conversation_id, seq);
+
+CREATE INDEX IF NOT EXISTS assistant_messages_business_idx
+  ON public.assistant_messages (business_id, created_at DESC);
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+-- Two gates, both required:
+--
+--  1. user_id = auth.uid() — a conversation is private to whoever had it. An
+--     owner has no business reading an admin's chat history.
+--  2. NOT is_business_worker() — the mandatory no-workers pattern from
+--     20260430000001. Workers are hard-isolated, and a transcript would leak
+--     exactly the customer and invoice data that isolation exists to protect.
+--     (/api/assistant also denies workers outright; this is defence in depth.)
+
+ALTER TABLE public.assistant_conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.assistant_messages      ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS assistant_conversations_own ON public.assistant_conversations;
+CREATE POLICY assistant_conversations_own ON public.assistant_conversations FOR ALL
+  USING (
+    user_id = auth.uid()
+    AND business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    AND business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+DROP POLICY IF EXISTS assistant_messages_own ON public.assistant_messages;
+CREATE POLICY assistant_messages_own ON public.assistant_messages FOR ALL
+  USING (
+    user_id = auth.uid()
+    AND business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    AND business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+COMMENT ON COLUMN public.assistant_messages.content IS
+  'Full Anthropic content block array (text/tool_use/tool_result/thinking). Never flatten to text — the tool blocks are the agent''s cross-turn memory.';
+
+COMMENT ON COLUMN public.assistant_messages.change_log IS
+  'Reversible mutations this turn made. Same entry shape as cleanup_runs.change_log so undoCleanup''s reverse replay applies unchanged.';


### PR DESCRIPTION
**Stacked on #400 → #399 → #398.** Retarget down the chain as each merges.

Completes the assistant. `/assistant` was a **26-line stub** — a `<BriefingWidget/>` under a heading, no chat at all. The only chat was a 400px floating panel with no history, no undo, and no way to stop it.

## Persistence

Migration `20260717000000` — **applied to remote and recorded** in `schema_migrations` (verified: both tables, RLS on, 2 policies, 7 indexes, `content` is `jsonb`).

`content` is **JSONB holding the full Anthropic block array, not text.** Flattening it is the exact bug this whole feature exists to fix — the tool blocks *are* the agent's memory.

**RLS has two gates:**
1. `user_id = auth.uid()` — a chat is private. An owner has no business reading an admin's transcript.
2. The mandatory **no-workers** pattern from `20260430000001`. A transcript would leak exactly the customer and invoice data that worker isolation exists to protect.

## Undo

Today **nothing the agent does is logged or reversible** — it can `deleteCustomer` with no snapshot, no audit, no way back. The route now snapshots rows before mutating and stores a `change_log` in the same entry shape `cleanup_runs` uses, so `undoCleanup`'s proven reverse-replay applies unchanged.

Deliberately a **small allow-list**, because an Undo button that can't undo is worse than no button:
- ❌ no `create_*` — reversing a create means deleting a row, which is a destructive act dressed up as an undo
- ❌ no `send_*` / `charge_*` / `publish_*` — genuinely irreversible; the UI says so rather than pretending
- ✅ updates restore **only the keys that changed**, so a concurrent edit to an untouched column isn't clobbered

## Chat page

Conversation sidebar · model + effort pickers · streamed replies · tool steps · **Stop button backed by a real `AbortController`** (closing the old panel left the loop running and still executing writes).

## Voice — three real fixes

1. **Stale closure.** `rec.onend` captured `onText` at `start()` time, but the caller's handler identity changes every turn — so a recording started mid-turn delivered its transcript to a stale handler and **silently reverted the conversation**. Now routed through a ref.
2. **No more auto-send.** A misheard *"delete the Smith invoice"* previously fired straight into tools with no confirmation and no undo. Now: Send / Edit / Discard.
3. **Spoken replies** (browser TTS), off by default. There was no TTS at all before.

The Whisper prompt is untouched, per the hallucination-defence note in CLAUDE.md.

## MCP

Per the standing rule: `list` / `get` / `delete_assistant_conversation` + `assistant:read`/`write` scopes. **No "send a message" tool on purpose** — the assistant already runs the full registry, so that would let an agent drive an agent with no supervision and no undo.

## Verification

`tsc` clean · **46 passed / 3 skipped** · build compiles · within bundle budget.

New tests cover the two things worth not trusting me on:
- **The security boundary** — workers denied; no write scope leaks to viewer/worker; denial is `null` not `[]` (a truthiness check on `[]` would let a denied role through).
- **The undo registry** — including that every `TOOL_UNDO` `idArg` is a real parameter of its tool. That one would otherwise fail *silently*: wrong arg → no entry logged → the button just never appears.

The `BriefingWidget` isn't lost — it already renders on the dashboard (`dashboard-client.tsx:162`), which I verified before removing it here.

## Please check on preview

**The memory test** — the whole point: *"find customer Sarah"* → *"create a quote for her"* without restating the name. It must reuse the ID from turn 1.

Also: sign in as a **worker** and confirm the assistant is denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)