### PR TITLE
style: Plus Jakarta Sans typeface

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: var(--font-sans), "Geist", "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-sans: var(--font-sans), "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));
   --color-card: hsl(var(--card));
@@ -108,16 +108,20 @@
   body {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
-    font-feature-settings: "rlig" 1, "calt" 1, "ss01" 1, "cv11" 1;
+    /* Plus Jakarta ligatures/contextual alternates only — the ss01/cv11
+       character variants were Geist-specific and do nothing here. */
+    font-feature-settings: "rlig" 1, "calt" 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
   }
+  /* Plus Jakarta is geometric and reads wide, so headings want slightly
+     tighter tracking than a humanist sans would. */
   h1, h2, h3, h4 {
-    letter-spacing: -0.015em;
+    letter-spacing: -0.02em;
   }
   h1 {
-    letter-spacing: -0.02em;
+    letter-spacing: -0.03em;
   }
 }
 
@@ -177,12 +181,14 @@
 [data-theme="console"] {
   background-color: hsl(var(--background));
   color: hsl(var(--foreground));
-  font-feature-settings: "ss01", "cv11";
 }
 
+/* Display headings share the one typeface — Plus Jakarta, tightly tracked,
+   rather than a separate serif. Weight is left to the call site (as it was
+   with Fraunces) so a `font-semibold` utility alongside still wins. */
 .font-display {
-  font-family: var(--font-display), "Newsreader", "Fraunces", ui-serif, Georgia, serif;
-  letter-spacing: -0.015em;
+  font-family: var(--font-sans);
+  letter-spacing: -0.03em;
 }
 
 /* ─── Sidebar theme presets ───────────────────────────────── */
@@ -352,7 +358,7 @@
 .ch-page-title {
   font-size: 24px;
   font-weight: 700;
-  letter-spacing: -0.015em;
+  letter-spacing: -0.025em;
   color: hsl(var(--foreground));
   margin: 0;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,25 +11,21 @@ export const viewport: Viewport = {
   initialScale: 1,
   minimumScale: 1,
 };
-import { Geist, Fraunces } from "next/font/google";
+import { Plus_Jakarta_Sans } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { PWARegister } from "@/components/pwa-register";
 import { IconProvider } from "@/components/ui/icon-provider";
 
-const geist = Geist({
+// One typeface across the app. Plus Jakarta is a variable font (weights
+// 200–800), so both the UI stack (--font-sans) and the heavier display stack
+// (--font-display) resolve to it — the display face just leans on the top of
+// the weight range instead of a separate serif.
+const jakarta = Plus_Jakarta_Sans({
   subsets: ["latin"],
   variable: "--font-sans",
   display: "swap",
-});
-
-const fraunces = Fraunces({
-  subsets: ["latin"],
-  variable: "--font-display",
-  display: "swap",
-  style: ["normal", "italic"],
-  axes: ["opsz", "SOFT"],
 });
 
 export const metadata: Metadata = {
@@ -57,7 +53,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" data-theme="console" suppressHydrationWarning>
-      <body className={`${geist.variable} ${fraunces.variable} font-sans antialiased`} suppressHydrationWarning>
+      <body className={`${jakarta.variable} font-sans antialiased`} suppressHydrationWarning>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -207,7 +207,7 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
       {/* List */}
       {filtered.length === 0 ? (
         <div className="py-24 text-center">
-          <p className="font-display text-2xl text-muted-foreground italic">
+          <p className="font-display text-2xl font-semibold text-muted-foreground">
             No contacts {search || stageFilter !== "all" ? "match your filter" : "yet"}
           </p>
           {(!search && stageFilter === "all") && (
@@ -294,7 +294,7 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
       >
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto bg-card">
           <DialogHeader>
-            <DialogTitle className="font-display text-2xl">
+            <DialogTitle className="font-display text-2xl font-bold">
               {editing ? "Edit contact" : "New contact"}
             </DialogTitle>
           </DialogHeader>
@@ -355,7 +355,7 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
       <AlertDialog open={!!deleteId} onOpenChange={(o) => { if (!o) setDeleteId(null); }}>
         <AlertDialogContent className="bg-card">
           <AlertDialogHeader>
-            <AlertDialogTitle className="font-display text-2xl">Archive contact?</AlertDialogTitle>
+            <AlertDialogTitle className="font-display text-2xl font-bold">Archive contact?</AlertDialogTitle>
             <AlertDialogDescription>You can restore it from the database if needed.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
Switches the app from Geist + a Fraunces display serif to a single typeface — **Plus Jakarta Sans** (variable, 200–800) — for both UI and display headings.

## What changed
- `layout.tsx`: one `Plus_Jakarta_Sans` instance exposing `--font-sans`; dropped the Geist + Fraunces imports.
- `globals.css`: font stack, and `.font-display` now points at the shared sans (family + tracking only, weight left to the call site as Fraunces did).
- Tighter heading tracking to suit the wider geometric letterforms (h1 −0.03em, h2–h4 −0.02em, page-title −0.025em).
- Removed the Geist-only `ss01`/`cv11` OpenType feature settings.
- Gave the three `.font-display` call sites explicit weights; replaced a serif-only italic empty-state caption.

## Verified
- Browser: computed `body` font-family resolves to Plus Jakarta Sans and the face loads.
- `npx tsc --noEmit` clean, `npm run build` compiles (next/font fetches the font at build time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)