### PR TITLE
redesign(leads): Board, List and Calendar in one workspace

### DIFF
--- a/src/app/(dashboard)/leads/loading.tsx
+++ b/src/app/(dashboard)/leads/loading.tsx
@@ -1,21 +1,33 @@
+/**
+ * Mirrors the leads workspace shape — header, 4 KPIs, view switcher + search,
+ * then the board — so the canvas doesn't reflow when the real content streams
+ * in.
+ */
 export default function Loading() {
   return (
-    <div className="space-y-6 animate-pulse">
+    <div className="space-y-5 animate-pulse">
       <div className="flex items-center justify-between">
         <div className="h-8 w-24 bg-muted rounded-lg" />
         <div className="h-9 w-28 bg-muted rounded-lg" />
       </div>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-16 bg-muted rounded-xl" />
+          <div key={i} className="h-20 bg-muted rounded-xl" />
         ))}
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+
+      <div className="flex items-center justify-between gap-3">
+        <div className="h-10 w-56 bg-muted rounded-xl" />
+        <div className="h-10 w-64 bg-muted rounded-xl" />
+      </div>
+
+      <div className="flex gap-4 overflow-hidden xl:grid xl:grid-cols-5">
         {[...Array(5)].map((_, i) => (
-          <div key={i} className="space-y-3">
-            <div className="h-6 bg-muted rounded" />
+          <div key={i} className="w-[280px] shrink-0 xl:w-auto space-y-2">
+            <div className="h-9 bg-muted rounded-lg" />
             {[...Array(3)].map((_, j) => (
-              <div key={j} className="h-24 bg-muted rounded-xl" />
+              <div key={j} className="h-28 bg-muted rounded-xl" />
             ))}
           </div>
         ))}

--- a/src/components/leads/lead-actions.tsx
+++ b/src/components/leads/lead-actions.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * The per-lead actions menu, shared by Board, List and Calendar.
+ *
+ * This was inlined in the kanban card, so any view that wasn't the board had
+ * no way to convert or move a lead. One definition now.
+ */
+
+import { MoreHorizontal, Trash2 } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
+  DropdownMenuSeparator, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { STAGES, type LeadActionHandlers } from "./lead-shared";
+import type { Lead } from "@/types/database";
+
+export function LeadActions({
+  lead,
+  busy,
+  handlers,
+}: {
+  lead: Lead;
+  busy: boolean;
+  handlers: LeadActionHandlers;
+}) {
+  const { onMove, onEdit, onDelete, onConvert, onAddAsContact } = handlers;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          aria-label={`Actions for ${lead.name}`}
+          // The board card is draggable; without this a press on the menu
+          // starts a drag instead of opening it.
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem onClick={() => onEdit(lead.id)}>Edit</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => onAddAsContact(lead.id)} disabled={busy}>
+          Add as contact
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => onConvert(lead.id, "customer")}
+          disabled={busy || !!lead.customer_id}
+        >
+          Convert to customer{lead.customer_id ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onConvert(lead.id, "quote")} disabled={busy}>
+          Convert to quote
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onConvert(lead.id, "work_order")} disabled={busy}>
+          Convert to work order
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {STAGES.filter((s) => s.status !== lead.status).map((s) => (
+          <DropdownMenuItem key={s.status} onClick={() => onMove(lead.id, s.status)}>
+            <span className={`mr-2 h-2 w-2 rounded-full ${s.dot}`} /> Move to {s.label}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => onDelete(lead.id)}
+          className="text-destructive focus:text-destructive"
+        >
+          <Trash2 className="h-3.5 w-3.5 mr-2" /> Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/leads/lead-card.tsx
+++ b/src/components/leads/lead-card.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * A lead card for the board.
+ *
+ * Deliberately quiet. The old card filled its whole surface with one of five
+ * stage colours, so a full board was five columns of saturated blocks and
+ * nothing stood out. Stage now reads from a 3px left rail plus the column it
+ * sits in — the surface stays neutral, so the lead's own details are what you
+ * actually see.
+ */
+
+import { Phone, Mail, MapPin, Clock, ChevronRight, User } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { LeadActions } from "./lead-actions";
+import {
+  STAGE_BY_STATUS, NEXT_STATUS, formatDate, formatSourceLabel,
+  type LeadActionHandlers,
+} from "./lead-shared";
+import type { Lead } from "@/types/database";
+
+export function LeadCard({
+  lead,
+  busy,
+  handlers,
+  dragging,
+}: {
+  lead: Lead;
+  busy: boolean;
+  handlers: LeadActionHandlers;
+  /** Rendered inside the drag overlay — lifts and tilts slightly. */
+  dragging?: boolean;
+}) {
+  const stage = STAGE_BY_STATUS[lead.status];
+  const next = NEXT_STATUS[lead.status];
+
+  return (
+    <div
+      className={`rounded-xl border border-border border-l-[3px] ${stage?.rail ?? ""} bg-card p-3 space-y-2 transition-shadow ${
+        dragging ? "shadow-lg rotate-[1.5deg] cursor-grabbing" : "shadow-sm hover:shadow-md"
+      }`}
+    >
+      {/* Name + menu */}
+      <div className="flex items-start justify-between gap-1">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="font-semibold text-sm break-words">{lead.name}</span>
+        </div>
+        <LeadActions lead={lead} busy={busy} handlers={handlers} />
+      </div>
+
+      {/* Details */}
+      <div className="space-y-1">
+        {lead.phone && (
+          <a
+            href={`tel:${lead.phone.replace(/\s/g, "")}`}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <Phone className="h-3 w-3 shrink-0" />
+            <span className="break-words">{lead.phone}</span>
+          </a>
+        )}
+        {lead.email && (
+          <a
+            href={`mailto:${lead.email}`}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <Mail className="h-3 w-3 shrink-0" />
+            <span className="break-words">{lead.email}</span>
+          </a>
+        )}
+        {lead.suburb && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <MapPin className="h-3 w-3 shrink-0" />
+            <span className="break-words">{lead.suburb}</span>
+          </div>
+        )}
+        {lead.service && (
+          <p className="text-xs text-foreground/80 break-words">{lead.service}</p>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-border/60">
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          {formatDate(lead.created_at)}
+        </span>
+        <div className="flex items-center gap-1.5">
+          {lead.source && lead.source !== "manual" && (
+            <span className="text-[10px] bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
+              {formatSourceLabel(lead.source)}
+            </span>
+          )}
+          {next && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-[11px] px-2 gap-0.5"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={() => handlers.onMove(lead.id, next)}
+            >
+              {next.charAt(0).toUpperCase() + next.slice(1)}
+              <ChevronRight className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/leads/lead-shared.ts
+++ b/src/components/leads/lead-shared.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared vocabulary for the leads workspace.
+ *
+ * Board, List and Calendar all need the same stage colours, source labels and
+ * date formatting. Keeping them here means a stage's colour is defined once —
+ * previously the board had a `COLUMNS` map, a `STATUS_BADGE` map and a
+ * `CARD_TONE` map that each encoded the same five stages separately.
+ */
+
+import type { LeadStatus } from "@/types/database";
+
+export interface StageDef {
+  status: LeadStatus;
+  label: string;
+  /** Solid dot / left-rail colour. */
+  dot: string;
+  /** Soft tint for pills and column headers. */
+  soft: string;
+  /** Left-rail border colour for cards. */
+  rail: string;
+}
+
+export const STAGES: StageDef[] = [
+  { status: "new",       label: "New",       dot: "bg-blue-500",    soft: "bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300",          rail: "border-l-blue-500" },
+  { status: "contacted", label: "Contacted", dot: "bg-amber-500",   soft: "bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",      rail: "border-l-amber-500" },
+  { status: "quoted",    label: "Quoted",    dot: "bg-violet-500",  soft: "bg-violet-50 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300",  rail: "border-l-violet-500" },
+  { status: "won",       label: "Won",       dot: "bg-emerald-500", soft: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300", rail: "border-l-emerald-500" },
+  { status: "lost",      label: "Lost",      dot: "bg-rose-500",    soft: "bg-rose-50 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300",          rail: "border-l-rose-500" },
+];
+
+export const STAGE_BY_STATUS: Record<LeadStatus, StageDef> = Object.fromEntries(
+  STAGES.map((s) => [s.status, s])
+) as Record<LeadStatus, StageDef>;
+
+/** The one-click "advance" target for each stage. Won/lost are terminal. */
+export const NEXT_STATUS: Partial<Record<LeadStatus, LeadStatus>> = {
+  new: "contacted",
+  contacted: "quoted",
+  quoted: "won",
+};
+
+/** Friendly labels for known sources. Anything else is title-cased. */
+const SOURCE_LABELS: Record<string, string> = {
+  "landing-page": "Landing Page",
+  "website": "Website",
+  "referral": "Referral",
+  "telegram": "Telegram",
+  "email": "Email",
+  "phone": "Phone",
+  "manual": "Manual",
+  "hipages": "HiPages",
+  "service-seeking": "ServiceSeeking",
+  "google": "Google",
+  "facebook": "Facebook",
+  "instagram": "Instagram",
+  "word-of-mouth": "Word of mouth",
+};
+
+export function formatSourceLabel(s: string): string {
+  return SOURCE_LABELS[s] ?? s.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-AU", { day: "numeric", month: "short" });
+}
+
+/** Local Y-M-D. Not toISOString — that shifts to UTC and can land a lead on
+ *  the wrong calendar day for anyone away from Greenwich. */
+export function ymd(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export type ConvertTarget = "customer" | "quote" | "work_order";
+
+/** Everything a view needs to act on a lead, passed down from the orchestrator. */
+export interface LeadActionHandlers {
+  onMove: (id: string, status: LeadStatus) => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onConvert: (id: string, target: ConvertTarget) => void;
+  onAddAsContact: (id: string) => void;
+}

--- a/src/components/leads/leads-board.tsx
+++ b/src/components/leads/leads-board.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+/**
+ * The pipeline board.
+ *
+ * Drag is @dnd-kit rather than native HTML5 DnD. The native API gave no drag
+ * preview worth the name, couldn't animate, and fired inconsistently across
+ * browsers; dnd-kit gives a real overlay and a spring drop.
+ *
+ * Cards are draggable but NOT sortable: `leads` has no sort_order column, so
+ * within-column ordering couldn't be persisted and offering it would be a lie.
+ * You drag a card to a *column*, which changes its status — that's the whole
+ * interaction.
+ */
+
+import { useState } from "react";
+import {
+  DndContext, DragOverlay, PointerSensor, useSensor, useSensors,
+  useDraggable, useDroppable, closestCorners,
+  type DragStartEvent, type DragEndEvent,
+} from "@dnd-kit/core";
+import { motion, AnimatePresence } from "framer-motion";
+import { LeadCard } from "./lead-card";
+import { STAGES, type LeadActionHandlers } from "./lead-shared";
+import type { Lead, LeadStatus } from "@/types/database";
+
+function DraggableCard({
+  lead,
+  busy,
+  handlers,
+}: {
+  lead: Lead;
+  busy: boolean;
+  handlers: LeadActionHandlers;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: lead.id });
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      layout
+      layoutId={`lead-${lead.id}`}
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: isDragging ? 0.35 : 1, y: 0 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ type: "spring", stiffness: 500, damping: 40 }}
+      className="cursor-grab active:cursor-grabbing touch-none"
+      {...listeners}
+      {...attributes}
+    >
+      <LeadCard lead={lead} busy={busy} handlers={handlers} />
+    </motion.div>
+  );
+}
+
+function Column({
+  status,
+  label,
+  dot,
+  soft,
+  leads,
+  busyId,
+  handlers,
+}: {
+  status: LeadStatus;
+  label: string;
+  dot: string;
+  soft: string;
+  leads: Lead[];
+  busyId: string | null;
+  handlers: LeadActionHandlers;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: status });
+
+  return (
+    <div className="flex flex-col gap-2 w-[280px] shrink-0 xl:w-auto xl:shrink">
+      {/* Header */}
+      <div className={`rounded-lg px-3 py-2 flex items-center gap-2 ${soft}`}>
+        <span className={`h-2 w-2 rounded-full ${dot}`} />
+        <span className="text-sm font-semibold">{label}</span>
+        <span className="ml-auto text-xs font-semibold tabular-nums bg-background/70 rounded px-1.5 py-0.5">
+          {leads.length}
+        </span>
+      </div>
+
+      {/* Drop zone */}
+      <div
+        ref={setNodeRef}
+        className={`flex flex-col gap-2 rounded-xl p-1.5 min-h-[120px] transition-colors ${
+          isOver ? "bg-primary/5 ring-2 ring-primary/30 ring-inset" : ""
+        }`}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          {leads.map((lead) => (
+            <DraggableCard
+              key={lead.id}
+              lead={lead}
+              busy={busyId === lead.id}
+              handlers={handlers}
+            />
+          ))}
+        </AnimatePresence>
+
+        {leads.length === 0 && (
+          <div
+            className={`rounded-lg border border-dashed p-4 text-center text-xs transition-colors ${
+              isOver ? "border-primary/50 text-primary" : "border-border/60 text-muted-foreground"
+            }`}
+          >
+            {isOver ? "Drop here" : "No leads"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function LeadsBoard({
+  leads,
+  busyId,
+  handlers,
+}: {
+  leads: Lead[];
+  busyId: string | null;
+  handlers: LeadActionHandlers;
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  // A few px of travel before a drag starts, so clicking the actions menu or a
+  // phone link still registers as a click rather than a stillborn drag.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
+  );
+
+  const active = activeId ? leads.find((l) => l.id === activeId) ?? null : null;
+
+  const onDragEnd = (e: DragEndEvent) => {
+    setActiveId(null);
+    const overId = e.over?.id as LeadStatus | undefined;
+    if (!overId) return;
+
+    const lead = leads.find((l) => l.id === e.active.id);
+    if (lead && lead.status !== overId) handlers.onMove(lead.id, overId);
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={(e: DragStartEvent) => setActiveId(String(e.active.id))}
+      onDragEnd={onDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
+      {/* Horizontal scroll below xl instead of wrapping into 1–2 ragged
+          columns — a pipeline reads left-to-right, so let it. */}
+      <div className="flex gap-4 overflow-x-auto pb-2 xl:grid xl:grid-cols-5 xl:overflow-visible">
+        {STAGES.map((s) => (
+          <Column
+            key={s.status}
+            status={s.status}
+            label={s.label}
+            dot={s.dot}
+            soft={s.soft}
+            leads={leads.filter((l) => l.status === s.status)}
+            busyId={busyId}
+            handlers={handlers}
+          />
+        ))}
+      </div>
+
+      <DragOverlay dropAnimation={{ duration: 200, easing: "cubic-bezier(0.18, 0.67, 0.6, 1.22)" }}>
+        {active && (
+          <div className="w-[268px]">
+            <LeadCard lead={active} busy={false} handlers={handlers} dragging />
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/src/components/leads/leads-calendar.tsx
+++ b/src/components/leads/leads-calendar.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+/**
+ * Leads by the day they arrived.
+ *
+ * The board answers "where is this lead up to"; this answers "when is work
+ * coming in" — which days are busy, whether a campaign landed, how long a
+ * pile of New leads has been sitting there.
+ *
+ * All leads are already in memory, so paging months is local state with no
+ * refetch.
+ */
+
+import { useState, useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronLeft, ChevronRight, Phone, Mail } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { LeadActions } from "./lead-actions";
+import {
+  STAGE_BY_STATUS, ymd, formatSourceLabel, type LeadActionHandlers,
+} from "./lead-shared";
+import type { Lead } from "@/types/database";
+
+const DOW = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+/** Chips per day cell before collapsing into "+k more". */
+const MAX_CHIPS = 3;
+
+/** The Monday-first 6x7 grid covering a month, plus the neighbouring days that
+ *  fill the first and last weeks. */
+function monthGrid(year: number, month: number): Date[] {
+  const first = new Date(year, month, 1);
+  const offset = (first.getDay() + 6) % 7; // JS weeks start Sunday; ours don't.
+  const start = new Date(year, month, 1 - offset);
+  return Array.from({ length: 42 }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    return d;
+  });
+}
+
+export function LeadsCalendar({
+  leads,
+  busyId,
+  handlers,
+}: {
+  leads: Lead[];
+  busyId: string | null;
+  handlers: LeadActionHandlers;
+}) {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth());
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const byDay = useMemo(() => {
+    const map = new Map<string, Lead[]>();
+    for (const l of leads) {
+      const key = ymd(new Date(l.created_at));
+      map.set(key, [...(map.get(key) ?? []), l]);
+    }
+    return map;
+  }, [leads]);
+
+  const cells = monthGrid(year, month);
+  const today = ymd(now);
+  const label = new Date(year, month, 1).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+
+  const shift = (by: number) => {
+    const d = new Date(year, month + by, 1);
+    setYear(d.getFullYear());
+    setMonth(d.getMonth());
+    setSelected(null);
+  };
+
+  const monthCount = cells.filter((d) => d.getMonth() === month)
+    .reduce((n, d) => n + (byDay.get(ymd(d))?.length ?? 0), 0);
+
+  const selectedLeads = selected ? byDay.get(selected) ?? [] : [];
+
+  return (
+    <div className="space-y-3">
+      {/* Month nav */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Button variant="outline" size="sm" className="h-8 w-8 p-0" onClick={() => shift(-1)} aria-label="Previous month">
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </Button>
+          <span className="text-sm font-semibold px-2 min-w-[9.5rem] text-center">{label}</span>
+          <Button variant="outline" size="sm" className="h-8 w-8 p-0" onClick={() => shift(1)} aria-label="Next month">
+            <ChevronRight className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 text-xs ml-1"
+            onClick={() => { setYear(now.getFullYear()); setMonth(now.getMonth()); setSelected(null); }}
+          >
+            Today
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground tabular-nums">
+          {monthCount} lead{monthCount === 1 ? "" : "s"} this month
+        </p>
+      </div>
+
+      {/* Grid */}
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <div className="grid grid-cols-7 border-b border-border bg-muted/40">
+          {DOW.map((d) => (
+            <div key={d} className="px-2 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground text-center">
+              {d}
+            </div>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-7">
+          {cells.map((d) => {
+            const key = ymd(d);
+            const items = byDay.get(key) ?? [];
+            const outside = d.getMonth() !== month;
+            const isSelected = selected === key;
+
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setSelected(items.length ? (isSelected ? null : key) : null)}
+                className={`min-h-[5.5rem] border-b border-r border-border p-1 space-y-1 text-left align-top transition-colors ${
+                  outside ? "bg-muted/20" : ""
+                } ${isSelected ? "ring-2 ring-primary/40 ring-inset" : ""} ${
+                  items.length ? "hover:bg-muted/40 cursor-pointer" : "cursor-default"
+                }`}
+              >
+                <span
+                  className={`block text-[10px] px-1 tabular-nums ${
+                    key === today
+                      ? "font-bold text-primary"
+                      : outside
+                        ? "text-muted-foreground/50"
+                        : "text-muted-foreground"
+                  }`}
+                >
+                  {d.getDate()}
+                </span>
+
+                {items.slice(0, MAX_CHIPS).map((l) => (
+                  <span
+                    key={l.id}
+                    className="flex items-center gap-1 rounded px-1 py-0.5 text-[10px] bg-muted/70"
+                    title={`${l.name} — ${STAGE_BY_STATUS[l.status]?.label ?? l.status}`}
+                  >
+                    <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${STAGE_BY_STATUS[l.status]?.dot ?? "bg-muted-foreground"}`} />
+                    <span className="truncate">{l.name}</span>
+                  </span>
+                ))}
+
+                {items.length > MAX_CHIPS && (
+                  <span className="block text-[10px] text-muted-foreground px-1">
+                    +{items.length - MAX_CHIPS} more
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Selected day */}
+      <AnimatePresence mode="wait">
+        {selected && (
+          <motion.div
+            key={selected}
+            initial={{ opacity: 0, y: -6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={{ duration: 0.18 }}
+            className="rounded-xl border border-border bg-card p-3 space-y-2"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-semibold">
+                {new Date(`${selected}T12:00:00`).toLocaleDateString(undefined, {
+                  weekday: "long", day: "numeric", month: "long",
+                })}
+              </p>
+              <span className="text-xs text-muted-foreground tabular-nums">
+                {selectedLeads.length} lead{selectedLeads.length === 1 ? "" : "s"}
+              </span>
+            </div>
+
+            <ul className="space-y-1.5">
+              {selectedLeads.map((lead) => {
+                const stage = STAGE_BY_STATUS[lead.status];
+                return (
+                  <li key={lead.id} className="flex items-center gap-2 rounded-lg border border-border/70 p-2">
+                    <span className={`h-2 w-2 rounded-full shrink-0 ${stage?.dot ?? ""}`} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium break-words">{lead.name}</span>
+                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${stage?.soft ?? ""}`}>
+                          {stage?.label ?? lead.status}
+                        </span>
+                        {lead.source && lead.source !== "manual" && (
+                          <span className="text-[10px] bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
+                            {formatSourceLabel(lead.source)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5 flex-wrap">
+                        {lead.phone && (
+                          <a href={`tel:${lead.phone.replace(/\s/g, "")}`} className="inline-flex items-center gap-1 hover:text-foreground">
+                            <Phone className="h-3 w-3" /> {lead.phone}
+                          </a>
+                        )}
+                        {lead.email && (
+                          <a href={`mailto:${lead.email}`} className="inline-flex items-center gap-1 hover:text-foreground break-all">
+                            <Mail className="h-3 w-3" /> {lead.email}
+                          </a>
+                        )}
+                        {lead.service && <span className="break-words">{lead.service}</span>}
+                      </div>
+                    </div>
+                    <LeadActions lead={lead} busy={busyId === lead.id} handlers={handlers} />
+                  </li>
+                );
+              })}
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -1,23 +1,33 @@
 "use client";
 
-import { useState } from "react";
-import { motion } from "framer-motion";
-import {
-  Plus, Phone, Mail, MapPin, Clock, MoreHorizontal,
-  Trash2, User, TrendingUp, ChevronRight, Search, Filter,
-} from "@/components/ui/icons";
+/**
+ * The leads workspace.
+ *
+ * One orchestrator owning lead state, the shared dialogs and every mutation;
+ * three views rendering it. The board answers "where is this lead up to", the
+ * list "show me all of them without scrolling five columns", the calendar
+ * "when did the work come in".
+ *
+ * The old page was the board alone, with six gradient KPI tiles restating the
+ * five column counts directly beneath them. The KPIs here are the four numbers
+ * the columns and filter tabs DON'T already give you.
+ */
+
+import { useState, useMemo } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
+import {
+  Plus, Search, TrendingUp, Users, Sparkles, CheckCircle,
+  LayoutGrid, ListChecks, Calendar as CalendarIcon,
+} from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatTile, AnimatedPress, FadeIn } from "@/components/ui/kirei";
-import {
-  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
-  DropdownMenuSeparator, DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
@@ -25,65 +35,28 @@ import {
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
 } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useRouter } from "next/navigation";
-import { updateLeadStatus, deleteLead, createLead, updateLead, convertLeadToCustomer, convertLeadToQuote, convertLeadToWorkOrder } from "@/lib/actions/leads";
+import { LeadsBoard } from "./leads-board";
+import { LeadsList } from "./leads-list";
+import { LeadsCalendar } from "./leads-calendar";
+import { formatSourceLabel, type ConvertTarget, type LeadActionHandlers } from "./lead-shared";
+import {
+  updateLeadStatus, deleteLead, createLead, updateLead,
+  convertLeadToCustomer, convertLeadToQuote, convertLeadToWorkOrder,
+} from "@/lib/actions/leads";
 import { addLeadAsContact } from "@/lib/actions/contacts";
 import type { Lead, LeadStatus, LeadSource } from "@/types/database";
 import { BUILT_IN_LEAD_SOURCES } from "@/types/database";
 
-const COLUMNS: { status: LeadStatus; label: string; color: string; dot: string }[] = [
-  { status: "new",       label: "New",       color: "bg-blue-50 dark:bg-blue-950/30",   dot: "bg-blue-500" },
-  { status: "contacted", label: "Contacted", color: "bg-yellow-50 dark:bg-yellow-950/30", dot: "bg-yellow-500" },
-  { status: "quoted",    label: "Quoted",    color: "bg-purple-50 dark:bg-purple-950/30", dot: "bg-purple-500" },
-  { status: "won",       label: "Won",       color: "bg-green-50 dark:bg-green-950/30",  dot: "bg-green-500" },
-  { status: "lost",      label: "Lost",      color: "bg-red-50 dark:bg-red-950/30",     dot: "bg-red-500" },
+type View = "board" | "list" | "calendar";
+const VIEWS: { id: View; label: string; icon: typeof LayoutGrid }[] = [
+  { id: "board", label: "Board", icon: LayoutGrid },
+  { id: "list", label: "List", icon: ListChecks },
+  { id: "calendar", label: "Calendar", icon: CalendarIcon },
 ];
 
-const STATUS_BADGE: Record<LeadStatus, string> = {
-  new:       "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
-  contacted: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300",
-  quoted:    "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
-  won:       "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
-  lost:      "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
-};
-
-/** Friendly labels for known sources. Anything not in here renders as-is. */
-const SOURCE_LABELS: Record<string, string> = {
-  "landing-page":   "Landing Page",
-  "website":        "Website",
-  "referral":       "Referral",
-  "telegram":       "Telegram",
-  "email":          "Email",
-  "phone":          "Phone",
-  "manual":         "Manual",
-  "hipages":        "HiPages",
-  "service-seeking":"ServiceSeeking",
-  "google":         "Google",
-  "facebook":       "Facebook",
-  "instagram":      "Instagram",
-  "word-of-mouth":  "Word of mouth",
-};
-
-function formatSourceLabel(s: string): string {
-  return SOURCE_LABELS[s] ?? s.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString("en-AU", { day: "numeric", month: "short" });
-}
-
 interface NewLeadForm {
-  name: string;
-  phone: string;
-  email: string;
-  suburb: string;
-  service: string;
-  property_type: string;
-  timing: string;
-  notes: string;
+  name: string; phone: string; email: string; suburb: string;
+  service: string; property_type: string; timing: string; notes: string;
   source: LeadSource;
 }
 
@@ -94,8 +67,11 @@ const EMPTY_FORM: NewLeadForm = {
 
 export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
   const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
   const [leads, setLeads] = useState(initial);
-  const [converting, setConverting] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
@@ -103,25 +79,45 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
   const [saving, setSaving] = useState(false);
   const [editLead, setEditLead] = useState<Lead | null>(null);
   const [editForm, setEditForm] = useState<Partial<Lead>>({});
-  const [dragOverCol, setDragOverCol] = useState<LeadStatus | null>(null);
 
-  const filtered = search
-    ? leads.filter((l) =>
-        `${l.name} ${l.email ?? ""} ${l.phone ?? ""} ${l.suburb ?? ""} ${l.service ?? ""}`
-          .toLowerCase()
-          .includes(search.toLowerCase())
-      )
-    : leads;
+  // View lives in the URL so it survives a refresh and can be linked to —
+  // same pattern as the Content Studio hub.
+  const view = (params.get("view") as View) ?? "board";
+  const setView = (v: View) => router.replace(`${pathname}?view=${v}`, { scroll: false });
 
-  const byStatus = (status: LeadStatus) => filtered.filter((l) => l.status === status);
+  const filtered = useMemo(() => {
+    if (!search.trim()) return leads;
+    const q = search.toLowerCase();
+    return leads.filter((l) =>
+      `${l.name} ${l.email ?? ""} ${l.phone ?? ""} ${l.suburb ?? ""} ${l.service ?? ""}`
+        .toLowerCase()
+        .includes(q)
+    );
+  }, [leads, search]);
+
+  const stats = useMemo(() => {
+    const total = leads.length;
+    const won = leads.filter((l) => l.status === "won").length;
+    return {
+      total,
+      new: leads.filter((l) => l.status === "new").length,
+      won,
+      conversion: total > 0 ? Math.round((won / total) * 100) : 0,
+    };
+  }, [leads]);
+
+  // ── mutations ─────────────────────────────────────────────────────────────
 
   const handleMove = async (id: string, status: LeadStatus) => {
+    const before = leads;
     setLeads((prev) => prev.map((l) => (l.id === id ? { ...l, status } : l)));
     try {
       await updateLeadStatus(id, status);
     } catch {
-      toast.error("Failed to update status");
-      setLeads(initial);
+      toast.error("Couldn't update the status");
+      setLeads(before); // revert to what was actually on screen, not the
+                        // server's first response — the user may have made
+                        // other edits since the page loaded.
     }
   };
 
@@ -131,12 +127,14 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
       await deleteLead(deleteId);
       setLeads((prev) => prev.filter((l) => l.id !== deleteId));
       toast.success("Lead deleted");
-    } catch { toast.error("Failed to delete lead"); }
+    } catch {
+      toast.error("Couldn't delete the lead");
+    }
     setDeleteId(null);
   };
 
   const handleAdd = async () => {
-    if (!form.name) { toast.error("Name is required"); return; }
+    if (!form.name.trim()) { toast.error("A name is required"); return; }
     setSaving(true);
     try {
       const lead = await createLead({
@@ -154,47 +152,66 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
       setForm(EMPTY_FORM);
       setShowAdd(false);
       toast.success("Lead added");
-    } catch { toast.error("Failed to add lead"); }
+    } catch {
+      toast.error("Couldn't add the lead");
+    }
     setSaving(false);
   };
 
   const handleAddAsContact = async (id: string) => {
-    setConverting(id);
+    setBusyId(id);
     try {
       await addLeadAsContact(id);
       toast.success("Added as contact");
       router.push("/contacts");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to add as contact");
+      toast.error(e instanceof Error ? e.message : "Couldn't add as a contact");
     } finally {
-      setConverting(null);
+      setBusyId(null);
     }
   };
 
-  const handleConvert = async (id: string, target: "customer" | "quote" | "work_order") => {
-    setConverting(id);
+  const handleConvert = async (id: string, target: ConvertTarget) => {
+    setBusyId(id);
     try {
       if (target === "customer") {
         const { customer_id } = await convertLeadToCustomer(id);
-        setLeads((prev) => prev.map((l) => (l.id === id ? { ...l, customer_id, status: l.status === "new" ? "contacted" : l.status } : l)));
+        setLeads((prev) => prev.map((l) =>
+          l.id === id ? { ...l, customer_id, status: l.status === "new" ? "contacted" : l.status } : l
+        ));
         toast.success("Customer created");
         router.push(`/customers/${customer_id}`);
       } else if (target === "quote") {
         const { quote_id, customer_id } = await convertLeadToQuote(id);
-        setLeads((prev) => prev.map((l) => (l.id === id ? { ...l, customer_id, quote_id, status: "quoted" } : l)));
+        setLeads((prev) => prev.map((l) =>
+          l.id === id ? { ...l, customer_id, quote_id, status: "quoted" } : l
+        ));
         toast.success("Draft quote created");
         router.push(`/quotes/${quote_id}`);
       } else {
         const { work_order_id, customer_id } = await convertLeadToWorkOrder(id);
-        setLeads((prev) => prev.map((l) => (l.id === id ? { ...l, customer_id, status: "won" } : l)));
+        setLeads((prev) => prev.map((l) =>
+          l.id === id ? { ...l, customer_id, status: "won" } : l
+        ));
         toast.success("Work order created");
         router.push(`/work-orders/${work_order_id}`);
       }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Conversion failed");
     } finally {
-      setConverting(null);
+      setBusyId(null);
     }
+  };
+
+  const openEdit = (id: string) => {
+    const lead = leads.find((l) => l.id === id);
+    if (!lead) return;
+    setEditLead(lead);
+    setEditForm({
+      name: lead.name, phone: lead.phone, email: lead.email, suburb: lead.suburb,
+      service: lead.service, property_type: lead.property_type, timing: lead.timing,
+      notes: lead.notes,
+    });
   };
 
   const handleEditSave = async () => {
@@ -205,31 +222,27 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
       setLeads((prev) => prev.map((l) => (l.id === editLead.id ? { ...l, ...editForm } : l)));
       setEditLead(null);
       toast.success("Lead updated");
-    } catch { toast.error("Failed to update lead"); }
+    } catch {
+      toast.error("Couldn't update the lead");
+    }
     setSaving(false);
   };
 
-  const stats = {
-    total: leads.length,
-    new: leads.filter((l) => l.status === "new").length,
-    won: leads.filter((l) => l.status === "won").length,
-    lost: leads.filter((l) => l.status === "lost").length,
+  const handlers: LeadActionHandlers = {
+    onMove: handleMove,
+    onEdit: openEdit,
+    onDelete: (id) => setDeleteId(id),
+    onConvert: handleConvert,
+    onAddAsContact: handleAddAsContact,
   };
 
-  // Map kanban-column → soft gradient + tone for the new stat tiles
-  const STAT_STYLE = [
-    { gradient: "softBlue"   as const, tone: "#1e3a8a" },
-    { gradient: "softAmber"  as const, tone: "#78350f" },
-    { gradient: "softViolet" as const, tone: "#3b1d6b" },
-    { gradient: "softTeal"   as const, tone: "#064e3b" },
-    { gradient: "softRose"   as const, tone: "#9f1239" },
-  ];
+  // ── render ────────────────────────────────────────────────────────────────
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <PageHeader
         title="Leads"
-        subtitle={`${stats.total} total · ${stats.new} new · ${stats.won} won · ${stats.lost} lost`}
+        subtitle={`${stats.total} total · ${stats.new} awaiting first contact`}
         accent="linear-gradient(180deg, #60a5fa 0%, #1d4ed8 100%)"
         actions={
           <>
@@ -244,118 +257,87 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
         }
       />
 
-      {/* Stat tiles per stage + conversion rate */}
-      <div className="grid grid-cols-2 lg:grid-cols-6 gap-3">
-        {COLUMNS.map((col, i) => {
-          const count = byStatus(col.status).length;
-          const style = STAT_STYLE[i] ?? STAT_STYLE[0];
-          return (
-            <FadeIn key={col.status} delay={60 + i * 40}>
-              <StatTile
-                gradient={style.gradient}
-                toneColor={style.tone}
-                icon={<span className={`block w-2.5 h-2.5 rounded-full ${col.dot}`} />}
-                label={col.label}
-                value={String(count)}
-                sub=" "
-              />
-            </FadeIn>
-          );
-        })}
-        <FadeIn delay={260}>
-          <StatTile
-            gradient="softTeal"
-            toneColor="#064e3b"
-            icon={<TrendingUp className="w-3.5 h-3.5" />}
-            label="Conv. rate"
-            value={`${stats.total > 0 ? Math.round((stats.won / stats.total) * 100) : 0}%`}
-            sub="won / total"
-          />
-        </FadeIn>
+      {/* Four KPIs — the numbers the board columns and list tabs don't repeat. */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {[
+          { icon: <Users className="w-3.5 h-3.5" />, label: "Total leads", value: String(stats.total), sub: "all time", gradient: "softBlue" as const, tone: "#1e3a8a" },
+          { icon: <Sparkles className="w-3.5 h-3.5" />, label: "New", value: String(stats.new), sub: "need first contact", gradient: "softAmber" as const, tone: "#78350f" },
+          { icon: <CheckCircle className="w-3.5 h-3.5" />, label: "Won", value: String(stats.won), sub: "converted", gradient: "softTeal" as const, tone: "#064e3b" },
+          { icon: <TrendingUp className="w-3.5 h-3.5" />, label: "Conv. rate", value: `${stats.conversion}%`, sub: "won / total", gradient: "softViolet" as const, tone: "#3b1d6b" },
+        ].map((k, i) => (
+          <FadeIn key={k.label} delay={60 + i * 40}>
+            <StatTile
+              gradient={k.gradient}
+              toneColor={k.tone}
+              icon={k.icon}
+              label={k.label}
+              value={k.value}
+              sub={k.sub}
+            />
+          </FadeIn>
+        ))}
       </div>
 
-      {/* Search */}
-      <div className="relative max-w-sm">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search leads…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-9 h-10 rounded-xl"
-        />
-      </div>
-
-      {/* Kanban */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 min-h-[400px]">
-        {COLUMNS.map((col) => {
-          const colLeads = byStatus(col.status);
-          const isOver = dragOverCol === col.status;
-          return (
-            <div
-              key={col.status}
-              className="flex flex-col gap-2"
-              onDragOver={(e) => { e.preventDefault(); setDragOverCol(col.status); }}
-              onDragLeave={() => setDragOverCol((c) => c === col.status ? null : c)}
-              onDrop={(e) => {
-                e.preventDefault();
-                setDragOverCol(null);
-                const id = e.dataTransfer.getData("text/lead-id");
-                const fromStatus = e.dataTransfer.getData("text/lead-status") as LeadStatus;
-                if (id && fromStatus !== col.status) handleMove(id, col.status);
-              }}
-            >
-              {/* Column header */}
-              <div className={`rounded-lg px-3 py-2 flex items-center gap-2 ${col.color}`}>
-                <span className={`h-2 w-2 rounded-full ${col.dot}`} />
-                <span className="text-sm font-semibold capitalize">{col.label}</span>
-                <span className="ml-auto text-xs font-medium text-muted-foreground bg-background/60 rounded px-1.5 py-0.5">
-                  {colLeads.length}
-                </span>
-              </div>
-
-              {/* Cards */}
-              <div className={`flex flex-col gap-2 rounded-lg p-1 transition-colors ${isOver ? "bg-primary/5 ring-2 ring-primary/30 ring-inset" : ""}`}>
-                {colLeads.map((lead) => (
-                  <div
-                    key={lead.id}
-                    draggable
-                    onDragStart={(e) => {
-                      e.dataTransfer.setData("text/lead-id", lead.id);
-                      e.dataTransfer.setData("text/lead-status", lead.status);
-                      e.dataTransfer.effectAllowed = "move";
-                    }}
-                    className="cursor-grab active:cursor-grabbing"
-                  >
-                    <LeadCard
-                      lead={lead}
-                      converting={converting === lead.id}
-                      onMove={handleMove}
-                      onDelete={() => setDeleteId(lead.id)}
-                      onEdit={() => { setEditLead(lead); setEditForm({ name: lead.name, phone: lead.phone, email: lead.email, suburb: lead.suburb, service: lead.service, property_type: lead.property_type, timing: lead.timing, notes: lead.notes }); }}
-                      onConvert={(target) => handleConvert(lead.id, target)}
-                      onAddAsContact={() => handleAddAsContact(lead.id)}
-                    />
-                  </div>
-                ))}
-                {colLeads.length === 0 && (
-                  <div className={`rounded-lg border border-dashed p-4 text-center text-xs ${isOver ? "border-primary/50 text-primary" : "border-border/60 text-muted-foreground"}`}>
-                    {isOver ? "Drop here" : "No leads"}
-                  </div>
+      {/* View switcher + search */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-1 p-1 rounded-xl bg-muted/60 border border-border">
+          {VIEWS.map((v) => {
+            const active = view === v.id;
+            return (
+              <button
+                key={v.id}
+                type="button"
+                onClick={() => setView(v.id)}
+                className={`relative inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors ${
+                  active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {active && (
+                  <motion.span
+                    layoutId="leads-view-pill"
+                    className="absolute inset-0 rounded-lg bg-background shadow-sm"
+                    transition={{ type: "spring", stiffness: 500, damping: 40 }}
+                  />
                 )}
-              </div>
-            </div>
-          );
-        })}
+                <v.icon className="w-3.5 h-3.5 relative z-10" />
+                <span className="relative z-10">{v.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="relative w-full sm:w-auto sm:min-w-[260px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search leads…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 h-10 rounded-xl"
+          />
+        </div>
       </div>
 
-      {/* Add Lead Dialog */}
+      {/* The active view */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={view}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.2 }}
+        >
+          {view === "board" && <LeadsBoard leads={filtered} busyId={busyId} handlers={handlers} />}
+          {view === "list" && <LeadsList leads={filtered} busyId={busyId} handlers={handlers} />}
+          {view === "calendar" && <LeadsCalendar leads={filtered} busyId={busyId} handlers={handlers} />}
+        </motion.div>
+      </AnimatePresence>
+
+      {/* Add */}
       <Dialog open={showAdd} onOpenChange={setShowAdd}>
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Add Lead</DialogTitle>
-          </DialogHeader>
+          <DialogHeader><DialogTitle>Add lead</DialogTitle></DialogHeader>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-2">
-            <div className="col-span-2 space-y-1.5">
+            <div className="col-span-full space-y-1.5">
               <Label>Name *</Label>
               <Input value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="John Smith" />
             </div>
@@ -376,7 +358,7 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
               <Input value={form.service} onChange={(e) => setForm((f) => ({ ...f, service: e.target.value }))} placeholder="Gutter cleaning" />
             </div>
             <div className="space-y-1.5">
-              <Label>Property Type</Label>
+              <Label>Property type</Label>
               <Input value={form.property_type} onChange={(e) => setForm((f) => ({ ...f, property_type: e.target.value }))} placeholder="Residential" />
             </div>
             <div className="space-y-1.5">
@@ -392,38 +374,35 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
                 placeholder="e.g. HiPages, referral, walk-in"
               />
               <datalist id="lead-source-suggestions">
-                {/* Built-in presets */}
                 {BUILT_IN_LEAD_SOURCES.map((s) => (
                   <option key={`builtin-${s}`} value={s}>{formatSourceLabel(s)}</option>
                 ))}
-                {/* Sources already used on this business's leads — keeps the
-                    list tidy and lets typing 'Hi…' autocomplete to a past value. */}
+                {/* Sources already on this business's leads, so typing 'Hi…'
+                    autocompletes to a value that's actually been used. */}
                 {Array.from(new Set(leads.map((l) => l.source).filter(Boolean) as string[]))
                   .filter((s) => !(BUILT_IN_LEAD_SOURCES as readonly string[]).includes(s))
                   .map((s) => <option key={`past-${s}`} value={s}>{formatSourceLabel(s)}</option>)}
               </datalist>
               <p className="text-[11px] text-muted-foreground">Pick a suggestion or type your own.</p>
             </div>
-            <div className="col-span-2 space-y-1.5">
+            <div className="col-span-full space-y-1.5">
               <Label>Notes</Label>
-              <Textarea value={form.notes} onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))} rows={3} placeholder="Any additional notes..." />
+              <Textarea value={form.notes} onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))} rows={3} placeholder="Anything else worth knowing…" />
             </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowAdd(false)}>Cancel</Button>
-            <Button onClick={handleAdd} disabled={saving}>{saving ? "Saving..." : "Add Lead"}</Button>
+            <Button onClick={handleAdd} disabled={saving}>{saving ? "Saving…" : "Add lead"}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* Edit Lead Dialog */}
+      {/* Edit */}
       <Dialog open={!!editLead} onOpenChange={(o) => { if (!o) setEditLead(null); }}>
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Edit Lead</DialogTitle>
-          </DialogHeader>
+          <DialogHeader><DialogTitle>Edit lead</DialogTitle></DialogHeader>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-2">
-            <div className="col-span-2 space-y-1.5">
+            <div className="col-span-full space-y-1.5">
               <Label>Name *</Label>
               <Input value={editForm.name ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, name: e.target.value }))} />
             </div>
@@ -444,177 +423,40 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
               <Input value={editForm.service ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, service: e.target.value }))} />
             </div>
             <div className="space-y-1.5">
-              <Label>Property Type</Label>
+              <Label>Property type</Label>
               <Input value={editForm.property_type ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, property_type: e.target.value }))} />
             </div>
             <div className="space-y-1.5">
               <Label>Timing</Label>
               <Input value={editForm.timing ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, timing: e.target.value }))} />
             </div>
-            <div className="col-span-2 space-y-1.5">
+            <div className="col-span-full space-y-1.5">
               <Label>Notes</Label>
               <Textarea value={editForm.notes ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, notes: e.target.value }))} rows={3} />
             </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setEditLead(null)}>Cancel</Button>
-            <Button onClick={handleEditSave} disabled={saving}>{saving ? "Saving..." : "Save Changes"}</Button>
+            <Button onClick={handleEditSave} disabled={saving}>{saving ? "Saving…" : "Save changes"}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* Delete Confirm */}
+      {/* Delete */}
       <AlertDialog open={!!deleteId} onOpenChange={(o) => { if (!o) setDeleteId(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete lead?</AlertDialogTitle>
-            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+            <AlertDialogDescription>This can&apos;t be undone.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">Delete</AlertDialogAction>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              Delete
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </div>
-  );
-}
-
-// Whole-card tinting per stage so a glance at the kanban tells you where each
-// lead stands. Soft surface + matching left rail; dark mode uses translucent
-// overlays so the prototype's neutral surface still shows through.
-const CARD_TONE: Record<LeadStatus, string> = {
-  new:       "bg-blue-50/80   dark:bg-blue-950/30   border-blue-200/70   dark:border-blue-900/60   border-l-4 border-l-blue-500",
-  contacted: "bg-amber-50/80  dark:bg-amber-950/30  border-amber-200/70  dark:border-amber-900/60  border-l-4 border-l-amber-500",
-  quoted:    "bg-violet-50/80 dark:bg-violet-950/30 border-violet-200/70 dark:border-violet-900/60 border-l-4 border-l-violet-500",
-  won:       "bg-emerald-50/90 dark:bg-emerald-950/40 border-emerald-200/80 dark:border-emerald-900/60 border-l-4 border-l-emerald-500",
-  lost:      "bg-rose-50/80   dark:bg-rose-950/30   border-rose-200/70   dark:border-rose-900/60   border-l-4 border-l-rose-500 opacity-90",
-};
-
-function LeadCard({
-  lead,
-  converting,
-  onMove,
-  onDelete,
-  onEdit,
-  onConvert,
-  onAddAsContact,
-}: {
-  lead: Lead;
-  converting: boolean;
-  onMove: (id: string, status: LeadStatus) => void;
-  onDelete: () => void;
-  onEdit: () => void;
-  onConvert: (target: "customer" | "quote" | "work_order") => void;
-  onAddAsContact: () => void;
-}) {
-  const NEXT_STATUS: Partial<Record<LeadStatus, LeadStatus>> = {
-    new: "contacted",
-    contacted: "quoted",
-    quoted: "won",
-  };
-  const next = NEXT_STATUS[lead.status];
-  const tone = CARD_TONE[lead.status] ?? "bg-card border-border";
-
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 4 }}
-      animate={{ opacity: 1, y: 0 }}
-      className={`rounded-lg border shadow-sm p-3 space-y-2 hover:shadow-md transition-shadow ${tone}`}
-    >
-      {/* Name + menu */}
-      <div className="flex items-start justify-between gap-1">
-        <div className="flex items-center gap-1.5 min-w-0">
-          <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          <span className="font-medium text-sm break-words">{lead.name}</span>
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={onEdit}>Edit</DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onAddAsContact} disabled={converting}>
-              Add as contact
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onConvert("customer")} disabled={converting || !!lead.customer_id}>
-              Convert to customer{lead.customer_id ? " ✓" : ""}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onConvert("quote")} disabled={converting}>
-              Convert to quote
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onConvert("work_order")} disabled={converting}>
-              Convert to work order
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            {COLUMNS.filter((c) => c.status !== lead.status).map((c) => (
-              <DropdownMenuItem key={c.status} onClick={() => onMove(lead.id, c.status)}>
-                Move to {c.label}
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onDelete} className="text-destructive focus:text-destructive">
-              <Trash2 className="h-3.5 w-3.5 mr-2" /> Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      {/* Details */}
-      <div className="space-y-1">
-        {lead.phone && (
-          <a href={`tel:${lead.phone.replace(/\s/g, "")}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
-            <Phone className="h-3 w-3 shrink-0" />
-            <span className="break-words">{lead.phone}</span>
-          </a>
-        )}
-        {lead.email && (
-          <a href={`mailto:${lead.email}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
-            <Mail className="h-3 w-3 shrink-0" />
-            <span className="break-words">{lead.email}</span>
-          </a>
-        )}
-        {lead.suburb && (
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <MapPin className="h-3 w-3 shrink-0" />
-            <span className="break-words">{lead.suburb}</span>
-          </div>
-        )}
-        {lead.service && (
-          <div className="text-xs text-muted-foreground break-words">{lead.service}</div>
-        )}
-      </div>
-
-      {/* Footer */}
-      <div className="flex items-center justify-between pt-1 border-t border-border/50">
-        <div className="flex items-center gap-1 text-xs text-muted-foreground">
-          <Clock className="h-3 w-3" />
-          {formatDate(lead.created_at)}
-        </div>
-        {next && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 text-xs px-3 gap-1"
-            onClick={() => onMove(lead.id, next)}
-          >
-            {next.charAt(0).toUpperCase() + next.slice(1)}
-            <ChevronRight className="h-3 w-3" />
-          </Button>
-        )}
-      </div>
-
-      {/* Source badge */}
-      {lead.source && lead.source !== "manual" && (
-        <div className="pt-0">
-          <span className="text-xs bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
-            {formatSourceLabel(lead.source)}
-          </span>
-        </div>
-      )}
-    </motion.div>
   );
 }

--- a/src/components/leads/leads-list.tsx
+++ b/src/components/leads/leads-list.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * The list view — for when the board has more leads than you can scan.
+ *
+ * Filters by stage, then pages. Paging is in memory: the page already loads
+ * every lead via getLeads(), so a round-trip per page would be slower and
+ * would lose the client-side search.
+ */
+
+import { useState, useEffect, useMemo } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { ChevronLeft, ChevronRight, Phone, Mail, MapPin } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { KireiTabs, KireiAvatar, EmptyState } from "@/components/ui/kirei";
+import { LeadActions } from "./lead-actions";
+import {
+  STAGES, STAGE_BY_STATUS, formatDate, formatSourceLabel,
+  type LeadActionHandlers,
+} from "./lead-shared";
+import type { Lead, LeadStatus } from "@/types/database";
+
+const PER_PAGE = 12;
+
+type Filter = LeadStatus | "all";
+
+export function LeadsList({
+  leads,
+  busyId,
+  handlers,
+}: {
+  leads: Lead[];
+  busyId: string | null;
+  handlers: LeadActionHandlers;
+}) {
+  const [filter, setFilter] = useState<Filter>("all");
+  const [page, setPage] = useState(1);
+
+  const shown = useMemo(
+    () => (filter === "all" ? leads : leads.filter((l) => l.status === filter)),
+    [leads, filter]
+  );
+
+  const pageCount = Math.max(1, Math.ceil(shown.length / PER_PAGE));
+
+  // Changing the filter (or a search upstream shrinking the set) can strand you
+  // on a page that no longer exists — clamp instead of showing an empty page.
+  useEffect(() => {
+    if (page > pageCount) setPage(1);
+  }, [page, pageCount]);
+
+  const start = (page - 1) * PER_PAGE;
+  const rows = shown.slice(start, start + PER_PAGE);
+
+  const tabs = [
+    { value: "all" as const, label: "All", count: leads.length },
+    ...STAGES.map((s) => ({
+      value: s.status,
+      label: s.label,
+      count: leads.filter((l) => l.status === s.status).length,
+    })),
+  ];
+
+  return (
+    <div className="space-y-3">
+      <KireiTabs
+        tabs={tabs}
+        value={filter}
+        onChange={(v) => { setFilter(v as Filter); setPage(1); }}
+      />
+
+      {shown.length === 0 ? (
+        <EmptyState
+          title="No leads here"
+          hint={filter === "all" ? "Add a lead to get started." : `Nothing in ${STAGE_BY_STATUS[filter as LeadStatus]?.label ?? filter}.`}
+        />
+      ) : (
+        <>
+          {/* Rows, keyed on filter+page: React swaps the whole set and framer
+              animates the incoming page in. No AnimatePresence — an exit
+              animation on a pager isn't worth nesting one mode="wait" inside
+              the view switcher's. */}
+          <motion.ul
+              key={`${filter}-${page}`}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.18 }}
+              className="space-y-1.5"
+            >
+              {rows.map((lead) => {
+                const stage = STAGE_BY_STATUS[lead.status];
+                return (
+                  <li
+                    key={lead.id}
+                    className="flex items-center gap-3 p-2.5 rounded-xl border border-border bg-card hover:border-primary/30 transition-colors"
+                  >
+                    <KireiAvatar name={lead.name} size={38} />
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Link
+                          href={`/leads/${lead.id}`}
+                          className="text-sm font-semibold break-words hover:text-primary transition-colors"
+                        >
+                          {lead.name}
+                        </Link>
+                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${stage?.soft ?? ""}`}>
+                          {stage?.label ?? lead.status}
+                        </span>
+                        {lead.source && lead.source !== "manual" && (
+                          <span className="text-[10px] bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
+                            {formatSourceLabel(lead.source)}
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground flex-wrap">
+                        {lead.phone && (
+                          <a href={`tel:${lead.phone.replace(/\s/g, "")}`} className="inline-flex items-center gap-1 hover:text-foreground">
+                            <Phone className="h-3 w-3" /> {lead.phone}
+                          </a>
+                        )}
+                        {lead.email && (
+                          <a href={`mailto:${lead.email}`} className="inline-flex items-center gap-1 hover:text-foreground break-all">
+                            <Mail className="h-3 w-3" /> {lead.email}
+                          </a>
+                        )}
+                        {lead.suburb && (
+                          <span className="inline-flex items-center gap-1">
+                            <MapPin className="h-3 w-3" /> {lead.suburb}
+                          </span>
+                        )}
+                        {lead.service && <span className="break-words">{lead.service}</span>}
+                      </div>
+                    </div>
+
+                    <span className="text-[11px] text-muted-foreground shrink-0 hidden sm:block">
+                      {formatDate(lead.created_at)}
+                    </span>
+                    <LeadActions lead={lead} busy={busyId === lead.id} handlers={handlers} />
+                  </li>
+                );
+              })}
+            </motion.ul>
+
+          {/* Pager */}
+          <div className="flex items-center justify-between gap-2 pt-1">
+            <p className="text-xs text-muted-foreground tabular-nums">
+              Showing {start + 1}–{Math.min(start + PER_PAGE, shown.length)} of {shown.length}
+            </p>
+
+            {pageCount > 1 && (
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  disabled={page === 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  aria-label="Previous page"
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+
+                {Array.from({ length: pageCount }, (_, i) => i + 1)
+                  // Keep the pager short on long lists: first, last, and a
+                  // window around the current page.
+                  .filter((n) => n === 1 || n === pageCount || Math.abs(n - page) <= 1)
+                  .map((n, i, arr) => (
+                    <span key={n} className="flex items-center gap-1">
+                      {i > 0 && arr[i - 1] !== n - 1 && (
+                        <span className="text-xs text-muted-foreground px-0.5">…</span>
+                      )}
+                      <Button
+                        variant={n === page ? "default" : "outline"}
+                        size="sm"
+                        className="h-8 min-w-8 px-2 text-xs tabular-nums"
+                        onClick={() => setPage(n)}
+                        aria-current={n === page ? "page" : undefined}
+                      >
+                        {n}
+                      </Button>
+                    </span>
+                  ))}
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  disabled={page === pageCount}
+                  onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+                  aria-label="Next page"
+                >
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The leads page was one kanban carrying everything at once — six gradient KPI tiles restating the five column counts right beneath them, every card filled with one of five stage colours, native HTML5 drag with no real preview, and no compact or by-date way to look at leads.

Now **three views behind a switcher**, with the active view in the URL (`?view=`) so it survives a refresh and can be linked.

## Board (default)
- Drag moves to **@dnd-kit** (already a dependency): real drag overlay, spring drop, cards animate into place.
- Cards are draggable but **not sortable** — `leads` has no `sort_order` column, so within-column ordering couldn't persist and offering it would be a lie. You drag to a *column*, which sets status.
- Scrolls horizontally below `xl` instead of wrapping into ragged columns.

## List
- Stage filter tabs with counts, compact avatar rows, **pagination (12/page)**.
- Paging is in memory: the page already loads every lead, so a round-trip per page would be slower and would break the client-side search.

## Calendar
- Leads bucketed by arrival date; click a day to see them. Month-grid helpers ported from the Content Studio calendar.

## Declutter
- 6 KPIs → the 4 the columns and filter tabs don't already repeat.
- Cards go neutral with a 3px stage rail instead of a full colour fill.
- Stage colours now live in one place (`lead-shared.ts`); they were spread across three separate maps. The actions menu is extracted from the kanban card — otherwise List and Calendar would have had no way to convert or move a lead.

## Scope
No server-action, DB or MCP changes — the mutations are the existing ones. No new capability, so no MCP tool needed.

## Verified
`tsc` · `build` · `bundle:check` all clean. Behaviour checked against a throwaway harness with mock leads (the real page needs auth and the local Supabase keys are stale), then removed: paging 1→2→1, filter resetting to page 1, calendar day-select and month nav (12 July + 5 June = 17 leads), and a synthetic pointer drag that moved a card optimistically and then reverted with the error toast — the server action having no DB in the harness.

Note: `src/lib/content/__tests__/prompts.test.ts` fails locally, but it fails on `main` too and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)