### PR TITLE
fix(security): Phase 0 — RLS gaps, crons fail closed, worker isolation

### DIFF
--- a/src/app/api/cron/booking-reminders/route.ts
+++ b/src/app/api/cron/booking-reminders/route.ts
@@ -11,17 +11,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { notifyBookingReminder, fireBookingWebhook } from "@/lib/booking/notify";
+import { requireCron } from "@/lib/cron-auth";
 import type { Appointment, BookingForm } from "@/types/database";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  // Light gate: allow Vercel Cron, or a matching CRON_SECRET if configured.
-  const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const ok = req.headers.get("authorization") === `Bearer ${secret}` || req.headers.get("x-vercel-cron") !== null;
-    if (!ok) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  // Was a "light gate" that failed open when CRON_SECRET was unset AND accepted
+  // any request carrying an x-vercel-cron header — a header the caller controls,
+  // on a route the middleware makes public. Vercel Cron sends the bearer token
+  // itself when CRON_SECRET is set, so the header check bought nothing.
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sb = createAdminClient() as any;

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { emailBase } from "@/lib/emails/base";
 import { Resend } from "resend";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 60;
 
@@ -37,10 +38,8 @@ function statRow(label: string, value: string, highlight = false): string {
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const today = todayUTC();

--- a/src/app/api/cron/invoice-reminders/route.ts
+++ b/src/app/api/cron/invoice-reminders/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { emailBase, btn } from "@/lib/emails/base";
 import { Resend } from "resend";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 60;
 
@@ -29,10 +30,8 @@ function fmtDate(d: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const now = new Date().toISOString();

--- a/src/app/api/cron/process-scheduled-sends/route.ts
+++ b/src/app/api/cron/process-scheduled-sends/route.ts
@@ -19,6 +19,7 @@ import { getResolvedEmailTemplate } from "@/lib/emails/templates";
 import { customerAllowsCard } from "@/lib/payment-methods";
 import { appUrl } from "@/lib/app-url";
 import type { LineItem } from "@/types/database";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 60;
 
@@ -201,10 +202,8 @@ async function dispatchQuote(
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const nowIso = new Date().toISOString();

--- a/src/app/api/cron/quote-followup/route.ts
+++ b/src/app/api/cron/quote-followup/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { emailBase } from "@/lib/emails/base";
 import { Resend } from "resend";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 60;
 
@@ -29,10 +30,8 @@ function fmtDate(d: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const today = new Date();

--- a/src/app/api/cron/recurring-invoices/route.ts
+++ b/src/app/api/cron/recurring-invoices/route.ts
@@ -12,16 +12,15 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { advanceOccurrence } from "@/lib/recurring/cadence";
 import { generateRecurringInvoice } from "@/lib/recurring/generate-invoice";
 import type { RecurringInvoice, LineItem } from "@/types/database";
+import { requireCron } from "@/lib/cron-auth";
 
 function todayISO(): string {
   return new Date().toISOString().split("T")[0];
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const today = todayISO();

--- a/src/app/api/cron/recurring-jobs/route.ts
+++ b/src/app/api/cron/recurring-jobs/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { advanceOccurrence } from "@/lib/recurring/cadence";
 import type { RecurringJob, LineItem } from "@/types/database";
+import { requireCron } from "@/lib/cron-auth";
 
 function todayISO(): string {
   return new Date().toISOString().split("T")[0];
@@ -26,10 +27,8 @@ function endTimeFromStart(start: string | null, durationMinutes: number | null):
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const today = todayISO();

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Resend } from "resend";
+import { requireCron } from "@/lib/cron-auth";
 
 const BUSINESS_ID = process.env.AGENT_BUSINESS_ID ?? "ff3a47f3-54b0-45e3-b7a9-69ddc9fa787e";
 const BOT_TOKEN   = process.env.TELEGRAM_BOT_TOKEN!;
@@ -74,10 +75,8 @@ async function getJobsForDate(sb: any, date: string) {
 
 export async function GET(req: NextRequest) {
   // Auth: Vercel sets CRON_SECRET, or allow explicit bearer
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   const today    = todayAEST();

--- a/src/app/api/cron/seo-audits/route.ts
+++ b/src/app/api/cron/seo-audits/route.ts
@@ -8,15 +8,14 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { runSiteAudit } from "@/lib/seo/engine";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { appUrl } from "@/lib/app-url";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 300;
 const MAX_PER_TICK = 3;
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/cron/seo-gsc-sync/route.ts
+++ b/src/app/api/cron/seo-gsc-sync/route.ts
@@ -13,16 +13,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { decryptSecret } from "@/lib/crypto";
 import { accessTokenFor, querySearchAnalytics } from "@/lib/seo/gsc";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 300;
 
 const isoDate = (d: Date) => d.toISOString().split("T")[0];
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/cron/seo-jobs/route.ts
+++ b/src/app/api/cron/seo-jobs/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { advanceContentJob } from "@/lib/seo/engine";
+import { requireCron } from "@/lib/cron-auth";
 
 // Give each tick room for a few sequential Claude calls.
 export const maxDuration = 300;
@@ -16,10 +17,8 @@ export const maxDuration = 300;
 const MAX_JOBS_PER_TICK = 4;
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/cron/seo-reports/route.ts
+++ b/src/app/api/cron/seo-reports/route.ts
@@ -8,14 +8,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { assembleReport } from "@/lib/seo/report";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 300;
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/cron/workorder-complete/route.ts
+++ b/src/app/api/cron/workorder-complete/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { emailBase } from "@/lib/emails/base";
 import { Resend } from "resend";
+import { requireCron } from "@/lib/cron-auth";
 
 export const maxDuration = 60;
 
@@ -25,10 +26,8 @@ function fmtDate(d: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
+  const denied = requireCron(req);
+  if (denied) return denied;
 
   const sb = createAdminClient();
   // Look back 5 hours (slightly more than the 4-hour cron interval)

--- a/src/lib/__tests__/rls-coverage.test.ts
+++ b/src/lib/__tests__/rls-coverage.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Structural guard: every business-scoped table must have RLS enabled.
+ *
+ * Three tables (sms_conversations, sms_messages, report_sessions) shipped with
+ * no RLS at all and sat that way for months — readable cross-tenant with the
+ * anon key, and two of them streaming over Realtime. Nothing caught it, because
+ * nothing was looking.
+ *
+ * This parses the migration SQL rather than querying a database, so it runs in
+ * CI with no credentials. It is deliberately dumb: any CREATE TABLE with a
+ * business_id column must be followed somewhere by ENABLE ROW LEVEL SECURITY.
+ */
+
+const MIGRATIONS = join(process.cwd(), "supabase", "migrations");
+
+function allSql(): string {
+  return readdirSync(MIGRATIONS)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()
+    .map((f) => readFileSync(join(MIGRATIONS, f), "utf8"))
+    .join("\n");
+}
+
+/** Tables created with a business_id column. */
+function businessScopedTables(sql: string): string[] {
+  const found = new Set<string>();
+  // CREATE TABLE [IF NOT EXISTS] [public.]name ( ...body... )
+  const re = /CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(?:public\.)?"?([a-z0-9_]+)"?\s*\(/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sql))) {
+    const name = m[1];
+    // Walk to the matching close paren so we only read this table's body.
+    let depth = 0, i = re.lastIndex - 1;
+    for (; i < sql.length; i++) {
+      if (sql[i] === "(") depth++;
+      else if (sql[i] === ")") { depth--; if (depth === 0) break; }
+    }
+    const body = sql.slice(re.lastIndex, i);
+    if (/\bbusiness_id\b/.test(body)) found.add(name);
+  }
+  return [...found].sort();
+}
+
+/**
+ * Tables with RLS switched on.
+ *
+ * Two forms in this repo, and missing the second produces false positives:
+ *   1. literal   — ALTER TABLE public.foo ENABLE ROW LEVEL SECURITY;
+ *   2. generated — a DO $$ block looping over an array of table names and
+ *                  EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL
+ *                  SECURITY', t). Used by the booking, prospects and SEO
+ *                  foundation migrations.
+ *
+ * For form 2 the table names are not statically known, so we collect every
+ * quoted identifier inside a DO block that performs the ENABLE, and treat those
+ * as covered. Slightly over-permissive, which is the right direction: this test
+ * exists to catch a table nobody protected at all, not to police style.
+ */
+function rlsEnabledTables(sql: string): Set<string> {
+  const s = new Set<string>();
+
+  const literal = /ALTER TABLE\s+(?:IF EXISTS\s+)?(?:public\.)?"?([a-z0-9_]+)"?\s+ENABLE ROW LEVEL SECURITY/gi;
+  let m: RegExpExecArray | null;
+  while ((m = literal.exec(sql))) s.add(m[1]);
+
+  // DO $$ ... $$; blocks that enable RLS dynamically.
+  const doBlocks = sql.match(/DO\s*\$\$[\s\S]*?\$\$\s*;/gi) ?? [];
+  for (const block of doBlocks) {
+    if (!/ENABLE ROW LEVEL SECURITY/i.test(block)) continue;
+    for (const q of block.match(/'([a-z0-9_]+)'/gi) ?? []) {
+      s.add(q.slice(1, -1).toLowerCase());
+    }
+  }
+
+  return s;
+}
+
+describe("RLS coverage", () => {
+  const sql = allSql();
+  const scoped = businessScopedTables(sql);
+  const enabled = rlsEnabledTables(sql);
+
+  it("finds business-scoped tables to check", () => {
+    // Sanity: if the parser breaks, the test must fail loudly rather than pass
+    // by checking nothing.
+    expect(scoped.length).toBeGreaterThan(20);
+  });
+
+  it("enables RLS on every table carrying a business_id", () => {
+    const missing = scoped.filter((t) => !enabled.has(t));
+    expect(
+      missing,
+      `These tables have a business_id but never get ENABLE ROW LEVEL SECURITY.\n` +
+        `Every business-scoped table needs it — RLS is the only security gate for\n` +
+        `normal requests. Add it in a migration.\n\n  ${missing.join("\n  ")}\n`
+    ).toEqual([]);
+  });
+});

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Authenticate a cron request. Fails CLOSED.
+ *
+ * Twelve of the fourteen cron routes previously guarded with:
+ *
+ *     if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`)
+ *
+ * — so if the variable was ever unset, renamed, or missing from an environment,
+ * the check vanished entirely and the route became a public endpoint. That is
+ * the wrong direction to fail for handlers that generate invoices, charge saved
+ * cards off-session on a live Stripe integration, and email every tenant's
+ * customers from a verified domain.
+ *
+ * `/api/cron/` is unconditionally public in the middleware, so this function is
+ * the only gate these routes have.
+ *
+ * Returns a NextResponse to return immediately, or null when the caller is
+ * authorised.
+ */
+export function requireCron(req: NextRequest): NextResponse | null {
+  const secret = process.env.CRON_SECRET;
+
+  // Misconfiguration is a server error, not an open door. 500 rather than 401
+  // so it is visibly broken (and shows up in monitoring) instead of looking
+  // like a caller problem.
+  if (!secret) {
+    console.error("[cron] CRON_SECRET is not set — refusing to run");
+    return NextResponse.json({ error: "Cron is not configured" }, { status: 500 });
+  }
+
+  if (req.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/supabase/migrations/20260719120000_rls_sms_and_report_sessions.sql
+++ b/supabase/migrations/20260719120000_rls_sms_and_report_sessions.sql
@@ -1,0 +1,74 @@
+-- Close three tables that shipped with NO row-level security.
+--
+-- Verified against production before writing this: pg_class.relrowsecurity was
+-- false and pg_policies returned zero rows for all three. Because signup is
+-- public, any authenticated user could read every tenant's rows with the anon
+-- key — and sms_conversations/sms_messages are in the supabase_realtime
+-- publication, so Postgres was streaming other tenants' customer names, phone
+-- numbers and message bodies into their browsers live.
+--
+-- Enabling RLS also fixes the Realtime leak: postgres_changes honours RLS, so
+-- once a policy exists a subscriber only receives rows it is allowed to read.
+--
+-- Access model per table:
+--   sms_conversations / sms_messages — read+write by src/lib/actions/sms.ts via
+--     the USER client, so they need a real member policy. Workers are excluded:
+--     SMS is customer communication, and worker isolation is meant to keep
+--     workers away from customer contact details (CLAUDE.md).
+--   report_sessions — only ever touched by the ADMIN client
+--     (src/app/api/report-sessions/**), which bypasses RLS. So the correct
+--     policy is none at all: RLS on with no policy = deny everyone except the
+--     service role. Same shape already used for business_api_keys and
+--     oauth_codes.
+
+-- ── sms_conversations ───────────────────────────────────────────────────────
+ALTER TABLE public.sms_conversations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "sms_conversations_no_workers" ON public.sms_conversations;
+CREATE POLICY "sms_conversations_no_workers" ON public.sms_conversations
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ── sms_messages ────────────────────────────────────────────────────────────
+-- Carries its own business_id, so it is gated directly rather than through a
+-- join on the conversation — one less way for the two to disagree.
+ALTER TABLE public.sms_messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "sms_messages_no_workers" ON public.sms_messages;
+CREATE POLICY "sms_messages_no_workers" ON public.sms_messages
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ── report_sessions ─────────────────────────────────────────────────────────
+-- Deliberately NO policy. Service-role only.
+ALTER TABLE public.report_sessions ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260719121000_worker_isolation_gaps.sql
+++ b/supabase/migrations/20260719121000_worker_isolation_gaps.sql
@@ -1,0 +1,115 @@
+-- Worker isolation: close the four tables it was never applied to.
+--
+-- CLAUDE.md documents "worker" as a hard-isolation role that only ever sees the
+-- work orders assigned to it. That guarantee is enforced by adding
+-- `AND NOT public.is_business_worker(business_id)` to each table's policy —
+-- done in 20260430000001 for customers, products, invoices, quotes, payments
+-- and reports, and never done for these four.
+--
+-- Verified against production before writing: pg_policies shows the sole policy
+-- on each of leads / contacts / sites / recurring_jobs has no is_business_worker
+-- clause. The web app masks these by path (WORKER_ALLOWED_PATHS in
+-- src/lib/permissions.ts allows only /dashboard, /work-orders, /schedule, /help,
+-- /settings/profile) — but mobile queries PostgREST directly with the worker's
+-- own JWT, so the path list is not a security boundary. Half the documented
+-- guarantee was not real.
+--
+-- DELIBERATELY NOT INCLUDED — `tasks`:
+--   An audit finding claimed its write policies name roles that do not exist
+--   ('admin','manager','staff') so editors fail silently. That is wrong.
+--   `tasks_all` is a permissive FOR ALL policy for any active member, and
+--   Postgres OR's permissive policies together — so it already grants everything
+--   and the role-specific policies add nothing. The real issue is the opposite
+--   (a viewer can write tasks, and three policies are dead code naming roles
+--   outside the Role union). That is a permissions design decision, not a
+--   tenancy leak, so it is not bundled into a safety migration.
+
+-- ── leads ───────────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "leads_business_access" ON public.leads;
+CREATE POLICY "leads_no_workers" ON public.leads
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ── contacts ────────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "contacts_all" ON public.contacts;
+CREATE POLICY "contacts_no_workers" ON public.contacts
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ── sites ───────────────────────────────────────────────────────────────────
+-- Serviced addresses, including access notes and gate codes. Workers reach a
+-- job's address through work_orders.property_address, not through this table:
+-- the only mobile query on sites is the customer-detail screen, which workers
+-- are already denied by customers_no_workers.
+DROP POLICY IF EXISTS "sites_all" ON public.sites;
+CREATE POLICY "sites_no_workers" ON public.sites
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ── recurring_jobs ──────────────────────────────────────────────────────────
+-- Schedule configuration, not the job itself. A worker sees the materialised
+-- work orders assigned to them; the recurrence rules are management config.
+DROP POLICY IF EXISTS "recurring_jobs_business_access" ON public.recurring_jobs;
+CREATE POLICY "recurring_jobs_no_workers" ON public.recurring_jobs
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );


### PR DESCRIPTION
Phase 0 of the fix plan. Every item verified against the production database or code **before** changing it.

## 0.1 — Three tables had no RLS at all
`sms_conversations`, `sms_messages`, `report_sessions` had `relrowsecurity=false` and zero policies; the SMS pair is in the `supabase_realtime` publication. Signup is public, so any authenticated user could read every tenant's customer names, phone numbers and message bodies — and Realtime streamed new rows live.

- SMS → member policy, workers excluded (the feature reads via the **user** client, so it needs a real policy)
- `report_sessions` → RLS with **no** policy (deny-all); only the admin client touches it

Real exposure today: 4 conversations, 5 messages, one business, `report_sessions` empty. A hole to close before customer #2 — not a breach that already happened.

## 0.2 — Twelve crons failed open
`if (process.env.CRON_SECRET && auth !== ...)` — an unset variable removed the check entirely, on handlers that generate invoices, charge saved cards off-session against **live** Stripe, and email customers from a verified domain. Now one `requireCron()`: 500 on misconfiguration, 401 on mismatch.

`booking-reminders` was worse than reported and my own first scan missed it — it also accepted any request carrying an `x-vercel-cron` header, which the caller controls, on a public route.

## 0.3 — Worker isolation was half-real
`leads`, `contacts`, `sites`, `recurring_jobs` never got `AND NOT is_business_worker(business_id)`. The web app hides them by path, but **mobile queries PostgREST with the worker's own JWT**, so the path list was never a boundary.

Plus a structural test asserting every `business_id` table enables RLS — the thing that would have caught 0.1. Verified it bites.

## Two audit claims corrected, not implemented
- **`tasks` roles** — the claim that `'manager'`/`'staff'` policies make editor writes fail is wrong. `tasks_all` is a permissive `FOR ALL` policy and Postgres ORs permissive policies, so it already grants everything. The real issue is the reverse (viewers can write) — a permissions decision, not a tenancy leak, so it's out of a safety migration.
- **My own new test** first flagged 7 booking/prospect tables as unprotected. Production disagreed: they enable RLS inside `DO $$` loops via `EXECUTE format()`. Fixed the parser.

## Verification
`tsc` clean · 85 tests pass · migrations applied to the live DB, recorded, and **read back** (`pg_class.relrowsecurity`, `pg_policies.qual`) rather than trusting exit codes.

`src/lib/content/__tests__/prompts.test.ts` fails locally on `main` too (pre-existing, passes in CI) — confirmed by stashing these changes.

## Not included
0.4 is yours: replace `ANTHROPIC_API_KEY` (returns 401, all AI dead) and set `SENTRY_DSN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)