### PR TITLE
fix(money): $NaN totals — stop summing Postgres numerics as strings

### DIFF
--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -29,7 +29,7 @@ import {
   AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
-import { formatCurrency, formatDate, getStatusColor } from "@/lib/utils";
+import { formatCurrency, formatDate, getStatusColor, num, sumMoney } from "@/lib/utils";
 import { AddressLink, MapPinLink } from "@/components/ui/address-link";
 import { CustomerForm } from "./customer-form";
 import { PortalLinkButton } from "@/components/customer-portal/portal-link-button";
@@ -491,8 +491,13 @@ export function CustomerDetailClient({
   const [savingNote, startNote] = useTransition();
   const [, startDelete] = useTransition();
 
-  const totalSpent = invoices.filter(i => i.status === "paid").reduce((s, i) => s + i.total, 0);
-  const outstanding = invoices.filter(i => ["sent", "partial"].includes(i.status)).reduce((s, i) => s + (i.total - i.amount_paid), 0);
+  // Money columns are Postgres numerics — PostgREST returns them as strings, so
+  // `+` concatenated and "Total spent" read $NaN from two paid invoices onward.
+  const totalSpent = sumMoney(invoices.filter(i => i.status === "paid"), i => i.total);
+  const outstanding = sumMoney(
+    invoices.filter(i => ["sent", "partial"].includes(i.status)),
+    i => num(i.total) - num(i.amount_paid),
+  );
 
   const handleAddNote = () => {
     if (!noteText.trim()) return;

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -25,7 +25,7 @@ import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
 import { scheduleSend } from "@/lib/actions/scheduled-sends";
 import { ShareWithCustomerDialog } from "@/components/share/share-with-customer-dialog";
 
-import { formatCurrency, formatDate } from "@/lib/utils";
+import { formatCurrency, formatDate, num } from "@/lib/utils";
 import {
   DetailHero, FactCard, AnimatedPress, FadeIn, GradientTile, KireiPill, Confetti,
 } from "@/components/ui/kirei";
@@ -144,7 +144,9 @@ export function InvoiceDetailClient({
       toast.success("Payment recorded");
       setShowPayment(false);
       // If this payment closes the invoice, celebrate.
-      if (!wasPaid && (invoice.amount_paid + paid + 0.005) >= Number(invoice.total)) {
+      // amount_paid arrives as a string, so this was "100.00" + 50 → "100.0050"
+      // and the comparison never fired: the invoice went paid without confetti.
+      if (!wasPaid && (num(invoice.amount_paid) + paid + 0.005) >= num(invoice.total)) {
         setConfettiKey((k) => k + 1);
       }
       router.refresh();

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -11,7 +11,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { deleteInvoice, duplicateInvoice, updateInvoice } from "@/lib/actions/invoices";
-import { formatCurrency, formatDate } from "@/lib/utils";
+import { formatCurrency, formatDate, num, sumMoney } from "@/lib/utils";
 import {
   StatTile, KireiTabs, KireiPill, EmptyState, AnimatedPress, FadeIn, GradientTile,
 } from "@/components/ui/kirei";
@@ -65,12 +65,19 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
   }, [invoices]);
 
   const totalOutstanding = useMemo(
-    () => invoices.filter((i) => ["sent", "partial", "overdue"].includes(i.status))
-                  .reduce((s, i) => s + (i.total - i.amount_paid), 0),
+    // Correct before only by accident: `-` coerces its operands, so the inner
+    // subtraction produced a real number even with string inputs. Made explicit
+    // so nobody "simplifies" it into the same bug as the line below.
+    () => sumMoney(
+      invoices.filter((i) => ["sent", "partial", "overdue"].includes(i.status)),
+      (i) => num(i.total) - num(i.amount_paid),
+    ),
     [invoices]
   );
   const totalPaid = useMemo(
-    () => invoices.filter((i) => i.status === "paid").reduce((s, i) => s + i.total, 0),
+    // num(): `total` is a Postgres numeric, so PostgREST hands it over as a
+    // string and `+` concatenated instead of adding — $NaN from two rows up.
+    () => sumMoney(invoices.filter((i) => i.status === "paid"), (i) => i.total),
     [invoices]
   );
 

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -11,7 +11,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { createProduct, updateProduct, deleteProduct, bulkImportProducts } from "@/lib/actions/products";
 import { BulkImportModal } from "@/components/shared/bulk-import-modal";
 import { ProductForm } from "./product-form";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, sumMoney } from "@/lib/utils";
 import {
   StatTile, KireiPill, EmptyState, AnimatedPress, FadeIn, GradientTile,
 } from "@/components/ui/kirei";
@@ -77,7 +77,10 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
     setDeleteId(null);
   };
 
-  const totalCatalogValue = products.reduce((s, p) => s + (p.unit_price ?? 0), 0);
+  // `?? 0` guarded null but not the string PostgREST actually returns for a
+  // numeric column, so this concatenated. Products is a default-on page, so
+  // any business with two products saw $NaN.
+  const totalCatalogValue = sumMoney(products, (p) => p.unit_price);
   const archivedCount = products.filter((p) => p.archived).length;
   const activeCount = products.length - archivedCount;
 

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -11,7 +11,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { deleteQuote, convertQuoteToInvoice, updateQuote } from "@/lib/actions/quotes";
-import { formatCurrency, formatDate } from "@/lib/utils";
+import { formatCurrency, formatDate, sumMoney } from "@/lib/utils";
 import {
   StatTile, KireiTabs, KireiPill, EmptyState, AnimatedPress, FadeIn, GradientTile,
 } from "@/components/ui/kirei";
@@ -57,8 +57,11 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
     return c;
   }, [quotes]);
 
-  const totalPipeline = useMemo(() => quotes.filter((q) => q.status === "sent").reduce((s, q) => s + q.total, 0), [quotes]);
-  const totalAccepted = useMemo(() => quotes.filter((q) => q.status === "accepted").reduce((s, q) => s + q.total, 0), [quotes]);
+  // quotes.total is a Postgres numeric → PostgREST returns a string → `+`
+  // concatenated. Both KPIs read $NaN from two quotes onward. Not in the audit's
+  // list; found by sweeping for the same pattern.
+  const totalPipeline = useMemo(() => sumMoney(quotes.filter((q) => q.status === "sent"), (q) => q.total), [quotes]);
+  const totalAccepted = useMemo(() => sumMoney(quotes.filter((q) => q.status === "accepted"), (q) => q.total), [quotes]);
   const acceptanceRate = quotes.length === 0
     ? 0
     : Math.round((counts.accepted / Math.max(counts.accepted + counts.rejected + counts.expired, 1)) * 100);

--- a/src/lib/__tests__/money.test.ts
+++ b/src/lib/__tests__/money.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { num, sumMoney, formatCurrency } from "../utils";
+
+/**
+ * Postgres `numeric` columns arrive from PostgREST as STRINGS while the
+ * TypeScript types claim `number`. Summing them with `+` concatenates.
+ *
+ * These tests reproduce the exact shipped bug: the invoices list "Paid" KPI,
+ * the customer "Total spent", and the products "Catalog value" all rendered
+ * `$NaN` — but only for a business with two or more rows, which is why it
+ * survived review and shipped.
+ */
+
+describe("num", () => {
+  it("coerces the strings PostgREST actually returns", () => {
+    expect(num("500.00")).toBe(500);
+    expect(num("0.05")).toBe(0.05);
+    expect(num(250)).toBe(250);
+  });
+
+  it("falls back to 0 rather than producing NaN", () => {
+    expect(num(null)).toBe(0);
+    expect(num(undefined)).toBe(0);
+    expect(num("")).toBe(0);
+    expect(num("not a number")).toBe(0);
+    expect(num(NaN)).toBe(0);
+    expect(num(Infinity)).toBe(0);
+  });
+});
+
+describe("sumMoney", () => {
+  it("adds string amounts instead of concatenating them", () => {
+    // The bug, precisely: 0 + "500.00" + "250.00" === "0500.00250.00"
+    const rows = [{ total: "500.00" }, { total: "250.00" }];
+
+    const broken = rows.reduce<number>((s, r) => s + (r.total as unknown as number), 0);
+    expect(String(broken)).toBe("0500.00250.00");
+    expect(formatCurrency(Number(broken))).toContain("NaN");
+
+    expect(sumMoney(rows, (r) => r.total)).toBe(750);
+    expect(formatCurrency(sumMoney(rows, (r) => r.total))).not.toContain("NaN");
+  });
+
+  it("is correct with 0 and 1 rows — which is why the bug shipped", () => {
+    expect(sumMoney([], (r: { total: string }) => r.total)).toBe(0);
+    expect(sumMoney([{ total: "500.00" }], (r) => r.total)).toBe(500);
+  });
+
+  it("handles a computed expression per row", () => {
+    const rows = [
+      { total: "500.00", amount_paid: "100.00" },
+      { total: "250.00", amount_paid: "250.00" },
+    ];
+    expect(sumMoney(rows, (r) => num(r.total) - num(r.amount_paid))).toBe(400);
+  });
+
+  it("survives null amounts mixed in", () => {
+    const rows = [{ unit_price: "12.50" }, { unit_price: null }, { unit_price: "7.50" }];
+    expect(sumMoney(rows, (r) => r.unit_price)).toBe(20);
+  });
+});
+
+describe("the paid-confetti comparison", () => {
+  it("fires when a string amount_paid closes the invoice", () => {
+    // Was: "100.00" + 50 → "100.0050", so the >= never became true and an
+    // invoice reached paid with no confetti.
+    const invoice = { amount_paid: "100.00", total: "150.00" };
+    const paid = 50;
+
+    const broken = ((invoice.amount_paid as unknown as number) + paid + 0.005) >= Number(invoice.total);
+    expect(broken).toBe(false);
+
+    const fixed = (num(invoice.amount_paid) + paid + 0.005) >= num(invoice.total);
+    expect(fixed).toBe(true);
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,31 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Coerce a value that *should* be a number but may not be.
+ *
+ * Postgres `numeric` columns arrive from PostgREST as STRINGS. The TypeScript
+ * types say `number`, so nothing warns you — and `+` then concatenates instead
+ * of adding: `0 + "500.00" + "250.00"` is `"0500.00250.00"`, which
+ * formatCurrency turns into `$NaN`.
+ *
+ * The reason this survives code review and shipping: it renders correctly with
+ * zero or one row and only breaks at two or more. Note that `-` coerces, so
+ * subtracting totals looks fine while summing them does not — which is why
+ * "outstanding" was right on the same screen where "paid" was NaN.
+ *
+ * Use this on any money column read from the database before doing arithmetic.
+ */
+export function num(v: unknown): number {
+  const n = typeof v === "number" ? v : parseFloat(String(v ?? 0));
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Sum a money column across rows, coercing each value. */
+export function sumMoney<T>(rows: T[], pick: (row: T) => unknown): number {
+  return rows.reduce<number>((s, r) => s + num(pick(r)), 0);
+}
+
 export function formatCurrency(amount: number, currency = "GBP", locale = "en-GB"): string {
   return new Intl.NumberFormat(locale, {
     style: "currency",


### PR DESCRIPTION
**Batch 1.1** of the fix plan — the first cross-cutting sweep.

## The bug
PostgREST returns `numeric` columns as **strings** while the TS types say `number`, so `+` concatenates:

```
0 + "500.00" + "250.00"  →  "0500.00250.00"  →  formatCurrency  →  $NaN
```

Correct with 0–1 rows, broken at 2+. That's why it shipped.

Confirmed at the database rather than assumed — `invoices.total`, `invoices.amount_paid`, `products.unit_price`, `quotes.total` are all `numeric` per `information_schema`.

## Fixed
| Where | Symptom |
|---|---|
| Invoices list "Paid" KPI | `$NaN` |
| Customer detail "Total spent" | `$NaN` |
| Products "Catalog value" (default-on page) | `$NaN` |
| Paid-confetti comparison | `"100.00" + 50` → `"100.0050"`, so it never fired |
| **Quotes "Open pipeline" + "Accepted"** | `$NaN` — **not in the audit**, found by sweeping |

That last pair is the one that matters most: it's where the only real customer's **$327k of open quotes** is displayed.

## Also
Made invoices "Outstanding" explicit. It was correct *by accident* — `-` coerces its operands, so the inner subtraction worked while the addition beside it didn't. Left implicit, someone eventually "simplifies" it into the same bug.

## Approach
Adds `num()` / `sumMoney()` to `lib/utils` beside `formatCurrency`. Five near-identical private `num()` helpers already exist across `lib/actions` (three return `0`, one returns `null`) — left alone rather than widening this PR, but new code should use the shared one.

## Tests
`src/lib/__tests__/money.test.ts` reproduces the real defect first — asserting the broken expression genuinely yields `"0500.00250.00"` and `$NaN` — then asserts the fix. Includes the 0-row and 1-row cases that let it ship.

`tsc` clean · 92 tests pass (was 85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)