### PR TITLE
fix(data): stop rendering query failures as "you have no data"

### DIFF
--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { unwrap, unwrapRows, assertOk } from "../db";
+
+/**
+ * The house trap: callers destructure `{ data }` and ignore `{ error }`, so a
+ * failed query is indistinguishable from an empty table and the UI renders its
+ * empty state. The user believes it and re-enters the data — which is how
+ * PR #398's duplicate customer was created.
+ *
+ * These pin the distinction: a real error throws; genuinely-empty stays empty.
+ */
+
+const err = (message: string, code?: string) => ({ data: null, error: { message, code } });
+
+describe("unwrapRows", () => {
+  it("throws on a query error instead of returning nothing", () => {
+    // The old shape: `const { data } = res; return data ?? []` → [] → "No
+    // invoices yet" on a page whose query actually failed.
+    const res = err('column "captured_at" does not exist', "42703");
+    const swallowed = (res.data as unknown[] | null) ?? [];
+    expect(swallowed).toEqual([]); // what the user used to see
+
+    expect(() => unwrapRows(res, "invoices")).toThrowError(/Couldn't load invoices/);
+    expect(() => unwrapRows(res, "invoices")).toThrowError(/captured_at/);
+  });
+
+  it("returns [] for a genuinely empty table", () => {
+    expect(unwrapRows({ data: [], error: null }, "invoices")).toEqual([]);
+    expect(unwrapRows({ data: null, error: null }, "invoices")).toEqual([]);
+  });
+
+  it("passes rows through untouched", () => {
+    const rows = [{ id: "a" }, { id: "b" }];
+    expect(unwrapRows({ data: rows, error: null }, "invoices")).toBe(rows);
+  });
+});
+
+describe("unwrap", () => {
+  it("throws on error", () => {
+    expect(() => unwrap(err("permission denied for table quotes", "42501"), "quotes"))
+      .toThrowError(/Couldn't load quotes: permission denied/);
+  });
+
+  it("treats a missing single row as null, not an error", () => {
+    // maybeSingle() on a business with no settings row is legitimate.
+    expect(unwrap({ data: null, error: null }, "settings")).toBeNull();
+  });
+});
+
+describe("assertOk", () => {
+  it("throws when a write was rejected", () => {
+    // addPayment fired this insert without destructuring, so a rejected write
+    // returned normally and the UI reported "Payment recorded".
+    expect(() => assertOk(err("new row violates row-level security policy", "42501"), "record the payment"))
+      .toThrowError(/Couldn't record the payment/);
+  });
+
+  it("is silent on success", () => {
+    expect(() => assertOk({ error: null }, "record the payment")).not.toThrow();
+  });
+});

--- a/src/lib/actions/account-contacts.ts
+++ b/src/lib/actions/account-contacts.ts
@@ -6,6 +6,7 @@ import { getActiveBizId } from "@/lib/active-business";
 import type { AccountContact, AccountContactRole } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
+import { assertOk } from "@/lib/db";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
 
@@ -73,5 +74,8 @@ export async function updateContact(id: string, payload: Partial<AccountContactP
 
 export async function archiveContact(id: string): Promise<void> {
   const { supabase, businessId } = await ctx();
-  await tbl(supabase, "account_contacts").update({ archived: true }).eq("id", id).eq("business_id", businessId);
+  assertOk(
+    await tbl(supabase, "account_contacts").update({ archived: true }).eq("id", id).eq("business_id", businessId),
+    "archive the contact",
+  );
 }

--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 
 import { getUser } from "@/lib/auth";
+import { unwrap, unwrapRows } from "@/lib/db";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
 
@@ -58,13 +59,18 @@ export async function getBusinessAnalytics(range: AnalyticsRange = "90d"): Promi
   const toIso   = to.toISOString();
 
   // Pull everything in parallel — small businesses, all-rows is cheap.
+  //
+  // Each result is unwrapped rather than destructured to `{ data }` alone: a
+  // failed query used to fall through to `?? []` and render the page as
+  // £0 revenue / 0 invoices, which an owner reads as "my business earned
+  // nothing this month" rather than "the query broke".
   const [
-    { data: invoicesRaw },
-    { data: quotesRaw },
-    { data: leadsRaw },
-    { data: workOrdersRaw },
-    { data: customersRaw },
-    { data: business },
+    invoicesRes,
+    quotesRes,
+    leadsRes,
+    workOrdersRes,
+    customersRes,
+    businessRes,
   ] = await Promise.all([
     tbl(supabase, "invoices")
       .select("id, customer_id, total, amount_paid, status, issue_date, due_date, created_at, customers(name)")
@@ -85,15 +91,16 @@ export async function getBusinessAnalytics(range: AnalyticsRange = "90d"): Promi
     tbl(supabase, "businesses").select("currency").eq("id", businessId).maybeSingle(),
   ]);
 
-  const invoices = (invoicesRaw ?? []) as Array<{
+  const invoices = unwrapRows(invoicesRes, "invoices") as Array<{
     id: string; customer_id: string | null; total: unknown; amount_paid: unknown;
     status: string; issue_date: string | null; due_date: string | null; created_at: string;
     customers: { name: string } | null;
   }>;
-  const quotes  = (quotesRaw ?? []) as Array<{ status: string; total: unknown; created_at: string }>;
-  const leads   = (leadsRaw ?? []) as Array<{ status: string; created_at: string }>;
-  const wos     = (workOrdersRaw ?? []) as Array<{ status: string }>;
-  const customers = (customersRaw ?? []) as Array<{ id: string; name: string }>;
+  const quotes  = unwrapRows(quotesRes, "quotes") as Array<{ status: string; total: unknown; created_at: string }>;
+  const leads   = unwrapRows(leadsRes, "leads") as Array<{ status: string; created_at: string }>;
+  const wos     = unwrapRows(workOrdersRes, "work orders") as Array<{ status: string }>;
+  const customers = unwrapRows(customersRes, "customers") as Array<{ id: string; name: string }>;
+  const business = unwrap(businessRes, "business settings") as { currency: string } | null;
 
   // ─── Totals (in range) ─────────────────────────────────────────────────
   const inRange = (iso: string) => iso >= fromIso && iso <= toIso;

--- a/src/lib/actions/billing-profiles.ts
+++ b/src/lib/actions/billing-profiles.ts
@@ -6,6 +6,7 @@ import { getActiveBizId } from "@/lib/active-business";
 import type { BillingProfile } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
+import { assertOk } from "@/lib/db";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
 
@@ -97,7 +98,10 @@ export async function updateBillingProfile(id: string, payload: Partial<BillingP
 
 export async function archiveBillingProfile(id: string): Promise<void> {
   const { supabase, businessId } = await ctx();
-  await tbl(supabase, "billing_profiles").update({ archived: true }).eq("id", id).eq("business_id", businessId);
+  assertOk(
+    await tbl(supabase, "billing_profiles").update({ archived: true }).eq("id", id).eq("business_id", businessId),
+    "archive the billing profile",
+  );
 }
 
 // site_billing

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { assertOk } from "@/lib/db";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { dispatchWebhook } from "@/lib/webhooks";
@@ -342,13 +343,31 @@ export async function addPayment(invoiceId: string, payment: { amount: number; d
 
   const businessId = await getActiveBizId(supabase, user.id);
 
+  // Validate before touching the database. Nothing else did: a NaN from a bad
+  // parseFloat, or a negative amount, would be written straight through and
+  // then folded into amount_paid.
+  const amount = Number(payment.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error("Payment amount must be a positive number.");
+  }
+
   const { data: invoice } = await tbl(supabase, "invoices")
     .select("total, amount_paid")
     .eq("id", invoiceId)
     .single();
   if (!invoice) throw new Error("Invoice not found");
 
-  await tbl(supabase, "payments").insert({ ...payment, invoice_id: invoiceId, user_id: user.id, business_id: businessId });
+  // This insert used to be fired without destructuring, so a rejected write —
+  // RLS denial, CHECK violation, bad date — returned normally. The recompute
+  // below then read the payments table (unchanged), wrote the SAME amount_paid
+  // back, and the UI said "Payment recorded". The user believed money had been
+  // recorded against an invoice that had nothing written to it.
+  assertOk(
+    await tbl(supabase, "payments").insert({
+      ...payment, amount, invoice_id: invoiceId, user_id: user.id, business_id: businessId,
+    }),
+    "record the payment",
+  );
 
   // Recompute this invoice's amount_paid from truth (payments table + any
   // children's collections if it's a parent of a progress-billed job). This
@@ -369,7 +388,14 @@ export async function addPayment(invoiceId: string, payment: { amount: number; d
   const newAmountPaid = directSum + childSum;
   const newStatus = newAmountPaid >= invoice.total - 0.01 ? "paid" : "partial";
 
-  await tbl(supabase, "invoices").update({ amount_paid: newAmountPaid, status: newStatus }).eq("id", invoiceId);
+  // Also unchecked before: a failed rollup left the payment row written but
+  // amount_paid stale, so the invoice under-reported what had been collected.
+  assertOk(
+    await tbl(supabase, "invoices")
+      .update({ amount_paid: newAmountPaid, status: newStatus })
+      .eq("id", invoiceId),
+    "update the invoice balance",
+  );
 
   // If this invoice is a child of a progress-billed parent, roll the new
   // payment up so the parent reflects everything collected toward the job.
@@ -414,9 +440,12 @@ export async function addPayment(invoiceId: string, payment: { amount: number; d
         else if (totalCollected > 0.01) nextStatus = "partial";
       }
 
-      await tbl(supabase, "invoices")
-        .update({ amount_paid: totalCollected, status: nextStatus })
-        .eq("id", parentId);
+      assertOk(
+        await tbl(supabase, "invoices")
+          .update({ amount_paid: totalCollected, status: nextStatus })
+          .eq("id", parentId),
+        "roll the payment up to the parent invoice",
+      );
 
       if (nextStatus === "paid" && currentStatus !== "paid") {
         dispatchWebhook(businessId, "invoice.paid", { id: parentId, total: parentTotal, via_progress: true });

--- a/src/lib/actions/sites.ts
+++ b/src/lib/actions/sites.ts
@@ -6,6 +6,7 @@ import { getActiveBizId } from "@/lib/active-business";
 import type { Site, SiteContact } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
+import { assertOk } from "@/lib/db";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
 
@@ -109,7 +110,12 @@ export async function updateSite(id: string, payload: SitePayload): Promise<Site
 
 export async function archiveSite(id: string): Promise<void> {
   const { supabase, businessId } = await ctx();
-  await tbl(supabase, "sites").update({ archived: true }).eq("id", id).eq("business_id", businessId);
+  // Was unchecked: an RLS denial or constraint failure returned normally and
+  // the UI reported the site archived while the row was untouched.
+  assertOk(
+    await tbl(supabase, "sites").update({ archived: true }).eq("id", id).eq("business_id", businessId),
+    "archive the site",
+  );
 }
 
 // site_contacts (link)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,59 @@
+/**
+ * Unwrap a PostgREST result, throwing instead of silently returning nothing.
+ *
+ * The house trap (CLAUDE.md "Known traps"): callers destructure `{ data }` and
+ * ignore `{ error }`, so a failed query is indistinguishable from an empty
+ * table. The UI then renders its empty state — "No customers yet", "$0 revenue"
+ * — and the user believes it.
+ *
+ * That is not a cosmetic bug. The rational response to a fabricated empty state
+ * is to re-enter the data, which is exactly how PR #398's duplicate customer
+ * was created: a search 400'd on a name containing a comma, the caller ignored
+ * the error, the agent saw "no results" and made a second customer.
+ *
+ * Reserve empty states for genuinely empty. Everything else is an error and
+ * should say so.
+ *
+ * Usage:
+ *   const rows = unwrap(await sb.from("invoices").select("*"), "invoices");
+ */
+export function unwrap<T>(
+  res: { data: T | null; error: { message: string; code?: string } | null },
+  what: string,
+): T {
+  if (res.error) {
+    throw new Error(`Couldn't load ${what}: ${res.error.message}`);
+  }
+  return res.data as T;
+}
+
+/**
+ * Same, but for reads where "no rows" is legitimately fine — returns [] rather
+ * than null so callers can drop their `?? []`, while a real error still throws.
+ */
+export function unwrapRows<T>(
+  res: { data: T[] | null; error: { message: string; code?: string } | null },
+  what: string,
+): T[] {
+  if (res.error) {
+    throw new Error(`Couldn't load ${what}: ${res.error.message}`);
+  }
+  return res.data ?? [];
+}
+
+/**
+ * Assert a write succeeded.
+ *
+ * Several actions fired an insert/update/delete without destructuring at all
+ * (`await sb.from(...).insert(...)`), so a rejected write — an RLS denial, a
+ * CHECK violation, a bad date — returned normally and the UI reported success.
+ * The user is then told their payment was recorded when nothing was written.
+ */
+export function assertOk(
+  res: { error: { message: string; code?: string } | null },
+  what: string,
+): void {
+  if (res.error) {
+    throw new Error(`Couldn't ${what}: ${res.error.message}`);
+  }
+}

--- a/src/lib/layout-data.ts
+++ b/src/lib/layout-data.ts
@@ -12,6 +12,7 @@
  * async functions, and we also export tag-name helpers (strings).
  */
 import { unstable_cache } from "next/cache";
+import { unwrap, unwrapRows } from "@/lib/db";
 import { createClient } from "@/lib/supabase/server";
 import type { Business } from "@/types/database";
 
@@ -73,14 +74,30 @@ export async function getPluginFlags(businessId: string): Promise<PluginFlagRows
   const sb = supabase as any;
   return unstable_cache(
     async () => {
-      const [{ data: installRows }, { data: quoting }, { data: onboarding }, { data: formBuilder }] = await Promise.all([
+      const [installRes, quotingRes, onboardingRes, formBuilderRes] = await Promise.all([
         sb.from("business_agent_installs").select("agent_id, enabled").eq("business_id", businessId),
         sb.from("quoting_agent_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
         sb.from("onboarding_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
         sb.from("form_builder_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
       ]);
+
+      // Throw rather than fall through to `?? []`. On a failed query the old
+      // code resolved to "no install rows, no settings", the resolver fell back
+      // to registry defaults, and the business's enabled plugins silently
+      // vanished from the nav — then unstable_cache stored that wrong answer for
+      // five minutes, so a one-off blip persisted long after it cleared.
+      //
+      // Throwing widens the blast radius (this backs every dashboard page), but
+      // a 500 is recoverable by refresh and now reaches Sentry, whereas
+      // half the product quietly disappearing is neither. A missing settings
+      // row is NOT an error — maybeSingle gives data:null, error:null.
+      const installRows = unwrapRows(installRes, "plugin installs") as PluginFlagRows["installRows"];
+      const quoting = unwrap(quotingRes, "quoting agent settings") as { enabled: boolean } | null;
+      const onboarding = unwrap(onboardingRes, "onboarding settings") as { enabled: boolean } | null;
+      const formBuilder = unwrap(formBuilderRes, "form builder settings") as { enabled: boolean } | null;
+
       return {
-        installRows: (installRows ?? []) as PluginFlagRows["installRows"],
+        installRows,
         quoting: quoting ? !!quoting.enabled : null,
         onboarding: onboarding ? !!onboarding.enabled : null,
         formBuilder: formBuilder ? !!formBuilder.enabled : null,


### PR DESCRIPTION
**Batch 1.2** of the fix plan.

## The trap
Callers destructure `{ data }` and ignore `{ error }`, so a failed query is indistinguishable from an empty table. The UI shows its empty state and the user believes it.

Not cosmetic: the rational response to a fabricated empty state is to **re-enter the data**. That's exactly how PR #398's duplicate customer happened — a search 400'd on a name with a comma, the caller ignored the error, the agent saw "no results" and created a second record.

## Fixed, worst first

**`addPayment`** — the insert was fired with *no destructuring at all*, so a rejected write returned normally. The recompute below then re-read the payments table (unchanged), wrote the **same** `amount_paid` back, and the UI said "Payment recorded". The user believes money was recorded against an invoice that had nothing written to it. Both follow-up updates and the parent rollup were unchecked too. Also added amount validation that never existed — a `NaN` from a bad `parseFloat` went straight to the database.

**`analytics`** — all six queries. A failure rendered £0 revenue / 0 invoices, which an owner reads as *"my business earned nothing this month"*.

**Archive actions** (`sites`, `account-contacts`, `billing-profiles`) — reported success while the row was untouched.

**`layout-data` plugin flags** — worst of the set because it **cached** the wrong answer. A failed query resolved to "no installs, no settings", the resolver fell back to registry defaults, the business's enabled plugins vanished from the nav — and `unstable_cache` served that for 5 minutes, long after the blip cleared.

## A deliberate trade
The `layout-data` change **widens** blast radius: it backs every dashboard page, so a throw 500s the app instead of degrading. I think that's right — a 500 is recoverable by refresh and now reaches **Sentry** (enabled in Phase 0), whereas half the product silently disappearing is neither recoverable nor visible.

A missing settings row is still *not* an error: `maybeSingle()` gives `data:null, error:null` and is handled exactly as before.

## Tests
Both directions — a real error throws with the underlying message; genuinely-empty still returns empty.

`tsc` clean · 92 tests pass · `npm run build` compiles.

## Not in this PR
The 19 mobile fetch sites — flagged in the plan as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)