### PR TITLE
fix(ui): confirm destructive actions, starting with the unguarded ones

### DIFF
--- a/src/components/assets/assets-view.tsx
+++ b/src/components/assets/assets-view.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
+
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -24,6 +26,7 @@ const todayISO = () => new Date().toISOString().split("T")[0];
 
 export function AssetsView({ assets, members }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [isPending, startTransition] = useTransition();
   const [addOpen, setAddOpen] = useState(false);
   const [serviceFor, setServiceFor] = useState<Asset | null>(null);
@@ -54,7 +57,14 @@ export function AssetsView({ assets, members }: Props) {
   function handleStatus(a: Asset, status: AssetStatus) {
     startTransition(async () => { try { await updateAsset(a.id, { status }); router.refresh(); } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update"); } });
   }
-  function handleDelete(id: string) {
+  // deleteAsset is a hard row delete, not an archive — the asset and its
+  // service history go for good, from an unconfirmed 16px icon.
+  async function handleDelete(id: string) {
+    if (!(await confirm({
+      title: "Delete this asset?",
+      body: "The asset and its full service history are permanently deleted. This cannot be undone.",
+      confirmLabel: "Delete asset",
+    }))) return;
     startTransition(async () => { try { await deleteAsset(id); toast.success("Deleted"); router.refresh(); } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't delete"); } });
   }
   function handleLogService() {

--- a/src/components/booking/booking-admin-client.tsx
+++ b/src/components/booking/booking-admin-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Copy, Plus, Trash2, Calendar, Clock, Users, Link2, ExternalLink } from "@/components/ui/icons";
@@ -44,6 +45,7 @@ export function BookingAdminClient({
 }) {
   const [blockUntimed, setBlockUntimed] = useState(blockUntimedJobs);
   const [forms, setForms] = useState(initialForms);
+  const confirm = useConfirm();
   const [types, setTypes] = useState(initialTypes);
   const [resources, setResources] = useState(initialResources);
   const [exceptions, setExceptions] = useState(initialExceptions);
@@ -113,13 +115,20 @@ export function BookingAdminClient({
       {selectedForm && (
         <FormEditor key={selectedForm.id} form={selectedForm} types={types} resources={resources} appUrl={appUrl}
           onChange={(f) => setForms((arr) => arr.map((x) => x.id === f.id ? f : x))}
-          onDelete={() => start(async () => {
+          onDelete={async () => {
             if (forms.length <= 1) { toast.error("Keep at least one form."); return; }
-            await deleteForm(selectedForm.id);
-            setForms((arr) => arr.filter((x) => x.id !== selectedForm.id));
-            setSelectedFormId(forms.find((x) => x.id !== selectedForm.id)?.id ?? null);
-            toast.success("Form deleted");
-          })} />
+            if (!(await confirm({
+              title: `Delete "${selectedForm.name}"?`,
+              body: "Its public booking link will stop working immediately. Anyone who has it bookmarked will get a 404.",
+              confirmLabel: "Delete form",
+            }))) return;
+            start(async () => {
+              await deleteForm(selectedForm.id);
+              setForms((arr) => arr.filter((x) => x.id !== selectedForm.id));
+              setSelectedFormId(forms.find((x) => x.id !== selectedForm.id)?.id ?? null);
+              toast.success("Form deleted");
+            });
+          }} />
       )}
 
       {/* Shared: Services */}
@@ -133,7 +142,14 @@ export function BookingAdminClient({
                 <div className="text-xs text-muted-foreground">{t.duration_minutes} min{t.price_display ? ` · ${t.price_display}` : ""}{t.active ? "" : " · hidden"}</div>
               </div>
               <Switch checked={t.active} onCheckedChange={(v) => start(async () => { await updateAppointmentType(t.id, { active: v }); setTypes((arr) => arr.map((x) => x.id === t.id ? { ...x, active: v } : x)); })} />
-              <Button size="icon" variant="ghost" onClick={() => start(async () => { await deleteAppointmentType(t.id); setTypes((arr) => arr.filter((x) => x.id !== t.id)); toast.success("Service removed"); })}><Trash2 className="size-4" /></Button>
+              <Button size="icon" variant="ghost" onClick={async () => {
+                if (!(await confirm({
+                  title: `Remove "${t.name}"?`,
+                  body: "Customers will no longer be able to book this service.",
+                  confirmLabel: "Remove service",
+                }))) return;
+                start(async () => { await deleteAppointmentType(t.id); setTypes((arr) => arr.filter((x) => x.id !== t.id)); toast.success("Service removed"); });
+              }}><Trash2 className="size-4" /></Button>
             </div>
           ))}
           {types.length === 0 && <div className="text-sm text-muted-foreground">No services yet — add one below.</div>}
@@ -153,7 +169,22 @@ export function BookingAdminClient({
           {resources.map((r) => (
             <ResourceRow key={r.id} resource={r} teamMembers={teamMembers}
               onLink={(memberId) => start(async () => { await updateResource(r.id, { member_profile_id: memberId }); setResources((arr) => arr.map((x) => x.id === r.id ? { ...x, member_profile_id: memberId } : x)); })}
-              onDelete={() => start(async () => { await deleteResource(r.id); setResources((arr) => arr.filter((x) => x.id !== r.id)); })} />
+              onDelete={async () => {
+                // appointments.resource_id REFERENCES booking_resources
+                // ON DELETE CASCADE — so this does not just remove the
+                // resource, it permanently deletes every appointment ever
+                // booked against it. That has to be said out loud.
+                if (!(await confirm({
+                  title: `Delete "${r.display_name}"?`,
+                  body: "Every appointment ever booked against this resource will be permanently deleted too, including past bookings. This cannot be undone.",
+                  confirmLabel: "Delete resource and its appointments",
+                }))) return;
+                start(async () => {
+                  await deleteResource(r.id);
+                  setResources((arr) => arr.filter((x) => x.id !== r.id));
+                  toast.success("Resource deleted");
+                });
+              }} />
           ))}
           {resources.length === 0 && <div className="text-sm text-muted-foreground">Add at least one bookable person/resource.</div>}
         </div>
@@ -167,7 +198,10 @@ export function BookingAdminClient({
           {exceptions.map((e) => (
             <div key={e.id} className="flex items-center gap-3 rounded-md border p-3 text-sm">
               <div className="flex-1">{e.date} — {e.is_closed ? "Closed" : `${e.start_time}–${e.end_time}`}{e.reason ? ` (${e.reason})` : ""}</div>
-              <Button size="icon" variant="ghost" onClick={() => start(async () => { await deleteException(e.id); setExceptions((arr) => arr.filter((x) => x.id !== e.id)); })}><Trash2 className="size-4" /></Button>
+              <Button size="icon" variant="ghost" onClick={async () => {
+                if (!(await confirm({ title: `Remove the ${e.date} exception?`, body: "Normal working hours will apply on that date again.", confirmLabel: "Remove" }))) return;
+                start(async () => { await deleteException(e.id); setExceptions((arr) => arr.filter((x) => x.id !== e.id)); });
+              }}><Trash2 className="size-4" /></Button>
             </div>
           ))}
           {exceptions.length === 0 && <div className="text-sm text-muted-foreground">No blackout dates.</div>}

--- a/src/components/expenses/expenses-view.tsx
+++ b/src/components/expenses/expenses-view.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
+
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -24,6 +26,7 @@ const woLabel = (w?: WO) => w ? (w.title || w.number || "Job") : null;
 
 export function ExpensesView({ expenses, workOrders }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -83,7 +86,14 @@ export function ExpensesView({ expenses, workOrders }: Props) {
     });
   }
 
-  function handleDelete(id: string) {
+  // Was a bare click on a 16px trash icon sitting next to the view-receipt
+  // icon — one misclick permanently destroyed a financial record.
+  async function handleDelete(id: string) {
+    if (!(await confirm({
+      title: "Delete this expense?",
+      body: "The expense and its receipt link are permanently removed. This cannot be undone.",
+      confirmLabel: "Delete expense",
+    }))) return;
     startTransition(async () => {
       try { await deleteExpense(id); toast.success("Deleted"); router.refresh(); }
       catch (err) { toast.error(err instanceof Error ? err.message : "Couldn't delete"); }

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
+
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -57,6 +59,7 @@ export function InvoiceDetailClient({
   progressInvoices = [], parentInvoice = null,
 }: InvoiceDetailClientProps) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [invoice, setInvoice] = useState(initial);
   const [editing, setEditing] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
@@ -504,7 +507,15 @@ export function InvoiceDetailClient({
                 <AnimatedPress
                   onClick={async () => {
                     if (charging) return;
-                    if (!confirm(`Charge the saved card${customer.stripe_pm_last4 ? ` •••• ${customer.stripe_pm_last4}` : ""} for the outstanding balance?`)) return;
+                    // This moves real money on a live Stripe integration, so it
+                    // gets a styled dialog naming the amount rather than an
+                    // unstyled browser prompt the browser is allowed to suppress.
+                    if (!(await confirm({
+                      title: "Charge the saved card?",
+                      body: `${formatCurrency(Number(invoice.total) - Number(invoice.amount_paid), business.currency)} will be charged immediately to ${customer.name}'s card${customer.stripe_pm_last4 ? ` ending ${customer.stripe_pm_last4}` : ""}. Refunds have to be issued from Stripe.`,
+                      confirmLabel: "Charge card",
+                      destructive: false,
+                    }))) return;
                     setCharging(true);
                     try {
                       const res = await chargeSavedCardNow(invoice.id);

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -6,6 +6,7 @@ import { AppSidebar } from "./app-sidebar";
 import { AppHeader } from "./app-header";
 import { AppearanceProvider } from "./appearance-provider";
 import { AppLoadingProvider } from "./app-loading";
+import { ConfirmProvider } from "@/components/ui/confirm";
 import { RouteProgress } from "./route-progress";
 // The floating AI assistant starts closed and drags in framer-motion + voice
 // capture. Lazy-load it (client-only) so its chunk stays out of every dashboard
@@ -37,6 +38,7 @@ export function DashboardShell({ business, businesses, user, userRole, features,
   return (
     <AppearanceProvider accentColor={business.accent_color} bgPattern={business.bg_pattern} sidebarTheme={business.sidebar_theme}>
       <AppLoadingProvider>
+      <ConfirmProvider>
       <Suspense fallback={null}><RouteProgress /></Suspense>
       <div className="flex h-screen overflow-hidden bg-background">
         {/* Sidebar */}
@@ -80,6 +82,7 @@ export function DashboardShell({ business, businesses, user, userRole, features,
       </div>
 
       <AgentPanel />
+      </ConfirmProvider>
       </AppLoadingProvider>
     </AppearanceProvider>
   );

--- a/src/components/recurring/recurring-invoices-client.tsx
+++ b/src/components/recurring/recurring-invoices-client.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
+
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, Repeat, Pause, Play, Trash2, Edit2, CreditCard, Zap } from "@/components/ui/icons";
@@ -60,6 +62,7 @@ function emptyForm() {
 
 export function RecurringInvoicesClient({ initial, customers, products, currency, stripeEnabled }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -110,7 +113,16 @@ export function RecurringInvoicesClient({ initial, customers, products, currency
   };
 
   const runNow = async (r: RecurringInvoice) => {
-    if (!confirm(`Generate ${r.name} now${r.auto_charge ? " and charge the saved card" : ""}?`)) return;
+    // When auto_charge is on this bills a real customer immediately — worth a
+    // dialog that says so plainly rather than a browser prompt.
+    if (!(await confirm({
+      title: `Run "${r.name}" now?`,
+      body: r.auto_charge
+        ? "An invoice will be generated AND the customer's saved card charged immediately. This is outside the normal schedule."
+        : "An invoice will be generated now and emailed to the customer, outside the normal schedule.",
+      confirmLabel: r.auto_charge ? "Generate and charge" : "Generate now",
+      destructive: false,
+    }))) return;
     setBusyId(r.id);
     try {
       const res = await runRecurringInvoiceNow(r.id);

--- a/src/components/settings/team-settings.tsx
+++ b/src/components/settings/team-settings.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
+
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Loader2, UserPlus, Trash2, Crown, ShieldCheck, Pencil, Eye, Link2, Wrench } from "@/components/ui/icons";
@@ -42,6 +44,7 @@ export function TeamSettings({ members: initialMembers, ownerEmail, userRole }: 
   const [role, setRole] = useState<MemberRole>("editor");
   const [isPending, startTransition] = useTransition();
   const [removingId, setRemovingId] = useState<string | null>(null);
+  const confirm = useConfirm();
   const [updatingId, setUpdatingId] = useState<string | null>(null);
 
   const handleAdd = () => {
@@ -89,7 +92,14 @@ export function TeamSettings({ members: initialMembers, ownerEmail, userRole }: 
     });
   };
 
-  const handleRemove = (memberId: string, memberEmail: string) => {
+  const handleRemove = async (memberId: string, memberEmail: string) => {
+    // Was unguarded: one click on a trash icon revoked a colleague's access
+    // with no way back except re-inviting them.
+    if (!(await confirm({
+      title: `Remove ${memberEmail}?`,
+      body: "They lose access to this business immediately. Their work stays, but they will need a fresh invite to get back in.",
+      confirmLabel: "Remove member",
+    }))) return;
     setRemovingId(memberId);
     startTransition(async () => {
       try {

--- a/src/components/tasks/kanban-board.tsx
+++ b/src/components/tasks/kanban-board.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useConfirm } from "@/components/ui/confirm";
+
 import { useMemo, useState, useTransition } from "react";
 import {
   DndContext,
@@ -68,6 +70,7 @@ export function KanbanBoard({
   contacts?: ContactLite[];
 }) {
   const [tasks, setTasks] = useState<Task[]>(initialTasks);
+  const confirm = useConfirm();
   const [activeId, setActiveId] = useState<string | null>(null);
   const [editing, setEditing] = useState<Task | null>(null);
   const [composerStatus, setComposerStatus] = useState<TaskStatus | null>(null);
@@ -217,11 +220,23 @@ export function KanbanBoard({
   }
 
   async function handleDelete(id: string) {
+    // Was unguarded, and the optimistic removal below means a misclick made the
+    // task vanish instantly with no undo and no confirmation.
+    if (!(await confirm({
+      title: "Delete this task?",
+      body: "The task and its details are permanently removed. This cannot be undone.",
+      confirmLabel: "Delete task",
+    }))) return;
+
     setTasks((prev) => prev.filter((t) => t.id !== id));
     setEditing(null);
     try {
       await deleteTask({ id });
     } catch (err) {
+      // NOTE (separate from this batch): the optimistic removal above already
+      // hid the task, so a failure here leaves the board showing it as deleted
+      // when it was not. Needs a rollback + toast; this file imports neither
+      // sonner nor useRouter, so it is left for the error-handling sweep.
       console.error("deleteTask failed", err);
     }
   }

--- a/src/components/ui/confirm.tsx
+++ b/src/components/ui/confirm.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/**
+ * One confirmation dialog for the whole app.
+ *
+ * Two problems this replaces:
+ *
+ * 1. Destructive actions with NO confirmation at all — a 16px trash icon that
+ *    permanently deletes a financial record, removes a team member, or (worst)
+ *    deletes a booking resource, which CASCADEs to every appointment ever
+ *    booked against it (appointments.resource_id ... ON DELETE CASCADE).
+ *
+ * 2. Native `window.confirm()` — which does technically confirm, but is
+ *    unstyled, blocks the main thread, is suppressible by the browser ("prevent
+ *    this page from creating additional dialogs"), and cannot show the one thing
+ *    that matters: WHAT ELSE goes with it.
+ *
+ * The API deliberately mirrors `confirm()` so migrating a call site is nearly
+ * mechanical:
+ *
+ *     if (!(await confirm({ title: "Delete this?" }))) return;
+ */
+
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export interface ConfirmOptions {
+  title: string;
+  /** The consequence. Spell out anything that goes with it — cascades especially. */
+  body?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Red confirm button. Default true: this exists for destructive actions. */
+  destructive?: boolean;
+}
+
+type Ask = (opts: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<Ask | null>(null);
+
+export function ConfirmProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [opts, setOpts] = useState<ConfirmOptions | null>(null);
+  const resolver = useRef<((ok: boolean) => void) | null>(null);
+
+  const ask = useCallback<Ask>((next) => {
+    setOpts(next);
+    setOpen(true);
+    return new Promise<boolean>((resolve) => { resolver.current = resolve; });
+  }, []);
+
+  const settle = (ok: boolean) => {
+    setOpen(false);
+    // Resolve after the state update so the caller never runs against a dialog
+    // that is still visually open.
+    const r = resolver.current;
+    resolver.current = null;
+    r?.(ok);
+  };
+
+  return (
+    <ConfirmContext.Provider value={ask}>
+      {children}
+      <AlertDialog
+        open={open}
+        // Covers Escape and outside-click, which must count as "cancel" rather
+        // than leaving the promise dangling forever.
+        onOpenChange={(v) => { if (!v) settle(false); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{opts?.title}</AlertDialogTitle>
+            {opts?.body && <AlertDialogDescription>{opts.body}</AlertDialogDescription>}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => settle(false)}>
+              {opts?.cancelLabel ?? "Cancel"}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => settle(true)}
+              className={opts?.destructive === false ? undefined : "bg-destructive text-destructive-foreground hover:bg-destructive/90"}
+            >
+              {opts?.confirmLabel ?? "Confirm"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </ConfirmContext.Provider>
+  );
+}
+
+/**
+ * Ask the user to confirm. Resolves false on cancel, Escape or outside-click.
+ *
+ * Falls back to native confirm() when no provider is mounted — some surfaces
+ * (the customer portal, the public booking manager) render outside the
+ * dashboard shell, and a missing provider must not mean "no confirmation".
+ */
+export function useConfirm(): Ask {
+  const ctx = useContext(ConfirmContext);
+  return useCallback<Ask>(
+    (opts) => {
+      if (ctx) return ctx(opts);
+      const text = opts.body ? `${opts.title}\n\n${opts.body}` : opts.title;
+      return Promise.resolve(window.confirm(text));
+    },
+    [ctx],
+  );
+}


### PR DESCRIPTION
**Batch 1.3** of the fix plan. One confirmation primitive (`ConfirmProvider` + `useConfirm`), applied where an action was **genuinely unguarded** — a bare click that destroyed something.

```ts
if (!(await confirm({ title: "Delete this?" }))) return;
```

Mirrors `window.confirm()` so migration is mechanical, and falls back to it when no provider is mounted — the customer portal and public booking manager render outside the dashboard shell, and a missing provider must never mean *no* confirmation.

## Worst first: booking resources
Verified against the schema rather than assumed:

```sql
appointments.resource_id UUID NOT NULL
  REFERENCES public.booking_resources(id) ON DELETE CASCADE
```

Deleting a bookable resource **permanently destroyed every appointment ever booked against it**, including past bookings — from one unconfirmed click on a 16px trash icon. The dialog now says exactly that.

## Newly guarded (previously nothing asked)
| Action | Why it matters |
|---|---|
| Booking form delete | Kills a live public booking link — bookmarks 404 |
| Booking service type / availability exception | Customers silently lose the ability to book |
| Remove team member | Access revoked instantly, re-invite required |
| Delete expense | Permanent loss of a financial record |
| Delete asset | **Hard row delete**, not archive — service history goes too |
| Delete task | Removed optimistically, so a misclick vanished instantly |

## Upgraded from native `confirm()` — the two money actions
- **Charge saved card** — moves real money on a live Stripe integration; the dialog now names the amount and the card, and notes refunds must go through Stripe
- **Run recurring invoice now** — bills a customer immediately when `auto_charge` is on

## Scope, stated honestly
**13 native `confirm()` calls remain** (7 in `job-portfolio-client`, plus forms, onboarding, quoting-agent, stripe-settings, manage-widget).

The audit counted these as "no confirmation". That's wrong — `window.confirm` **does** confirm. They're an inconsistency and a UX problem, not a safety one, so they're a follow-up rather than padding this PR. Every case where *nothing asked at all* is now closed.

## Deliberately left alone
kanban's `handleDelete` removes the task optimistically and swallows the failure, so a failed delete leaves the board lying about what happened. That's an error-handling bug, not a confirmation one, and the file imports neither `sonner` nor `useRouter`. Noted in a comment for the error sweep rather than widening this change.

`tsc` clean · tests pass · `npm run build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)