### PR TITLE
feat: document templates for invoices & quotes (editor + presets + per-doc selection)

### DIFF
--- a/src/app/(dashboard)/settings/document-templates/page.tsx
+++ b/src/app/(dashboard)/settings/document-templates/page.tsx
@@ -1,0 +1,9 @@
+import { getDocumentTemplates } from "@/lib/actions/document-templates";
+import { DocumentTemplatesClient } from "@/components/settings/document-templates-client";
+
+export const metadata = { title: "Document Templates" };
+
+export default async function DocumentTemplatesPage() {
+  const templates = await getDocumentTemplates();
+  return <DocumentTemplatesClient initialTemplates={templates} />;
+}

--- a/src/app/api/pdf/invoice/[id]/route.ts
+++ b/src/app/api/pdf/invoice/[id]/route.ts
@@ -3,6 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getInvoice } from "@/lib/actions/invoices";
 import { getBusiness } from "@/lib/actions/business";
+import { resolveDocumentConfig } from "@/lib/documents/resolve";
+import { registerPdfFonts } from "@/lib/documents/template-config";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -15,9 +17,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     let inv: any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let business: any;
+    // Client used to resolve the template config (admin for token path, the
+    // RLS-scoped server client for signed-in users).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resolverSb: any;
 
     if (token) {
       const sb = createAdminClient();
+      resolverSb = sb;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tbl = (s: any, n: string) => s.from(n);
 
@@ -51,6 +58,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       business = bizData as any;
     } else {
       const supabase = await createClient();
+      resolverSb = supabase;
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
@@ -64,17 +72,29 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     const customer = inv.customers ?? null;
     const lineItems = inv.line_items ?? [];
 
+    // Resolve the template config. `?template=` lets the authenticated editor
+    // preview a specific template without saving it to the invoice; the public
+    // token path never honours it.
+    const previewTemplateId = token ? null : req.nextUrl.searchParams.get("template");
+    const config = await resolveDocumentConfig(resolverSb, {
+      businessId: business.id,
+      docType: "invoice",
+      templateId: previewTemplateId ?? inv.template_id ?? null,
+      pdfSettings: business.pdf_settings ?? null,
+    });
+
     // Dynamic import to avoid SSR issues
-    const { renderToStream } = await import("@react-pdf/renderer");
+    const { renderToStream, Font } = await import("@react-pdf/renderer");
     const { InvoicePDFDocument } = await import("@/components/invoices/invoice-pdf-document");
     const React = await import("react");
+    registerPdfFonts(Font);
 
     const element = React.createElement(InvoicePDFDocument, {
       invoice: inv,
       customer,
       business,
       lineItems,
-      pdfSettings: business.pdf_settings ?? null,
+      config,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/pdf/quote/[id]/route.ts
+++ b/src/app/api/pdf/quote/[id]/route.ts
@@ -3,6 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getQuote } from "@/lib/actions/quotes";
 import { getBusiness } from "@/lib/actions/business";
+import { resolveDocumentConfig } from "@/lib/documents/resolve";
+import { registerPdfFonts } from "@/lib/documents/template-config";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -17,9 +19,12 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     let business: any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let customer: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resolverSb: any;
 
     if (token) {
       const sb = createAdminClient();
+      resolverSb = sb;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tbl = (s: any, n: string) => s.from(n);
 
@@ -52,6 +57,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       customer = cust;
     } else {
       const supabase = await createClient();
+      resolverSb = supabase;
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
@@ -63,16 +69,25 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
     const lineItems = quote.line_items ?? [];
 
-    const { renderToStream } = await import("@react-pdf/renderer");
+    const previewTemplateId = token ? null : req.nextUrl.searchParams.get("template");
+    const config = await resolveDocumentConfig(resolverSb, {
+      businessId: business.id,
+      docType: "quote",
+      templateId: previewTemplateId ?? quote.template_id ?? null,
+      pdfSettings: business?.pdf_settings ?? null,
+    });
+
+    const { renderToStream, Font } = await import("@react-pdf/renderer");
     const { QuotePDFDocument } = await import("@/components/quotes/quote-pdf-document");
     const React = await import("react");
+    registerPdfFonts(Font);
 
     const element = React.createElement(QuotePDFDocument, {
       quote,
       customer,
       business,
       lineItems,
-      pdfSettings: business?.pdf_settings ?? null,
+      config,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/pdf/template-preview/route.ts
+++ b/src/app/api/pdf/template-preview/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getBusiness } from "@/lib/actions/business";
+import { DEFAULT_TEMPLATE_CONFIG, registerPdfFonts } from "@/lib/documents/template-config";
+import type { TemplateConfig } from "@/lib/documents/template-config";
+
+// Live preview for the template editor. POST { doc_type, config } → a PDF of a
+// representative sample document rendered with that (possibly unsaved) config.
+// Authenticated (editor only); returns inline PDF for an <iframe>/<embed>.
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const body = (await req.json()) as { doc_type?: "invoice" | "quote"; config?: Partial<TemplateConfig> };
+    const docType = body.doc_type === "quote" ? "quote" : "invoice";
+    const config: TemplateConfig = {
+      ...DEFAULT_TEMPLATE_CONFIG,
+      document_title: docType === "quote" ? "QUOTATION" : DEFAULT_TEMPLATE_CONFIG.document_title,
+      ...(body.config ?? {}),
+    };
+    if (!Array.isArray(config.columns) || config.columns.length === 0) config.columns = DEFAULT_TEMPLATE_CONFIG.columns;
+    if (!Array.isArray(config.custom_fields)) config.custom_fields = [];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const business = (await getBusiness()) as any;
+
+    const sampleCustomer = {
+      id: "sample", name: "Sample Customer Pty Ltd", company: "Sample Co", email: "customer@example.com",
+      phone: "0400 000 000", address: "12 Example Street", city: "Sydney", postcode: "2000",
+      country: "Australia", tax_number: "12 345 678 901",
+    };
+    const sampleItems = [
+      { id: "1", name: "Labour — installation", description: "On-site work, 2 crew", quantity: 8, unit_price: 95, tax_rate: 10, total: 760 },
+      { id: "2", name: "Materials", description: "Fixings, sealant, sundries", quantity: 1, unit_price: 240, tax_rate: 10, total: 240 },
+      { id: "3", name: "Site clean-up", description: "", quantity: 1, unit_price: 120, tax_rate: 10, total: 120 },
+    ];
+    const subtotal = 1120, tax_total = 112, total = 1232;
+    const today = new Date().toISOString();
+    const later = new Date(Date.now() + 14 * 864e5).toISOString();
+
+    const { renderToStream, Font } = await import("@react-pdf/renderer");
+    const React = await import("react");
+    registerPdfFonts(Font);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let element: any;
+    if (docType === "quote") {
+      const { QuotePDFDocument } = await import("@/components/quotes/quote-pdf-document");
+      element = React.createElement(QuotePDFDocument, {
+        quote: { id: "sample", number: "QUO-0001", status: "sent", issue_date: today, expiry_date: later,
+          subtotal, discount_amount: 0, tax_total, total, notes: "Thank you for the opportunity to quote.\nPrices held for 14 days.",
+          terms: "50% deposit to commence.\nBalance on completion.", property_address: "12 Example Street, Sydney 2000" } as never,
+        customer: sampleCustomer as never, business, lineItems: sampleItems as never, config,
+      });
+    } else {
+      const { InvoicePDFDocument } = await import("@/components/invoices/invoice-pdf-document");
+      element = React.createElement(InvoicePDFDocument, {
+        invoice: { id: "sample", number: "INV-0001", status: "sent", issue_date: today, due_date: later,
+          subtotal, discount_amount: 0, tax_total, total, amount_paid: 0,
+          notes: "Thank you for your business.", terms: "Payment due within 14 days.",
+          property_address: "12 Example Street, Sydney 2000" } as never,
+        customer: sampleCustomer as never, business, lineItems: sampleItems as never, config,
+      });
+    }
+
+    const stream = await renderToStream(element);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return new NextResponse(Buffer.concat(chunks), {
+      headers: { "Content-Type": "application/pdf", "Content-Disposition": "inline; filename=preview.pdf", "Cache-Control": "no-store" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[PDF/preview]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/documents/template-picker.tsx
+++ b/src/components/documents/template-picker.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getDocumentTemplates, setDocumentTemplate } from "@/lib/actions/document-templates";
+
+/**
+ * Per-document template selector shown on the invoice/quote detail pages.
+ * Self-fetches the business's templates; renders nothing until at least one
+ * exists, so it stays invisible for businesses that never made a template.
+ */
+export function TemplatePicker({ docType, docId, currentTemplateId }: {
+  docType: "invoice" | "quote";
+  docId: string;
+  currentTemplateId?: string | null;
+}) {
+  const router = useRouter();
+  const [opts, setOpts] = useState<{ id: string; name: string }[] | null>(null);
+  const [val, setVal] = useState(currentTemplateId ?? "");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    getDocumentTemplates(docType)
+      .then((t) => setOpts(t.map((x) => ({ id: x.id, name: x.name }))))
+      .catch(() => setOpts([]));
+  }, [docType]);
+
+  if (!opts || opts.length === 0) return null;
+
+  return (
+    <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      Template
+      <select
+        value={val}
+        disabled={saving}
+        onChange={async (e) => {
+          const v = e.target.value;
+          setVal(v);
+          setSaving(true);
+          try {
+            await setDocumentTemplate(docType, docId, v || null);
+            router.refresh();
+          } finally {
+            setSaving(false);
+          }
+        }}
+        className="h-8 rounded-md border border-border bg-card px-2 text-sm text-foreground max-w-[180px]"
+      >
+        <option value="">Business default</option>
+        {opts.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+      </select>
+    </label>
+  );
+}

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -21,6 +21,7 @@ import { chargeSavedCardNow } from "@/lib/actions/stripe";
 import { SendDocumentModal } from "@/components/send/send-document-modal";
 import { InvoiceEditor } from "./invoice-editor";
 import { InvoicePDFDownload } from "./invoice-pdf";
+import { TemplatePicker } from "@/components/documents/template-picker";
 import { ProgressInvoiceModal } from "./progress-invoice-modal";
 import { DeliveryStatusCard } from "@/components/delivery/delivery-status-card";
 import { ScheduledSendsCard } from "@/components/delivery/scheduled-sends-card";
@@ -236,6 +237,7 @@ export function InvoiceDetailClient({
                 <Link2 className="w-4 h-4" /> Share
               </AnimatedPress>
             )}
+            <TemplatePicker docType="invoice" docId={invoice.id} currentTemplateId={invoice.template_id} />
             <InvoicePDFDownload invoiceId={invoice.id} invoiceNumber={invoice.number} />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/src/components/invoices/invoice-pdf-document.tsx
+++ b/src/components/invoices/invoice-pdf-document.tsx
@@ -1,16 +1,13 @@
 import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/renderer";
 import type { Business, Customer, Invoice, LineItem, PdfSettings } from "@/types/database";
-import { DEFAULT_PDF_SETTINGS } from "@/types/database";
+import type { TemplateConfig, TemplateColumn } from "@/lib/documents/template-config";
+import { resolveTemplateConfig, fontFamilyFor, resolvePlaceholders } from "@/lib/documents/template-config";
 
 function fmtCurrency(amount: number, currency: string): string {
   return new Intl.NumberFormat("en-AU", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    style: "currency", currency, minimumFractionDigits: 2, maximumFractionDigits: 2,
   }).format(amount);
 }
-
 function fmtDate(d: string): string {
   return new Date(d).toLocaleDateString("en-AU", { day: "2-digit", month: "short", year: "numeric" });
 }
@@ -20,149 +17,192 @@ interface Props {
   customer: Customer | null;
   business: Business;
   lineItems: LineItem[];
+  /** Preferred: a fully-resolved template config. */
+  config?: TemplateConfig | null;
+  /** Back-compat: legacy per-business settings (used when `config` is absent). */
   pdfSettings?: PdfSettings | null;
 }
 
-export function InvoicePDFDocument({ invoice, customer, business, lineItems, pdfSettings }: Props) {
-  const settings: PdfSettings = { ...DEFAULT_PDF_SETTINGS, ...(pdfSettings ?? business.pdf_settings ?? {}) };
+export function InvoicePDFDocument({ invoice, customer, business, lineItems, config, pdfSettings }: Props) {
+  const cfg: TemplateConfig = config ?? resolveTemplateConfig({
+    pdfSettings: pdfSettings ?? business.pdf_settings ?? null,
+    docType: "invoice",
+  });
+
   const currency = business.currency ?? "AUD";
   const fmt = (amount: number) => fmtCurrency(amount, currency);
-  const primary = settings.primary_color;
-  const logoSize = settings.logo_size;
-  const template = settings.invoice_template;
+  const scale = cfg.font_scale || 1;
+  const fs = (n: number) => Math.round(n * scale * 10) / 10;
 
-  const isMinimal = template === "minimal";
-  const isModern = template === "modern";
+  const fam = fontFamilyFor(cfg.font_family);
+  const isHelv = cfg.font_family === "helvetica";
+  const bold = isHelv ? { fontFamily: "Helvetica-Bold" as const } : { fontFamily: fam.bold, fontWeight: 700 as const };
 
-  const muted = "#64748b";
+  const primary = cfg.primary_color;
+  const text = cfg.text_color;
+  const muted = cfg.muted_color;
+  const heading = cfg.heading_color;
   const border = "#e2e8f0";
-  const text = "#0f172a";
   const white = "#ffffff";
-  const bg = isMinimal ? white : "#f8fafc";
+  const isMinimal = cfg.base === "minimal";
+  const isModern = cfg.base === "modern";
+
+  // Placeholders available to custom fields.
+  const vars: Record<string, string> = {
+    customer_name: customer?.name ?? "",
+    customer_company: customer?.company ?? "",
+    customer_email: customer?.email ?? "",
+    invoice_number: invoice.number,
+    document_number: invoice.number,
+    issue_date: fmtDate(invoice.issue_date),
+    due_date: fmtDate(invoice.due_date),
+    total: fmt(invoice.total),
+    balance: fmt(invoice.total - invoice.amount_paid),
+    business_name: business.name,
+    property_address: invoice.property_address ?? "",
+  };
+  const fieldsAt = (p: "header" | "meta" | "footer") =>
+    cfg.custom_fields.filter((f) => f.placement === p && (f.label || f.value));
 
   const styles = StyleSheet.create({
-    page: { fontFamily: "Helvetica", fontSize: 9, color: text, padding: 40, backgroundColor: white },
+    page: { fontFamily: fam.regular, fontSize: fs(9), color: text, padding: 40, backgroundColor: cfg.background_color },
+    bgLayer: { position: "absolute", top: 0, left: 0, right: 0, bottom: 0 },
+    bgImage: { width: "100%", height: "100%", objectFit: "cover", opacity: cfg.background_image_opacity },
+    watermark: { position: "absolute", top: "42%", left: 0, right: 0, textAlign: "center", fontSize: 90, color: muted, opacity: cfg.watermark_opacity, transform: "rotate(-24deg)", ...bold },
 
-    // ── Header ──
     header: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", marginBottom: isModern ? 0 : 32 },
     headerModernWrap: { marginBottom: 28 },
-    modernTopBar: { backgroundColor: "#111827", flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingHorizontal: 40, paddingVertical: 14, marginHorizontal: -40, marginTop: -40, marginBottom: 24 },
-    logo: { width: logoSize, height: logoSize, objectFit: "contain" },
-    businessName: { fontSize: 13, fontFamily: "Helvetica-Bold", marginBottom: 3 },
-    businessDetail: { color: muted, fontSize: 8, lineHeight: 1.5 },
+    modernTopBar: { backgroundColor: cfg.secondary_color, flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingHorizontal: 40, paddingVertical: 14, marginHorizontal: -40, marginTop: -40, marginBottom: 24 },
+    logo: { width: cfg.logo_size, height: cfg.logo_size, objectFit: "contain", marginBottom: 8 },
+    bizBlock: { alignItems: cfg.logo_position === "center" ? "center" : cfg.logo_position === "right" ? "flex-end" : "flex-start" },
+    businessName: { fontSize: fs(13), ...bold, marginBottom: 3, color: heading },
+    businessDetail: { color: muted, fontSize: fs(8), lineHeight: 1.5 },
 
-    invoiceLabelClassic: { fontSize: 22, fontFamily: "Helvetica-Bold", color: primary, textAlign: "right" },
-    invoiceLabelMinimal: { fontSize: 22, fontFamily: "Helvetica-Bold", color: text, textAlign: "right" },
-    invoiceLabelModern: { fontSize: 22, fontFamily: "Helvetica-Bold", color: white, textAlign: "right" },
-    invoiceNumber: { fontSize: 16, fontFamily: "Helvetica-Bold", textAlign: "right", marginTop: 2 },
-    invoiceNumberModern: { fontSize: 16, fontFamily: "Helvetica-Bold", color: white, textAlign: "right", marginTop: 2 },
-    minimalRule: { borderBottomWidth: 2, borderBottomColor: text, marginBottom: 24 },
+    docLabel: { fontSize: fs(22), ...bold, color: isModern ? white : (isMinimal ? heading : primary), textAlign: "right" },
+    docNumber: { fontSize: fs(16), ...bold, textAlign: "right", marginTop: 2, color: isModern ? white : text },
+    minimalRule: { borderBottomWidth: 2, borderBottomColor: heading, marginBottom: 24 },
 
-    // ── Section ──
     section: { flexDirection: "row", justifyContent: "space-between", marginBottom: 24 },
-    billToLabel: { fontSize: 7, fontFamily: "Helvetica-Bold", color: muted, textTransform: "uppercase", letterSpacing: 1, marginBottom: 6 },
-    billToName: { fontFamily: "Helvetica-Bold", fontSize: 10, marginBottom: 3 },
+    smallLabel: { fontSize: fs(7), ...bold, color: muted, textTransform: "uppercase", letterSpacing: 1, marginBottom: 6 },
+    billToName: { ...bold, fontSize: fs(10), marginBottom: 3, color: heading },
     billToDetail: { color: muted, lineHeight: 1.5 },
     dateRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 4 },
-    dateLabel: { color: muted, fontSize: 8, width: 60 },
-    dateValue: { fontFamily: "Helvetica-Bold", textAlign: "right" },
+    dateLabel: { color: muted, fontSize: fs(8) },
+    dateValue: { ...bold, textAlign: "right" },
 
-    // ── Table ──
-    tableHeader: {
-      flexDirection: "row",
-      backgroundColor: isMinimal ? white : bg,
-      padding: "8 10",
-      borderRadius: isMinimal ? 0 : 4,
-      borderBottomWidth: isMinimal ? 1 : 0,
-      borderBottomColor: text,
-      marginBottom: 2,
-    },
+    tableHeader: { flexDirection: "row", backgroundColor: isMinimal ? white : cfg.table_header_bg, padding: "8 10", borderRadius: isMinimal ? 0 : 4, borderBottomWidth: isMinimal ? 1 : 0, borderBottomColor: heading, marginBottom: 2 },
     tableRow: { flexDirection: "row", padding: "8 10", borderBottomWidth: 1, borderBottomColor: border, borderStyle: "dashed" },
-    tableItem: { flex: 1 },
-    tableItemName: { fontFamily: "Helvetica-Bold", marginBottom: 2 },
-    tableItemDesc: { color: muted, fontSize: 8 },
-    tableQty: { width: 40, textAlign: "center" },
-    tablePrice: { width: 60, textAlign: "right" },
-    tableTax: { width: 40, textAlign: "center" },
-    tableTotal: { width: 70, textAlign: "right", fontFamily: "Helvetica-Bold" },
-    colHeader: { fontSize: 7, fontFamily: "Helvetica-Bold", color: isMinimal ? text : muted, textTransform: "uppercase", letterSpacing: 0.5 },
+    colHeader: { fontSize: fs(7), ...bold, color: isMinimal ? heading : cfg.table_header_text, textTransform: "uppercase", letterSpacing: 0.5 },
+    cellName: { ...bold, marginBottom: 2 },
+    cellDesc: { color: muted, fontSize: fs(8) },
 
-    // ── Totals ──
     totalsSection: { flexDirection: "row", justifyContent: "flex-end", marginTop: 16 },
     totalsBox: { width: 200 },
     totalRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 6 },
     totalLabel: { color: muted },
-    grandTotalRow: { flexDirection: "row", justifyContent: "space-between", borderTopWidth: 1.5, borderTopColor: text, paddingTop: 8, marginTop: 4 },
-    grandTotalLabel: { fontFamily: "Helvetica-Bold", fontSize: 11 },
-    grandTotalValue: { fontFamily: "Helvetica-Bold", fontSize: 11, color: isMinimal ? text : primary },
+    grandTotalRow: { flexDirection: "row", justifyContent: "space-between", borderTopWidth: 1.5, borderTopColor: heading, paddingTop: 8, marginTop: 4 },
+    grandTotalLabel: { ...bold, fontSize: fs(11) },
+    grandTotalValue: { ...bold, fontSize: fs(11), color: isMinimal ? heading : primary },
 
-    // ── Footer ──
     footer: { marginTop: 32, paddingTop: 16, borderTopWidth: 1, borderTopColor: border, flexDirection: "row", justifyContent: "space-between" },
     footerSection: { flex: 1, marginRight: 20 },
-    footerTitle: { fontSize: 7, fontFamily: "Helvetica-Bold", color: muted, textTransform: "uppercase", letterSpacing: 0.5, marginBottom: 6 },
-    footerText: { color: muted, lineHeight: 1.6, fontSize: 8 },
+    footerTitle: { fontSize: fs(7), ...bold, color: muted, textTransform: "uppercase", letterSpacing: 0.5, marginBottom: 6 },
+    footerText: { color: muted, lineHeight: 1.6, fontSize: fs(8) },
     bankRow: { flexDirection: "row", marginBottom: 3 },
     bankLabel: { color: muted, width: 70 },
     bankValue: { flex: 1 },
     badge: { paddingHorizontal: 8, paddingVertical: 3, borderRadius: 4, alignSelf: "flex-start" },
     paidBadge: { backgroundColor: "#dcfce7" },
-    paidText: { color: "#16a34a", fontFamily: "Helvetica-Bold", fontSize: 8 },
+    paidText: { color: "#16a34a", ...bold, fontSize: fs(8) },
+    fieldRow: { flexDirection: "row", marginBottom: 2 },
+    fieldLabel: { color: muted, marginRight: 4 },
   });
 
-  const invoiceTitle = settings.invoice_title;
+  // Column geometry: fixed widths for the numeric columns, description flexes.
+  const colStyle = (key: TemplateColumn["key"]) => {
+    switch (key) {
+      case "description": return { flex: 1 };
+      case "quantity": return { width: 40, textAlign: "center" as const };
+      case "unit_price": return { width: 60, textAlign: "right" as const };
+      case "tax": return { width: 40, textAlign: "center" as const };
+      case "total": return { width: 70, textAlign: "right" as const };
+    }
+  };
+  const visibleCols = cfg.columns.filter((c) => c.visible);
+  const cellValue = (item: LineItem, key: TemplateColumn["key"]) => {
+    switch (key) {
+      case "quantity": return String(item.quantity);
+      case "unit_price": return fmt(item.unit_price);
+      case "tax": return `${item.tax_rate}%`;
+      case "total": return fmt(item.total);
+      default: return null;
+    }
+  };
 
-  // Classic / Minimal header
+  const CustomFields = ({ where }: { where: "header" | "meta" | "footer" }) => {
+    const list = fieldsAt(where);
+    if (!list.length) return null;
+    return (
+      <View style={where === "footer" ? styles.footerSection : { marginTop: where === "meta" ? 8 : 6 }}>
+        {where === "footer" && <Text style={styles.footerTitle}>Details</Text>}
+        {list.map((f) => (
+          <View key={f.id} style={styles.fieldRow}>
+            {f.label ? <Text style={[styles.fieldLabel, where !== "footer" ? bold : {}]}>{f.label}:</Text> : null}
+            <Text style={where === "footer" ? styles.footerText : {}}>{resolvePlaceholders(f.value, vars)}</Text>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  const BizDetails = () => (
+    <>
+      {business.address && <Text style={styles.businessDetail}>{business.address}</Text>}
+      {business.city && <Text style={styles.businessDetail}>{business.city}{business.postcode ? `, ${business.postcode}` : ""}</Text>}
+      {business.email && <Text style={styles.businessDetail}>{business.email}</Text>}
+      {business.phone && <Text style={styles.businessDetail}>{business.phone}</Text>}
+      {business.tax_number && <Text style={styles.businessDetail}>ABN: {business.tax_number}</Text>}
+    </>
+  );
+
+  const PaidBadge = ({ mt = 0 }: { mt?: number }) => invoice.status === "paid" ? (
+    <View style={[styles.badge, styles.paidBadge, mt ? { marginTop: mt } : {}]}><Text style={styles.paidText}>PAID</Text></View>
+  ) : null;
+
   const ClassicHeader = () => (
     <View style={styles.header}>
-      <View>
-        {business.logo_url && <Image src={business.logo_url} style={styles.logo} />}
+      <View style={styles.bizBlock}>
+        {cfg.show_logo && business.logo_url && <Image src={business.logo_url} style={styles.logo} />}
         <Text style={styles.businessName}>{business.name}</Text>
-        {business.address && <Text style={styles.businessDetail}>{business.address}</Text>}
-        {business.city && <Text style={styles.businessDetail}>{business.city}{business.postcode ? `, ${business.postcode}` : ""}</Text>}
-        {business.email && <Text style={styles.businessDetail}>{business.email}</Text>}
-        {business.phone && <Text style={styles.businessDetail}>{business.phone}</Text>}
-        {business.tax_number && <Text style={styles.businessDetail}>ABN: {business.tax_number}</Text>}
+        <BizDetails />
+        <CustomFields where="header" />
       </View>
       <View>
-        <Text style={isMinimal ? styles.invoiceLabelMinimal : styles.invoiceLabelClassic}>{invoiceTitle}</Text>
-        <Text style={styles.invoiceNumber}>{invoice.number}</Text>
-        {invoice.status === "paid" && (
-          <View style={[styles.badge, styles.paidBadge]}>
-            <Text style={styles.paidText}>PAID</Text>
-          </View>
-        )}
+        <Text style={styles.docLabel}>{cfg.document_title}</Text>
+        <Text style={styles.docNumber}>{invoice.number}</Text>
+        <PaidBadge />
       </View>
     </View>
   );
 
-  // Modern header (dark top bar)
   const ModernHeader = () => (
     <View style={styles.headerModernWrap}>
       <View style={styles.modernTopBar}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
-          {business.logo_url && <Image src={business.logo_url} style={[styles.logo, { marginBottom: 0 }]} />}
+          {cfg.show_logo && business.logo_url && <Image src={business.logo_url} style={[styles.logo, { marginBottom: 0 }]} />}
           <View>
-            <Text style={{ fontFamily: "Helvetica-Bold", fontSize: 13, color: white }}>{business.name}</Text>
-            {business.email && <Text style={{ fontSize: 8, color: "#9ca3af" }}>{business.email}</Text>}
+            <Text style={{ ...bold, fontSize: fs(13), color: white }}>{business.name}</Text>
+            {business.email && <Text style={{ fontSize: fs(8), color: "#cbd5e1" }}>{business.email}</Text>}
           </View>
         </View>
         <View style={{ alignItems: "flex-end" }}>
-          <Text style={styles.invoiceLabelModern}>{invoiceTitle}</Text>
-          <Text style={styles.invoiceNumberModern}>{invoice.number}</Text>
-          {invoice.status === "paid" && (
-            <View style={[styles.badge, styles.paidBadge, { marginTop: 3 }]}>
-              <Text style={styles.paidText}>PAID</Text>
-            </View>
-          )}
+          <Text style={styles.docLabel}>{cfg.document_title}</Text>
+          <Text style={styles.docNumber}>{invoice.number}</Text>
+          <PaidBadge mt={3} />
         </View>
       </View>
       <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-        <View>
-          {business.address && <Text style={styles.businessDetail}>{business.address}</Text>}
-          {business.city && <Text style={styles.businessDetail}>{business.city}{business.postcode ? `, ${business.postcode}` : ""}</Text>}
-          {business.phone && <Text style={styles.businessDetail}>{business.phone}</Text>}
-          {business.tax_number && <Text style={styles.businessDetail}>ABN: {business.tax_number}</Text>}
-        </View>
+        <View><BizDetails /><CustomFields where="header" /></View>
       </View>
     </View>
   );
@@ -170,13 +210,18 @@ export function InvoicePDFDocument({ invoice, customer, business, lineItems, pdf
   return (
     <Document>
       <Page size="A4" style={styles.page}>
+        {cfg.background_image_url && (
+          <View style={styles.bgLayer} fixed><Image src={cfg.background_image_url} style={styles.bgImage} /></View>
+        )}
+        {cfg.watermark_text && <Text style={styles.watermark} fixed>{cfg.watermark_text}</Text>}
+        {cfg.header_text && <Text style={{ fontSize: fs(8), color: muted, marginBottom: 8 }}>{cfg.header_text}</Text>}
+
         {isModern ? <ModernHeader /> : <ClassicHeader />}
         {isMinimal && <View style={styles.minimalRule} />}
 
-        {/* Bill To + Dates */}
         <View style={styles.section}>
           <View style={{ flex: 1, marginRight: 20 }}>
-            <Text style={styles.billToLabel}>Bill To</Text>
+            <Text style={styles.smallLabel}>{cfg.section_title_billto}</Text>
             {customer ? (
               <>
                 <Text style={styles.billToName}>{customer.name}</Text>
@@ -189,7 +234,7 @@ export function InvoicePDFDocument({ invoice, customer, business, lineItems, pdf
             ) : <Text style={styles.billToDetail}>—</Text>}
             {invoice.property_address && (
               <>
-                <Text style={[styles.billToLabel, { marginTop: 10 }]}>Service Address</Text>
+                <Text style={[styles.smallLabel, { marginTop: 10 }]}>Service Address</Text>
                 <Text style={styles.billToDetail}>{invoice.property_address}</Text>
               </>
             )}
@@ -197,27 +242,26 @@ export function InvoicePDFDocument({ invoice, customer, business, lineItems, pdf
           <View style={{ width: 150 }}>
             <View style={styles.dateRow}><Text style={styles.dateLabel}>Issue date</Text><Text style={styles.dateValue}>{fmtDate(invoice.issue_date)}</Text></View>
             <View style={styles.dateRow}><Text style={styles.dateLabel}>Due date</Text><Text style={styles.dateValue}>{fmtDate(invoice.due_date)}</Text></View>
+            <CustomFields where="meta" />
           </View>
         </View>
 
-        {/* Line items */}
+        {/* Line items — columns driven by config */}
         <View style={styles.tableHeader}>
-          <Text style={[styles.tableItem, styles.colHeader]}>Description</Text>
-          <Text style={[styles.tableQty, styles.colHeader]}>Qty</Text>
-          <Text style={[styles.tablePrice, styles.colHeader]}>Price</Text>
-          <Text style={[styles.tableTax, styles.colHeader]}>{settings.label_tax}</Text>
-          <Text style={[styles.tableTotal, styles.colHeader]}>Total</Text>
+          {visibleCols.map((c) => (
+            <Text key={c.key} style={[colStyle(c.key), styles.colHeader]}>{c.key === "tax" ? cfg.label_tax : c.label}</Text>
+          ))}
         </View>
         {lineItems.map((item) => (
           <View key={item.id} style={styles.tableRow}>
-            <View style={styles.tableItem}>
-              <Text style={styles.tableItemName}>{item.name}</Text>
-              {item.description && <Text style={styles.tableItemDesc}>{item.description}</Text>}
-            </View>
-            <Text style={styles.tableQty}>{item.quantity}</Text>
-            <Text style={styles.tablePrice}>{fmt(item.unit_price)}</Text>
-            <Text style={styles.tableTax}>{item.tax_rate}%</Text>
-            <Text style={styles.tableTotal}>{fmt(item.total)}</Text>
+            {visibleCols.map((c) => c.key === "description" ? (
+              <View key={c.key} style={colStyle(c.key)}>
+                <Text style={styles.cellName}>{item.name}</Text>
+                {item.description && <Text style={styles.cellDesc}>{item.description}</Text>}
+              </View>
+            ) : (
+              <Text key={c.key} style={[colStyle(c.key), c.key === "total" ? bold : {}]}>{cellValue(item, c.key)}</Text>
+            ))}
           </View>
         ))}
 
@@ -226,45 +270,40 @@ export function InvoicePDFDocument({ invoice, customer, business, lineItems, pdf
           <View style={styles.totalsBox}>
             <View style={styles.totalRow}><Text style={styles.totalLabel}>Subtotal</Text><Text>{fmt(invoice.subtotal)}</Text></View>
             {invoice.discount_amount > 0 && <View style={styles.totalRow}><Text style={styles.totalLabel}>Discount</Text><Text>- {fmt(invoice.discount_amount)}</Text></View>}
-            <View style={styles.totalRow}><Text style={styles.totalLabel}>{settings.label_tax}</Text><Text>{fmt(invoice.tax_total)}</Text></View>
-            <View style={styles.grandTotalRow}>
-              <Text style={styles.grandTotalLabel}>Total</Text>
-              <Text style={styles.grandTotalValue}>{fmt(invoice.total)}</Text>
-            </View>
+            <View style={styles.totalRow}><Text style={styles.totalLabel}>{cfg.label_tax}</Text><Text>{fmt(invoice.tax_total)}</Text></View>
+            <View style={styles.grandTotalRow}><Text style={styles.grandTotalLabel}>Total</Text><Text style={styles.grandTotalValue}>{fmt(invoice.total)}</Text></View>
             {invoice.amount_paid > 0 && (
               <>
                 <View style={[styles.totalRow, { marginTop: 8 }]}><Text style={{ color: "#16a34a" }}>Paid</Text><Text style={{ color: "#16a34a" }}>{fmt(invoice.amount_paid)}</Text></View>
-                <View style={styles.totalRow}><Text style={styles.totalLabel}>Balance due</Text><Text style={{ fontFamily: "Helvetica-Bold" }}>{fmt(invoice.total - invoice.amount_paid)}</Text></View>
+                <View style={styles.totalRow}><Text style={styles.totalLabel}>Balance due</Text><Text style={bold}>{fmt(invoice.total - invoice.amount_paid)}</Text></View>
               </>
             )}
           </View>
         </View>
 
-        {/* Footer: notes, terms, bank */}
-        {(invoice.notes || invoice.terms || business.bank_account_name) && (
+        {/* Footer */}
+        {cfg.show_footer && (invoice.notes || invoice.terms || business.bank_account_name || cfg.footer_text || fieldsAt("footer").length > 0) && (
           <View style={styles.footer}>
-            {invoice.notes && (
+            {cfg.show_notes && invoice.notes && (
+              <View style={styles.footerSection}><Text style={styles.footerTitle}>{cfg.section_title_notes}</Text><Text style={styles.footerText}>{invoice.notes}</Text></View>
+            )}
+            {cfg.show_terms && invoice.terms && (
+              <View style={styles.footerSection}><Text style={styles.footerTitle}>{cfg.section_title_terms}</Text><Text style={styles.footerText}>{invoice.terms}</Text></View>
+            )}
+            {cfg.show_payment_details && business.bank_account_name && (
               <View style={styles.footerSection}>
-                <Text style={styles.footerTitle}>Notes</Text>
-                <Text style={styles.footerText}>{invoice.notes}</Text>
+                <Text style={styles.footerTitle}>{cfg.section_title_payment}</Text>
+                {business.bank_name && <View style={styles.bankRow}><Text style={styles.bankLabel}>{cfg.label_bank}</Text><Text style={styles.bankValue}>{business.bank_name}</Text></View>}
+                <View style={styles.bankRow}><Text style={styles.bankLabel}>{cfg.label_account_name}</Text><Text style={styles.bankValue}>{business.bank_account_name}</Text></View>
+                {business.bank_account_number && <View style={styles.bankRow}><Text style={styles.bankLabel}>{cfg.label_account_number}</Text><Text style={styles.bankValue}>{business.bank_account_number}</Text></View>}
+                {business.bank_sort_code && <View style={styles.bankRow}><Text style={styles.bankLabel}>{cfg.label_bsb}</Text><Text style={styles.bankValue}>{business.bank_sort_code}</Text></View>}
               </View>
             )}
-            {invoice.terms && (
-              <View style={styles.footerSection}>
-                <Text style={styles.footerTitle}>Payment Terms</Text>
-                <Text style={styles.footerText}>{invoice.terms}</Text>
-              </View>
-            )}
-            {business.bank_account_name && (
-              <View style={styles.footerSection}>
-                <Text style={styles.footerTitle}>Payment Details</Text>
-                {business.bank_name && <View style={styles.bankRow}><Text style={styles.bankLabel}>{settings.label_bank}</Text><Text style={styles.bankValue}>{business.bank_name}</Text></View>}
-                <View style={styles.bankRow}><Text style={styles.bankLabel}>{settings.label_account_name}</Text><Text style={styles.bankValue}>{business.bank_account_name}</Text></View>
-                {business.bank_account_number && <View style={styles.bankRow}><Text style={styles.bankLabel}>{settings.label_account_number}</Text><Text style={styles.bankValue}>{business.bank_account_number}</Text></View>}
-                {business.bank_sort_code && <View style={styles.bankRow}><Text style={styles.bankLabel}>{settings.label_bsb}</Text><Text style={styles.bankValue}>{business.bank_sort_code}</Text></View>}
-              </View>
-            )}
+            <CustomFields where="footer" />
           </View>
+        )}
+        {cfg.show_footer && cfg.footer_text && (
+          <Text style={{ fontSize: fs(7.5), color: muted, textAlign: "center", marginTop: 12 }} fixed>{cfg.footer_text}</Text>
         )}
       </Page>
     </Document>

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -18,6 +18,7 @@ import { scheduleSend } from "@/lib/actions/scheduled-sends";
 import { SendDocumentModal } from "@/components/send/send-document-modal";
 import { QuoteEditor } from "./quote-editor";
 import { QuotePDFDownload } from "./quote-pdf";
+import { TemplatePicker } from "@/components/documents/template-picker";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import {
   DetailHero, FactCard, AnimatedPress, FadeIn,
@@ -135,6 +136,7 @@ export function QuoteDetailClient({ quote: initial, customers, products, busines
                 <Link2 className="w-4 h-4" /> Share
               </AnimatedPress>
             )}
+            <TemplatePicker docType="quote" docId={quote.id} currentTemplateId={quote.template_id} />
             <QuotePDFDownload quoteId={quote.id} quoteNumber={quote.number} />
             <AnimatedPress
               onClick={() => setEditing(true)}

--- a/src/components/quotes/quote-pdf-document.tsx
+++ b/src/components/quotes/quote-pdf-document.tsx
@@ -1,301 +1,207 @@
 import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/renderer";
 import type { Business, Customer, Quote, LineItem, PdfSettings } from "@/types/database";
-import { DEFAULT_PDF_SETTINGS } from "@/types/database";
+import type { TemplateConfig, TemplateColumn } from "@/lib/documents/template-config";
+import { resolveTemplateConfig, fontFamilyFor, resolvePlaceholders } from "@/lib/documents/template-config";
 
 interface Props {
   quote: Quote;
   customer: Customer | null;
   business: Business;
   lineItems: LineItem[];
+  config?: TemplateConfig | null;
   pdfSettings?: PdfSettings | null;
 }
 
 function fmtCurrency(amount: number, currency: string): string {
   return new Intl.NumberFormat("en-AU", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    style: "currency", currency, minimumFractionDigits: 2, maximumFractionDigits: 2,
   }).format(amount);
 }
-
 function fmtDate(d: string): string {
   return new Date(d).toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
 }
 
-export function QuotePDFDocument({ quote, customer, business, lineItems, pdfSettings }: Props) {
-  const settings: PdfSettings = { ...DEFAULT_PDF_SETTINGS, ...(pdfSettings ?? business.pdf_settings ?? {}) };
-  const currency = business.currency ?? "AUD";
-  const fmt = (n: number) => fmtCurrency(n, currency);
-  const accent = settings.primary_color || business.accent_color || "#B8860B";
-  const logoSize = settings.logo_size;
-  const isClassic = settings.quote_template === "classic";
-
-  const dark = "#111827";
-  const midDark = "#374151";
-  const border = "#e5e7eb";
-  const muted = "#6b7280";
-  const white = "#ffffff";
-  const lightBg = "#f9f6f0";
-
-  // Derive subtitle: first line item name + site address
-  const siteAddress = [customer?.address, customer?.city, customer?.postcode, customer?.country]
-    .filter(Boolean)
-    .join(", ");
-  const firstItemName = lineItems[0]?.name ?? "";
-  const subtitle = firstItemName && siteAddress
-    ? `${firstItemName} — ${siteAddress}`
-    : siteAddress || firstItemName || quote.number;
-
-  // Parse notes and terms into bullet lines
-  const noteLines = (quote.notes ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
-  const termLines = (quote.terms ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
-  const allNotes = [...noteLines, ...termLines];
-
-  const styles = StyleSheet.create({
-    page: {
-      fontFamily: "Helvetica",
-      fontSize: 9,
-      color: dark,
-      backgroundColor: white,
-      paddingBottom: 56,
-    },
-
-    // Fixed footer
-    footer: {
-      position: "absolute",
-      bottom: 0,
-      left: 0,
-      right: 0,
-      borderTopWidth: 1,
-      borderTopColor: border,
-      paddingVertical: 9,
-      paddingHorizontal: 40,
-      backgroundColor: white,
-    },
-    footerText: {
-      fontSize: 7.5,
-      color: muted,
-      textAlign: "center",
-      lineHeight: 1.5,
-    },
-
-    // Header
-    headerWrap: { paddingHorizontal: 40, paddingTop: 32, paddingBottom: 16 },
-    header: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
-    logo: { width: logoSize, height: logoSize * 0.7, objectFit: "contain" },
-    headerRight: { textAlign: "right" },
-    headerContact: { fontSize: 8, color: muted, lineHeight: 1.7, textAlign: "right" },
-    headerLink: { fontSize: 8, color: accent, textAlign: "right", lineHeight: 1.7 },
-
-    // Title band
-    titleBand: {
-      backgroundColor: dark,
-      paddingVertical: 16,
-      paddingHorizontal: 40,
-      marginBottom: 0,
-    },
-    titleText: {
-      fontSize: 26,
-      fontFamily: "Helvetica-Bold",
-      color: accent,
-      textAlign: "center",
-      letterSpacing: 4,
-    },
-
-    // Subtitle
-    subtitleRow: {
-      paddingHorizontal: 40,
-      paddingTop: 14,
-      paddingBottom: 4,
-    },
-    subtitleText: {
-      textAlign: "center",
-      fontSize: 10,
-      color: midDark,
-    },
-
-    // Content padding wrapper
-    body: { paddingHorizontal: 40, paddingTop: 18 },
-
-    // Info section
-    infoSection: { flexDirection: "row", justifyContent: "space-between", marginBottom: 18 },
-    quoteToBox: {
-      backgroundColor: lightBg,
-      padding: 14,
-      width: "47%",
-    },
-    quoteToLabel: {
-      fontSize: 7.5,
-      fontFamily: "Helvetica-Bold",
-      color: accent,
-      textTransform: "uppercase",
-      letterSpacing: 1,
-      marginBottom: 6,
-    },
-    quoteToName: { fontFamily: "Helvetica-Bold", fontSize: 11, marginBottom: 2 },
-    quoteToDetail: { fontSize: 9, color: midDark, lineHeight: 1.6 },
-    infoRight: { width: "47%", paddingTop: 2 },
-    infoRow: { flexDirection: "row", justifyContent: "flex-end", marginBottom: 5, alignItems: "flex-start" },
-    infoLabel: { color: muted, fontSize: 9, marginRight: 6 },
-    infoValue: { fontFamily: "Helvetica-Bold", fontSize: 9, textAlign: "right" },
-    infoValueLg: { fontFamily: "Helvetica-Bold", fontSize: 11, textAlign: "right" },
-
-    // Site address bar
-    siteBar: {
-      backgroundColor: midDark,
-      paddingVertical: 8,
-      paddingHorizontal: 12,
-      marginBottom: 16,
-      flexDirection: "row",
-      alignItems: "center",
-    },
-    siteLabel: { fontSize: 8.5, fontFamily: "Helvetica-Bold", color: accent, marginRight: 8 },
-    siteAddressText: { fontSize: 9, color: white },
-
-    // Scope of works table
-    tableWrap: { marginBottom: 14 },
-    tableTitle: {
-      backgroundColor: dark,
-      paddingVertical: 9,
-      paddingHorizontal: 10,
-    },
-    tableTitleText: {
-      fontSize: 11,
-      fontFamily: "Helvetica-Bold",
-      color: accent,
-      textAlign: "center",
-    },
-    colHeaders: {
-      flexDirection: "row",
-      backgroundColor: "#f3f4f6",
-      paddingVertical: 6,
-      paddingHorizontal: 10,
-      borderBottomWidth: 1,
-      borderBottomColor: border,
-    },
-    colHeader: {
-      fontSize: 8,
-      fontFamily: "Helvetica-Bold",
-      color: dark,
-    },
-    tableRow: {
-      flexDirection: "row",
-      paddingVertical: 7,
-      paddingHorizontal: 10,
-      borderBottomWidth: 1,
-      borderBottomColor: border,
-    },
-    tableRowAlt: { backgroundColor: "#fafafa" },
-    colNum: { width: 20, fontSize: 9 },
-    colDesc: { flex: 1, paddingRight: 8 },
-    colDescName: { fontSize: 9, fontFamily: "Helvetica-Bold" },
-    colDescDetail: { fontSize: 8, color: muted, marginTop: 1 },
-    colQty: { width: 46, textAlign: "center", fontSize: 9 },
-    colAmt: { width: 82, textAlign: "right", fontSize: 9 },
-
-    // Totals
-    totalsWrap: { flexDirection: "row", justifyContent: "flex-end", marginBottom: 18 },
-    totalsBox: { width: 240 },
-    totalsBorder: { borderTopWidth: 1, borderTopColor: border, marginBottom: 0 },
-    totalRow: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      paddingVertical: 5,
-      paddingHorizontal: 10,
-    },
-    totalLabel: { fontSize: 9, color: muted },
-    totalValue: { fontSize: 9 },
-    grandTotalRow: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      paddingVertical: 7,
-      paddingHorizontal: 10,
-      backgroundColor: dark,
-    },
-    grandTotalLabel: { fontSize: 10, fontFamily: "Helvetica-Bold", color: accent },
-    grandTotalValue: { fontSize: 10, fontFamily: "Helvetica-Bold", color: accent },
-
-    // Notes & conditions
-    notesBox: {
-      borderWidth: 1,
-      borderColor: border,
-      padding: 14,
-      marginBottom: 16,
-    },
-    notesTitle: { fontSize: 9, fontFamily: "Helvetica-Bold", marginBottom: 8 },
-    notesItem: { fontSize: 8.5, color: midDark, lineHeight: 1.7, marginBottom: 2 },
-
-    // Acceptance of quote
-    acceptBox: {
-      borderWidth: 1,
-      borderColor: border,
-      padding: 18,
-      marginTop: 4,
-    },
-    acceptTitle: { fontSize: 10, fontFamily: "Helvetica-Bold", marginBottom: 10 },
-    acceptText: { fontSize: 9, color: midDark, lineHeight: 1.7, marginBottom: 16 },
-    acceptRow: {
-      flexDirection: "row",
-      alignItems: "flex-end",
-      marginBottom: 18,
-    },
-    acceptLabel: { fontSize: 9, marginRight: 8, minWidth: 72 },
-    acceptUnderline: {
-      flex: 1,
-      borderBottomWidth: 1,
-      borderBottomColor: dark,
-      height: 18,
-    },
-    acceptDateLabel: { fontSize: 9, marginLeft: 20, marginRight: 8, minWidth: 32 },
-    acceptDateLine: {
-      width: 100,
-      borderBottomWidth: 1,
-      borderBottomColor: dark,
-      height: 18,
-    },
-    acceptSigRow: {
-      flexDirection: "row",
-      alignItems: "flex-end",
-      marginBottom: 18,
-    },
-    acceptSigLine: {
-      width: 200,
-      borderBottomWidth: 1,
-      borderBottomColor: dark,
-      height: 18,
-    },
-    acceptContact: { fontSize: 9, color: midDark, lineHeight: 1.7 },
+export function QuotePDFDocument({ quote, customer, business, lineItems, config, pdfSettings }: Props) {
+  const cfg: TemplateConfig = config ?? resolveTemplateConfig({
+    pdfSettings: pdfSettings ?? business.pdf_settings ?? null,
+    docType: "quote",
   });
 
-  const footerStr = [
-    business.name,
-    business.phone ? `Ph: ${business.phone}` : null,
-    business.email,
-    business.website,
-  ]
-    .filter(Boolean)
-    .join(" | ");
-  const footerLine2 = business.tax_number ? `ABN: ${business.tax_number}` : null;
+  const currency = business.currency ?? "AUD";
+  const fmt = (n: number) => fmtCurrency(n, currency);
+  const scale = cfg.font_scale || 1;
+  const fs = (n: number) => Math.round(n * scale * 10) / 10;
+
+  const fam = fontFamilyFor(cfg.font_family);
+  const isHelv = cfg.font_family === "helvetica";
+  const bold = isHelv ? { fontFamily: "Helvetica-Bold" as const } : { fontFamily: fam.bold, fontWeight: 700 as const };
+
+  const accent = cfg.primary_color;
+  const dark = cfg.secondary_color;
+  const midDark = "#374151";
+  const border = "#e5e7eb";
+  const muted = cfg.muted_color;
+  const white = "#ffffff";
+  const lightBg = cfg.table_header_bg;
+  const isClassic = cfg.base === "classic";
+
+  const siteAddress = [customer?.address, customer?.city, customer?.postcode, customer?.country].filter(Boolean).join(", ");
+  const firstItemName = lineItems[0]?.name ?? "";
+  const subtitle = firstItemName && siteAddress ? `${firstItemName} — ${siteAddress}` : siteAddress || firstItemName || quote.number;
+
+  const noteLines = (quote.notes ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
+  const termLines = (quote.terms ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
+  const allNotes = [
+    ...(cfg.show_notes ? noteLines : []),
+    ...(cfg.show_terms ? termLines : []),
+  ];
+
+  const vars: Record<string, string> = {
+    customer_name: customer?.name ?? "",
+    customer_company: customer?.company ?? "",
+    customer_email: customer?.email ?? "",
+    quote_number: quote.number,
+    document_number: quote.number,
+    issue_date: fmtDate(quote.issue_date),
+    expiry_date: fmtDate(quote.expiry_date),
+    total: fmt(quote.total),
+    business_name: business.name,
+    property_address: quote.property_address ?? "",
+  };
+  const fieldsAt = (p: "header" | "meta" | "footer") => cfg.custom_fields.filter((f) => f.placement === p && (f.label || f.value));
+
+  // Columns: the scope table always leads with a # column; the rest come from
+  // the configured, visible columns (description always shown).
+  const visibleCols = cfg.columns.filter((c) => c.visible && c.key !== "description");
+  const colWidth = (key: TemplateColumn["key"]) =>
+    key === "quantity" ? 46 : key === "tax" ? 46 : 82;
+  const colValue = (item: LineItem, key: TemplateColumn["key"]) => {
+    switch (key) {
+      case "quantity": return String(item.quantity);
+      case "unit_price": return fmt(item.unit_price);
+      case "tax": return `${item.tax_rate}%`;
+      case "total": return item.total === 0 ? "Included" : fmt(item.total);
+      default: return "";
+    }
+  };
+
+  const styles = StyleSheet.create({
+    page: { fontFamily: fam.regular, fontSize: fs(9), color: cfg.text_color, backgroundColor: cfg.background_color, paddingBottom: 56 },
+    bgLayer: { position: "absolute", top: 0, left: 0, right: 0, bottom: 0 },
+    bgImage: { width: "100%", height: "100%", objectFit: "cover", opacity: cfg.background_image_opacity },
+    watermark: { position: "absolute", top: "42%", left: 0, right: 0, textAlign: "center", fontSize: 90, color: muted, opacity: cfg.watermark_opacity, transform: "rotate(-24deg)", ...bold },
+
+    footer: { position: "absolute", bottom: 0, left: 0, right: 0, borderTopWidth: 1, borderTopColor: border, paddingVertical: 9, paddingHorizontal: 40, backgroundColor: cfg.background_color },
+    footerText: { fontSize: fs(7.5), color: muted, textAlign: "center", lineHeight: 1.5 },
+
+    headerWrap: { paddingHorizontal: 40, paddingTop: 32, paddingBottom: 16 },
+    header: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+    logo: { width: cfg.logo_size, height: cfg.logo_size * 0.7, objectFit: "contain" },
+    headerRight: { textAlign: "right" },
+    headerContact: { fontSize: fs(8), color: muted, lineHeight: 1.7, textAlign: "right" },
+    headerLink: { fontSize: fs(8), color: accent, textAlign: "right", lineHeight: 1.7 },
+
+    titleBand: { backgroundColor: dark, paddingVertical: 16, paddingHorizontal: 40 },
+    titleText: { fontSize: fs(26), ...bold, color: accent, textAlign: "center", letterSpacing: 4 },
+
+    subtitleRow: { paddingHorizontal: 40, paddingTop: 14, paddingBottom: 4 },
+    subtitleText: { textAlign: "center", fontSize: fs(10), color: midDark },
+
+    body: { paddingHorizontal: 40, paddingTop: 18 },
+
+    infoSection: { flexDirection: "row", justifyContent: "space-between", marginBottom: 18 },
+    quoteToBox: { backgroundColor: lightBg, padding: 14, width: "47%" },
+    quoteToLabel: { fontSize: fs(7.5), ...bold, color: accent, textTransform: "uppercase", letterSpacing: 1, marginBottom: 6 },
+    quoteToName: { ...bold, fontSize: fs(11), marginBottom: 2 },
+    quoteToDetail: { fontSize: fs(9), color: midDark, lineHeight: 1.6 },
+    infoRight: { width: "47%", paddingTop: 2 },
+    infoRow: { flexDirection: "row", justifyContent: "flex-end", marginBottom: 5, alignItems: "flex-start" },
+    infoLabel: { color: muted, fontSize: fs(9), marginRight: 6 },
+    infoValue: { ...bold, fontSize: fs(9), textAlign: "right" },
+    infoValueLg: { ...bold, fontSize: fs(11), textAlign: "right" },
+
+    siteBar: { backgroundColor: midDark, paddingVertical: 8, paddingHorizontal: 12, marginBottom: 16, flexDirection: "row", alignItems: "center" },
+    siteLabel: { fontSize: fs(8.5), ...bold, color: accent, marginRight: 8 },
+    siteAddressText: { fontSize: fs(9), color: white },
+
+    tableWrap: { marginBottom: 14 },
+    tableTitle: { backgroundColor: dark, paddingVertical: 9, paddingHorizontal: 10 },
+    tableTitleText: { fontSize: fs(11), ...bold, color: accent, textAlign: "center" },
+    colHeaders: { flexDirection: "row", backgroundColor: lightBg, paddingVertical: 6, paddingHorizontal: 10, borderBottomWidth: 1, borderBottomColor: border },
+    colHeader: { fontSize: fs(8), ...bold, color: cfg.heading_color },
+    tableRow: { flexDirection: "row", paddingVertical: 7, paddingHorizontal: 10, borderBottomWidth: 1, borderBottomColor: border },
+    tableRowAlt: { backgroundColor: "#fafafa" },
+    colNum: { width: 20, fontSize: fs(9) },
+    colDesc: { flex: 1, paddingRight: 8 },
+    colDescName: { fontSize: fs(9), ...bold },
+    colDescDetail: { fontSize: fs(8), color: muted, marginTop: 1 },
+
+    totalsWrap: { flexDirection: "row", justifyContent: "flex-end", marginBottom: 18 },
+    totalsBox: { width: 240 },
+    totalsBorder: { borderTopWidth: 1, borderTopColor: border },
+    totalRow: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 5, paddingHorizontal: 10 },
+    totalLabel: { fontSize: fs(9), color: muted },
+    totalValue: { fontSize: fs(9) },
+    grandTotalRow: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 7, paddingHorizontal: 10, backgroundColor: dark },
+    grandTotalLabel: { fontSize: fs(10), ...bold, color: accent },
+    grandTotalValue: { fontSize: fs(10), ...bold, color: accent },
+
+    notesBox: { borderWidth: 1, borderColor: border, padding: 14, marginBottom: 16 },
+    notesTitle: { fontSize: fs(9), ...bold, marginBottom: 8, color: cfg.heading_color },
+    notesItem: { fontSize: fs(8.5), color: midDark, lineHeight: 1.7, marginBottom: 2 },
+
+    fieldRow: { flexDirection: "row", marginBottom: 2 },
+    fieldLabel: { color: muted, marginRight: 4, ...bold },
+
+    acceptBox: { borderWidth: 1, borderColor: border, padding: 18, marginTop: 4 },
+    acceptTitle: { fontSize: fs(10), ...bold, marginBottom: 10, color: cfg.heading_color },
+    acceptText: { fontSize: fs(9), color: midDark, lineHeight: 1.7, marginBottom: 16 },
+    acceptRow: { flexDirection: "row", alignItems: "flex-end", marginBottom: 18 },
+    acceptLabel: { fontSize: fs(9), marginRight: 8, minWidth: 72 },
+    acceptUnderline: { flex: 1, borderBottomWidth: 1, borderBottomColor: dark, height: 18 },
+    acceptDateLabel: { fontSize: fs(9), marginLeft: 20, marginRight: 8, minWidth: 32 },
+    acceptDateLine: { width: 100, borderBottomWidth: 1, borderBottomColor: dark, height: 18 },
+    acceptSigRow: { flexDirection: "row", alignItems: "flex-end", marginBottom: 18 },
+    acceptSigLine: { width: 200, borderBottomWidth: 1, borderBottomColor: dark, height: 18 },
+    acceptContact: { fontSize: fs(9), color: midDark, lineHeight: 1.7 },
+  });
+
+  const footerStr = [business.name, business.phone ? `Ph: ${business.phone}` : null, business.email, business.website].filter(Boolean).join(" | ");
+  const footerLine2 = cfg.footer_text || (business.tax_number ? `ABN: ${business.tax_number}` : null);
+
+  const Background = () => (
+    <>
+      {cfg.background_image_url && <View style={styles.bgLayer} fixed><Image src={cfg.background_image_url} style={styles.bgImage} /></View>}
+      {cfg.watermark_text && <Text style={styles.watermark} fixed>{cfg.watermark_text}</Text>}
+    </>
+  );
+
+  const CustomFields = ({ where }: { where: "header" | "meta" | "footer" }) => {
+    const list = fieldsAt(where);
+    if (!list.length) return null;
+    return (
+      <View style={{ marginTop: 6 }}>
+        {list.map((f) => (
+          <View key={f.id} style={styles.fieldRow}>
+            {f.label ? <Text style={styles.fieldLabel}>{f.label}:</Text> : null}
+            <Text style={{ fontSize: fs(9), color: midDark }}>{resolvePlaceholders(f.value, vars)}</Text>
+          </View>
+        ))}
+      </View>
+    );
+  };
 
   const Header = () => (
     <View style={styles.headerWrap}>
       <View style={styles.header}>
-        <View>
-          {business.logo_url && <Image src={business.logo_url} style={styles.logo} />}
-        </View>
+        <View>{cfg.show_logo && business.logo_url && <Image src={business.logo_url} style={styles.logo} />}</View>
         <View style={styles.headerRight}>
           {(business.phone || business.email) && (
-            <Text style={styles.headerContact}>
-              {[business.phone ? `Ph: ${business.phone}` : null, business.email]
-                .filter(Boolean)
-                .join(" | ")}
-            </Text>
+            <Text style={styles.headerContact}>{[business.phone ? `Ph: ${business.phone}` : null, business.email].filter(Boolean).join(" | ")}</Text>
           )}
           {business.website && <Text style={styles.headerLink}>{business.website}</Text>}
-          {business.tax_number && (
-            <Text style={styles.headerContact}>ABN: {business.tax_number}</Text>
-          )}
+          {business.tax_number && <Text style={styles.headerContact}>ABN: {business.tax_number}</Text>}
+          <CustomFields where="header" />
         </View>
       </View>
     </View>
@@ -310,47 +216,32 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, pdfSett
 
   return (
     <Document>
-      {/* ── PAGE 1: Main quote content ── */}
       <Page size="A4" style={styles.page}>
+        <Background />
         <Header />
 
-        {/* QUOTATION banner */}
-        {!isClassic && (
-          <View style={styles.titleBand}>
-            <Text style={styles.titleText}>QUOTATION</Text>
-          </View>
-        )}
-        {isClassic && (
+        {!isClassic ? (
+          <View style={styles.titleBand}><Text style={styles.titleText}>{cfg.document_title}</Text></View>
+        ) : (
           <View style={{ paddingHorizontal: 40, paddingTop: 8, paddingBottom: 4 }}>
-            <Text style={{ fontSize: 22, fontFamily: "Helvetica-Bold", color: accent }}>QUOTATION</Text>
+            <Text style={{ fontSize: fs(22), ...bold, color: accent }}>{cfg.document_title}</Text>
           </View>
         )}
 
-        {/* Subtitle */}
-        <View style={styles.subtitleRow}>
-          <Text style={styles.subtitleText}>{subtitle}</Text>
-        </View>
+        <View style={styles.subtitleRow}><Text style={styles.subtitleText}>{subtitle}</Text></View>
 
         <View style={styles.body}>
-          {/* Quote To + Details */}
           <View style={styles.infoSection}>
             <View style={styles.quoteToBox}>
-              <Text style={styles.quoteToLabel}>QUOTE TO:</Text>
+              <Text style={styles.quoteToLabel}>{cfg.section_title_billto.toUpperCase()}:</Text>
               {customer ? (
                 <>
                   <Text style={styles.quoteToName}>{customer.name}</Text>
                   {customer.company && <Text style={styles.quoteToDetail}>{customer.company}</Text>}
                   {customer.address && <Text style={styles.quoteToDetail}>{customer.address}</Text>}
-                  {customer.city && (
-                    <Text style={styles.quoteToDetail}>
-                      {customer.city}
-                      {customer.postcode ? ` ${customer.postcode}` : ""}
-                    </Text>
-                  )}
+                  {customer.city && <Text style={styles.quoteToDetail}>{customer.city}{customer.postcode ? ` ${customer.postcode}` : ""}</Text>}
                 </>
-              ) : (
-                <Text style={styles.quoteToDetail}>—</Text>
-              )}
+              ) : <Text style={styles.quoteToDetail}>—</Text>}
               {quote.property_address && (
                 <>
                   <Text style={[styles.quoteToLabel, { marginTop: 8 }]}>SERVICE ADDRESS:</Text>
@@ -360,32 +251,14 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, pdfSett
             </View>
 
             <View style={styles.infoRight}>
-              <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Quote Number:</Text>
-                <Text style={styles.infoValueLg}>{quote.number}</Text>
-              </View>
-              <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Quote Date:</Text>
-                <Text style={styles.infoValue}>{fmtDate(quote.issue_date)}</Text>
-              </View>
-              <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Valid Until:</Text>
-                <Text style={styles.infoValue}>{fmtDate(quote.expiry_date)}</Text>
-              </View>
-              <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Inspector:</Text>
-                <Text style={styles.infoValue}>{business.name}</Text>
-              </View>
-              {business.tax_number && (
-                <View style={styles.infoRow}>
-                  <Text style={styles.infoLabel}>ABN:</Text>
-                  <Text style={styles.infoValue}>{business.tax_number}</Text>
-                </View>
-              )}
+              <View style={styles.infoRow}><Text style={styles.infoLabel}>Quote Number:</Text><Text style={styles.infoValueLg}>{quote.number}</Text></View>
+              <View style={styles.infoRow}><Text style={styles.infoLabel}>Quote Date:</Text><Text style={styles.infoValue}>{fmtDate(quote.issue_date)}</Text></View>
+              <View style={styles.infoRow}><Text style={styles.infoLabel}>Valid Until:</Text><Text style={styles.infoValue}>{fmtDate(quote.expiry_date)}</Text></View>
+              {business.tax_number && <View style={styles.infoRow}><Text style={styles.infoLabel}>ABN:</Text><Text style={styles.infoValue}>{business.tax_number}</Text></View>}
+              <View style={{ alignItems: "flex-end" }}><CustomFields where="meta" /></View>
             </View>
           </View>
 
-          {/* Site address bar */}
           {siteAddress && (
             <View style={styles.siteBar}>
               <Text style={styles.siteLabel}>SITE ADDRESS:</Text>
@@ -393,16 +266,16 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, pdfSett
             </View>
           )}
 
-          {/* Scope of works table */}
           <View style={styles.tableWrap}>
-            <View style={styles.tableTitle}>
-              <Text style={styles.tableTitleText}>SCOPE OF WORKS</Text>
-            </View>
+            <View style={styles.tableTitle}><Text style={styles.tableTitleText}>{cfg.section_title_items.toUpperCase()}</Text></View>
             <View style={styles.colHeaders}>
               <Text style={[styles.colHeader, styles.colNum]}>#</Text>
               <Text style={[styles.colHeader, styles.colDesc]}>Description of Works</Text>
-              <Text style={[styles.colHeader, styles.colQty]}>Qty</Text>
-              <Text style={[styles.colHeader, styles.colAmt]}>Amount ({currency})</Text>
+              {visibleCols.map((c) => (
+                <Text key={c.key} style={[styles.colHeader, { width: colWidth(c.key), textAlign: c.key === "quantity" ? "center" : "right" }]}>
+                  {c.key === "tax" ? cfg.label_tax : c.key === "total" ? `Amount (${currency})` : c.label}
+                </Text>
+              ))}
             </View>
             {lineItems.map((item, i) => (
               <View key={item.id} style={[styles.tableRow, i % 2 === 1 ? styles.tableRowAlt : {}]} wrap={false}>
@@ -411,46 +284,30 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, pdfSett
                   <Text style={styles.colDescName}>{item.name}</Text>
                   {item.description && <Text style={styles.colDescDetail}>{item.description}</Text>}
                 </View>
-                <Text style={styles.colQty}>{item.quantity}</Text>
-                <Text style={styles.colAmt}>
-                  {item.total === 0 ? "Included" : fmt(item.total)}
-                </Text>
+                {visibleCols.map((c) => (
+                  <Text key={c.key} style={{ width: colWidth(c.key), fontSize: fs(9), textAlign: c.key === "quantity" ? "center" : "right" }}>
+                    {colValue(item, c.key)}
+                  </Text>
+                ))}
               </View>
             ))}
           </View>
 
-          {/* Totals */}
           <View style={styles.totalsWrap}>
             <View style={styles.totalsBox}>
               <View style={styles.totalsBorder} />
-              <View style={styles.totalRow}>
-                <Text style={styles.totalLabel}>Subtotal (excl. {settings.label_tax})</Text>
-                <Text style={styles.totalValue}>{fmt(quote.subtotal)}</Text>
-              </View>
-              {quote.discount_amount > 0 && (
-                <View style={styles.totalRow}>
-                  <Text style={styles.totalLabel}>Discount</Text>
-                  <Text style={styles.totalValue}>- {fmt(quote.discount_amount)}</Text>
-                </View>
-              )}
-              <View style={styles.totalRow}>
-                <Text style={styles.totalLabel}>{settings.label_tax}</Text>
-                <Text style={styles.totalValue}>{fmt(quote.tax_total)}</Text>
-              </View>
-              <View style={styles.grandTotalRow}>
-                <Text style={styles.grandTotalLabel}>TOTAL (incl. {settings.label_tax})</Text>
-                <Text style={styles.grandTotalValue}>{fmt(quote.total)} {currency}</Text>
-              </View>
+              <View style={styles.totalRow}><Text style={styles.totalLabel}>Subtotal (excl. {cfg.label_tax})</Text><Text style={styles.totalValue}>{fmt(quote.subtotal)}</Text></View>
+              {quote.discount_amount > 0 && <View style={styles.totalRow}><Text style={styles.totalLabel}>Discount</Text><Text style={styles.totalValue}>- {fmt(quote.discount_amount)}</Text></View>}
+              <View style={styles.totalRow}><Text style={styles.totalLabel}>{cfg.label_tax}</Text><Text style={styles.totalValue}>{fmt(quote.tax_total)}</Text></View>
+              <View style={styles.grandTotalRow}><Text style={styles.grandTotalLabel}>TOTAL (incl. {cfg.label_tax})</Text><Text style={styles.grandTotalValue}>{fmt(quote.total)} {currency}</Text></View>
             </View>
           </View>
 
-          {/* Notes & Conditions */}
           {allNotes.length > 0 && (
             <View style={styles.notesBox}>
-              <Text style={styles.notesTitle}>NOTES &amp; CONDITIONS</Text>
-              {allNotes.map((line, i) => (
-                <Text key={i} style={styles.notesItem}>• {line}</Text>
-              ))}
+              <Text style={styles.notesTitle}>{cfg.section_title_notes.toUpperCase()} &amp; CONDITIONS</Text>
+              {allNotes.map((line, i) => <Text key={i} style={styles.notesItem}>• {line}</Text>)}
+              <CustomFields where="footer" />
             </View>
           )}
         </View>
@@ -458,43 +315,30 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, pdfSett
         <Footer />
       </Page>
 
-      {/* ── PAGE 2: Acceptance ── */}
-      <Page size="A4" style={styles.page}>
-        <Header />
-        <View style={styles.body}>
-          <View style={styles.acceptBox}>
-            <Text style={styles.acceptTitle}>ACCEPTANCE OF QUOTE</Text>
-            <Text style={styles.acceptText}>
-              I/We accept the above quote and authorise {business.name} to proceed with the works described.
-            </Text>
-            <View style={styles.acceptRow}>
-              <Text style={styles.acceptLabel}>Client Name:</Text>
-              <View style={styles.acceptUnderline} />
-              <Text style={styles.acceptDateLabel}>Date:</Text>
-              <View style={styles.acceptDateLine} />
-            </View>
-            <View style={styles.acceptSigRow}>
-              <Text style={styles.acceptLabel}>Signature:</Text>
-              <View style={styles.acceptSigLine} />
-            </View>
-            {(business.email || business.phone) && (
-              <View>
-                {business.email && (
-                  <Text style={styles.acceptContact}>
-                    To accept, please sign and return this document to: {business.email}
-                  </Text>
-                )}
-                {business.phone && (
-                  <Text style={styles.acceptContact}>
-                    or call {business.phone} to confirm.
-                  </Text>
-                )}
+      {cfg.show_signature && (
+        <Page size="A4" style={styles.page}>
+          <Background />
+          <Header />
+          <View style={styles.body}>
+            <View style={styles.acceptBox}>
+              <Text style={styles.acceptTitle}>ACCEPTANCE OF QUOTE</Text>
+              <Text style={styles.acceptText}>I/We accept the above quote and authorise {business.name} to proceed with the works described.</Text>
+              <View style={styles.acceptRow}>
+                <Text style={styles.acceptLabel}>Client Name:</Text><View style={styles.acceptUnderline} />
+                <Text style={styles.acceptDateLabel}>Date:</Text><View style={styles.acceptDateLine} />
               </View>
-            )}
+              <View style={styles.acceptSigRow}><Text style={styles.acceptLabel}>Signature:</Text><View style={styles.acceptSigLine} /></View>
+              {(business.email || business.phone) && (
+                <View>
+                  {business.email && <Text style={styles.acceptContact}>To accept, please sign and return this document to: {business.email}</Text>}
+                  {business.phone && <Text style={styles.acceptContact}>or call {business.phone} to confirm.</Text>}
+                </View>
+              )}
+            </View>
           </View>
-        </View>
-        <Footer />
-      </Page>
+          <Footer />
+        </Page>
+      )}
     </Document>
   );
 }

--- a/src/components/settings/document-templates-client.tsx
+++ b/src/components/settings/document-templates-client.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Plus, Trash2, Star, Copy, ArrowLeft, ChevronUp, ChevronDown, Upload, Loader2, FileText,
+} from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { useConfirm } from "@/components/ui/confirm";
+import { PageHeader } from "@/components/layout/page-header";
+import type { DocumentTemplate } from "@/types/database";
+import type { TemplateConfig, CustomField, FieldPlacement, FontKey } from "@/lib/documents/template-config";
+import { DEFAULT_TEMPLATE_CONFIG, DEFAULT_COLUMNS, FONT_LABELS } from "@/lib/documents/template-config";
+import { TEMPLATE_PRESETS } from "@/lib/documents/presets";
+import {
+  createDocumentTemplate, updateDocumentTemplate, deleteDocumentTemplate,
+  setDefaultDocumentTemplate, uploadTemplateAsset,
+} from "@/lib/actions/document-templates";
+
+type DocType = "invoice" | "quote" | "both";
+
+function mergeConfig(partial?: unknown): TemplateConfig {
+  const c = { ...DEFAULT_TEMPLATE_CONFIG, ...((partial as Partial<TemplateConfig>) ?? {}) } as TemplateConfig;
+  if (!Array.isArray(c.columns) || c.columns.length === 0) c.columns = DEFAULT_COLUMNS.map((x) => ({ ...x }));
+  if (!Array.isArray(c.custom_fields)) c.custom_fields = [];
+  return c;
+}
+
+export function DocumentTemplatesClient({ initialTemplates }: { initialTemplates: DocumentTemplate[] }) {
+  const router = useRouter();
+  const confirm = useConfirm();
+  const [templates, setTemplates] = useState(initialTemplates);
+  useEffect(() => setTemplates(initialTemplates), [initialTemplates]);
+
+  // null = manager view; object = editing (id null means brand-new).
+  const [editing, setEditing] = useState<null | { id: string | null; name: string; doc_type: DocType; config: TemplateConfig }>(null);
+  const [gallery, setGallery] = useState(false);
+
+  const startNewFromPreset = (presetKey: string | null) => {
+    const preset = presetKey ? TEMPLATE_PRESETS.find((p) => p.key === presetKey) : null;
+    setGallery(false);
+    setEditing({
+      id: null,
+      name: preset ? preset.name : "My template",
+      doc_type: "both",
+      config: mergeConfig(preset?.config ?? null),
+    });
+  };
+
+  const editExisting = (tpl: DocumentTemplate) =>
+    setEditing({ id: tpl.id, name: tpl.name, doc_type: tpl.doc_type, config: mergeConfig(tpl.config) });
+
+  if (editing) {
+    return <TemplateEditor editing={editing} setEditing={setEditing} onSaved={() => { setEditing(null); router.refresh(); }} />;
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Document Templates"
+        subtitle="Design the look of your invoice and quote PDFs. Save as many as you like and set a default."
+        actions={<Button onClick={() => setGallery(true)}><Plus className="w-4 h-4 mr-1.5" />New template</Button>}
+      />
+
+      {templates.length === 0 ? (
+        <div className="ch-empty text-center py-16">
+          <FileText className="w-10 h-10 mx-auto text-muted-foreground mb-3" />
+          <p className="font-medium">No templates yet</p>
+          <p className="text-sm text-muted-foreground mb-4">Your invoices and quotes currently use the built-in default. Create a template to customise them.</p>
+          <Button onClick={() => setGallery(true)}><Plus className="w-4 h-4 mr-1.5" />Create your first template</Button>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {templates.map((tpl) => {
+            const cfg = mergeConfig(tpl.config);
+            return (
+              <div key={tpl.id} className="rounded-xl border border-border bg-card p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-2 mb-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="inline-block w-4 h-4 rounded-full border border-border" style={{ background: cfg.primary_color }} />
+                      <h3 className="font-semibold break-words">{tpl.name}</h3>
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-1">
+                      <span className="ch-pill text-[10px] uppercase">{tpl.doc_type}</span>
+                      {tpl.is_default && <span className="ch-pill paid text-[10px] flex items-center gap-0.5"><Star className="w-3 h-3" />Default</span>}
+                    </div>
+                  </div>
+                </div>
+                {/* Mini preview swatch */}
+                <div className="h-24 rounded-lg border border-border mb-3 overflow-hidden flex flex-col" style={{ background: cfg.background_color }}>
+                  <div className="h-6" style={{ background: cfg.base === "modern" ? cfg.secondary_color : "transparent" }} />
+                  <div className="px-2 py-1"><div className="h-2 w-1/2 rounded" style={{ background: cfg.primary_color }} /></div>
+                  <div className="px-2 space-y-1 mt-1">
+                    <div className="h-1.5 w-full rounded" style={{ background: cfg.table_header_bg }} />
+                    <div className="h-1 w-3/4 rounded bg-border" />
+                    <div className="h-1 w-2/3 rounded bg-border" />
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  <Button size="sm" variant="outline" onClick={() => editExisting(tpl)}>Edit</Button>
+                  {!tpl.is_default && (
+                    <Button size="sm" variant="ghost" onClick={async () => { await setDefaultDocumentTemplate(tpl.id); router.refresh(); }}>
+                      <Star className="w-3.5 h-3.5 mr-1" />Set default
+                    </Button>
+                  )}
+                  <Button size="sm" variant="ghost" onClick={async () => {
+                    await createDocumentTemplate({ name: `${tpl.name} copy`, doc_type: tpl.doc_type, config: cfg });
+                    router.refresh();
+                  }}><Copy className="w-3.5 h-3.5 mr-1" />Duplicate</Button>
+                  <Button size="sm" variant="ghost" className="text-destructive" onClick={async () => {
+                    if (!(await confirm({ title: "Delete this template?", body: "Documents using it will fall back to the default." }))) return;
+                    await deleteDocumentTemplate(tpl.id); router.refresh();
+                  }}><Trash2 className="w-3.5 h-3.5" /></Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {gallery && <PresetGallery onPick={startNewFromPreset} onClose={() => setGallery(false)} />}
+    </div>
+  );
+}
+
+function PresetGallery({ onPick, onClose }: { onPick: (key: string | null) => void; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
+      <div className="bg-card rounded-2xl border border-border shadow-xl w-full max-w-3xl max-h-[85vh] overflow-y-auto p-6" onClick={(e) => e.stopPropagation()}>
+        <h2 className="text-lg font-semibold mb-1">Start from a template</h2>
+        <p className="text-sm text-muted-foreground mb-4">Pick a ready-made style — you can change everything after.</p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <button onClick={() => onPick(null)} className="text-left rounded-xl border-2 border-dashed border-border p-4 hover:border-primary transition">
+            <div className="font-medium">Blank</div>
+            <div className="text-xs text-muted-foreground">Start from the default look</div>
+          </button>
+          {TEMPLATE_PRESETS.map((p) => (
+            <button key={p.key} onClick={() => onPick(p.key)} className="text-left rounded-xl border border-border p-4 hover:border-primary hover:shadow-sm transition">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="w-4 h-4 rounded-full border border-border" style={{ background: p.swatch }} />
+                <span className="font-medium">{p.name}</span>
+              </div>
+              <div className="text-xs text-muted-foreground">{p.description}</div>
+            </button>
+          ))}
+        </div>
+        <div className="mt-4 text-right"><Button variant="ghost" onClick={onClose}>Cancel</Button></div>
+      </div>
+    </div>
+  );
+}
+
+// ── Editor ──────────────────────────────────────────────────────────────────
+
+type EditState = { id: string | null; name: string; doc_type: DocType; config: TemplateConfig };
+
+function TemplateEditor({ editing, setEditing, onSaved }: {
+  editing: EditState;
+  setEditing: (s: EditState | null) => void;
+  onSaved: () => void;
+}) {
+  const [name, setName] = useState(editing.name);
+  const [docType, setDocType] = useState<DocType>(editing.doc_type);
+  const [config, setConfig] = useState<TemplateConfig>(editing.config);
+  const [saving, setSaving] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewDoc, setPreviewDoc] = useState<"invoice" | "quote">(editing.doc_type === "quote" ? "quote" : "invoice");
+  const [uploading, setUploading] = useState(false);
+  const lastUrl = useRef<string | null>(null);
+
+  const set = useCallback(<K extends keyof TemplateConfig>(key: K, value: TemplateConfig[K]) =>
+    setConfig((c) => ({ ...c, [key]: value })), []);
+
+  // Debounced live preview.
+  const cfgKey = useMemo(() => JSON.stringify(config) + previewDoc, [config, previewDoc]);
+  useEffect(() => {
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      setPreviewing(true);
+      try {
+        const res = await fetch("/api/pdf/template-preview", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ doc_type: previewDoc, config }),
+        });
+        if (!res.ok || cancelled) { setPreviewing(false); return; }
+        const blob = await res.blob();
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        if (lastUrl.current) URL.revokeObjectURL(lastUrl.current);
+        lastUrl.current = url;
+        setPreviewUrl(url);
+      } finally {
+        if (!cancelled) setPreviewing(false);
+      }
+    }, 500);
+    return () => { cancelled = true; clearTimeout(handle); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cfgKey]);
+
+  useEffect(() => () => { if (lastUrl.current) URL.revokeObjectURL(lastUrl.current); }, []);
+
+  const save = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      if (editing.id) await updateDocumentTemplate(editing.id, { name, doc_type: docType, config });
+      else await createDocumentTemplate({ name, doc_type: docType, config });
+      onSaved();
+    } finally { setSaving(false); }
+  };
+
+  const onUpload = async (file: File) => {
+    setUploading(true);
+    try {
+      const fd = new FormData(); fd.append("file", file);
+      const { url } = await uploadTemplateAsset(fd);
+      set("background_image_url", url);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Upload failed");
+    } finally { setUploading(false); }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0">
+          <Button variant="ghost" size="sm" onClick={() => setEditing(null)}><ArrowLeft className="w-4 h-4" /></Button>
+          <Input value={name} onChange={(e) => setName(e.target.value)} className="max-w-xs font-semibold" placeholder="Template name" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex rounded-lg border border-border overflow-hidden text-sm">
+            <button onClick={() => setPreviewDoc("invoice")} className={`px-3 py-1.5 ${previewDoc === "invoice" ? "bg-primary text-primary-foreground" : "bg-card"}`}>Invoice</button>
+            <button onClick={() => setPreviewDoc("quote")} className={`px-3 py-1.5 ${previewDoc === "quote" ? "bg-primary text-primary-foreground" : "bg-card"}`}>Quote</button>
+          </div>
+          <Button onClick={save} disabled={saving || !name.trim()}>
+            {saving ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : null}Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-[minmax(0,380px)_1fr] gap-4 items-start">
+        {/* Controls */}
+        <div className="space-y-3 lg:max-h-[calc(100vh-160px)] lg:overflow-y-auto pr-1">
+          <Section title="Basics">
+            <Field label="Applies to">
+              <Select value={docType} onChange={(v) => setDocType(v as DocType)} options={[["both", "Invoices & quotes"], ["invoice", "Invoices only"], ["quote", "Quotes only"]]} />
+            </Field>
+            <Field label="Layout">
+              <Select value={config.base} onChange={(v) => set("base", v as TemplateConfig["base"])} options={[["classic", "Classic"], ["minimal", "Minimal"], ["modern", "Modern (header band)"]]} />
+            </Field>
+          </Section>
+
+          <Section title="Colours">
+            <Color label="Primary / accent" value={config.primary_color} onChange={(v) => set("primary_color", v)} />
+            <Color label="Header band / dark" value={config.secondary_color} onChange={(v) => set("secondary_color", v)} />
+            <Color label="Heading text" value={config.heading_color} onChange={(v) => set("heading_color", v)} />
+            <Color label="Body text" value={config.text_color} onChange={(v) => set("text_color", v)} />
+            <Color label="Muted text" value={config.muted_color} onChange={(v) => set("muted_color", v)} />
+            <Color label="Table header" value={config.table_header_bg} onChange={(v) => set("table_header_bg", v)} />
+          </Section>
+
+          <Section title="Typography">
+            <Field label="Font">
+              <Select value={config.font_family} onChange={(v) => set("font_family", v as FontKey)} options={Object.entries(FONT_LABELS)} />
+            </Field>
+            <Field label={`Text size (${config.font_scale.toFixed(2)}×)`}>
+              <input type="range" min={0.9} max={1.2} step={0.05} value={config.font_scale} onChange={(e) => set("font_scale", parseFloat(e.target.value))} className="w-full" />
+            </Field>
+          </Section>
+
+          <Section title="Logo & header">
+            <Toggle label="Show logo" checked={config.show_logo} onChange={(v) => set("show_logo", v)} />
+            <Field label="Logo size">
+              <Select value={String(config.logo_size)} onChange={(v) => set("logo_size", Number(v))} options={[["48", "Small"], ["72", "Medium"], ["108", "Large"]]} />
+            </Field>
+            <Field label="Logo position">
+              <Select value={config.logo_position} onChange={(v) => set("logo_position", v as TemplateConfig["logo_position"])} options={[["left", "Left"], ["center", "Centre"], ["right", "Right"]]} />
+            </Field>
+            <Field label="Header note (optional)">
+              <Input value={config.header_text ?? ""} onChange={(e) => set("header_text", e.target.value || null)} placeholder="e.g. Licensed & insured" />
+            </Field>
+            <Field label="Footer note (optional)">
+              <Input value={config.footer_text ?? ""} onChange={(e) => set("footer_text", e.target.value || null)} placeholder="Shown at the bottom of every page" />
+            </Field>
+          </Section>
+
+          <Section title="Background">
+            <Color label="Page colour" value={config.background_color} onChange={(v) => set("background_color", v)} />
+            <Field label="Background / letterhead image">
+              {config.background_image_url ? (
+                <div className="flex items-center gap-2">
+                  <img src={config.background_image_url} alt="" className="w-10 h-10 object-cover rounded border border-border" />
+                  <Button size="sm" variant="ghost" className="text-destructive" onClick={() => set("background_image_url", null)}>Remove</Button>
+                </div>
+              ) : (
+                <label className="inline-flex items-center gap-2 text-sm cursor-pointer rounded-lg border border-dashed border-border px-3 py-2 hover:border-primary">
+                  {uploading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Upload className="w-4 h-4" />}
+                  <span>{uploading ? "Uploading…" : "Upload image"}</span>
+                  <input type="file" accept="image/*" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) onUpload(f); }} />
+                </label>
+              )}
+            </Field>
+            {config.background_image_url && (
+              <Field label={`Image opacity (${Math.round(config.background_image_opacity * 100)}%)`}>
+                <input type="range" min={0.05} max={1} step={0.05} value={config.background_image_opacity} onChange={(e) => set("background_image_opacity", parseFloat(e.target.value))} className="w-full" />
+              </Field>
+            )}
+            <Field label="Watermark text (optional)">
+              <Input value={config.watermark_text ?? ""} onChange={(e) => set("watermark_text", e.target.value || null)} placeholder="e.g. DRAFT" />
+            </Field>
+          </Section>
+
+          <Section title="Labels & titles">
+            <Field label="Document title"><Input value={config.document_title} onChange={(e) => set("document_title", e.target.value)} /></Field>
+            <Field label="Tax label"><Input value={config.label_tax} onChange={(e) => set("label_tax", e.target.value)} /></Field>
+            <Field label={'"Bill to" heading'}><Input value={config.section_title_billto} onChange={(e) => set("section_title_billto", e.target.value)} /></Field>
+            <Field label="Items heading"><Input value={config.section_title_items} onChange={(e) => set("section_title_items", e.target.value)} /></Field>
+            <Field label="Notes heading"><Input value={config.section_title_notes} onChange={(e) => set("section_title_notes", e.target.value)} /></Field>
+            <Field label="Payment heading"><Input value={config.section_title_payment} onChange={(e) => set("section_title_payment", e.target.value)} /></Field>
+          </Section>
+
+          <Section title="Sections">
+            <Toggle label="Notes" checked={config.show_notes} onChange={(v) => set("show_notes", v)} />
+            <Toggle label="Terms" checked={config.show_terms} onChange={(v) => set("show_terms", v)} />
+            <Toggle label="Payment details" checked={config.show_payment_details} onChange={(v) => set("show_payment_details", v)} />
+            <Toggle label="Footer" checked={config.show_footer} onChange={(v) => set("show_footer", v)} />
+            <Toggle label="Quote signature page" checked={config.show_signature} onChange={(v) => set("show_signature", v)} />
+          </Section>
+
+          <Section title="Line-item columns">
+            <ColumnsEditor config={config} setConfig={setConfig} />
+          </Section>
+
+          <Section title="Custom fields">
+            <CustomFieldsEditor config={config} setConfig={setConfig} />
+          </Section>
+        </div>
+
+        {/* Preview */}
+        <div className="rounded-xl border border-border bg-muted/30 overflow-hidden lg:sticky lg:top-4 min-h-[70vh] relative">
+          {previewing && <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5 text-xs bg-card/90 border border-border rounded-full px-2.5 py-1"><Loader2 className="w-3 h-3 animate-spin" />Rendering…</div>}
+          {previewUrl ? (
+            <iframe title="preview" src={previewUrl} className="w-full h-[80vh] bg-white" />
+          ) : (
+            <div className="h-[80vh] flex items-center justify-center text-muted-foreground"><Loader2 className="w-6 h-6 animate-spin" /></div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ColumnsEditor({ config, setConfig }: { config: TemplateConfig; setConfig: (fn: (c: TemplateConfig) => TemplateConfig) => void }) {
+  const cols = config.columns;
+  const move = (i: number, dir: -1 | 1) => setConfig((c) => {
+    const next = [...c.columns]; const j = i + dir;
+    if (j < 0 || j >= next.length) return c;
+    [next[i], next[j]] = [next[j], next[i]];
+    return { ...c, columns: next };
+  });
+  return (
+    <div className="space-y-2">
+      {cols.map((col, i) => (
+        <div key={col.key} className="flex items-center gap-2">
+          <Switch checked={col.visible} onCheckedChange={(v) => setConfig((c) => ({ ...c, columns: c.columns.map((x) => x.key === col.key ? { ...x, visible: v } : x) }))} />
+          <Input value={col.label} onChange={(e) => setConfig((c) => ({ ...c, columns: c.columns.map((x) => x.key === col.key ? { ...x, label: e.target.value } : x) }))} className="h-8 flex-1" />
+          <span className="text-[10px] uppercase text-muted-foreground w-16 truncate">{col.key.replace("_", " ")}</span>
+          <div className="flex flex-col">
+            <button onClick={() => move(i, -1)} className="text-muted-foreground hover:text-foreground"><ChevronUp className="w-3.5 h-3.5" /></button>
+            <button onClick={() => move(i, 1)} className="text-muted-foreground hover:text-foreground"><ChevronDown className="w-3.5 h-3.5" /></button>
+          </div>
+        </div>
+      ))}
+      <p className="text-[11px] text-muted-foreground">The Description column always shows. On quotes, an item numbered # column is always shown too.</p>
+    </div>
+  );
+}
+
+function CustomFieldsEditor({ config, setConfig }: { config: TemplateConfig; setConfig: (fn: (c: TemplateConfig) => TemplateConfig) => void }) {
+  const add = () => setConfig((c) => ({
+    ...c,
+    custom_fields: [...c.custom_fields, { id: `f${c.custom_fields.length + 1}-${c.custom_fields.length}`, label: "Label", value: "", placement: "meta" as FieldPlacement }],
+  }));
+  const update = (id: string, patch: Partial<CustomField>) =>
+    setConfig((c) => ({ ...c, custom_fields: c.custom_fields.map((f) => f.id === id ? { ...f, ...patch } : f) }));
+  const remove = (id: string) => setConfig((c) => ({ ...c, custom_fields: c.custom_fields.filter((f) => f.id !== id) }));
+  return (
+    <div className="space-y-2">
+      {config.custom_fields.map((f) => (
+        <div key={f.id} className="rounded-lg border border-border p-2 space-y-1.5">
+          <div className="flex gap-1.5">
+            <Input value={f.label} onChange={(e) => update(f.id, { label: e.target.value })} placeholder="Label" className="h-8" />
+            <button onClick={() => remove(f.id)} className="text-destructive px-1"><Trash2 className="w-3.5 h-3.5" /></button>
+          </div>
+          <Input value={f.value} onChange={(e) => update(f.id, { value: e.target.value })} placeholder="Value — supports {{customer_name}}, {{document_number}}…" className="h-8" />
+          <Select value={f.placement} onChange={(v) => update(f.id, { placement: v as FieldPlacement })} options={[["header", "In the header"], ["meta", "Near the dates"], ["footer", "In the footer"]]} />
+        </div>
+      ))}
+      <Button size="sm" variant="outline" onClick={add}><Plus className="w-3.5 h-3.5 mr-1" />Add field</Button>
+    </div>
+  );
+}
+
+// ── tiny primitives ─────────────────────────────────────────────────────────
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-3">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2.5">{title}</h3>
+      <div className="space-y-2.5">{children}</div>
+    </div>
+  );
+}
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div><label className="text-xs text-muted-foreground block mb-1">{label}</label>{children}</div>;
+}
+function Color({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <Field label={label}>
+      <div className="flex items-center gap-2">
+        <input type="color" value={value} onChange={(e) => onChange(e.target.value)} className="w-8 h-8 rounded border border-border p-0.5 bg-card cursor-pointer" />
+        <Input value={value} onChange={(e) => onChange(e.target.value)} className="h-8 font-mono text-xs" />
+      </div>
+    </Field>
+  );
+}
+function Toggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return <div className="flex items-center justify-between"><span className="text-sm">{label}</span><Switch checked={checked} onCheckedChange={onChange} /></div>;
+}
+function Select({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: [string, string][] }) {
+  return (
+    <select value={value} onChange={(e) => onChange(e.target.value)} className="w-full h-9 rounded-md border border-border bg-card px-2 text-sm">
+      {options.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+    </select>
+  );
+}

--- a/src/components/settings/settings-client.tsx
+++ b/src/components/settings/settings-client.tsx
@@ -407,6 +407,22 @@ export function SettingsClient({ business: initial, apiKeys, emailConfig, webhoo
         <TabsContent value="documents" className="space-y-4 mt-6">
           <Card>
             <CardHeader className="flex flex-row items-center gap-2.5 space-y-0">
+              <GradientTile gradient="primary" size={28} radius={8}><FileText className="w-3.5 h-3.5" /></GradientTile>
+              <CardTitle className="text-base">PDF templates</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between gap-4">
+              <p className="text-sm text-muted-foreground">
+                Design the look of your invoice and quote PDFs — colours, fonts, background,
+                logo, custom fields and columns. Save as many templates as you like, set a
+                default, and pick one per document.
+              </p>
+              <Button asChild variant="outline" className="shrink-0">
+                <a href="/settings/document-templates">Manage templates</a>
+              </Button>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center gap-2.5 space-y-0">
               <GradientTile gradient="amber" size={28} radius={8}><FileText className="w-3.5 h-3.5" /></GradientTile>
               <CardTitle className="text-base">Invoice & Quote Numbering</CardTitle>
             </CardHeader>

--- a/src/lib/actions/document-templates.ts
+++ b/src/lib/actions/document-templates.ts
@@ -157,6 +157,31 @@ export async function deleteDocumentTemplate(id: string): Promise<void> {
   revalidatePath("/settings/document-templates");
 }
 
+/** Upload a background/letterhead image for a template. Returns the public URL
+ *  to store in config.background_image_url. */
+export async function uploadTemplateAsset(formData: FormData): Promise<{ url: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) throw new Error("No file provided.");
+  if (file.size > 5 * 1024 * 1024) throw new Error("Image must be under 5MB.");
+  if (!file.type.startsWith("image/")) throw new Error("Only image files are allowed.");
+
+  const ext = (file.name.split(".").pop() || "png").toLowerCase().replace(/[^a-z0-9]/g, "");
+  // No Math.random in some sandboxes; a timestamp+size key is unique enough here.
+  const key = `${businessId}/${Date.now()}-${file.size}.${ext}`;
+
+  const { error } = await supabase.storage.from("document-assets").upload(key, file, {
+    contentType: file.type, upsert: false,
+  });
+  if (error) throw new Error(error.message);
+
+  const { data } = supabase.storage.from("document-assets").getPublicUrl(key);
+  return { url: data.publicUrl };
+}
+
 /** Attach (or clear, with null) a template on a specific invoice or quote. */
 export async function setDocumentTemplate(
   docType: "invoice" | "quote",

--- a/src/lib/actions/document-templates.ts
+++ b/src/lib/actions/document-templates.ts
@@ -1,0 +1,179 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/auth";
+import { getActiveBizId } from "@/lib/active-business";
+import type { DocumentTemplate } from "@/types/database";
+import type { TemplateConfig } from "@/lib/documents/template-config";
+import { DEFAULT_TEMPLATE_CONFIG } from "@/lib/documents/template-config";
+import { presetByKey } from "@/lib/documents/presets";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+type DocType = "invoice" | "quote" | "both";
+
+/** doc_types whose default a new default of `docType` should clear. */
+function overlapping(docType: DocType): DocType[] {
+  if (docType === "both") return ["invoice", "quote", "both"];
+  return [docType, "both"];
+}
+
+export async function getDocumentTemplates(docType?: "invoice" | "quote"): Promise<DocumentTemplate[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  let query = tbl(supabase, "document_templates")
+    .select("*")
+    .eq("business_id", businessId)
+    .order("created_at", { ascending: true });
+  if (docType) query = query.in("doc_type", [docType, "both"]);
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []) as DocumentTemplate[];
+}
+
+export async function getDocumentTemplate(id: string): Promise<DocumentTemplate | null> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "document_templates")
+    .select("*")
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .maybeSingle();
+  if (error) throw error;
+  return (data ?? null) as DocumentTemplate | null;
+}
+
+export async function createDocumentTemplate(input: {
+  name: string;
+  doc_type: DocType;
+  config?: Partial<TemplateConfig>;
+  from_preset?: string | null;
+  make_default?: boolean;
+}): Promise<DocumentTemplate> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const name = input.name?.trim();
+  if (!name) throw new Error("Template name is required.");
+
+  const preset = input.from_preset ? presetByKey(input.from_preset) : undefined;
+  const config: TemplateConfig = {
+    ...DEFAULT_TEMPLATE_CONFIG,
+    ...(preset?.config ?? {}),
+    ...(input.config ?? {}),
+  };
+
+  const { data, error } = await tbl(supabase, "document_templates")
+    .insert({
+      business_id: businessId,
+      name,
+      doc_type: input.doc_type,
+      config,
+      source: preset ? "preset" : "user",
+      preset_key: preset?.key ?? null,
+      is_default: false,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+
+  if (input.make_default) await setDefaultDocumentTemplate(data.id);
+
+  revalidatePath("/settings/document-templates");
+  return data as DocumentTemplate;
+}
+
+export async function updateDocumentTemplate(
+  id: string,
+  patch: { name?: string; doc_type?: DocType; config?: Partial<TemplateConfig> },
+): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fields: Record<string, any> = {};
+  if (patch.name !== undefined) {
+    const n = patch.name.trim();
+    if (!n) throw new Error("Template name cannot be empty.");
+    fields.name = n;
+  }
+  if (patch.doc_type !== undefined) fields.doc_type = patch.doc_type;
+  if (patch.config !== undefined) {
+    // Merge over the stored config so partial saves don't drop other fields.
+    const { data: existing } = await tbl(supabase, "document_templates")
+      .select("config").eq("id", id).eq("business_id", businessId).maybeSingle();
+    fields.config = { ...(existing?.config ?? {}), ...patch.config };
+  }
+  if (Object.keys(fields).length === 0) return;
+
+  const { error } = await tbl(supabase, "document_templates")
+    .update(fields).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+
+  revalidatePath("/settings/document-templates");
+}
+
+export async function setDefaultDocumentTemplate(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: row } = await tbl(supabase, "document_templates")
+    .select("doc_type").eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (!row) throw new Error("Template not found.");
+
+  // Clear defaults on every template whose doc_type overlaps this one, then set.
+  await tbl(supabase, "document_templates")
+    .update({ is_default: false })
+    .eq("business_id", businessId)
+    .in("doc_type", overlapping(row.doc_type as DocType));
+
+  const { error } = await tbl(supabase, "document_templates")
+    .update({ is_default: true }).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+
+  revalidatePath("/settings/document-templates");
+}
+
+export async function deleteDocumentTemplate(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // FK on invoices/quotes is ON DELETE SET NULL — affected docs revert to default.
+  const { error } = await tbl(supabase, "document_templates")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+
+  revalidatePath("/settings/document-templates");
+}
+
+/** Attach (or clear, with null) a template on a specific invoice or quote. */
+export async function setDocumentTemplate(
+  docType: "invoice" | "quote",
+  docId: string,
+  templateId: string | null,
+): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const table = docType === "invoice" ? "invoices" : "quotes";
+  const { error } = await tbl(supabase, table)
+    .update({ template_id: templateId })
+    .eq("id", docId)
+    .eq("business_id", businessId);
+  if (error) throw error;
+
+  revalidatePath(`/${table}/${docId}`);
+  revalidatePath(`/${table}`);
+}

--- a/src/lib/documents/presets.ts
+++ b/src/lib/documents/presets.ts
@@ -1,0 +1,115 @@
+// Ready-made starter templates. Selecting one clones its config into a new
+// document_templates row the user can then rename and tweak. Each preset is a
+// partial config layered over DEFAULT_TEMPLATE_CONFIG.
+
+import type { TemplateConfig } from "./template-config";
+import { DEFAULT_TEMPLATE_CONFIG, DEFAULT_COLUMNS } from "./template-config";
+
+export interface TemplatePreset {
+  key: string;
+  name: string;
+  description: string;
+  /** Accent shown on the gallery card. */
+  swatch: string;
+  config: TemplateConfig;
+}
+
+function preset(over: Partial<TemplateConfig>): TemplateConfig {
+  return { ...DEFAULT_TEMPLATE_CONFIG, columns: DEFAULT_COLUMNS, ...over };
+}
+
+export const TEMPLATE_PRESETS: TemplatePreset[] = [
+  {
+    key: "classic-blue",
+    name: "Classic Blue",
+    description: "Clean two-column layout with a blue accent. The dependable default.",
+    swatch: "#2563eb",
+    config: preset({ base: "classic", primary_color: "#2563eb", heading_color: "#0f172a" }),
+  },
+  {
+    key: "minimal-mono",
+    name: "Minimal Mono",
+    description: "Understated black-and-white with a strong rule. Lets the work speak.",
+    swatch: "#111827",
+    config: preset({
+      base: "minimal",
+      primary_color: "#111827",
+      heading_color: "#111827",
+      table_header_bg: "#ffffff",
+      font_family: "inter",
+    }),
+  },
+  {
+    key: "modern-teal",
+    name: "Modern Teal",
+    description: "Dark header band with a teal accent — matches the Kirei brand.",
+    swatch: "#3a847e",
+    config: preset({
+      base: "modern",
+      primary_color: "#3a847e",
+      secondary_color: "#0f2e2b",
+      table_header_bg: "#ecf5f4",
+      font_family: "inter",
+    }),
+  },
+  {
+    key: "bold-header",
+    name: "Bold Header",
+    description: "Big colour-blocked title bar. Confident and easy to scan.",
+    swatch: "#dc2626",
+    config: preset({
+      base: "modern",
+      primary_color: "#dc2626",
+      secondary_color: "#1f2937",
+      table_header_bg: "#fef2f2",
+      font_scale: 1.05,
+    }),
+  },
+  {
+    key: "elegant-serif",
+    name: "Elegant Serif",
+    description: "Serif typography and warm neutrals for a premium, considered feel.",
+    swatch: "#7c6f57",
+    config: preset({
+      base: "classic",
+      primary_color: "#7c6f57",
+      heading_color: "#3f3a2f",
+      muted_color: "#8a8172",
+      table_header_bg: "#f7f4ee",
+      background_color: "#fffdf9",
+      font_family: "lora",
+    }),
+  },
+  {
+    key: "trades-bold",
+    name: "Trades Bold",
+    description: "High-contrast, amber accent, roomy tables. Built for the field.",
+    swatch: "#d97706",
+    config: preset({
+      base: "classic",
+      primary_color: "#d97706",
+      secondary_color: "#111827",
+      heading_color: "#111827",
+      table_header_bg: "#fffbeb",
+      font_scale: 1.05,
+    }),
+  },
+  {
+    key: "letterhead",
+    name: "Letterhead",
+    description: "Minimal chrome, ready for a full-page background image or watermark.",
+    swatch: "#334155",
+    config: preset({
+      base: "minimal",
+      primary_color: "#334155",
+      heading_color: "#1e293b",
+      show_logo: true,
+      watermark_text: null,
+      font_family: "merriweather",
+    }),
+  },
+];
+
+export function presetByKey(key: string): TemplatePreset | undefined {
+  return TEMPLATE_PRESETS.find((p) => p.key === key);
+}

--- a/src/lib/documents/resolve.ts
+++ b/src/lib/documents/resolve.ts
@@ -1,0 +1,53 @@
+// Plain (non-"use server") helper so both the PDF routes and server actions can
+// resolve which template config a given invoice/quote should render with.
+//
+// Precedence: the document's own template_id → the business default template for
+// that doc type → legacy businesses.pdf_settings → built-in defaults.
+
+import type { PdfSettings } from "@/types/database";
+import type { TemplateConfig } from "./template-config";
+import { resolveTemplateConfig } from "./template-config";
+
+export async function resolveDocumentConfig(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  opts: {
+    businessId: string;
+    docType: "invoice" | "quote";
+    templateId?: string | null;
+    pdfSettings?: Partial<PdfSettings> | null;
+  },
+): Promise<TemplateConfig> {
+  const { businessId, docType, templateId, pdfSettings } = opts;
+  let templateConfig: Record<string, unknown> | null = null;
+
+  if (templateId) {
+    const { data } = await sb
+      .from("document_templates")
+      .select("config")
+      .eq("id", templateId)
+      .eq("business_id", businessId)
+      .maybeSingle();
+    templateConfig = data?.config ?? null;
+  }
+
+  if (!templateConfig) {
+    // Business default: a template flagged is_default whose doc_type covers this
+    // document ('both' matches either). Newest wins if somehow more than one.
+    const { data } = await sb
+      .from("document_templates")
+      .select("config, updated_at")
+      .eq("business_id", businessId)
+      .eq("is_default", true)
+      .in("doc_type", [docType, "both"])
+      .order("updated_at", { ascending: false })
+      .limit(1);
+    templateConfig = data?.[0]?.config ?? null;
+  }
+
+  return resolveTemplateConfig({
+    templateConfig: templateConfig as Partial<TemplateConfig> | null,
+    pdfSettings,
+    docType,
+  });
+}

--- a/src/lib/documents/template-config.ts
+++ b/src/lib/documents/template-config.ts
@@ -1,0 +1,282 @@
+// The full render config for a document template. A superset of the legacy
+// `PdfSettings`, so any existing businesses.pdf_settings maps cleanly onto it
+// (see resolveTemplateConfig). The PDF renderers read ONLY from a resolved
+// TemplateConfig — no more hardcoded palette/branches beyond the base skeleton.
+
+import type { PdfSettings } from "@/types/database";
+
+export type TemplateBase = "classic" | "minimal" | "modern";
+export type FontKey = "helvetica" | "inter" | "roboto" | "lora" | "merriweather" | "spacemono";
+export type LogoPosition = "left" | "center" | "right";
+export type FieldPlacement = "header" | "meta" | "footer";
+
+/** A labelled key/value line printed on the document. Values may contain
+ *  {{placeholders}} resolved at render time (see resolvePlaceholders). */
+export interface CustomField {
+  id: string;
+  label: string;
+  value: string;
+  placement: FieldPlacement;
+}
+
+/** A line-item table column. Built-in keys map to LineItem fields; `visible`
+ *  and `label` (and order in the array) are user-editable. */
+export type ColumnKey = "description" | "quantity" | "unit_price" | "tax" | "total";
+export interface TemplateColumn {
+  key: ColumnKey;
+  label: string;
+  visible: boolean;
+}
+
+export interface TemplateConfig {
+  base: TemplateBase;
+
+  // Palette
+  primary_color: string;
+  secondary_color: string;
+  text_color: string;
+  heading_color: string;
+  muted_color: string;
+  table_header_bg: string;
+  table_header_text: string;
+
+  // Background / letterhead
+  background_color: string;
+  background_image_url: string | null;
+  background_image_opacity: number;   // 0..1
+  watermark_text: string | null;
+  watermark_opacity: number;          // 0..1
+
+  // Typography
+  font_family: FontKey;
+  font_scale: number;                 // 0.9..1.2
+
+  // Logo
+  show_logo: boolean;
+  logo_size: number;
+  logo_position: LogoPosition;
+
+  // Header / footer chrome
+  header_text: string | null;
+  footer_text: string | null;
+  show_footer: boolean;
+
+  // Labels
+  document_title: string;             // "INVOICE" | "TAX INVOICE" | "QUOTE"
+  label_tax: string;
+  label_bank: string;
+  label_account_name: string;
+  label_account_number: string;
+  label_bsb: string;
+  section_title_billto: string;
+  section_title_items: string;
+  section_title_notes: string;
+  section_title_terms: string;
+  section_title_payment: string;
+
+  // Section visibility
+  show_notes: boolean;
+  show_terms: boolean;
+  show_payment_details: boolean;
+  show_signature: boolean;            // quote acceptance page
+
+  // Custom key/value fields + line-item columns
+  custom_fields: CustomField[];
+  columns: TemplateColumn[];
+}
+
+export const DEFAULT_COLUMNS: TemplateColumn[] = [
+  { key: "description", label: "Description", visible: true },
+  { key: "quantity",    label: "Qty",         visible: true },
+  { key: "unit_price",  label: "Price",       visible: true },
+  { key: "tax",         label: "GST",         visible: true },
+  { key: "total",       label: "Total",       visible: true },
+];
+
+export const DEFAULT_TEMPLATE_CONFIG: TemplateConfig = {
+  base: "classic",
+
+  primary_color: "#2563eb",
+  secondary_color: "#111827",
+  text_color: "#0f172a",
+  heading_color: "#0f172a",
+  muted_color: "#64748b",
+  table_header_bg: "#f8fafc",
+  table_header_text: "#64748b",
+
+  background_color: "#ffffff",
+  background_image_url: null,
+  background_image_opacity: 1,
+  watermark_text: null,
+  watermark_opacity: 0.06,
+
+  font_family: "helvetica",
+  font_scale: 1,
+
+  show_logo: true,
+  logo_size: 72,
+  logo_position: "left",
+
+  header_text: null,
+  footer_text: null,
+  show_footer: true,
+
+  document_title: "INVOICE",
+  label_tax: "GST",
+  label_bank: "Bank",
+  label_account_name: "Name",
+  label_account_number: "Account",
+  label_bsb: "BSB",
+  section_title_billto: "Bill To",
+  section_title_items: "Description",
+  section_title_notes: "Notes",
+  section_title_terms: "Payment Terms",
+  section_title_payment: "Payment Details",
+
+  show_notes: true,
+  show_terms: true,
+  show_payment_details: true,
+  show_signature: true,
+
+  custom_fields: [],
+  columns: DEFAULT_COLUMNS,
+};
+
+/**
+ * Build a full TemplateConfig for a document. Precedence:
+ *   template.config (if a template is selected)  →  legacy pdf_settings  →  defaults
+ * so a business with no templates yet renders exactly as it does today.
+ *
+ * `docType` seeds the right default title ("QUOTE" vs "INVOICE") when the
+ * template/settings don't specify one.
+ */
+export function resolveTemplateConfig(opts: {
+  templateConfig?: Partial<TemplateConfig> | null;
+  pdfSettings?: Partial<PdfSettings> | null;
+  docType: "invoice" | "quote";
+}): TemplateConfig {
+  const { templateConfig, pdfSettings, docType } = opts;
+
+  // Map the handful of overlapping legacy fields onto the new shape.
+  const fromLegacy: Partial<TemplateConfig> = pdfSettings
+    ? {
+        base: docType === "quote"
+          ? (pdfSettings.quote_template === "classic" ? "classic" : "modern")
+          : (pdfSettings.invoice_template as TemplateBase | undefined),
+        primary_color: pdfSettings.primary_color,
+        logo_size: pdfSettings.logo_size,
+        document_title: docType === "quote" ? "QUOTE" : pdfSettings.invoice_title,
+        label_tax: pdfSettings.label_tax,
+        label_bank: pdfSettings.label_bank,
+        label_account_name: pdfSettings.label_account_name,
+        label_account_number: pdfSettings.label_account_number,
+        label_bsb: pdfSettings.label_bsb,
+      }
+    : {};
+
+  const base: TemplateConfig = {
+    ...DEFAULT_TEMPLATE_CONFIG,
+    document_title: docType === "quote" ? "QUOTE" : DEFAULT_TEMPLATE_CONFIG.document_title,
+  };
+
+  // Drop undefined so a partial override never clobbers a good default.
+  const clean = <T extends object>(o: T): Partial<T> =>
+    Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined && v !== null)) as Partial<T>;
+
+  const merged: TemplateConfig = {
+    ...base,
+    ...clean(fromLegacy),
+    ...(templateConfig ? clean(templateConfig) : {}),
+  };
+
+  // Arrays: keep a valid non-empty column set even if a template saved [].
+  if (!Array.isArray(merged.columns) || merged.columns.length === 0) merged.columns = DEFAULT_COLUMNS;
+  if (!Array.isArray(merged.custom_fields)) merged.custom_fields = [];
+
+  return merged;
+}
+
+/** Google Fonts static TTFs (all SIL Open Font License). react-pdf fetches
+ *  these at render; Helvetica is a built-in PDF standard font and needs no
+ *  registration, so it stays the safe default. */
+export const FONT_SOURCES: Record<Exclude<FontKey, "helvetica">, { regular: string; bold: string; family: string }> = {
+  inter: {
+    family: "Inter",
+    regular: "https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.ttf",
+    bold:    "https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMa25L7.ttf",
+  },
+  roboto: {
+    family: "Roboto",
+    regular: "https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu4mxK.ttf",
+    bold:    "https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmWUlfBBc9.ttf",
+  },
+  lora: {
+    family: "Lora",
+    regular: "https://fonts.gstatic.com/s/lora/v32/0QI6MX1D_JOuGQbT0gvTJPa787weuxJBkqt_.ttf",
+    bold:    "https://fonts.gstatic.com/s/lora/v32/0QI6MX1D_JOuGQbT0gvTJPa787wsuxJBkqt_.ttf",
+  },
+  merriweather: {
+    family: "Merriweather",
+    regular: "https://fonts.gstatic.com/s/merriweather/v30/u-440qyriQwlOrhSvowK_l5-fCZM.ttf",
+    bold:    "https://fonts.gstatic.com/s/merriweather/v30/u-4n0qyriQwlOrhSvowK_l52xwNZWMf6hPvhPQ.ttf",
+  },
+  spacemono: {
+    family: "Space Mono",
+    regular: "https://fonts.gstatic.com/s/spacemono/v13/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf",
+    bold:    "https://fonts.gstatic.com/s/spacemono/v13/i7dMIFZifjKcF5UAWdDRaPpZUFWaHg.ttf",
+  },
+};
+
+/** Human labels for the font picker. */
+export const FONT_LABELS: Record<FontKey, string> = {
+  helvetica: "Helvetica (default)",
+  inter: "Inter",
+  roboto: "Roboto",
+  lora: "Lora (serif)",
+  merriweather: "Merriweather (serif)",
+  spacemono: "Space Mono",
+};
+
+let _registered = false;
+/**
+ * Register the curated font set with @react-pdf. Idempotent; call once before
+ * rendering. Registration only DECLARES sources — react-pdf fetches a family
+ * lazily when it's actually used, so a template on Helvetica never touches the
+ * network. Failures are swallowed: a missing font falls back to Helvetica
+ * rather than crashing the whole PDF.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function registerPdfFonts(Font: any): void {
+  if (_registered) return;
+  _registered = true;
+  for (const key of Object.keys(FONT_SOURCES) as Array<keyof typeof FONT_SOURCES>) {
+    const f = FONT_SOURCES[key];
+    try {
+      Font.register({
+        family: f.family,
+        fonts: [
+          { src: f.regular, fontWeight: "normal" },
+          { src: f.bold, fontWeight: "bold" },
+        ],
+      });
+    } catch {
+      /* ignore — Helvetica fallback */
+    }
+  }
+}
+
+/** Resolve the @react-pdf family names for a config's font. */
+export function fontFamilyFor(font: FontKey): { regular: string; bold: string } {
+  if (font === "helvetica") return { regular: "Helvetica", bold: "Helvetica-Bold" };
+  const f = FONT_SOURCES[font];
+  // Bold is the same family with fontWeight:"bold"; react-pdf picks the weight.
+  return { regular: f.family, bold: f.family };
+}
+
+/** Replace {{placeholders}} in a custom-field value. Unknown tokens are left
+ *  as-is so a typo is visible rather than silently blanked. */
+export function resolvePlaceholders(value: string, vars: Record<string, string>): string {
+  return value.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (m, key) =>
+    key in vars ? vars[key] : m,
+  );
+}

--- a/src/lib/documents/template-config.ts
+++ b/src/lib/documents/template-config.ts
@@ -165,7 +165,7 @@ export function resolveTemplateConfig(opts: {
           : (pdfSettings.invoice_template as TemplateBase | undefined),
         primary_color: pdfSettings.primary_color,
         logo_size: pdfSettings.logo_size,
-        document_title: docType === "quote" ? "QUOTE" : pdfSettings.invoice_title,
+        document_title: docType === "quote" ? "QUOTATION" : pdfSettings.invoice_title,
         label_tax: pdfSettings.label_tax,
         label_bank: pdfSettings.label_bank,
         label_account_name: pdfSettings.label_account_name,
@@ -176,7 +176,7 @@ export function resolveTemplateConfig(opts: {
 
   const base: TemplateConfig = {
     ...DEFAULT_TEMPLATE_CONFIG,
-    document_title: docType === "quote" ? "QUOTE" : DEFAULT_TEMPLATE_CONFIG.document_title,
+    document_title: docType === "quote" ? "QUOTATION" : DEFAULT_TEMPLATE_CONFIG.document_title,
   };
 
   // Drop undefined so a partial override never clobbers a good default.

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -26,6 +26,8 @@ import {
   type EmailTemplateType,
 } from "@/lib/emails/templates";
 import { customerAllowsCard } from "@/lib/payment-methods";
+import { DEFAULT_TEMPLATE_CONFIG } from "@/lib/documents/template-config";
+import { presetByKey, TEMPLATE_PRESETS } from "@/lib/documents/presets";
 import type { LineItem } from "@/types/database";
 import { ctxFrom, appBase, UUID, getOrMintPortalToken, type ToolFn } from "./tools/shared";
 import { registerPluginFormTools } from "./tools/plugin-form-tools";
@@ -653,6 +655,107 @@ export function registerTools(register: ToolFn): void {
       const { error } = await t(ctx, "email_templates").delete().eq("business_id", ctx.businessId).eq("template_type", args.template_type);
       if (error) throw error;
       return text({ reset: true, defaults: EMAIL_TEMPLATE_DEFAULTS[args.template_type as EmailTemplateType] });
+    });
+
+  // ===== DOCUMENT TEMPLATES (invoice / quote PDF templates) =====
+  const DOC_TPL_TYPE = z.enum(["invoice", "quote", "both"]);
+
+  tool("list_document_templates", "List saved PDF templates for invoices/quotes (name, doc_type, is_default). Optionally filter by doc_type. Also returns the built-in starter presets you can create from.",
+    { doc_type: z.enum(["invoice", "quote"]).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:read");
+      let q = t(ctx, "document_templates").select("id, name, doc_type, is_default, source, preset_key, created_at").eq("business_id", ctx.businessId).order("created_at", { ascending: true });
+      if (args.doc_type) q = q.in("doc_type", [args.doc_type, "both"]);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text({ templates: data ?? [], presets: TEMPLATE_PRESETS.map((p) => ({ key: p.key, name: p.name, description: p.description })) });
+    });
+
+  tool("get_document_template", "Get a document template's full config.",
+    { id: z.string() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:read");
+      const { data, error } = await t(ctx, "document_templates").select("*").eq("id", args.id).eq("business_id", ctx.businessId).maybeSingle();
+      if (error) throw error;
+      if (!data) return errorText("Template not found.");
+      return text(data);
+    });
+
+  tool("create_document_template", "Create a saved PDF template. Start from a built-in preset (from_preset, see list_document_templates) and/or pass a partial config to override (palette, fonts, background_image_url, watermark_text, custom_fields, columns, section toggles, labels — see the TemplateConfig shape). Optionally make it the default for its doc_type.",
+    {
+      name: z.string(),
+      doc_type: DOC_TPL_TYPE,
+      from_preset: z.string().optional(),
+      config: z.record(z.any()).optional(),
+      make_default: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const name = args.name?.trim();
+      if (!name) return errorText("name is required.");
+      const preset = args.from_preset ? presetByKey(args.from_preset) : undefined;
+      const config = { ...DEFAULT_TEMPLATE_CONFIG, ...(preset?.config ?? {}), ...(args.config ?? {}) };
+      const { data, error } = await t(ctx, "document_templates").insert({
+        business_id: ctx.businessId, name, doc_type: args.doc_type, config,
+        source: preset ? "preset" : "user", preset_key: preset?.key ?? null, is_default: false,
+      }).select().single();
+      if (error) throw error;
+      if (args.make_default) {
+        const overlap = args.doc_type === "both" ? ["invoice", "quote", "both"] : [args.doc_type, "both"];
+        await t(ctx, "document_templates").update({ is_default: false }).eq("business_id", ctx.businessId).in("doc_type", overlap);
+        await t(ctx, "document_templates").update({ is_default: true }).eq("id", data.id).eq("business_id", ctx.businessId);
+      }
+      return text({ created: true, id: data.id });
+    });
+
+  tool("update_document_template", "Update a template's name, doc_type, and/or config. config is merged onto the stored config, so pass only the fields you want to change.",
+    { id: z.string(), name: z.string().optional(), doc_type: DOC_TPL_TYPE.optional(), config: z.record(z.any()).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fields: Record<string, any> = {};
+      if (args.name !== undefined) fields.name = args.name.trim();
+      if (args.doc_type !== undefined) fields.doc_type = args.doc_type;
+      if (args.config !== undefined) {
+        const { data: ex } = await t(ctx, "document_templates").select("config").eq("id", args.id).eq("business_id", ctx.businessId).maybeSingle();
+        fields.config = { ...(ex?.config ?? {}), ...args.config };
+      }
+      if (Object.keys(fields).length === 0) return errorText("No fields to update.");
+      const { error } = await t(ctx, "document_templates").update(fields).eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("set_default_document_template", "Make a template the default for its doc_type (clears the previous default).",
+    { id: z.string() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const { data: row } = await t(ctx, "document_templates").select("doc_type").eq("id", args.id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!row) return errorText("Template not found.");
+      const overlap = row.doc_type === "both" ? ["invoice", "quote", "both"] : [row.doc_type, "both"];
+      await t(ctx, "document_templates").update({ is_default: false }).eq("business_id", ctx.businessId).in("doc_type", overlap);
+      const { error } = await t(ctx, "document_templates").update({ is_default: true }).eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ default: true });
+    });
+
+  tool("delete_document_template", "Delete a saved template. Documents using it revert to the business default.",
+    { id: z.string() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const { error } = await t(ctx, "document_templates").delete().eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("set_document_template", "Attach a saved template to a specific invoice or quote (or clear it with template_id null to fall back to the business default).",
+    { doc_type: z.enum(["invoice", "quote"]), doc_id: z.string(), template_id: z.string().nullable() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const table = args.doc_type === "invoice" ? "invoices" : "quotes";
+      const { error } = await t(ctx, table).update({ template_id: args.template_id }).eq("id", args.doc_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ attached: true });
     });
 
   // ===== STATS =====

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -174,6 +174,7 @@ export interface Invoice {
   site_id: string | null;
   property_address: string | null;
   parent_invoice_id?: string | null;
+  template_id?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -198,6 +199,22 @@ export interface Quote {
   invoice_id: string | null;
   site_id: string | null;
   property_address: string | null;
+  template_id?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A saved, named PDF template for invoices/quotes. `config` is a
+ *  Partial<TemplateConfig> (see src/lib/documents/template-config.ts). */
+export interface DocumentTemplate {
+  id: string;
+  business_id: string;
+  name: string;
+  doc_type: "invoice" | "quote" | "both";
+  is_default: boolean;
+  config: Record<string, unknown>;
+  source: "preset" | "user";
+  preset_key: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20260723090000_document_templates.sql
+++ b/supabase/migrations/20260723090000_document_templates.sql
@@ -1,0 +1,91 @@
+-- Document templates for invoices & quotes.
+--
+-- Businesses can save named, reusable PDF templates (theme, background, fonts,
+-- custom fields, column layout, section toggles, labels) and pick a default per
+-- document type. Each invoice/quote can point at a specific template; NULL means
+-- "use the business default", which itself falls back to the legacy
+-- businesses.pdf_settings so nothing that exists today changes appearance.
+--
+-- Mirrors the email_templates model (per-business rows, RLS: members read,
+-- owner/admin/editor write, workers blocked).
+
+CREATE TABLE IF NOT EXISTS public.document_templates (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name         text NOT NULL,
+  -- Which document types the template can be applied to.
+  doc_type     text NOT NULL DEFAULT 'both' CHECK (doc_type IN ('invoice','quote','both')),
+  -- The default template for its doc_type(s). Enforced to one-per-type in code
+  -- (setDefault clears siblings) — a partial unique index can't express the
+  -- 'both' overlap cleanly, so we keep the invariant in the server action.
+  is_default   boolean NOT NULL DEFAULT false,
+  -- Full render config (theme, background, fonts, custom fields, columns, …).
+  config       jsonb   NOT NULL DEFAULT '{}'::jsonb,
+  -- 'preset' = cloned from a built-in starter, 'user' = built from scratch.
+  source       text    NOT NULL DEFAULT 'user' CHECK (source IN ('preset','user')),
+  preset_key   text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS document_templates_business_idx
+  ON public.document_templates (business_id, doc_type);
+CREATE INDEX IF NOT EXISTS document_templates_default_idx
+  ON public.document_templates (business_id, doc_type, is_default);
+
+-- Per-document template selection. ON DELETE SET NULL so deleting a template
+-- silently reverts affected docs to the business default.
+ALTER TABLE public.invoices
+  ADD COLUMN IF NOT EXISTS template_id uuid
+  REFERENCES public.document_templates(id) ON DELETE SET NULL;
+ALTER TABLE public.quotes
+  ADD COLUMN IF NOT EXISTS template_id uuid
+  REFERENCES public.document_templates(id) ON DELETE SET NULL;
+
+-- updated_at maintenance
+CREATE OR REPLACE FUNCTION public.touch_document_templates_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END $$;
+
+DROP TRIGGER IF EXISTS trg_document_templates_updated_at ON public.document_templates;
+CREATE TRIGGER trg_document_templates_updated_at
+  BEFORE UPDATE ON public.document_templates
+  FOR EACH ROW EXECUTE FUNCTION public.touch_document_templates_updated_at();
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+ALTER TABLE public.document_templates ENABLE ROW LEVEL SECURITY;
+
+-- Read: owner or any active member that is NOT a worker.
+DROP POLICY IF EXISTS document_templates_read ON public.document_templates;
+CREATE POLICY document_templates_read ON public.document_templates
+  FOR SELECT USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- Write: owner or an active admin/editor member.
+DROP POLICY IF EXISTS document_templates_write ON public.document_templates;
+CREATE POLICY document_templates_write ON public.document_templates
+  FOR ALL USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active' AND role IN ('admin','editor')
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active' AND role IN ('admin','editor')
+    )
+    AND NOT public.is_business_worker(business_id)
+  );

--- a/supabase/migrations/20260723091000_document_assets_bucket.sql
+++ b/supabase/migrations/20260723091000_document_assets_bucket.sql
@@ -1,0 +1,41 @@
+-- Public bucket for document-template assets (background/letterhead images,
+-- watermark logos). Public-read so the @react-pdf renderer and the customer
+-- portal can fetch them by URL, exactly like business logos. Writes are limited
+-- to authenticated users, namespaced by business_id as the first path segment.
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('document-assets', 'document-assets', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Public read.
+DROP POLICY IF EXISTS "document_assets_public_read" ON storage.objects;
+CREATE POLICY "document_assets_public_read" ON storage.objects
+  FOR SELECT USING (bucket_id = 'document-assets');
+
+-- Authenticated write into a business the user can manage (owner/admin/editor).
+-- The first path segment must be that business_id.
+DROP POLICY IF EXISTS "document_assets_write" ON storage.objects;
+CREATE POLICY "document_assets_write" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'document-assets'
+    AND (storage.foldername(name))[1] IN (
+      SELECT id::text FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id::text FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active' AND role IN ('admin','editor')
+    )
+  );
+
+DROP POLICY IF EXISTS "document_assets_delete" ON storage.objects;
+CREATE POLICY "document_assets_delete" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'document-assets'
+    AND (storage.foldername(name))[1] IN (
+      SELECT id::text FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id::text FROM public.business_members
+       WHERE user_id = auth.uid() AND status = 'active' AND role IN ('admin','editor')
+    )
+  );


### PR DESCRIPTION
Saved, named PDF templates for invoices and quotes — a dedicated editor with live preview, ready-made starters, custom fields, custom backgrounds, configurable columns, and per-document selection.

## What's included
- **Data model** — `document_templates` (per-business, named, `doc_type`, `is_default`, JSONB `config`, preset source) + `template_id` on `invoices`/`quotes` (FK `SET NULL`). RLS mirrors `email_templates`. `document-assets` public storage bucket for background/letterhead images. *(Migrations already applied to the live DB.)*
- **Config-driven rendering** — both invoice and quote `@react-pdf` renderers now theme everything from a resolved `TemplateConfig` (palette, curated open-licence fonts, background image + watermark, logo placement, custom key/value fields, **editable line-item columns**, section toggles, custom labels/titles). Fully backward-compatible: a business with no templates renders exactly as before (`template → business default → legacy pdf_settings → defaults`).
- **7 ready-made starters** — Classic Blue, Minimal Mono, Modern Teal, Bold Header, Elegant Serif, Trades Bold, Letterhead.
- **Editor** — `Settings → Document Templates`: gallery + advanced editor (theme, typography, logo/header, background upload + watermark, labels, sections, reorderable columns, custom fields with `{{placeholders}}`) beside a **live PDF preview** (`/api/pdf/template-preview`).
- **Per-document picker** — a Template dropdown on the invoice & quote detail pages (hidden until a template exists) that attaches `template_id` and re-renders.
- **MCP** — 7 tools (`list/get/create/update/delete/set_default/attach`) under the `settings` scope, at parity with the app (standing repo rule).

## Verification
- `npx tsc --noEmit` clean · `npm run build` clean · `npm run bundle:check` within budget (2.17MB / 3.2MB).
- Tests: all 99 pass; 2 pre-existing skips. One unrelated suite (`content/prompts.test.ts`) fails on a Windows encoding quirk in a generated file — not touched by this PR.

## Notes
- Migrations (`20260723090000_document_templates`, `20260723091000_document_assets_bucket`) are applied + recorded on the live DB.
- Background-image upload ships; brand-font upload is a deliberate follow-up (curated open-licence font set for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)