### PR TITLE
fix(email): let Resend delivery webhook through auth middleware

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -59,6 +59,10 @@ export async function updateSession(request: NextRequest) {
     pathname === "/api/stripe/webhook" ||
     pathname === "/api/stripe/checkout" ||
     pathname === "/api/stripe/save-card" ||
+    // Resend delivery webhook (verifies its own Svix signature). Without this it
+    // was 307'd to /auth/login, so delivered/bounced events never reached the
+    // handler and every email stayed frozen at "Sent (in transit)".
+    pathname === "/api/webhooks/resend" ||
     (isBearerAuthRoute && hasBearer) ||
     (pathname.startsWith("/api/pdf/") && new URL(request.url).searchParams.get("token") !== null);
 


### PR DESCRIPTION
`/api/webhooks/resend` wasn't in the middleware's public-route allowlist, so Resend's delivery callbacks were redirected (HTTP 307) to `/auth/login` and never reached the handler. Result: every sent email stayed frozen at **"Sent (in transit)"** because the app never received the delivered/bounced events.

The route verifies its own Svix signature (it owns its auth), so it's safe to make public — exactly like `/api/stripe/webhook`. Verified against production: the endpoint 307'd before this change, and reaches its handler (400 on an empty body) after.

**Note:** the code fix is necessary but not sufficient on its own — the webhook endpoint must also be configured in the Resend dashboard (URL `https://www.kireihq.com/api/webhooks/resend`, delivery/bounce/opened events). Emails already stuck won't retroactively update; new sends will track once this ships + the endpoint is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)