### PR TITLE
fix(templates): quote footer custom fields render without notes

### DIFF
--- a/src/components/quotes/quote-pdf-document.tsx
+++ b/src/components/quotes/quote-pdf-document.tsx
@@ -303,10 +303,14 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, config,
             </View>
           </View>
 
-          {allNotes.length > 0 && (
+          {(allNotes.length > 0 || fieldsAt("footer").length > 0) && (
             <View style={styles.notesBox}>
-              <Text style={styles.notesTitle}>{cfg.section_title_notes.toUpperCase()} &amp; CONDITIONS</Text>
-              {allNotes.map((line, i) => <Text key={i} style={styles.notesItem}>• {line}</Text>)}
+              {allNotes.length > 0 && (
+                <>
+                  <Text style={styles.notesTitle}>{cfg.section_title_notes.toUpperCase()} &amp; CONDITIONS</Text>
+                  {allNotes.map((line, i) => <Text key={i} style={styles.notesItem}>• {line}</Text>)}
+                </>
+              )}
               <CustomFields where="footer" />
             </View>
           )}


### PR DESCRIPTION
The quote PDF renderer only rendered footer custom fields inside the NOTES & CONDITIONS block, which is gated on the quote having notes/terms. A template's footer fields (service T&Cs, cross-sell price lists) therefore disappeared on any quote without notes. Now the footer section renders when there are notes **or** footer custom fields; the NOTES heading only shows when notes exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)