### PR TITLE
feat(templates): multi-line rich text in custom fields

### DIFF
--- a/src/components/documents/rich-pdf-text.tsx
+++ b/src/components/documents/rich-pdf-text.tsx
@@ -1,0 +1,45 @@
+import { Text, View } from "@react-pdf/renderer";
+
+// Lightweight rich text for @react-pdf. Supports what template custom fields
+// need without a full markdown/HTML engine (which @react-pdf can't render):
+//   - new lines               → line breaks
+//   - blank line              → paragraph gap
+//   - line starting "- " / "• " → bullet
+//   - **bold** inline runs    → bold
+// Anything else is plain text.
+
+function parseBold(s: string): { text: string; bold: boolean }[] {
+  return s
+    .split(/\*\*/)
+    .map((t, i) => ({ text: t, bold: i % 2 === 1 }))
+    .filter((p) => p.text.length > 0);
+}
+
+export function RichPdfText({ text, style, boldStyle, bulletColor }: {
+  text: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  style?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  boldStyle?: any;
+  bulletColor?: string;
+}) {
+  const lines = (text ?? "").split("\n");
+  return (
+    <View>
+      {lines.map((line, i) => {
+        if (line.trim() === "") return <View key={i} style={{ height: 5 }} />;
+        const bullet = /^\s*[-•]\s+/.test(line);
+        const content = bullet ? line.replace(/^\s*[-•]\s+/, "") : line;
+        const runs = parseBold(content);
+        return (
+          <View key={i} style={{ flexDirection: "row" }}>
+            {bullet && <Text style={[style, { marginRight: 4, color: bulletColor ?? undefined }]}>•</Text>}
+            <Text style={[style, { flex: 1 }]}>
+              {runs.map((r, j) => (r.bold ? <Text key={j} style={boldStyle}>{r.text}</Text> : r.text))}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/src/components/invoices/invoice-pdf-document.tsx
+++ b/src/components/invoices/invoice-pdf-document.tsx
@@ -2,6 +2,7 @@ import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/render
 import type { Business, Customer, Invoice, LineItem, PdfSettings } from "@/types/database";
 import type { TemplateConfig, TemplateColumn } from "@/lib/documents/template-config";
 import { resolveTemplateConfig, fontFamilyFor, resolvePlaceholders } from "@/lib/documents/template-config";
+import { RichPdfText } from "@/components/documents/rich-pdf-text";
 
 function fmtCurrency(amount: number, currency: string): string {
   return new Intl.NumberFormat("en-AU", {
@@ -142,13 +143,18 @@ export function InvoicePDFDocument({ invoice, customer, business, lineItems, con
   const CustomFields = ({ where }: { where: "header" | "meta" | "footer" }) => {
     const list = fieldsAt(where);
     if (!list.length) return null;
+    const inFooter = where === "footer";
     return (
-      <View style={where === "footer" ? styles.footerSection : { marginTop: where === "meta" ? 8 : 6 }}>
-        {where === "footer" && <Text style={styles.footerTitle}>Details</Text>}
+      <View style={inFooter ? styles.footerSection : { marginTop: where === "meta" ? 8 : 6 }}>
         {list.map((f) => (
-          <View key={f.id} style={styles.fieldRow}>
-            {f.label ? <Text style={[styles.fieldLabel, where !== "footer" ? bold : {}]}>{f.label}:</Text> : null}
-            <Text style={where === "footer" ? styles.footerText : {}}>{resolvePlaceholders(f.value, vars)}</Text>
+          <View key={f.id} style={{ marginBottom: 5 }}>
+            {f.label ? <Text style={inFooter ? styles.footerTitle : [styles.fieldLabel, bold]}>{f.label}</Text> : null}
+            <RichPdfText
+              text={resolvePlaceholders(f.value, vars)}
+              style={inFooter ? styles.footerText : { fontSize: fs(8.5), color: muted }}
+              boldStyle={bold}
+              bulletColor={primary}
+            />
           </View>
         ))}
       </View>

--- a/src/components/quotes/quote-pdf-document.tsx
+++ b/src/components/quotes/quote-pdf-document.tsx
@@ -2,6 +2,7 @@ import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/render
 import type { Business, Customer, Quote, LineItem, PdfSettings } from "@/types/database";
 import type { TemplateConfig, TemplateColumn } from "@/lib/documents/template-config";
 import { resolveTemplateConfig, fontFamilyFor, resolvePlaceholders } from "@/lib/documents/template-config";
+import { RichPdfText } from "@/components/documents/rich-pdf-text";
 
 interface Props {
   quote: Quote;
@@ -179,12 +180,18 @@ export function QuotePDFDocument({ quote, customer, business, lineItems, config,
   const CustomFields = ({ where }: { where: "header" | "meta" | "footer" }) => {
     const list = fieldsAt(where);
     if (!list.length) return null;
+    const inFooter = where === "footer";
     return (
       <View style={{ marginTop: 6 }}>
         {list.map((f) => (
-          <View key={f.id} style={styles.fieldRow}>
-            {f.label ? <Text style={styles.fieldLabel}>{f.label}:</Text> : null}
-            <Text style={{ fontSize: fs(9), color: midDark }}>{resolvePlaceholders(f.value, vars)}</Text>
+          <View key={f.id} style={{ marginBottom: 5 }}>
+            {f.label ? <Text style={inFooter ? styles.notesTitle : styles.fieldLabel}>{f.label}</Text> : null}
+            <RichPdfText
+              text={resolvePlaceholders(f.value, vars)}
+              style={{ fontSize: fs(8.5), color: midDark, lineHeight: 1.6 }}
+              boldStyle={bold}
+              bulletColor={accent}
+            />
           </View>
         ))}
       </View>

--- a/src/components/settings/document-templates-client.tsx
+++ b/src/components/settings/document-templates-client.tsx
@@ -396,7 +396,14 @@ function CustomFieldsEditor({ config, setConfig }: { config: TemplateConfig; set
             <Input value={f.label} onChange={(e) => update(f.id, { label: e.target.value })} placeholder="Label" className="h-8" />
             <button onClick={() => remove(f.id)} className="text-destructive px-1"><Trash2 className="w-3.5 h-3.5" /></button>
           </div>
-          <Input value={f.value} onChange={(e) => update(f.id, { value: e.target.value })} placeholder="Value — supports {{customer_name}}, {{document_number}}…" className="h-8" />
+          <textarea
+            value={f.value}
+            onChange={(e) => update(f.id, { value: e.target.value })}
+            rows={4}
+            placeholder={"Value — one line per new line.\nStart a line with - for a bullet, wrap **text** for bold.\nPlaceholders: {{customer_name}}, {{document_number}}…"}
+            className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-sm min-h-[72px] resize-y font-[inherit]"
+          />
+          <p className="text-[10px] text-muted-foreground">New lines, <code>-</code> bullets and <code>**bold**</code> supported.</p>
           <Select value={f.placement} onChange={(v) => update(f.id, { placement: v as FieldPlacement })} options={[["header", "In the header"], ["meta", "Near the dates"], ["footer", "In the footer"]]} />
         </div>
       ))}


### PR DESCRIPTION
Template custom-field values were single-line plain text. This makes them multi-line with light rich text so they can hold real content like service terms and cross-sell lists.

- **Editor**: the value input is now a **textarea** — new lines are preserved. Hint shows the supported syntax.
- **Rendering** (, used by both invoice & quote PDFs): new lines → line breaks, lines starting `- `/`• ` → bullets, `**bold**` → bold. Anything else is plain text. (@react-pdf can't render full HTML/markdown, so this is a deliberate practical subset.)
- Field label now sits above the value so multi-line blocks read cleanly.

The four Connected Studio templates' terms/cross-sell were reformatted into bullet lists to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)