### PR TITLE
feat(templates): pick template + live PDF preview in the quote/invoice editor

### DIFF
--- a/src/app/api/pdf/draft-preview/route.ts
+++ b/src/app/api/pdf/draft-preview/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/auth";
+import { getActiveBizId } from "@/lib/active-business";
+import { getBusiness } from "@/lib/actions/business";
+import { resolveDocumentConfig } from "@/lib/documents/resolve";
+import { registerPdfFonts } from "@/lib/documents/template-config";
+
+// Live preview for the invoice/quote editor: renders the ACTUAL in-progress
+// document (real line items, totals, customer) with the selected template — so
+// the user sees exactly how their quote/invoice will look while building it.
+// Authenticated; returns inline PDF for an <iframe>.
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const user = await getUser();
+    const businessId = await getActiveBizId(supabase, user.id);
+
+    const body = (await req.json()) as {
+      doc_type?: "invoice" | "quote";
+      template_id?: string | null;
+      customer_id?: string | null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doc?: Record<string, any>;
+    };
+    const docType = body.doc_type === "quote" ? "quote" : "invoice";
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const business = (await getBusiness()) as any;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let customer: any = null;
+    if (body.customer_id) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data } = await (supabase as any)
+        .from("customers").select("*").eq("id", body.customer_id).eq("business_id", businessId).maybeSingle();
+      customer = data ?? null;
+    }
+
+    const config = await resolveDocumentConfig(supabase, {
+      businessId, docType,
+      templateId: body.template_id ?? null,
+      pdfSettings: business?.pdf_settings ?? null,
+    });
+
+    const d = body.doc ?? {};
+    const lineItems = Array.isArray(d.line_items) ? d.line_items : [];
+    const doc = {
+      id: "preview",
+      number: d.number || (docType === "quote" ? "QUO-PREVIEW" : "INV-PREVIEW"),
+      status: d.status ?? "draft",
+      customer_id: body.customer_id ?? null,
+      issue_date: d.issue_date || new Date().toISOString().slice(0, 10),
+      due_date: d.due_date || d.expiry_date || new Date().toISOString().slice(0, 10),
+      expiry_date: d.expiry_date || new Date().toISOString().slice(0, 10),
+      line_items: lineItems,
+      subtotal: Number(d.subtotal) || 0,
+      discount_type: d.discount_type ?? null,
+      discount_value: Number(d.discount_value) || 0,
+      discount_amount: Number(d.discount_amount) || 0,
+      tax_total: Number(d.tax_total) || 0,
+      total: Number(d.total) || 0,
+      amount_paid: Number(d.amount_paid) || 0,
+      notes: d.notes ?? null,
+      terms: d.terms ?? null,
+      property_address: d.property_address ?? null,
+    };
+
+    const { renderToStream, Font } = await import("@react-pdf/renderer");
+    const React = await import("react");
+    registerPdfFonts(Font);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let element: any;
+    if (docType === "quote") {
+      const { QuotePDFDocument } = await import("@/components/quotes/quote-pdf-document");
+      element = React.createElement(QuotePDFDocument, { quote: doc as never, customer, business, lineItems, config });
+    } else {
+      const { InvoicePDFDocument } = await import("@/components/invoices/invoice-pdf-document");
+      element = React.createElement(InvoicePDFDocument, { invoice: doc as never, customer, business, lineItems, config });
+    }
+
+    const stream = await renderToStream(element);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    return new NextResponse(Buffer.concat(chunks), {
+      headers: { "Content-Type": "application/pdf", "Content-Disposition": "inline; filename=preview.pdf", "Cache-Control": "no-store" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[PDF/draft-preview]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/documents/document-preview-pane.tsx
+++ b/src/components/documents/document-preview-pane.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Loader2, ChevronDown, ChevronUp } from "@/components/ui/icons";
+import { getDocumentTemplates } from "@/lib/actions/document-templates";
+
+/**
+ * Live PDF preview + template selector for the invoice/quote editor. Shows the
+ * ACTUAL in-progress document (real line items, totals, customer) rendered with
+ * the selected template, updating (debounced) as the user edits.
+ */
+export function DocumentPreviewPane({ docType, templateId, onTemplateChange, draft, customerId }: {
+  docType: "invoice" | "quote";
+  templateId: string | null;
+  onTemplateChange: (id: string | null) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  draft: Record<string, any>;
+  customerId: string | null;
+}) {
+  const [templates, setTemplates] = useState<{ id: string; name: string }[]>([]);
+  const [open, setOpen] = useState(true);
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const lastUrl = useRef<string | null>(null);
+
+  useEffect(() => {
+    getDocumentTemplates(docType)
+      .then((t) => setTemplates(t.map((x) => ({ id: x.id, name: x.name }))))
+      .catch(() => setTemplates([]));
+  }, [docType]);
+
+  const key = useMemo(() => JSON.stringify({ templateId, customerId, draft }), [templateId, customerId, draft]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/pdf/draft-preview", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ doc_type: docType, template_id: templateId, customer_id: customerId, doc: draft }),
+        });
+        if (cancelled) return;
+        if (!res.ok) { setError("Couldn't render preview"); return; }
+        const blob = await res.blob();
+        if (cancelled) return;
+        const next = URL.createObjectURL(blob);
+        if (lastUrl.current) URL.revokeObjectURL(lastUrl.current);
+        lastUrl.current = next;
+        setUrl(next);
+      } catch {
+        if (!cancelled) setError("Couldn't render preview");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 600);
+    return () => { cancelled = true; clearTimeout(handle); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, open]);
+
+  useEffect(() => () => { if (lastUrl.current) URL.revokeObjectURL(lastUrl.current); }, []);
+
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-semibold">Live preview</span>
+          {loading && <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />}
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            Template
+            <select
+              value={templateId ?? ""}
+              onChange={(e) => onTemplateChange(e.target.value || null)}
+              className="h-8 rounded-md border border-border bg-card px-2 text-sm text-foreground max-w-[200px]"
+            >
+              <option value="">Business default</option>
+              {templates.map((t) => <option key={t.id} value={t.id}>{t.name}</option>)}
+            </select>
+          </label>
+          <button type="button" onClick={() => setOpen((o) => !o)} className="text-muted-foreground hover:text-foreground">
+            {open ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+      {open && (
+        <div className="bg-muted/30">
+          {error ? (
+            <div className="h-[70vh] flex items-center justify-center text-sm text-muted-foreground">{error}</div>
+          ) : url ? (
+            <iframe title="Document preview" src={url} className="w-full h-[80vh] bg-white" />
+          ) : (
+            <div className="h-[70vh] flex items-center justify-center"><Loader2 className="w-6 h-6 animate-spin text-muted-foreground" /></div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/invoices/invoice-editor.tsx
+++ b/src/components/invoices/invoice-editor.tsx
@@ -20,6 +20,7 @@ import { createInvoice, updateInvoice, sendInvoiceEmail, sendInvoiceSms } from "
 import { SendDocumentModal } from "@/components/send/send-document-modal";
 import { LineItemsEditor } from "./line-items-editor";
 import { SmartFillModal } from "./smart-fill-modal";
+import { DocumentPreviewPane } from "@/components/documents/document-preview-pane";
 import type { SmartFillData } from "./smart-fill-modal";
 import { formatCurrency } from "@/lib/utils";
 import { ClientSelect } from "@/components/customers/client-select";
@@ -72,6 +73,7 @@ export function InvoiceEditor({ customers, products, business, invoice, defaultC
   const [propertyAddress, setPropertyAddress] = useState<string>(invoice?.property_address ?? "");
   const [sendOpen, setSendOpen] = useState(false);
   const [savedInvoice, setSavedInvoice] = useState<Invoice | null>(invoice ?? null);
+  const [templateId, setTemplateId] = useState<string | null>(invoice?.template_id ?? null);
 
   const { register, handleSubmit, watch, setValue } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -130,6 +132,7 @@ export function InvoiceEditor({ customers, products, business, invoice, defaultC
         terms: data.terms ?? null,
         site_id: siteId,
         property_address: propertyAddress || null,
+        template_id: templateId,
       };
 
       if (invoice) {
@@ -169,6 +172,25 @@ export function InvoiceEditor({ customers, products, business, invoice, defaultC
   });
 
   const selectedCustomer = localCustomers.find((c) => c.id === watch("customer_id")) ?? null;
+
+  const fv = watch();
+  const previewDraft = {
+    number: invoice?.number ?? "PREVIEW",
+    status: invoice?.status ?? "draft",
+    issue_date: fv.issue_date,
+    due_date: fv.due_date,
+    line_items: lineItems,
+    subtotal,
+    discount_type: fv.discount_type ?? null,
+    discount_value: fv.discount_value ?? 0,
+    discount_amount: discountAmount,
+    tax_total: taxTotal,
+    total,
+    amount_paid: invoice?.amount_paid ?? 0,
+    notes: fv.notes ?? null,
+    terms: fv.terms ?? null,
+    property_address: propertyAddress || null,
+  };
 
   return (
     <div className="space-y-6">
@@ -370,6 +392,14 @@ export function InvoiceEditor({ customers, products, business, invoice, defaultC
           }}
         />
       )}
+
+      <DocumentPreviewPane
+        docType="invoice"
+        templateId={templateId}
+        onTemplateChange={setTemplateId}
+        draft={previewDraft}
+        customerId={fv.customer_id || null}
+      />
 
       <SmartFillModal
         open={smartFillOpen}

--- a/src/components/quotes/quote-editor.tsx
+++ b/src/components/quotes/quote-editor.tsx
@@ -30,6 +30,7 @@ import { DEFAULT_PDF_SETTINGS } from "@/types/database";
 import Link from "next/link";
 import { AiAssistButton } from "@/components/ai/ai-assist-button";
 import { AiImageAnalyzer } from "@/components/ai/ai-image-analyzer";
+import { DocumentPreviewPane } from "@/components/documents/document-preview-pane";
 
 const schema = z.object({
   customer_id: z.string().optional(),
@@ -70,6 +71,7 @@ export function QuoteEditor({ customers, products, business, quote, defaultCusto
   const [propertyAddress, setPropertyAddress] = useState<string>(quote?.property_address ?? "");
   const [sendOpen, setSendOpen] = useState(false);
   const [savedQuote, setSavedQuote] = useState<Quote | null>(quote ?? null);
+  const [templateId, setTemplateId] = useState<string | null>(quote?.template_id ?? null);
 
   const { register, handleSubmit, watch, setValue } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -122,6 +124,7 @@ export function QuoteEditor({ customers, products, business, quote, defaultCusto
         invoice_id: quote?.invoice_id ?? null,
         site_id: siteId,
         property_address: propertyAddress || null,
+        template_id: templateId,
       };
 
       if (quote) {
@@ -157,6 +160,24 @@ export function QuoteEditor({ customers, products, business, quote, defaultCusto
   });
 
   const selectedCustomer = localCustomers.find((c) => c.id === watch("customer_id")) ?? null;
+
+  const fv = watch();
+  const previewDraft = {
+    number: quote?.number ?? "PREVIEW",
+    status: quote?.status ?? "draft",
+    issue_date: fv.issue_date,
+    expiry_date: fv.expiry_date,
+    line_items: lineItems,
+    subtotal,
+    discount_type: fv.discount_type ?? null,
+    discount_value: fv.discount_value ?? 0,
+    discount_amount: discountAmount,
+    tax_total: taxTotal,
+    total,
+    notes: fv.notes ?? null,
+    terms: fv.terms ?? null,
+    property_address: propertyAddress || null,
+  };
 
   return (
     <div className="space-y-6">
@@ -313,6 +334,14 @@ export function QuoteEditor({ customers, products, business, quote, defaultCusto
           }}
         />
       )}
+
+      <DocumentPreviewPane
+        docType="quote"
+        templateId={templateId}
+        onTemplateChange={setTemplateId}
+        draft={previewDraft}
+        customerId={fv.customer_id || null}
+      />
 
       <SmartFillModal
         open={smartFillOpen}


### PR DESCRIPTION
Two requests: select the template **while making** a quote/invoice, and see a **live PDF preview**.

- **DocumentPreviewPane** — a Template dropdown plus a **live PDF of the actual in-progress document** (your real line items, totals, dates, customer, notes), rendered with the selected template and updated as you edit (debounced 600ms). Collapsible so it stays out of the way.
- **New route** `/api/pdf/draft-preview` renders the unsaved draft + chosen template server-side (authenticated).
- **Both editors** now track `template_id`, include it on save (the create/update actions spread the payload, so it persists to the document), and show the pane at the bottom of the form. Editing an existing doc pre-selects its template.

tsc + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)