### PR TITLE
feat: Materials plugin — a cost-price catalog (Products clone)

### DIFF
--- a/src/app/(dashboard)/materials/page.tsx
+++ b/src/app/(dashboard)/materials/page.tsx
@@ -1,0 +1,8 @@
+import { getMaterials } from "@/lib/actions/materials";
+import { getBusiness } from "@/lib/actions/business";
+import { MaterialsClient } from "@/components/materials/materials-client";
+
+export default async function MaterialsPage() {
+  const [materials, business] = await Promise.all([getMaterials(), getBusiness()]);
+  return <MaterialsClient materials={materials} currency={business.currency} />;
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -58,6 +58,7 @@ const navSections: NavSection[] = [
   ]},
   { section: "Catalog", items: [
     { label: "Products",   href: "/products",   icon: Package,       plugin: "products" },
+    { label: "Materials",  href: "/materials",  icon: Package,       plugin: "materials" },
     { label: "Inventory",  href: "/inventory",  icon: Boxes,         plugin: "inventory" },
   ]},
   { section: "Workforce", items: [

--- a/src/components/materials/material-form.tsx
+++ b/src/components/materials/material-form.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { Material } from "@/types/database";
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  description: z.string().optional(),
+  sku: z.string().optional(),
+  supplier: z.string().optional(),
+  cost_price: z.coerce.number().min(0, "Cost must be positive"),
+  tax_rate: z.coerce.number().min(0).max(100),
+  unit: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface MaterialFormProps {
+  material?: Material;
+  onSubmit: (data: FormData & { archived: boolean }) => Promise<void>;
+  onCancel?: () => void;
+}
+
+export function MaterialForm({ material, onSubmit, onCancel }: MaterialFormProps) {
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: material ? {
+      name: material.name,
+      description: material.description ?? "",
+      sku: material.sku ?? "",
+      supplier: material.supplier ?? "",
+      cost_price: material.cost_price,
+      tax_rate: material.tax_rate,
+      unit: material.unit ?? "",
+    } : { tax_rate: 20 },
+  });
+
+  const handleFormSubmit = async (data: FormData) => {
+    await onSubmit({ ...data, archived: material?.archived ?? false });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
+      <div className="space-y-1.5">
+        <Label>Name *</Label>
+        <Input placeholder="e.g. 90mm PVC pipe" {...register("name")} />
+        {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
+      </div>
+      <div className="space-y-1.5">
+        <Label>Description</Label>
+        <Textarea placeholder="Brief description..." rows={2} {...register("description")} />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Cost price</Label>
+          <Input type="number" step="0.01" placeholder="0.00" {...register("cost_price")} />
+          {errors.cost_price && <p className="text-xs text-destructive">{errors.cost_price.message}</p>}
+        </div>
+        <div className="space-y-1.5">
+          <Label>Tax rate (%)</Label>
+          <Input type="number" step="0.01" placeholder="20" {...register("tax_rate")} />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>SKU / code</Label>
+          <Input placeholder="Optional" {...register("sku")} />
+        </div>
+        <div className="space-y-1.5">
+          <Label>Supplier</Label>
+          <Input placeholder="Optional" {...register("supplier")} />
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <Label>Unit</Label>
+        <Input placeholder="e.g. each, m, kg, box" {...register("unit")} />
+      </div>
+      <div className="flex gap-3 pt-2">
+        {onCancel && <Button type="button" variant="outline" className="flex-1" onClick={onCancel}>Cancel</Button>}
+        <Button type="submit" className="flex-1" disabled={isSubmitting}>
+          {isSubmitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+          {material ? "Save changes" : "Add material"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/materials/materials-client.tsx
+++ b/src/components/materials/materials-client.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Search, Package, Edit, Trash2, Upload, DollarSign, CheckCircle } from "@/components/ui/icons";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/layout/page-header";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { createMaterial, updateMaterial, deleteMaterial, bulkImportMaterials } from "@/lib/actions/materials";
+import { BulkImportModal } from "@/components/shared/bulk-import-modal";
+import { MaterialForm } from "./material-form";
+import { formatCurrency, sumMoney } from "@/lib/utils";
+import {
+  StatTile, KireiPill, EmptyState, AnimatedPress, FadeIn, GradientTile,
+} from "@/components/ui/kirei";
+import type { Material } from "@/types/database";
+
+const MATERIAL_COLUMNS = [
+  { key: "name", label: "Name", required: true },
+  { key: "cost_price", label: "Cost Price", required: true, type: "number" as const },
+  { key: "tax_rate", label: "Tax Rate (%)", type: "number" as const },
+  { key: "description", label: "Description" },
+  { key: "sku", label: "SKU" },
+  { key: "supplier", label: "Supplier" },
+  { key: "unit", label: "Unit" },
+];
+
+type FormValues = { name: string; cost_price: number; tax_rate: number; description?: string; sku?: string; supplier?: string; unit?: string; archived: boolean };
+
+export function MaterialsClient({ materials: initial, currency = "GBP" }: { materials: Material[]; currency?: string }) {
+  const [materials, setMaterials] = useState(initial);
+  const [search, setSearch] = useState("");
+  const [editMaterial, setEditMaterial] = useState<Material | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const filtered = materials.filter((m) =>
+    `${m.name} ${m.description ?? ""} ${m.sku ?? ""} ${m.supplier ?? ""}`.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const handleCreate = async (data: FormValues) => {
+    try {
+      const material = await createMaterial({
+        name: data.name,
+        cost_price: data.cost_price,
+        tax_rate: data.tax_rate,
+        description: data.description ?? null,
+        sku: data.sku ?? null,
+        supplier: data.supplier ?? null,
+        unit: data.unit ?? null,
+        archived: data.archived,
+      });
+      setMaterials((prev) => [...prev, material]);
+      setShowNew(false);
+      toast.success("Material added");
+    } catch { toast.error("Failed to add material"); }
+  };
+
+  const handleUpdate = async (data: Partial<FormValues>) => {
+    if (!editMaterial) return;
+    try {
+      const updated = await updateMaterial(editMaterial.id, {
+        ...data,
+        description: data.description ?? null,
+        sku: data.sku ?? null,
+        supplier: data.supplier ?? null,
+        unit: data.unit ?? null,
+      });
+      setMaterials((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
+      setEditMaterial(null);
+      toast.success("Material updated");
+    } catch { toast.error("Failed to update material"); }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    try {
+      await deleteMaterial(deleteId);
+      setMaterials((prev) => prev.filter((m) => m.id !== deleteId));
+      toast.success("Material deleted");
+    } catch { toast.error("Failed to delete"); }
+    setDeleteId(null);
+  };
+
+  // sumMoney coerces the string PostgREST returns for numeric columns, so this
+  // total is the real sum of cost prices, not a $NaN concatenation.
+  const totalCatalogCost = sumMoney(materials, (m) => m.cost_price);
+  const archivedCount = materials.filter((m) => m.archived).length;
+  const activeCount = materials.length - archivedCount;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Materials"
+        subtitle={`${activeCount} active · ${archivedCount} archived · cost reference catalog`}
+        accent="linear-gradient(180deg, #fbbf24 0%, #b45309 100%)"
+        actions={
+          <>
+            <button
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+              onClick={() => setShowImport(true)}
+            >
+              <Upload className="w-4 h-4" /> Import CSV
+            </button>
+            <AnimatedPress
+              onClick={() => setShowNew(true)}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer"
+            >
+              <Plus className="w-4 h-4" /> Add material
+            </AnimatedPress>
+          </>
+        }
+      />
+
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+        <FadeIn delay={60}><StatTile gradient="softAmber" toneColor="#78350f" icon={<Package     className="w-3.5 h-3.5" />} label="Total items"  value={String(materials.length)}                  sub="in catalog" /></FadeIn>
+        <FadeIn delay={110}><StatTile gradient="softAmber" toneColor="#78350f" icon={<DollarSign  className="w-3.5 h-3.5" />} label="Total cost"   value={formatCurrency(totalCatalogCost, currency)} sub="sum of cost prices" /></FadeIn>
+        <FadeIn delay={160}><StatTile gradient="softTeal"  toneColor="#064e3b" icon={<CheckCircle className="w-3.5 h-3.5" />} label="Active"       value={String(activeCount)}                        sub="materials on file" /></FadeIn>
+      </div>
+
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input className="pl-9 h-10 rounded-xl" placeholder="Search materials…" value={search} onChange={(e) => setSearch(e.target.value)} />
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          icon={<Package className="w-7 h-7" />}
+          gradient="amber"
+          title={search ? "No matches" : "No materials yet"}
+          hint={search ? "Try a different search." : "Build a catalog of your material costs to use as a reference when pricing jobs."}
+          cta={!search ? { label: "Add material", href: "#", icon: <Plus className="w-4 h-4" /> } : undefined}
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-muted/40 text-[10px] uppercase tracking-wide font-bold text-muted-foreground">
+            <span className="flex-1">Material</span>
+            <span className="hidden md:block w-24">Supplier</span>
+            <span className="hidden md:block w-20">Unit</span>
+            <span className="hidden md:block w-16 text-right">Tax</span>
+            <span className="w-24 text-right">Status</span>
+            <span className="w-28 text-right">Cost</span>
+            <span className="w-16" />
+          </div>
+          <div className="divide-y divide-border/60">
+            {filtered.map((material) => (
+              <div
+                key={material.id}
+                onClick={() => setEditMaterial(material)}
+                className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
+              >
+                <GradientTile gradient="amber" size={40} radius={10}>
+                  <Package className="w-4 h-4" />
+                </GradientTile>
+                <div className="flex-1 min-w-[140px] basis-0">
+                  <div className="text-sm font-semibold break-words">{material.name}</div>
+                  {(material.description || material.sku) && (
+                    <div className="text-xs text-muted-foreground break-words max-w-md">
+                      {material.sku ? `${material.sku}${material.description ? " · " : ""}` : ""}{material.description}
+                    </div>
+                  )}
+                </div>
+                <div className="hidden md:block w-24 text-xs text-muted-foreground break-words">{material.supplier ?? "—"}</div>
+                <div className="hidden md:block w-20 text-xs text-muted-foreground break-words">{material.unit ?? "—"}</div>
+                <div className="hidden md:block w-16 text-right text-xs text-muted-foreground">{material.tax_rate}%</div>
+                <div className="ml-auto md:ml-0 md:w-24 text-right">
+                  <KireiPill tone={material.archived ? "archived" : "active"} />
+                </div>
+                <div className="md:w-28 text-right text-sm font-semibold tabular-nums">{formatCurrency(material.cost_price, currency)}</div>
+                <div className="w-16 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
+                  <div className="flex items-center justify-end gap-1">
+                    <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground" onClick={() => setEditMaterial(material)}>
+                      <Edit className="w-3.5 h-3.5" />
+                    </button>
+                    <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-destructive" onClick={() => setDeleteId(material.id)}>
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <Sheet open={showNew} onOpenChange={setShowNew}>
+        <SheetContent className="overflow-y-auto">
+          <SheetHeader><SheetTitle>New material</SheetTitle></SheetHeader>
+          <div className="mt-6">
+            <MaterialForm onSubmit={handleCreate} onCancel={() => setShowNew(false)} />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={!!editMaterial} onOpenChange={(o) => !o && setEditMaterial(null)}>
+        <SheetContent className="overflow-y-auto">
+          <SheetHeader><SheetTitle>Edit material</SheetTitle></SheetHeader>
+          <div className="mt-6">
+            {editMaterial && <MaterialForm material={editMaterial} onSubmit={handleUpdate} onCancel={() => setEditMaterial(null)} />}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <BulkImportModal
+        open={showImport}
+        onOpenChange={setShowImport}
+        title="Import materials"
+        columns={MATERIAL_COLUMNS}
+        onImport={(rows) => bulkImportMaterials(rows as Parameters<typeof bulkImportMaterials>[0])}
+        onSuccess={(count) => {
+          toast.success(`${count} material${count !== 1 ? "s" : ""} imported`);
+          window.location.reload();
+        }}
+      />
+
+      <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete material?</AlertDialogTitle>
+            <AlertDialogDescription>This removes it from your cost catalog. Quotes and invoices are unaffected.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -1,0 +1,99 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import type { Material } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+type NewMaterial = Omit<Material, "id" | "created_at" | "updated_at" | "user_id" | "business_id">;
+
+export async function getMaterials(includeArchived = false): Promise<Material[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  let query = tbl(supabase, "materials").select("*").eq("business_id", businessId).order("name");
+  if (!includeArchived) query = query.eq("archived", false);
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return data as Material[];
+}
+
+export async function createMaterial(payload: NewMaterial): Promise<Material> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "materials")
+    .insert({ ...payload, user_id: user.id, business_id: businessId })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/materials");
+  return data as Material;
+}
+
+export async function updateMaterial(id: string, payload: Partial<Material>): Promise<Material> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "materials")
+    .update(payload)
+    .eq("id", id)
+    .eq("business_id", businessId)
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/materials");
+  return data as Material;
+}
+
+export async function deleteMaterial(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { error } = await tbl(supabase, "materials")
+    .delete()
+    .eq("id", id)
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/materials");
+}
+
+export async function bulkImportMaterials(
+  rows: Array<Omit<Material, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "archived">>,
+): Promise<{ imported: number; errors: string[] }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const errors: string[] = [];
+  let imported = 0;
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row.name?.trim()) { errors.push(`Row ${i + 1}: name is required`); continue; }
+    const price = Number(row.cost_price);
+    if (isNaN(price)) { errors.push(`Row ${i + 1} (${row.name}): cost_price must be a number`); continue; }
+    const { error } = await tbl(supabase, "materials").insert({
+      ...row,
+      name: row.name.trim(),
+      cost_price: price,
+      tax_rate: Number(row.tax_rate) || 0,
+      user_id: user.id,
+      business_id: businessId,
+      archived: false,
+    });
+    if (error) { errors.push(`Row ${i + 1} (${row.name}): ${error.message}`); continue; }
+    imported++;
+  }
+
+  revalidatePath("/materials");
+  return { imported, errors };
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -34,6 +34,7 @@ import { registerPluginFormTools } from "./tools/plugin-form-tools";
 import { registerSeoTools } from "./tools/seo-tools";
 import { registerContentTools } from "./tools/content-tools";
 import { registerExpenseTools } from "./tools/expenses-tools";
+import { registerMaterialTools } from "./tools/materials-tools";
 import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
@@ -1521,6 +1522,8 @@ export function registerTools(register: ToolFn): void {
 
   // ===== EXPENSES & JOB COSTING =====
   registerExpenseTools(tool);
+
+  registerMaterialTools(tool);
 
   // ===== INVENTORY & STOCK =====
   registerInventoryTools(tool);

--- a/src/lib/mcp/tools/materials-tools.ts
+++ b/src/lib/mcp/tools/materials-tools.ts
@@ -1,0 +1,78 @@
+/**
+ * MCP tools for the Materials plugin — a per-business catalog of materials with
+ * COST prices (an internal cost reference, distinct from products/retail).
+ * Scopes: materials:read / materials:write.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+
+export function registerMaterialTools(tool: ToolFn): void {
+  tool("list_materials", "List materials in the cost catalog (name, cost price, unit, supplier). Optional name search.",
+    { search: z.string().optional(), include_archived: z.boolean().optional(), limit: z.number().int().min(1).max(200).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "materials:read");
+      let q = t(ctx, "materials")
+        .select("id, name, description, sku, supplier, cost_price, tax_rate, unit, archived")
+        .eq("business_id", ctx.businessId).order("name").limit(args.limit ?? 100);
+      if (!args.include_archived) q = q.eq("archived", false);
+      if (args.search) q = q.ilike("name", `%${args.search}%`);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_material", "Add a material to the cost catalog. cost_price is what YOU pay (not the customer price).",
+    {
+      name: z.string().min(1),
+      cost_price: z.number(),
+      tax_rate: z.number().optional(),
+      description: z.string().optional(),
+      sku: z.string().optional(),
+      supplier: z.string().optional(),
+      unit: z.string().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "materials:write");
+      const { data, error } = await t(ctx, "materials").insert({
+        business_id: ctx.businessId, user_id: ctx.userId,
+        name: args.name, cost_price: args.cost_price, tax_rate: args.tax_rate ?? 20,
+        description: args.description ?? null, sku: args.sku ?? null, supplier: args.supplier ?? null,
+        unit: args.unit ?? null, archived: false,
+      }).select().single();
+      if (error) throw error;
+      return text({ created: true, material: data });
+    });
+
+  tool("update_material", "Update a material in the cost catalog. Only provided fields change.",
+    {
+      material_id: UUID,
+      name: z.string().optional(),
+      cost_price: z.number().optional(),
+      tax_rate: z.number().optional(),
+      description: z.string().optional(),
+      sku: z.string().optional(),
+      supplier: z.string().optional(),
+      unit: z.string().optional(),
+      archived: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "materials:write");
+      const { material_id, ...patch } = args;
+      const clean = Object.fromEntries(Object.entries(patch).filter(([, v]) => v !== undefined));
+      if (Object.keys(clean).length === 0) return errorText("No fields to update.");
+      const { data, error } = await t(ctx, "materials")
+        .update(clean).eq("id", material_id).eq("business_id", ctx.businessId).select().single();
+      if (error) throw error;
+      return text({ updated: true, material: data });
+    });
+
+  tool("delete_material", "Delete a material from the cost catalog.",
+    { material_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "materials:write");
+      const { error } = await t(ctx, "materials").delete().eq("id", args.material_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -73,6 +73,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
 
   // ── Catalog / comms / insights ────────────────────────────────────────────
   { id: "products", icon: "package",   name: "Products",      description: "Price list used across quotes and invoices.", kind: "module", category: "catalog", defaultEnabled: true, routePrefixes: ["/products"] },
+  { id: "materials", icon: "package",  name: "Materials",     description: "Cost-price catalog of materials, used as an internal reference when pricing jobs.", kind: "module", category: "catalog", defaultEnabled: false, routePrefixes: ["/materials"] },
   { id: "inventory", icon: "boxes", name: "Inventory", description: "Track stock on hand, reorder points and usage per job.", kind: "module", category: "catalog", defaultEnabled: false, dependencies: ["products"], routePrefixes: ["/inventory"] },
   { id: "messages", icon: "message-square",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "communication", defaultEnabled: true, routePrefixes: ["/messages"] },
   { id: "analytics", icon: "trending-up",  name: "Analytics",     description: "Revenue and pipeline insight.",          kind: "module", category: "insights", defaultEnabled: true, routePrefixes: ["/analytics"] },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -132,6 +132,24 @@ export interface Product {
   updated_at: string;
 }
 
+/** A material in the cost catalog (materials plugin). Mirrors Product but holds
+ *  a COST price (what we pay) rather than a retail/sell price. */
+export interface Material {
+  id: string;
+  business_id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  sku: string | null;
+  supplier: string | null;
+  cost_price: number;
+  tax_rate: number;
+  unit: string | null;
+  archived: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 /** Product with the inventory columns (migration 20260710160000). */
 export interface InventoryProduct extends Product {
   track_stock: boolean;
@@ -1513,6 +1531,8 @@ export type ApiScope =
   | 'tasks:write'
   | 'products:read'
   | 'products:write'
+  | 'materials:read'
+  | 'materials:write'
   | 'settings:read'
   | 'settings:write'
   | 'bookings:read'
@@ -1557,6 +1577,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'tasks:write',      label: 'Create / edit tasks', group: 'Tasks' },
   { value: 'products:read',    label: 'Read products',     group: 'Products' },
   { value: 'products:write',   label: 'Create / edit products', group: 'Products' },
+  { value: 'materials:read',   label: 'Read materials',    group: 'Materials' },
+  { value: 'materials:write',  label: 'Create / edit materials', group: 'Materials' },
   { value: 'settings:read',    label: 'Read settings',     group: 'Settings' },
   { value: 'settings:write',   label: 'Edit settings & preferences', group: 'Settings' },
   { value: 'bookings:read',    label: 'Read bookings & config', group: 'Bookings' },

--- a/supabase/migrations/20260724100000_materials.sql
+++ b/supabase/migrations/20260724100000_materials.sql
@@ -1,0 +1,48 @@
+-- Materials plugin — a per-business catalog of materials with COST prices,
+-- used as an internal cost reference. Structural clone of public.products
+-- (which holds RETAIL/sell prices), gated behind the "materials" plugin.
+
+CREATE TABLE IF NOT EXISTS public.materials (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id      UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  description  TEXT,
+  sku          TEXT,
+  supplier     TEXT,
+  cost_price   NUMERIC(12,2) NOT NULL DEFAULT 0,
+  tax_rate     NUMERIC(5,2) NOT NULL DEFAULT 20,
+  unit         TEXT,
+  archived     BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_materials_business ON public.materials (business_id, name);
+
+ALTER TABLE public.materials ENABLE ROW LEVEL SECURITY;
+
+-- Mirror the products_no_workers policy exactly: owner or active member, and
+-- never a worker (materials/cost data is admin-side).
+DROP POLICY IF EXISTS "materials_no_workers" ON public.materials;
+CREATE POLICY "materials_no_workers" ON public.materials
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+DROP TRIGGER IF EXISTS materials_updated_at ON public.materials;
+CREATE TRIGGER materials_updated_at BEFORE UPDATE ON public.materials
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
A new **Materials** plugin: a per-business catalog of materials with **cost prices** (what you pay), used as an internal reference when pricing jobs. It's a structural clone of Products — same list/CRUD/import UX — but tracks cost instead of retail, and is gated behind the plugin system.

## What's included
- **`materials` table** — mirrors the products RLS (members read/write, workers blocked) with `cost_price`, plus `sku` and `supplier`. Migration applied + recorded on the live DB.
- **Types + scopes** — `Material` interface; `materials:read`/`materials:write` API scopes.
- **Server actions** — get / create / update / delete / bulk-import (CSV).
- **UI** — `/materials` page with the same list, search, stat tiles (Total cost = sum of cost prices), add/edit sheet + form, and CSV import.
- **Plugin** — registry entry (category *Catalog*, default **off**, route-gated `/materials`) and a **Materials** sidebar item under Catalog. Nav + route gating are automatic off the registry entry — enable/disable per business in the Plugins store.
- **MCP** — `list/create/update/delete_material` tools (standing repo rule).

Enabled for the owner's four businesses via install rows so it's usable immediately; toggle per business in the Plugins store.

tsc + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)