### PR TITLE
feat: Revolut payments (second provider, alongside Stripe/bank transfer)

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import { listApiKeys } from "@/lib/actions/api-keys";
 import { getEmailConfig } from "@/lib/actions/email-config";
 import { listWebhooks } from "@/lib/actions/webhooks";
 import { getStripeAccountStatus } from "@/lib/actions/stripe";
+import { getRevolutStatus } from "@/lib/actions/revolut";
 import { getActiveBizId } from "@/lib/active-business";
 import { canManageSettings, type Role } from "@/lib/permissions";
 import { SettingsClient } from "@/components/settings/settings-client";
@@ -34,12 +35,13 @@ export default async function SettingsPage() {
 
   if (!canManageSettings(userRole)) redirect("/dashboard");
 
-  const [business, apiKeys, emailConfig, webhooks, stripeStatus] = await Promise.all([
+  const [business, apiKeys, emailConfig, webhooks, stripeStatus, revolutStatus] = await Promise.all([
     getBusiness(),
     listApiKeys(),
     getEmailConfig(),
     listWebhooks(),
     getStripeAccountStatus(),
+    getRevolutStatus(),
   ]);
 
   return (
@@ -49,6 +51,7 @@ export default async function SettingsPage() {
       emailConfig={emailConfig}
       webhooks={webhooks}
       stripeStatus={stripeStatus}
+      revolutStatus={revolutStatus}
       userRole={userRole}
     />
   );

--- a/src/app/api/revolut/checkout/route.ts
+++ b/src/app/api/revolut/checkout/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { customerAllowsCard } from "@/lib/payment-methods";
+import { decryptSecret } from "@/lib/crypto";
+import { createRevolutOrder, toRevolutAmount, type RevolutMode } from "@/lib/revolut";
+
+// Public, token-gated. Creates a Revolut order for an invoice's balance and
+// redirects the customer to Revolut's hosted checkout. Mirrors the Stripe
+// checkout route.
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const invoiceId = url.searchParams.get("invoice");
+  const token = url.searchParams.get("token");
+  if (!invoiceId || !token) {
+    return NextResponse.json({ error: "Missing invoice or token" }, { status: 400 });
+  }
+
+  try {
+    const sb = createAdminClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = (n: string) => (sb as any).from(n);
+
+    const { data: link } = await t("customer_portal_tokens")
+      .select("business_id, customer_id, expires_at, revoked_at").eq("token", token).maybeSingle();
+    if (!link || link.revoked_at) return NextResponse.json({ error: "Invalid token" }, { status: 404 });
+    if (link.expires_at && new Date(link.expires_at) < new Date()) {
+      return NextResponse.json({ error: "Token expired" }, { status: 404 });
+    }
+
+    const [{ data: invoice }, { data: business }, { data: customer }] = await Promise.all([
+      t("invoices").select("id, number, total, amount_paid, status, customer_id, business_id")
+        .eq("id", invoiceId).eq("business_id", link.business_id).eq("customer_id", link.customer_id).maybeSingle(),
+      t("businesses").select("revolut_enabled, revolut_secret_enc, revolut_mode, currency")
+        .eq("id", link.business_id).maybeSingle(),
+      t("customers").select("email, allowed_payment_methods").eq("id", link.customer_id).maybeSingle(),
+    ]);
+
+    if (!invoice) return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    if (!business?.revolut_enabled || !business.revolut_secret_enc) {
+      return NextResponse.json({ error: "Revolut is not enabled for this business" }, { status: 400 });
+    }
+    if (!customerAllowsCard(customer?.allowed_payment_methods)) {
+      return NextResponse.json({ error: "Card payment is not available for this customer" }, { status: 403 });
+    }
+
+    const balance = Math.max(0, Number(invoice.total) - Number(invoice.amount_paid ?? 0));
+    if (balance < 0.5) return NextResponse.json({ error: "Nothing to pay" }, { status: 400 });
+
+    const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || `${url.protocol}//${url.host}`;
+    const currency = (business.currency as string) || "AUD";
+    const secret = decryptSecret(business.revolut_secret_enc);
+    const mode = (business.revolut_mode as RevolutMode) ?? "sandbox";
+
+    const order = await createRevolutOrder({
+      secret, mode,
+      amountMinor: toRevolutAmount(balance),
+      currency,
+      description: `Invoice ${invoice.number}`,
+      customerEmail: customer?.email ?? null,
+      reference: invoice.id,
+      redirectUrl: `${base}/portal/${token}/invoice/${invoice.id}?paid=1`,
+    });
+
+    if (!order.checkout_url) {
+      return NextResponse.json({ error: "Revolut did not return a checkout URL" }, { status: 502 });
+    }
+
+    // Map the order so the webhook can reconcile it back to this invoice/business.
+    await t("revolut_orders").upsert({
+      order_id: order.id,
+      business_id: link.business_id,
+      invoice_id: invoice.id,
+      amount: balance,
+      currency,
+      portal_token: token,
+    });
+
+    return NextResponse.redirect(order.checkout_url, { status: 303 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[revolut/checkout]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/revolut/webhook/route.ts
+++ b/src/app/api/revolut/webhook/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { decryptSecret } from "@/lib/crypto";
+import { retrieveRevolutOrder, revolutOrderIsPaid, verifyRevolutSignature, type RevolutMode } from "@/lib/revolut";
+import { recordRevolutPayment } from "@/lib/revolut-payments";
+
+// Revolut webhook. Payload carries an order id; we map it back to the business,
+// verify the signature against THAT business's webhook secret, then re-fetch the
+// order from Revolut to authoritatively confirm it's paid before recording.
+export async function POST(req: NextRequest) {
+  const raw = await req.text();
+
+  let payload: { event?: string; order_id?: string };
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ error: "Bad JSON" }, { status: 400 });
+  }
+
+  const orderId = payload.order_id;
+  if (!orderId) return NextResponse.json({ ok: true }); // nothing to reconcile
+
+  try {
+    const sb = createAdminClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = (n: string) => (sb as any).from(n);
+
+    const { data: map } = await t("revolut_orders")
+      .select("business_id, invoice_id, amount, portal_token").eq("order_id", orderId).maybeSingle();
+    if (!map) return NextResponse.json({ ok: true }); // unknown order — not ours
+
+    const { data: biz } = await t("businesses")
+      .select("revolut_secret_enc, revolut_webhook_secret_enc, revolut_mode").eq("id", map.business_id).maybeSingle();
+    if (!biz?.revolut_secret_enc) return NextResponse.json({ ok: true });
+
+    // Verify signature when a webhook secret is configured. If it's set and the
+    // signature fails, reject — don't record on an unverified event.
+    if (biz.revolut_webhook_secret_enc) {
+      const ok = verifyRevolutSignature({
+        rawBody: raw,
+        signatureHeader: req.headers.get("revolut-signature"),
+        timestamp: req.headers.get("revolut-request-timestamp"),
+        secret: decryptSecret(biz.revolut_webhook_secret_enc),
+      });
+      if (!ok) return NextResponse.json({ error: "Bad signature" }, { status: 401 });
+    }
+
+    // Authoritative confirmation: re-fetch the order rather than trusting the event.
+    const secret = decryptSecret(biz.revolut_secret_enc);
+    const mode = (biz.revolut_mode as RevolutMode) ?? "sandbox";
+    const order = await retrieveRevolutOrder(secret, mode, orderId);
+    if (!revolutOrderIsPaid(order.state)) return NextResponse.json({ ok: true }); // not paid (yet)
+
+    await recordRevolutPayment(sb, {
+      businessId: map.business_id,
+      invoiceId: map.invoice_id,
+      orderId,
+      amount: Number(map.amount),
+      portalToken: map.portal_token ?? null,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[revolut/webhook]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
       .eq("business_id", link.business_id)
       .eq("customer_id", link.customer_id)
       .maybeSingle(),
-    tbl(sb, "businesses").select("name, logo_url, currency, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban, phone, email, stripe_charges_enabled, card_surcharge_enabled, card_surcharge_percent, card_surcharge_fixed, card_surcharge_note").eq("id", link.business_id).maybeSingle(),
+    tbl(sb, "businesses").select("name, logo_url, currency, bank_name, bank_account_name, bank_account_number, bank_sort_code, bank_iban, phone, email, stripe_charges_enabled, revolut_enabled, card_surcharge_enabled, card_surcharge_percent, card_surcharge_fixed, card_surcharge_note").eq("id", link.business_id).maybeSingle(),
     tbl(sb, "customers").select("name, company, email, phone, address, city, postcode, country, allowed_payment_methods, autopay_enabled, stripe_payment_method_id, stripe_pm_brand, stripe_pm_last4").eq("id", link.customer_id).maybeSingle(),
     tbl(sb, "payments")
       .select("amount, date, method, reference")
@@ -53,6 +53,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
   const offered = resolveOfferedMethods({
     allowed: customer?.allowed_payment_methods,
     stripeEnabled: !!business?.stripe_charges_enabled,
+    revolutEnabled: !!business?.revolut_enabled,
     hasBankDetails,
   });
 
@@ -253,6 +254,15 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
                 {surcharge > 0
                   ? `Pay ${formatCurrency(balance + surcharge, currency)} with card (incl. ${formatCurrency(surcharge, currency)} fee)`
                   : `Pay ${formatCurrency(balance, currency)} with card`}
+              </a>
+            )}
+            {!isPaid && balance > 0 && offered.revolut && (
+              <a
+                href={`/api/revolut/checkout?invoice=${invoice.id}&token=${token}`}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-[#0666EB] text-white text-sm font-semibold hover:opacity-90 transition-opacity shadow-sm"
+              >
+                <CreditCard className="w-4 h-4" />
+                Pay {formatCurrency(balance, currency)} with Revolut
               </a>
             )}
             <a

--- a/src/components/settings/revolut-settings.tsx
+++ b/src/components/settings/revolut-settings.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { GradientTile } from "@/components/ui/kirei";
+import { CreditCard, Loader2, CheckCircle } from "@/components/ui/icons";
+import { saveRevolutCredentials, disconnectRevolut, testRevolutConnection, type RevolutStatus } from "@/lib/actions/revolut";
+
+export function RevolutSettings({ initial }: { initial: RevolutStatus }) {
+  const [status, setStatus] = useState(initial);
+  const [secret, setSecret] = useState("");
+  const [webhookSecret, setWebhookSecret] = useState("");
+  const [mode, setMode] = useState(initial.mode);
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [saving, startSave] = useTransition();
+  const [testing, setTesting] = useState(false);
+
+  const save = () =>
+    startSave(async () => {
+      try {
+        if (enabled && !status.hasSecret && !secret.trim()) {
+          toast.error("Paste your Revolut Merchant Secret key first.");
+          return;
+        }
+        await saveRevolutCredentials({
+          secret: secret.trim() || undefined,
+          webhookSecret: webhookSecret.trim() || undefined,
+          mode,
+          enabled,
+        });
+        setStatus((s) => ({
+          ...s, enabled, mode,
+          hasSecret: s.hasSecret || !!secret.trim(),
+          hasWebhookSecret: s.hasWebhookSecret || !!webhookSecret.trim(),
+        }));
+        setSecret("");
+        setWebhookSecret("");
+        toast.success("Revolut settings saved");
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Failed to save");
+      }
+    });
+
+  const test = async () => {
+    setTesting(true);
+    try {
+      const r = await testRevolutConnection();
+      r.ok ? toast.success(r.message) : toast.error(r.message);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const disconnect = () =>
+    startSave(async () => {
+      try {
+        await disconnectRevolut();
+        setStatus((s) => ({ ...s, enabled: false, hasSecret: false, hasWebhookSecret: false }));
+        setEnabled(false);
+        toast.success("Revolut disconnected");
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Failed to disconnect");
+      }
+    });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center gap-2.5 space-y-0">
+        <GradientTile gradient="violet" size={28} radius={8}><CreditCard className="w-3.5 h-3.5" /></GradientTile>
+        <CardTitle className="text-base flex items-center gap-2">
+          Revolut
+          {status.enabled && status.hasSecret && (
+            <span className="ch-pill paid text-[10px] inline-flex items-center gap-0.5"><CheckCircle className="w-3 h-3" />Live {status.mode === "sandbox" ? "(sandbox)" : ""}</span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Accept card &amp; Revolut Pay payments straight into your Revolut Business account.
+          Paste your <strong>Merchant Secret key</strong> (server-side only — it&rsquo;s encrypted and never shown again).
+        </p>
+
+        {!status.encryptionReady && (
+          <p className="text-xs text-destructive">Credential storage is unavailable — the server needs APP_ENCRYPTION_KEY set.</p>
+        )}
+
+        <div className="space-y-1.5">
+          <Label>Merchant Secret key</Label>
+          <Input type="password" autoComplete="off" placeholder={status.hasSecret ? "•••••••• (saved — leave blank to keep)" : "sk_..."} value={secret} onChange={(e) => setSecret(e.target.value)} />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Webhook signing secret <span className="text-muted-foreground font-normal">(from your Revolut webhook)</span></Label>
+          <Input type="password" autoComplete="off" placeholder={status.hasWebhookSecret ? "•••••••• (saved — leave blank to keep)" : "wsk_..."} value={webhookSecret} onChange={(e) => setWebhookSecret(e.target.value)} />
+          <p className="text-[11px] text-muted-foreground">In Revolut, create a webhook to <code>{typeof window !== "undefined" ? window.location.origin : ""}/api/revolut/webhook</code> and paste its signing secret here.</p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label>Mode</Label>
+            <select value={mode} onChange={(e) => setMode(e.target.value as RevolutStatus["mode"])} className="w-full h-9 rounded-md border border-border bg-card px-2 text-sm">
+              <option value="sandbox">Sandbox (testing)</option>
+              <option value="live">Live</option>
+            </select>
+          </div>
+          <div className="flex items-end justify-between gap-3">
+            <div>
+              <Label className="block mb-1">Enabled</Label>
+              <p className="text-[11px] text-muted-foreground">Show &ldquo;Pay with Revolut&rdquo; on invoices.</p>
+            </div>
+            <Switch checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button onClick={save} disabled={saving}>{saving && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}Save</Button>
+          <Button variant="outline" onClick={test} disabled={testing || !status.hasSecret}>{testing && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}Test connection</Button>
+          {status.hasSecret && <Button variant="ghost" className="text-destructive ml-auto" onClick={disconnect} disabled={saving}>Disconnect</Button>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/settings/settings-client.tsx
+++ b/src/components/settings/settings-client.tsx
@@ -25,6 +25,8 @@ import { ApiKeysSettings } from "@/components/settings/api-keys-settings";
 import { EmailSettings } from "@/components/settings/email-settings";
 import { WebhooksSettings } from "@/components/settings/webhooks-settings";
 import { StripeSettings } from "@/components/settings/stripe-settings";
+import { RevolutSettings } from "@/components/settings/revolut-settings";
+import type { RevolutStatus } from "@/lib/actions/revolut";
 import type { StripeAccountStatus } from "@/lib/actions/stripe";
 import { AddressFields } from "@/components/addresses/address-fields";
 import type { Business, BusinessApiKey, BusinessEmailConfig, BusinessWebhook } from "@/types/database";
@@ -114,10 +116,11 @@ interface SettingsClientProps {
   emailConfig: (Omit<BusinessEmailConfig, "imap_pass"> & { imap_pass_masked: string }) | null;
   webhooks: BusinessWebhook[];
   stripeStatus: StripeAccountStatus;
+  revolutStatus: RevolutStatus;
   userRole: Role;
 }
 
-export function SettingsClient({ business: initial, apiKeys, emailConfig, webhooks, stripeStatus, userRole }: SettingsClientProps) {
+export function SettingsClient({ business: initial, apiKeys, emailConfig, webhooks, stripeStatus, revolutStatus, userRole }: SettingsClientProps) {
   const [business, setBusiness] = useState(initial);
   const [logoPreview, setLogoPreview] = useState<string | null>(initial.logo_url);
   const [uploadingLogo, setUploadingLogo] = useState(false);
@@ -377,6 +380,7 @@ export function SettingsClient({ business: initial, apiKeys, emailConfig, webhoo
         {/* ── Payment tab ── */}
         <TabsContent value="payment" className="space-y-4 mt-6">
           <StripeSettings initial={stripeStatus} />
+          <RevolutSettings initial={revolutStatus} />
           <Card>
             <CardHeader className="flex flex-row items-center gap-2.5 space-y-0">
               <GradientTile gradient="emerald" size={28} radius={8}><CreditCard className="w-3.5 h-3.5" /></GradientTile>

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -570,6 +570,7 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
   let portalUrl: string | null = null;
   let pdfUrl: string | null = null;
   let payUrl: string | null = null;
+  let revolutPayUrl: string | null = null;
   if (customer?.id) {
     const { data: existing } = await tbl(supabase, "customer_portal_tokens")
       .select("token")
@@ -598,6 +599,10 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
       if (businessData.stripe_charges_enabled && balance > 0.01 && customerAllowsCard(customer?.allowed_payment_methods)) {
         payUrl = `${base}/api/stripe/checkout?invoice=${invoiceData.id}&token=${token}`;
       }
+      // Revolut pay link — independent of Stripe (works when Stripe isn't set up).
+      if (businessData.revolut_enabled && balance > 0.01 && customerAllowsCard(customer?.allowed_payment_methods)) {
+        revolutPayUrl = `${base}/api/revolut/checkout?invoice=${invoiceData.id}&token=${token}`;
+      }
     }
   }
 
@@ -606,7 +611,7 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
   await sendEmail({
     to: recipients,
     subject: opts?.subject ?? invoiceEmailSubject({ invoice: invoiceData, customer, business: businessData }, emailTemplate),
-    html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl, pdfUrl, payUrl, template: emailTemplate }),
+    html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl, pdfUrl, payUrl, revolutPayUrl, template: emailTemplate }),
     attachments: [{ filename: `${invoiceData.number}.pdf`, content: pdfBuffer }],
     from: buildBusinessFrom({ name: businessData.name, localPart: "invoices" }),
     replyTo: businessData.email || undefined,

--- a/src/lib/actions/revolut.ts
+++ b/src/lib/actions/revolut.ts
@@ -1,0 +1,124 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/auth";
+import { getActiveBizId } from "@/lib/active-business";
+import { canManageSettings, type Role } from "@/lib/permissions";
+import { encryptSecret, decryptSecret, encryptionAvailable } from "@/lib/crypto";
+import { revolutKeyWorks, type RevolutMode } from "@/lib/revolut";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
+
+async function resolveRole(
+  supabase: Awaited<ReturnType<typeof createClient>>, userId: string, businessId: string,
+): Promise<Role> {
+  const { data: owned } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).maybeSingle();
+  if (owned?.user_id === userId) return "owner";
+  const { data: m } = await tbl(supabase, "business_members")
+    .select("role").eq("business_id", businessId).eq("user_id", userId).eq("status", "active").maybeSingle();
+  return (m?.role as Role) ?? "viewer";
+}
+
+export interface RevolutStatus {
+  enabled: boolean;
+  mode: RevolutMode;
+  hasSecret: boolean;
+  hasWebhookSecret: boolean;
+  encryptionReady: boolean;
+}
+
+export async function getRevolutStatus(): Promise<RevolutStatus> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: biz } = await tbl(supabase, "businesses")
+    .select("revolut_enabled, revolut_mode, revolut_secret_enc, revolut_webhook_secret_enc")
+    .eq("id", businessId)
+    .single();
+
+  return {
+    enabled: !!biz?.revolut_enabled,
+    mode: (biz?.revolut_mode as RevolutMode) ?? "sandbox",
+    hasSecret: !!biz?.revolut_secret_enc,
+    hasWebhookSecret: !!biz?.revolut_webhook_secret_enc,
+    encryptionReady: encryptionAvailable(),
+  };
+}
+
+/**
+ * Save Revolut credentials. Secrets are encrypted at rest and never returned to
+ * the client. An empty/undefined secret keeps the stored one (so the user isn't
+ * forced to re-enter it on every edit).
+ */
+export async function saveRevolutCredentials(input: {
+  secret?: string;
+  webhookSecret?: string;
+  mode: RevolutMode;
+  enabled: boolean;
+}): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const role = await resolveRole(supabase, user.id, businessId);
+  if (!canManageSettings(role)) throw new Error("Only owners and admins can manage Revolut settings.");
+
+  const secret = input.secret?.trim();
+  const webhookSecret = input.webhookSecret?.trim();
+
+  if ((secret || webhookSecret) && !encryptionAvailable()) {
+    throw new Error("Credential storage needs APP_ENCRYPTION_KEY set on the server.");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const update: Record<string, any> = {
+    revolut_mode: input.mode === "live" ? "live" : "sandbox",
+    revolut_enabled: input.enabled,
+  };
+  if (secret) update.revolut_secret_enc = encryptSecret(secret);
+  if (webhookSecret) update.revolut_webhook_secret_enc = encryptSecret(webhookSecret);
+
+  const { error } = await tbl(supabase, "businesses").update(update).eq("id", businessId);
+  if (error) throw error;
+
+  revalidatePath("/settings");
+}
+
+export async function disconnectRevolut(): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const role = await resolveRole(supabase, user.id, businessId);
+  if (!canManageSettings(role)) throw new Error("Only owners and admins can manage Revolut settings.");
+
+  await tbl(supabase, "businesses").update({
+    revolut_secret_enc: null,
+    revolut_webhook_secret_enc: null,
+    revolut_enabled: false,
+  }).eq("id", businessId);
+
+  revalidatePath("/settings");
+}
+
+/** Validate the stored key against Revolut (used by the "Test connection" button). */
+export async function testRevolutConnection(): Promise<{ ok: boolean; message: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: biz } = await tbl(supabase, "businesses")
+    .select("revolut_secret_enc, revolut_mode").eq("id", businessId).single();
+  if (!biz?.revolut_secret_enc) return { ok: false, message: "No Revolut key saved yet." };
+
+  try {
+    const secret = decryptSecret(biz.revolut_secret_enc);
+    const ok = await revolutKeyWorks(secret, (biz.revolut_mode as RevolutMode) ?? "sandbox");
+    return ok
+      ? { ok: true, message: `Connected to Revolut (${biz.revolut_mode ?? "sandbox"}).` }
+      : { ok: false, message: "Revolut rejected the key — check it's the Merchant Secret key for the right mode." };
+  } catch {
+    return { ok: false, message: "Couldn't read the stored key (encryption key changed?)." };
+  }
+}

--- a/src/lib/emails/invoice.ts
+++ b/src/lib/emails/invoice.ts
@@ -55,6 +55,7 @@ export function invoiceEmailHtml({
   portalUrl,
   pdfUrl,
   payUrl,
+  revolutPayUrl,
   template,
 }: {
   invoice: Invoice;
@@ -69,6 +70,9 @@ export function invoiceEmailHtml({
   /** Stripe Checkout link (tokenised). Renders a prominent 'Pay with card'
    *  button when the business has card payments enabled. */
   payUrl?: string | null;
+  /** Revolut hosted-checkout link (tokenised). Renders a 'Pay with Revolut'
+   *  button, independent of Stripe. */
+  revolutPayUrl?: string | null;
   /** Per-business template override; defaults when omitted. */
   template?: ResolvedEmailTemplate;
 }): string {
@@ -130,10 +134,11 @@ export function invoiceEmailHtml({
       </tr>
     </table>
 
-    ${t.show_buttons && (payUrl || portalUrl || pdfUrl) ? `
+    ${t.show_buttons && (payUrl || revolutPayUrl || portalUrl || pdfUrl) ? `
     <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
       <tr><td align="center">
         ${payUrl ? `<a href="${payUrl}" style="display:inline-block;background:${accent};color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;margin:0 4px 8px;">Pay ${fmt(balanceDue)} with card</a>` : ""}
+        ${revolutPayUrl ? `<a href="${revolutPayUrl}" style="display:inline-block;background:#0666EB;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;margin:0 4px 8px;">Pay ${fmt(balanceDue)} with Revolut</a>` : ""}
         ${portalUrl ? `<a href="${portalUrl}" style="display:inline-block;background:${payUrl ? "#ffffff" : accent};color:${payUrl ? accent : "#ffffff"};text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;${payUrl ? `border:1px solid ${accent};` : ""}margin:0 4px 8px;">View invoice online</a>` : ""}
         ${pdfUrl ? `<a href="${pdfUrl}" style="display:inline-block;background:#ffffff;color:${accent};text-decoration:none;font-size:14px;font-weight:600;padding:12px 24px;border-radius:8px;border:1px solid ${accent};margin:0 4px 8px;">Download PDF</a>` : ""}
       </td></tr>

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -27,6 +27,8 @@ import {
 } from "@/lib/emails/templates";
 import { customerAllowsCard } from "@/lib/payment-methods";
 import { DEFAULT_TEMPLATE_CONFIG } from "@/lib/documents/template-config";
+import { createRevolutOrder, toRevolutAmount, type RevolutMode } from "@/lib/revolut";
+import { decryptSecret } from "@/lib/crypto";
 import { presetByKey, TEMPLATE_PRESETS } from "@/lib/documents/presets";
 import type { LineItem } from "@/types/database";
 import { ctxFrom, appBase, UUID, getOrMintPortalToken, type ToolFn } from "./tools/shared";
@@ -1008,6 +1010,47 @@ export function registerTools(register: ToolFn): void {
       }, { stripeAccount: biz.stripe_account_id });
 
       return text({ payment_url: session.url, expires_at: session.expires_at, amount: requested });
+    });
+
+  tool("create_revolut_payment_link", "Create a Revolut hosted-checkout link for an invoice's balance (card + Revolut Pay). Requires the business to have Revolut enabled in Settings → Payments. Returns a URL to send the customer.",
+    { invoice_id: UUID, amount: z.number().positive().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "invoices:write");
+      const { data: biz } = await t(ctx, "businesses")
+        .select("revolut_enabled, revolut_secret_enc, revolut_mode, currency, name").eq("id", ctx.businessId).single();
+      if (!biz?.revolut_enabled || !biz.revolut_secret_enc) return errorText("Revolut isn't enabled for this business.");
+
+      const { data: invoice } = await t(ctx, "invoices")
+        .select("id, number, total, amount_paid, customer_id").eq("id", args.invoice_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!invoice) return errorText("Invoice not found.");
+
+      const balance = Math.max(0, Number(invoice.total) - Number(invoice.amount_paid ?? 0));
+      const requested = args.amount ?? balance;
+      if (requested < 0.5) return errorText("Nothing to pay on this invoice.");
+
+      const { data: customer } = invoice.customer_id
+        ? await t(ctx, "customers").select("email").eq("id", invoice.customer_id).maybeSingle()
+        : { data: null };
+
+      const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://kireihq.com";
+      const order = await createRevolutOrder({
+        secret: decryptSecret(biz.revolut_secret_enc),
+        mode: (biz.revolut_mode as RevolutMode) ?? "sandbox",
+        amountMinor: toRevolutAmount(requested),
+        currency: (biz.currency as string) || "AUD",
+        description: `Invoice ${invoice.number}`,
+        customerEmail: customer?.email ?? null,
+        reference: invoice.id,
+        redirectUrl: `${base}/invoices/${invoice.id}?paid=1`,
+      });
+      if (!order.checkout_url) return errorText("Revolut did not return a checkout URL.");
+
+      await t(ctx, "revolut_orders").upsert({
+        order_id: order.id, business_id: ctx.businessId, invoice_id: invoice.id,
+        amount: requested, currency: (biz.currency as string) || "AUD", portal_token: null,
+      });
+
+      return text({ payment_url: order.checkout_url, amount: requested });
     });
 
   tool("get_save_card_link", "Get a secure link to send a customer so they can save a card on file for automatic payments (autopay). Requires the business to have connected Stripe.",

--- a/src/lib/payment-methods.ts
+++ b/src/lib/payment-methods.ts
@@ -20,7 +20,12 @@ export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
 };
 
 export interface OfferedPaymentMethods {
+  /** Stripe card checkout. */
   card: boolean;
+  /** Revolut hosted checkout (card + Revolut Pay). Uses the same "card"
+   *  permission as Stripe, but a separate provider gate — so it can be offered
+   *  even when Stripe isn't connected. */
+  revolut: boolean;
   bank_transfer: boolean;
   cash: boolean;
 }
@@ -34,6 +39,8 @@ export function resolveOfferedMethods(opts: {
   allowed: string[] | null | undefined;
   /** business has Stripe charges enabled. */
   stripeEnabled: boolean;
+  /** business has Revolut enabled. */
+  revolutEnabled?: boolean;
   /** business has bank-transfer details filled in. */
   hasBankDetails: boolean;
 }): OfferedPaymentMethods {
@@ -43,6 +50,7 @@ export function resolveOfferedMethods(opts: {
   const permits = (m: PaymentMethod) => (list ? list.has(m) : true);
   return {
     card: opts.stripeEnabled && permits("card"),
+    revolut: !!opts.revolutEnabled && permits("card"),
     bank_transfer: opts.hasBankDetails && permits("bank_transfer"),
     // Cash is opt-in only: never shown unless explicitly allow-listed.
     cash: list ? list.has("cash") : false,

--- a/src/lib/revolut-payments.ts
+++ b/src/lib/revolut-payments.ts
@@ -1,0 +1,150 @@
+/**
+ * Record a successful Revolut payment against an invoice. Mirrors
+ * recordStripePayment (idempotent on (business_id, provider_payment_id), same
+ * invoice + parent rollup, same receipt email) but with provider "revolut" and
+ * no Stripe-specific fee/application-fee lookup.
+ */
+
+import { dispatchWebhook } from "@/lib/webhooks";
+
+interface RecordOpts {
+  businessId: string;
+  invoiceId: string;
+  /** Revolut order id — the idempotency + provider payment id. */
+  orderId: string;
+  amount: number;
+  /** Revolut processing fee, if known (often null until settled). */
+  fee?: number | null;
+  portalToken?: string | null;
+}
+
+export async function recordRevolutPayment(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any,
+  opts: RecordOpts,
+): Promise<boolean> {
+  const { businessId, invoiceId, orderId } = opts;
+
+  const { data: existing } = await sb.from("payments")
+    .select("id").eq("business_id", businessId).eq("provider_payment_id", orderId).maybeSingle();
+  if (existing) return false;
+
+  const { data: invoice } = await sb.from("invoices")
+    .select("id, total, amount_paid, parent_invoice_id, user_id, status, number, customer_id")
+    .eq("id", invoiceId).eq("business_id", businessId).single();
+  if (!invoice) {
+    console.warn("[revolut] invoice not found for payment", invoiceId);
+    return false;
+  }
+
+  const { error: insErr } = await sb.from("payments").insert({
+    invoice_id: invoiceId,
+    business_id: businessId,
+    user_id: invoice.user_id,
+    amount: opts.amount,
+    date: new Date().toISOString().slice(0, 10),
+    method: "Revolut",
+    reference: orderId,
+    notes: null,
+    provider: "revolut",
+    provider_payment_id: orderId,
+    provider_session_id: null,
+    provider_fee: opts.fee ?? null,
+    provider_platform_fee: null,
+  });
+  if (insErr) {
+    if (insErr.code === "23505") return false; // concurrent insert — already recorded
+    throw insErr;
+  }
+
+  await recomputeInvoice(sb, businessId, invoiceId, invoice.total);
+  if (invoice.parent_invoice_id) await recomputeParent(sb, businessId, invoice.parent_invoice_id);
+
+  try {
+    dispatchWebhook(businessId, "payment.received", {
+      invoice_id: invoiceId, amount: opts.amount, provider: "revolut", revolut_order_id: orderId,
+    });
+  } catch { /* never blocks */ }
+
+  try {
+    await sendPaymentReceipt(sb, { businessId, invoiceId, amount: opts.amount, portalToken: opts.portalToken ?? null });
+  } catch (err) {
+    console.warn("[revolut] receipt email failed", err);
+  }
+
+  return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function sendPaymentReceipt(sb: any, opts: { businessId: string; invoiceId: string; amount: number; portalToken: string | null }) {
+  const { data: invoice } = await sb.from("invoices")
+    .select("id, number, total, amount_paid, customer_id")
+    .eq("id", opts.invoiceId).eq("business_id", opts.businessId).single();
+  if (!invoice) return;
+
+  const [{ data: business }, { data: customer }] = await Promise.all([
+    sb.from("businesses").select("name, email, phone, currency").eq("id", opts.businessId).single(),
+    invoice.customer_id
+      ? sb.from("customers").select("name, email").eq("id", invoice.customer_id).maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
+  if (!customer?.email) return;
+
+  const { getResolvedEmailTemplate } = await import("@/lib/emails/templates");
+  const { paymentReceiptEmailHtml, paymentReceiptEmailSubject } = await import("@/lib/emails/payment-receipt");
+  const { sendEmail, buildBusinessFrom } = await import("@/lib/email");
+
+  const template = await getResolvedEmailTemplate(sb, opts.businessId, "payment_receipt");
+  const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "";
+  const portalUrl = opts.portalToken && base ? `${base}/portal/${opts.portalToken}/invoice/${invoice.id}` : null;
+  const args = {
+    invoice, customer, business,
+    amount: opts.amount,
+    paymentDate: new Date().toISOString(),
+    paymentMethod: "Revolut",
+  };
+
+  await sendEmail({
+    to: customer.email,
+    subject: paymentReceiptEmailSubject(args, template),
+    html: paymentReceiptEmailHtml({ ...args, portalUrl, template }),
+    from: business?.name ? buildBusinessFrom({ name: business.name, localPart: "invoices" }) : undefined,
+    replyTo: business?.email || undefined,
+    tags: { business_id: opts.businessId, doc_type: "payment_receipt", doc_id: invoice.id },
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function recomputeInvoice(sb: any, businessId: string, invoiceId: string, invoiceTotal: number) {
+  const [{ data: directs }, { data: childCollections }] = await Promise.all([
+    sb.from("payments").select("amount").eq("invoice_id", invoiceId).eq("business_id", businessId),
+    sb.from("invoices").select("amount_paid").eq("parent_invoice_id", invoiceId).eq("business_id", businessId),
+  ]);
+  const direct = (directs ?? []).reduce((s: number, r: { amount: unknown }) => s + Number(r.amount ?? 0), 0);
+  const childSum = (childCollections ?? []).reduce((s: number, r: { amount_paid: unknown }) => s + Number(r.amount_paid ?? 0), 0);
+  const total = Number(invoiceTotal);
+  const newPaid = direct + childSum;
+  const newStatus = newPaid >= total - 0.01 ? "paid" : "partial";
+  await sb.from("invoices").update({ amount_paid: newPaid, status: newStatus }).eq("id", invoiceId);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function recomputeParent(sb: any, businessId: string, parentId: string) {
+  const [{ data: siblings }, { data: parentDirects }, { data: parentRow }] = await Promise.all([
+    sb.from("invoices").select("amount_paid").eq("parent_invoice_id", parentId).eq("business_id", businessId),
+    sb.from("payments").select("amount").eq("invoice_id", parentId).eq("business_id", businessId),
+    sb.from("invoices").select("total, status").eq("id", parentId).eq("business_id", businessId).maybeSingle(),
+  ]);
+  if (!parentRow) return;
+  const collectedChildren = (siblings ?? []).reduce((s: number, r: { amount_paid: unknown }) => s + Number(r.amount_paid ?? 0), 0);
+  const direct = (parentDirects ?? []).reduce((s: number, r: { amount: unknown }) => s + Number(r.amount ?? 0), 0);
+  const totalCollected = direct + collectedChildren;
+  const parentTotal = Number(parentRow.total ?? 0);
+  const fullyCovered = totalCollected >= parentTotal - 0.01;
+  let nextStatus = parentRow.status as string;
+  if (nextStatus !== "cancelled" && nextStatus !== "draft") {
+    if (fullyCovered)               nextStatus = "paid";
+    else if (totalCollected > 0.01) nextStatus = "partial";
+  }
+  await sb.from("invoices").update({ amount_paid: totalCollected, status: nextStatus }).eq("id", parentId);
+}

--- a/src/lib/revolut.ts
+++ b/src/lib/revolut.ts
@@ -1,0 +1,140 @@
+/**
+ * Revolut Merchant API client (Hosted Checkout). Server-side only — the Merchant
+ * Secret key must never reach the browser.
+ *
+ * Flow: create an order -> get a `checkout_url` -> redirect the customer ->
+ * receive an ORDER_COMPLETED webhook. We ALSO re-fetch the order on webhook to
+ * confirm its state authoritatively (belt-and-suspenders over signature checks).
+ */
+
+import crypto from "crypto";
+
+export type RevolutMode = "sandbox" | "live";
+
+// Newer Merchant API (versioned). Bump when Revolut requires a newer version.
+const API_VERSION = "2024-09-01";
+
+export function revolutBase(mode: RevolutMode): string {
+  return mode === "live" ? "https://merchant.revolut.com" : "https://sandbox-merchant.revolut.com";
+}
+
+/** Amount to Revolut minor units (integer). Zero-decimal currencies are rare
+ *  for our users (AUD/GBP/EUR/USD all use 2), so a *100 round is correct here. */
+export function toRevolutAmount(amount: number): number {
+  return Math.round(amount * 100);
+}
+export function fromRevolutAmount(minor: number): number {
+  return Math.round(minor) / 100;
+}
+
+interface CreateOrderInput {
+  secret: string;
+  mode: RevolutMode;
+  amountMinor: number;
+  currency: string;
+  description?: string;
+  customerEmail?: string | null;
+  /** Our invoice id — echoed back on the order + webhook for reconciliation. */
+  reference: string;
+  /** Where Revolut sends the customer after paying. */
+  redirectUrl: string;
+}
+
+export interface RevolutOrder {
+  id: string;
+  state: string;
+  checkout_url?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [k: string]: any;
+}
+
+async function revolutFetch(secret: string, mode: RevolutMode, path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${revolutBase(mode)}${path}`, {
+    ...init,
+    headers: {
+      "Authorization": `Bearer ${secret}`,
+      "Revolut-Api-Version": API_VERSION,
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+export async function createRevolutOrder(input: CreateOrderInput): Promise<RevolutOrder> {
+  const body = {
+    amount: input.amountMinor,
+    currency: input.currency.toUpperCase(),
+    description: input.description,
+    ...(input.customerEmail ? { customer: { email: input.customerEmail } } : {}),
+    merchant_order_data: { reference: input.reference },
+    redirect_url: input.redirectUrl,
+  };
+  const res = await revolutFetch(input.secret, input.mode, "/api/orders", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Revolut order failed (${res.status}): ${txt.slice(0, 300)}`);
+  }
+  return (await res.json()) as RevolutOrder;
+}
+
+/** Authoritative state check — call on webhook before marking an invoice paid. */
+export async function retrieveRevolutOrder(secret: string, mode: RevolutMode, orderId: string): Promise<RevolutOrder> {
+  const res = await revolutFetch(secret, mode, `/api/orders/${orderId}`, { method: "GET" });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Revolut order fetch failed (${res.status}): ${txt.slice(0, 200)}`);
+  }
+  return (await res.json()) as RevolutOrder;
+}
+
+/** Cheap auth check used by "Test connection" — lists webhooks (needs a valid key). */
+export async function revolutKeyWorks(secret: string, mode: RevolutMode): Promise<boolean> {
+  try {
+    const res = await revolutFetch(secret, mode, "/api/1.0/webhooks", { method: "GET" });
+    // 200 = ok; 401/403 = bad key. Some plans 404 the list endpoint but still auth —
+    // treat only auth failures as "not working".
+    return res.status !== 401 && res.status !== 403;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify a Revolut webhook signature. Revolut signs
+ *   `v1.{Revolut-Request-Timestamp}.{rawBody}`
+ * with the webhook signing secret (HMAC-SHA256, hex), and sends it in
+ * `Revolut-Signature: v1=<hex>` (may carry multiple space/comma-separated sigs).
+ */
+export function verifyRevolutSignature(opts: {
+  rawBody: string;
+  signatureHeader: string | null;
+  timestamp: string | null;
+  secret: string;
+}): boolean {
+  const { rawBody, signatureHeader, timestamp, secret } = opts;
+  if (!signatureHeader || !timestamp || !secret) return false;
+  const payload = `v1.${timestamp}.${rawBody}`;
+  const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  const provided = signatureHeader
+    .split(/[\s,]+/)
+    .map((s) => s.trim().replace(/^v1=/, ""))
+    .filter(Boolean);
+  return provided.some((sig) => {
+    try {
+      return sig.length === expected.length &&
+        crypto.timingSafeEqual(Buffer.from(sig, "hex"), Buffer.from(expected, "hex"));
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** True when an order's state means the money is in. */
+export function revolutOrderIsPaid(state: string | undefined): boolean {
+  const s = (state ?? "").toLowerCase();
+  return s === "completed" || s === "paid" || s === "authorised" || s === "authorized";
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -59,6 +59,9 @@ export async function updateSession(request: NextRequest) {
     pathname === "/api/stripe/webhook" ||
     pathname === "/api/stripe/checkout" ||
     pathname === "/api/stripe/save-card" ||
+    // Revolut payment provider — signed webhook + token-gated hosted checkout.
+    pathname === "/api/revolut/webhook" ||
+    pathname === "/api/revolut/checkout" ||
     // Resend delivery webhook (verifies its own Svix signature). Without this it
     // was 307'd to /auth/login, so delivered/bounced events never reached the
     // handler and every email stayed frozen at "Sent (in transit)".

--- a/supabase/migrations/20260727100000_revolut_payments.sql
+++ b/supabase/migrations/20260727100000_revolut_payments.sql
@@ -1,0 +1,34 @@
+-- Revolut as a second payment provider (alongside Stripe). Per-business Merchant
+-- API credentials, stored encrypted (AES-256-GCM via APP_ENCRYPTION_KEY). Unlike
+-- Stripe Connect there's no onboarded account — each business pastes its own
+-- Revolut Merchant Secret key, so `revolut_enabled` is the gate (the equivalent
+-- of stripe_charges_enabled).
+
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS revolut_secret_enc         text,  -- encrypted Merchant Secret API key
+  ADD COLUMN IF NOT EXISTS revolut_webhook_secret_enc text,  -- encrypted webhook signing secret
+  ADD COLUMN IF NOT EXISTS revolut_mode               text NOT NULL DEFAULT 'sandbox', -- 'sandbox' | 'live'
+  ADD COLUMN IF NOT EXISTS revolut_enabled            boolean NOT NULL DEFAULT false;
+
+-- The payments table already carries provider-agnostic columns (provider,
+-- provider_payment_id, provider_fee, provider_platform_fee) plus the unique
+-- index on (business_id, provider_payment_id) — a Revolut order id slots in with
+-- no schema change.
+
+-- Maps a Revolut order id -> the invoice/business/portal-token it was created
+-- for, so the webhook (which arrives with only an order id) can find the right
+-- business, decrypt that business's key, and reconcile the payment.
+CREATE TABLE IF NOT EXISTS public.revolut_orders (
+  order_id     text PRIMARY KEY,
+  business_id  uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  invoice_id   uuid NOT NULL REFERENCES public.invoices(id) ON DELETE CASCADE,
+  amount       numeric(12,2) NOT NULL,
+  currency     text NOT NULL,
+  portal_token text,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS revolut_orders_business_idx ON public.revolut_orders (business_id);
+
+-- Service-role only (written by the token-gated checkout route + read by the
+-- webhook, both on the admin client). No client access needed.
+ALTER TABLE public.revolut_orders ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Adds **Revolut** (Merchant API — Hosted Checkout) as a second payment provider so businesses can take **card + Revolut Pay** payments, **per-business keyed** (each pastes its own Merchant Secret key — no marketplace onboarding). Works even when Stripe isn't connected, which is the immediate need (Stripe is stuck on one business).

## What's included
- **DB**: `businesses.revolut_secret_enc / revolut_webhook_secret_enc / revolut_mode / revolut_enabled` (secrets AES-256-GCM encrypted via `APP_ENCRYPTION_KEY`) + a `revolut_orders` mapping table (order id → invoice/business/token, so the webhook can reconcile). Migrations applied to the live DB.
- **`src/lib/revolut.ts`**: create/retrieve order, amount conversion, HMAC webhook-signature verification.
- **`/api/revolut/checkout`** (public, portal-token-gated): creates an order for the invoice balance → 303-redirects to Revolut's `checkout_url`.
- **`/api/revolut/webhook`**: verifies the signature against the business's webhook secret **and** re-fetches the order from Revolut to confirm it's paid before recording (belt-and-suspenders).
- **`recordRevolutPayment`**: mirrors `recordStripePayment` — idempotent on `(business_id, provider_payment_id)`, invoice + parent rollup, receipt email; `provider: "revolut"`.
- **Settings → Payments → Revolut** card: paste Merchant Secret + webhook signing secret, sandbox/live, enable, "Test connection".
- **"Pay with Revolut"** on the customer portal invoice page and the invoice email — gated via `resolveOfferedMethods` (new `revolut` method, independent of Stripe), respecting per-customer method toggles.
- **MCP**: `create_revolut_payment_link` (`invoices:write`).

## Not included (deliberate)
No Revolut equivalent of Stripe Connect platform fees, saved-cards/autopay, or synchronous fee lookup (`provider_platform_fee` stays null). Bank transfer + Stripe remain fully available alongside.

## Verification
`tsc --noEmit` clean · `npm run build` clean (both `/api/revolut/*` routes present). Migrations applied + recorded on the live DB.

Setup after merge: business pastes their live Merchant Secret key, creates a Revolut webhook to `https://www.kireihq.com/api/revolut/webhook` and pastes its signing secret, sets mode Live, enables — then a test payment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)