### PR TITLE
feat(payments): one-click Revolut webhook setup

### DIFF
--- a/src/components/settings/revolut-settings.tsx
+++ b/src/components/settings/revolut-settings.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { GradientTile } from "@/components/ui/kirei";
 import { CreditCard, Loader2, CheckCircle } from "@/components/ui/icons";
-import { saveRevolutCredentials, disconnectRevolut, testRevolutConnection, type RevolutStatus } from "@/lib/actions/revolut";
+import { saveRevolutCredentials, disconnectRevolut, testRevolutConnection, setupRevolutWebhook, type RevolutStatus } from "@/lib/actions/revolut";
 
 export function RevolutSettings({ initial }: { initial: RevolutStatus }) {
   const [status, setStatus] = useState(initial);
@@ -19,6 +19,7 @@ export function RevolutSettings({ initial }: { initial: RevolutStatus }) {
   const [enabled, setEnabled] = useState(initial.enabled);
   const [saving, startSave] = useTransition();
   const [testing, setTesting] = useState(false);
+  const [webhooking, setWebhooking] = useState(false);
 
   const save = () =>
     startSave(async () => {
@@ -53,6 +54,21 @@ export function RevolutSettings({ initial }: { initial: RevolutStatus }) {
       r.ok ? toast.success(r.message) : toast.error(r.message);
     } finally {
       setTesting(false);
+    }
+  };
+
+  const createWebhook = async () => {
+    setWebhooking(true);
+    try {
+      const r = await setupRevolutWebhook();
+      if (r.ok) {
+        setStatus((s) => ({ ...s, hasWebhookSecret: true }));
+        toast.success(r.message);
+      } else {
+        toast.error(r.message);
+      }
+    } finally {
+      setWebhooking(false);
     }
   };
 
@@ -97,7 +113,7 @@ export function RevolutSettings({ initial }: { initial: RevolutStatus }) {
         <div className="space-y-1.5">
           <Label>Webhook signing secret <span className="text-muted-foreground font-normal">(from your Revolut webhook)</span></Label>
           <Input type="password" autoComplete="off" placeholder={status.hasWebhookSecret ? "•••••••• (saved — leave blank to keep)" : "wsk_..."} value={webhookSecret} onChange={(e) => setWebhookSecret(e.target.value)} />
-          <p className="text-[11px] text-muted-foreground">In Revolut, create a webhook to <code>{typeof window !== "undefined" ? window.location.origin : ""}/api/revolut/webhook</code> and paste its signing secret here.</p>
+          <p className="text-[11px] text-muted-foreground">Can&rsquo;t find the webhook screen in Revolut? Save your Secret key, then click <strong>Create webhook</strong> below and Kirei sets it up for you.</p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -120,6 +136,7 @@ export function RevolutSettings({ initial }: { initial: RevolutStatus }) {
         <div className="flex flex-wrap gap-2 pt-1">
           <Button onClick={save} disabled={saving}>{saving && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}Save</Button>
           <Button variant="outline" onClick={test} disabled={testing || !status.hasSecret}>{testing && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}Test connection</Button>
+          <Button variant="outline" onClick={createWebhook} disabled={webhooking || !status.hasSecret}>{webhooking && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />}Create webhook</Button>
           {status.hasSecret && <Button variant="ghost" className="text-destructive ml-auto" onClick={disconnect} disabled={saving}>Disconnect</Button>}
         </div>
       </CardContent>

--- a/src/lib/actions/revolut.ts
+++ b/src/lib/actions/revolut.ts
@@ -5,8 +5,18 @@ import { createClient } from "@/lib/supabase/server";
 import { getUser } from "@/lib/auth";
 import { getActiveBizId } from "@/lib/active-business";
 import { canManageSettings, type Role } from "@/lib/permissions";
+import { headers } from "next/headers";
 import { encryptSecret, decryptSecret, encryptionAvailable } from "@/lib/crypto";
-import { revolutKeyWorks, type RevolutMode } from "@/lib/revolut";
+import { revolutKeyWorks, ensureRevolutWebhook, type RevolutMode } from "@/lib/revolut";
+
+async function appBaseUrl(): Promise<string> {
+  const env = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "");
+  if (env) return env;
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  const proto = h.get("x-forwarded-proto") ?? "https";
+  return host ? `${proto}://${host}` : "https://www.kireihq.com";
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: Awaited<ReturnType<typeof createClient>>, name: string) => (sb as any).from(name);
@@ -100,6 +110,41 @@ export async function disconnectRevolut(): Promise<void> {
   }).eq("id", businessId);
 
   revalidatePath("/settings");
+}
+
+/**
+ * Create (or reuse) the Revolut webhook via the API and store its signing
+ * secret — so the user never has to find Revolut's webhook screen. Requires the
+ * Merchant Secret key to be saved first.
+ */
+export async function setupRevolutWebhook(): Promise<{ ok: boolean; message: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const role = await resolveRole(supabase, user.id, businessId);
+  if (!canManageSettings(role)) throw new Error("Only owners and admins can manage Revolut settings.");
+
+  const { data: biz } = await tbl(supabase, "businesses")
+    .select("revolut_secret_enc, revolut_mode").eq("id", businessId).single();
+  if (!biz?.revolut_secret_enc) return { ok: false, message: "Save your Merchant Secret key first, then create the webhook." };
+
+  try {
+    const secret = decryptSecret(biz.revolut_secret_enc);
+    const mode = (biz.revolut_mode as RevolutMode) ?? "sandbox";
+    const url = `${await appBaseUrl()}/api/revolut/webhook`;
+    const { signingSecret } = await ensureRevolutWebhook(secret, mode, url);
+
+    if (signingSecret) {
+      if (!encryptionAvailable()) return { ok: false, message: "Webhook created, but APP_ENCRYPTION_KEY isn't set to store its secret." };
+      await tbl(supabase, "businesses").update({ revolut_webhook_secret_enc: encryptSecret(signingSecret) }).eq("id", businessId);
+      revalidatePath("/settings");
+      return { ok: true, message: "Webhook created and secured. You're ready to take payments." };
+    }
+    revalidatePath("/settings");
+    return { ok: true, message: "Webhook created. (Revolut didn't return a signing secret — payments are still confirmed by re-checking the order.)" };
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : "Couldn't create the webhook." };
+  }
 }
 
 /** Validate the stored key against Revolut (used by the "Test connection" button). */

--- a/src/lib/revolut.ts
+++ b/src/lib/revolut.ts
@@ -133,6 +133,49 @@ export function verifyRevolutSignature(opts: {
   });
 }
 
+interface RevolutWebhook {
+  id: string;
+  url: string;
+  events?: string[];
+  signing_secret?: string;
+}
+
+/**
+ * Ensure a Revolut webhook exists for `webhookUrl` and return its signing
+ * secret — so the app can wire the webhook itself instead of the user hunting
+ * for Revolut's dashboard. Reuses an existing webhook for the same URL (Revolut
+ * only allows 10), otherwise creates one for ORDER_COMPLETED/ORDER_AUTHORISED.
+ */
+export async function ensureRevolutWebhook(
+  secret: string, mode: RevolutMode, webhookUrl: string,
+): Promise<{ id: string; signingSecret: string | null }> {
+  const events = ["ORDER_COMPLETED", "ORDER_AUTHORISED"];
+
+  // Look for an existing webhook on this URL first.
+  const listRes = await revolutFetch(secret, mode, "/api/1.0/webhooks", { method: "GET" });
+  if (listRes.ok) {
+    const list = (await listRes.json()) as RevolutWebhook[];
+    const existing = Array.isArray(list) ? list.find((w) => w.url === webhookUrl) : undefined;
+    if (existing) {
+      // The list may omit the signing secret; fetch the single webhook for it.
+      const oneRes = await revolutFetch(secret, mode, `/api/1.0/webhooks/${existing.id}`, { method: "GET" });
+      const one = oneRes.ok ? ((await oneRes.json()) as RevolutWebhook) : existing;
+      return { id: existing.id, signingSecret: one.signing_secret ?? existing.signing_secret ?? null };
+    }
+  }
+
+  const res = await revolutFetch(secret, mode, "/api/1.0/webhooks", {
+    method: "POST",
+    body: JSON.stringify({ url: webhookUrl, events }),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Revolut webhook create failed (${res.status}): ${txt.slice(0, 300)}`);
+  }
+  const created = (await res.json()) as RevolutWebhook;
+  return { id: created.id, signingSecret: created.signing_secret ?? null };
+}
+
 /** True when an order's state means the money is in. */
 export function revolutOrderIsPaid(state: string | undefined): boolean {
   const s = (state ?? "").toLowerCase();


### PR DESCRIPTION
Follow-up to #417. Some Revolut Business accounts don't surface the webhook/Accept-payments screen, blocking setup. This adds a **Create webhook** button to Settings → Payments → Revolut: it calls the Merchant API with the saved Secret key to create (or reuse) a webhook at `/api/revolut/webhook` for `ORDER_COMPLETED`/`ORDER_AUTHORISED` and stores the returned signing secret (encrypted) — so the user never has to find Revolut's dashboard screen.

- `ensureRevolutWebhook()` in revolut.ts — lists existing webhooks (reuses one for our URL, honouring Revolut's 10-webhook cap) else creates, returns the signing secret.
- `setupRevolutWebhook()` server action — decrypts the key, resolves the app's webhook URL, stores the signing secret.
- Button in the Revolut card (enabled once the Secret key is saved).

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)