### PR TITLE
feat: multiselect + bulk delete (products/materials/work orders) + inline WO status

### DIFF
--- a/src/components/materials/materials-client.tsx
+++ b/src/components/materials/materials-client.tsx
@@ -7,8 +7,10 @@ import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layout/page-header";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { createMaterial, updateMaterial, deleteMaterial, bulkImportMaterials } from "@/lib/actions/materials";
+import { createMaterial, updateMaterial, deleteMaterial, bulkImportMaterials, bulkDeleteMaterials } from "@/lib/actions/materials";
 import { BulkImportModal } from "@/components/shared/bulk-import-modal";
+import { BulkBar } from "@/components/shared/bulk-bar";
+import { useConfirm } from "@/components/ui/confirm";
 import { MaterialForm } from "./material-form";
 import { formatCurrency, sumMoney } from "@/lib/utils";
 import {
@@ -35,10 +37,31 @@ export function MaterialsClient({ materials: initial, currency = "GBP" }: { mate
   const [showNew, setShowNew] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const confirm = useConfirm();
 
   const filtered = materials.filter((m) =>
     `${m.name} ${m.description ?? ""} ${m.sku ?? ""} ${m.supplier ?? ""}`.toLowerCase().includes(search.toLowerCase())
   );
+
+  const toggle = (id: string) => setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  const allSelected = filtered.length > 0 && filtered.every((m) => selected.has(m.id));
+  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(filtered.map((m) => m.id)));
+
+  const handleBulkDelete = async () => {
+    const ids = [...selected];
+    if (!ids.length) return;
+    if (!(await confirm({ title: `Delete ${ids.length} material${ids.length === 1 ? "" : "s"}?`, body: "This removes them from your cost catalog. Quotes and invoices are unaffected." }))) return;
+    setBulkBusy(true);
+    try {
+      await bulkDeleteMaterials(ids);
+      setMaterials((prev) => prev.filter((m) => !selected.has(m.id)));
+      setSelected(new Set());
+      toast.success(`${ids.length} material${ids.length === 1 ? "" : "s"} deleted`);
+    } catch { toast.error("Failed to delete"); }
+    setBulkBusy(false);
+  };
 
   const handleCreate = async (data: FormValues) => {
     try {
@@ -127,6 +150,8 @@ export function MaterialsClient({ materials: initial, currency = "GBP" }: { mate
         </div>
       </div>
 
+      <BulkBar count={selected.size} noun="material" busy={bulkBusy} onDelete={handleBulkDelete} onClear={() => setSelected(new Set())} />
+
       {filtered.length === 0 ? (
         <EmptyState
           icon={<Package className="w-7 h-7" />}
@@ -138,6 +163,7 @@ export function MaterialsClient({ materials: initial, currency = "GBP" }: { mate
       ) : (
         <div className="rounded-xl border border-border bg-card overflow-hidden">
           <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-muted/40 text-[10px] uppercase tracking-wide font-bold text-muted-foreground">
+            <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select all" />
             <span className="flex-1">Material</span>
             <span className="hidden md:block w-24">Supplier</span>
             <span className="hidden md:block w-20">Unit</span>
@@ -153,6 +179,7 @@ export function MaterialsClient({ materials: initial, currency = "GBP" }: { mate
                 onClick={() => setEditMaterial(material)}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
+                <input type="checkbox" checked={selected.has(material.id)} onChange={() => toggle(material.id)} onClick={(e) => e.stopPropagation()} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select material" />
                 <GradientTile gradient="amber" size={40} radius={10}>
                   <Package className="w-4 h-4" />
                 </GradientTile>

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -8,8 +8,10 @@ import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { createProduct, updateProduct, deleteProduct, bulkImportProducts } from "@/lib/actions/products";
+import { createProduct, updateProduct, deleteProduct, bulkImportProducts, bulkDeleteProducts } from "@/lib/actions/products";
 import { BulkImportModal } from "@/components/shared/bulk-import-modal";
+import { BulkBar } from "@/components/shared/bulk-bar";
+import { useConfirm } from "@/components/ui/confirm";
 import { ProductForm } from "./product-form";
 import { formatCurrency, sumMoney } from "@/lib/utils";
 import {
@@ -32,10 +34,31 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
   const [showNew, setShowNew] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const confirm = useConfirm();
 
   const filtered = products.filter((p) =>
     `${p.name} ${p.description}`.toLowerCase().includes(search.toLowerCase())
   );
+
+  const toggle = (id: string) => setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  const allSelected = filtered.length > 0 && filtered.every((p) => selected.has(p.id));
+  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(filtered.map((p) => p.id)));
+
+  const handleBulkDelete = async () => {
+    const ids = [...selected];
+    if (!ids.length) return;
+    if (!(await confirm({ title: `Delete ${ids.length} product${ids.length === 1 ? "" : "s"}?`, body: "This can't be undone. Existing invoices and quotes are unaffected." }))) return;
+    setBulkBusy(true);
+    try {
+      await bulkDeleteProducts(ids);
+      setProducts((prev) => prev.filter((p) => !selected.has(p.id)));
+      setSelected(new Set());
+      toast.success(`${ids.length} product${ids.length === 1 ? "" : "s"} deleted`);
+    } catch { toast.error("Failed to delete"); }
+    setBulkBusy(false);
+  };
 
   const handleCreate = async (data: { name: string; unit_price: number; tax_rate: number; description?: string; unit?: string; archived: boolean }) => {
     try {
@@ -122,6 +145,8 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
         </div>
       </div>
 
+      <BulkBar count={selected.size} noun="product" busy={bulkBusy} onDelete={handleBulkDelete} onClear={() => setSelected(new Set())} />
+
       {filtered.length === 0 ? (
         <EmptyState
           icon={<Package className="w-7 h-7" />}
@@ -133,6 +158,7 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
       ) : (
         <div className="rounded-xl border border-border bg-card overflow-hidden">
           <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-muted/40 text-[10px] uppercase tracking-wide font-bold text-muted-foreground">
+            <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select all" />
             <span className="flex-1">Product</span>
             <span className="hidden md:block w-20">Unit</span>
             <span className="hidden md:block w-16 text-right">Tax</span>
@@ -147,6 +173,7 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
                 onClick={() => setEditProduct(product)}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
+                <input type="checkbox" checked={selected.has(product.id)} onChange={() => toggle(product.id)} onClick={(e) => e.stopPropagation()} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select product" />
                 <GradientTile gradient="emerald" size={40} radius={10}>
                   <Package className="w-4 h-4" />
                 </GradientTile>

--- a/src/components/shared/bulk-bar.tsx
+++ b/src/components/shared/bulk-bar.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Trash2, X } from "@/components/ui/icons";
+
+/** Selection action bar shown when one or more rows are ticked in a list. */
+export function BulkBar({ count, onDelete, onClear, busy, noun = "item" }: {
+  count: number;
+  onDelete: () => void;
+  onClear: () => void;
+  busy?: boolean;
+  noun?: string;
+}) {
+  if (count === 0) return null;
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-primary/40 bg-primary/5 px-4 py-2.5">
+      <span className="text-sm font-medium">{count} {noun}{count === 1 ? "" : "s"} selected</span>
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          onClick={onDelete}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 disabled:opacity-60"
+        >
+          <Trash2 className="w-3.5 h-3.5" /> {busy ? "Deleting…" : "Delete selected"}
+        </button>
+        <button onClick={onClear} className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-border bg-card text-sm text-muted-foreground hover:text-foreground">
+          <X className="w-3.5 h-3.5" /> Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -9,9 +9,11 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
-import { deleteWorkOrder } from "@/lib/actions/work-orders";
+import { BulkBar } from "@/components/shared/bulk-bar";
+import { useConfirm } from "@/components/ui/confirm";
+import { deleteWorkOrder, bulkDeleteWorkOrders, updateWorkOrderStatus } from "@/lib/actions/work-orders";
 import {
-  StatTile, KireiTabs, KireiPill, EmptyState, AnimatedPress, FadeIn, GradientTile,
+  StatTile, KireiTabs, EmptyState, AnimatedPress, FadeIn, GradientTile,
 } from "@/components/ui/kirei";
 import type { GradientName as KireiGradient } from "@/components/ui/kirei";
 import type { WorkOrderWithCustomer, WorkOrderStatus, BusinessMember } from "@/types/database";
@@ -26,6 +28,16 @@ const TABS: { value: WorkOrderStatus | "all"; label: string }[] = [
   { value: "submitted",   label: "Submitted"   },
   { value: "reviewed",    label: "Reviewed"    },
   { value: "completed",   label: "Completed"   },
+];
+
+const STATUS_OPTIONS: { value: WorkOrderStatus; label: string }[] = [
+  { value: "draft",       label: "Draft"       },
+  { value: "assigned",    label: "Assigned"    },
+  { value: "in_progress", label: "In progress" },
+  { value: "submitted",   label: "Submitted"   },
+  { value: "reviewed",    label: "Reviewed"    },
+  { value: "completed",   label: "Completed"   },
+  { value: "cancelled",   label: "Cancelled"   },
 ];
 
 const STATUS_GRADIENT: Record<WorkOrderStatus, KireiGradient> = {
@@ -50,6 +62,9 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
   const [tab, setTab] = useState<typeof TABS[number]["value"]>("all");
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const confirm = useConfirm();
 
   const filtered = useMemo(
     () => tab === "all" ? workOrders : workOrders.filter((w) => w.status === tab),
@@ -80,6 +95,32 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
     } catch { toast.error("Failed to delete"); }
     setBusy(false);
     setDeleteId(null);
+  };
+
+  const toggle = (id: string) => setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  const allSelected = filtered.length > 0 && filtered.every((w) => selected.has(w.id));
+  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(filtered.map((w) => w.id)));
+
+  const handleBulkDelete = async () => {
+    const ids = [...selected];
+    if (!ids.length) return;
+    if (!(await confirm({ title: `Delete ${ids.length} work order${ids.length === 1 ? "" : "s"}?`, body: "This permanently deletes the orders and their photos." }))) return;
+    setBulkBusy(true);
+    try {
+      await bulkDeleteWorkOrders(ids);
+      setSelected(new Set());
+      toast.success(`${ids.length} work order${ids.length === 1 ? "" : "s"} deleted`);
+      router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Failed to delete"); }
+    setBulkBusy(false);
+  };
+
+  const changeStatus = async (id: string, status: WorkOrderStatus) => {
+    try {
+      await updateWorkOrderStatus(id, status);
+      toast.success("Status updated");
+      router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update status"); }
   };
 
   return (
@@ -113,6 +154,8 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
         tabs={TABS.map((t) => ({ value: t.value, label: t.label, count: counts[t.value] ?? 0 }))}
       />
 
+      {canDelete && <BulkBar count={selected.size} noun="work order" busy={bulkBusy} onDelete={handleBulkDelete} onClear={() => setSelected(new Set())} />}
+
       {filtered.length === 0 ? (
         <EmptyState
           icon={<Wrench className="w-7 h-7" />}
@@ -124,6 +167,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
       ) : (
         <div className="rounded-xl border border-border bg-card overflow-hidden">
           <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-muted/40 text-[10px] uppercase tracking-wide font-bold text-muted-foreground">
+            {canDelete && <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select all" />}
             <span className="flex-1">Job</span>
             <span className="hidden lg:block w-44">Customer</span>
             <span className="hidden md:block w-44">Address</span>
@@ -140,6 +184,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
                 onMouseEnter={() => router.prefetch(`/work-orders/${wo.id}`)}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
+                {canDelete && <input type="checkbox" checked={selected.has(wo.id)} onChange={() => toggle(wo.id)} onClick={(e) => e.stopPropagation()} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select work order" />}
                 <GradientTile gradient={STATUS_GRADIENT[wo.status] ?? "primary"} size={40} radius={10}>
                   <Briefcase className="w-4 h-4" />
                 </GradientTile>
@@ -168,8 +213,15 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
                     <span className="inline-flex items-center gap-0.5"><Camera className="w-3 h-3" />{wo.photos?.length}</span>
                   ) : "—"}
                 </div>
-                <div className="ml-auto text-right">
-                  <KireiPill tone={wo.status} />
+                <div className="ml-auto text-right shrink-0" onClick={(e) => e.stopPropagation()}>
+                  <select
+                    value={wo.status}
+                    onChange={(e) => changeStatus(wo.id, e.target.value as WorkOrderStatus)}
+                    className="h-8 rounded-md border border-border bg-card px-2 text-xs font-medium cursor-pointer max-w-[132px]"
+                    aria-label="Change status"
+                  >
+                    {STATUS_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                  </select>
                 </div>
                 <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                   <DropdownMenu>

--- a/src/lib/actions/materials.ts
+++ b/src/lib/actions/materials.ts
@@ -67,6 +67,16 @@ export async function deleteMaterial(id: string): Promise<void> {
   revalidatePath("/materials");
 }
 
+export async function bulkDeleteMaterials(ids: string[]): Promise<void> {
+  if (!ids.length) return;
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "materials").delete().in("id", ids).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/materials");
+}
+
 export async function bulkImportMaterials(
   rows: Array<Omit<Material, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "archived">>,
 ): Promise<{ imported: number; errors: string[] }> {

--- a/src/lib/actions/products.ts
+++ b/src/lib/actions/products.ts
@@ -69,6 +69,16 @@ export async function deleteProduct(id: string): Promise<void> {
   revalidatePath("/products");
 }
 
+export async function bulkDeleteProducts(ids: string[]): Promise<void> {
+  if (!ids.length) return;
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "products").delete().in("id", ids).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/products");
+}
+
 export async function bulkImportProducts(
   rows: Array<Omit<Product, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "archived">>
 ): Promise<{ imported: number; errors: string[] }> {

--- a/src/lib/actions/work-orders.ts
+++ b/src/lib/actions/work-orders.ts
@@ -430,6 +430,27 @@ export async function deleteWorkOrder(id: string): Promise<void> {
   revalidatePath("/work-orders");
 }
 
+export async function bulkDeleteWorkOrders(ids: string[]): Promise<void> {
+  if (!ids.length) return;
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // Same gate as deleteWorkOrder — owners + admins only.
+  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
+  const isOwner = biz?.user_id === user.id;
+  if (!isOwner) {
+    const { data: member } = await tbl(supabase, "business_members")
+      .select("role").eq("business_id", businessId).eq("user_id", user.id).eq("status", "active").maybeSingle();
+    if (!member || member.role !== "admin") throw new Error("Only owners and admins can delete work orders");
+  }
+
+  const { error } = await tbl(supabase, "work_orders").delete().in("id", ids).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/work-orders");
+  revalidatePath("/schedule");
+}
+
 // ── Share link (customer-facing portfolio) ───────────────────────────────────
 
 export async function enableWorkOrderShareLink(id: string): Promise<{ token: string }> {


### PR DESCRIPTION
Adds bulk selection + delete to Products, Materials and Work Orders lists (row checkboxes + select-all + a selection bar, confirm before delete; business-scoped .in() delete actions; WO bulk keeps the owner/admin gate). Work Orders also get inline status change from the table via a per-row dropdown (updateWorkOrderStatus). tsc + build clean.