### PR TITLE
feat(work-orders): bulk status change from the selection bar

### DIFF
--- a/src/components/shared/bulk-bar.tsx
+++ b/src/components/shared/bulk-bar.tsx
@@ -3,18 +3,21 @@
 import { Trash2, X } from "@/components/ui/icons";
 
 /** Selection action bar shown when one or more rows are ticked in a list. */
-export function BulkBar({ count, onDelete, onClear, busy, noun = "item" }: {
+export function BulkBar({ count, onDelete, onClear, busy, noun = "item", extra }: {
   count: number;
   onDelete: () => void;
   onClear: () => void;
   busy?: boolean;
   noun?: string;
+  /** Extra action(s) (e.g. a bulk status selector) shown before Delete. */
+  extra?: React.ReactNode;
 }) {
   if (count === 0) return null;
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-primary/40 bg-primary/5 px-4 py-2.5">
+    <div className="flex items-center gap-3 rounded-xl border border-primary/40 bg-primary/5 px-4 py-2.5 flex-wrap">
       <span className="text-sm font-medium">{count} {noun}{count === 1 ? "" : "s"} selected</span>
-      <div className="ml-auto flex items-center gap-2">
+      <div className="ml-auto flex items-center gap-2 flex-wrap">
+        {extra}
         <button
           onClick={onDelete}
           disabled={busy}

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -11,7 +11,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { CleanupButton } from "@/components/cleanup/cleanup-button";
 import { BulkBar } from "@/components/shared/bulk-bar";
 import { useConfirm } from "@/components/ui/confirm";
-import { deleteWorkOrder, bulkDeleteWorkOrders, updateWorkOrderStatus } from "@/lib/actions/work-orders";
+import { deleteWorkOrder, bulkDeleteWorkOrders, updateWorkOrderStatus, bulkUpdateWorkOrderStatus } from "@/lib/actions/work-orders";
 import {
   StatTile, KireiTabs, EmptyState, AnimatedPress, FadeIn, GradientTile,
 } from "@/components/ui/kirei";
@@ -115,6 +115,19 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
     setBulkBusy(false);
   };
 
+  const handleBulkStatus = async (status: WorkOrderStatus) => {
+    const ids = [...selected];
+    if (!ids.length) return;
+    setBulkBusy(true);
+    try {
+      await bulkUpdateWorkOrderStatus(ids, status);
+      setSelected(new Set());
+      toast.success(`${ids.length} work order${ids.length === 1 ? "" : "s"} updated`);
+      router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update status"); }
+    setBulkBusy(false);
+  };
+
   const changeStatus = async (id: string, status: WorkOrderStatus) => {
     try {
       await updateWorkOrderStatus(id, status);
@@ -154,7 +167,27 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
         tabs={TABS.map((t) => ({ value: t.value, label: t.label, count: counts[t.value] ?? 0 }))}
       />
 
-      {canDelete && <BulkBar count={selected.size} noun="work order" busy={bulkBusy} onDelete={handleBulkDelete} onClear={() => setSelected(new Set())} />}
+      {canDelete && (
+        <BulkBar
+          count={selected.size}
+          noun="work order"
+          busy={bulkBusy}
+          onDelete={handleBulkDelete}
+          onClear={() => setSelected(new Set())}
+          extra={
+            <select
+              defaultValue=""
+              disabled={bulkBusy}
+              onChange={(e) => { const v = e.target.value; if (v) handleBulkStatus(v as WorkOrderStatus); }}
+              className="h-8 rounded-md border border-border bg-card px-2 text-sm cursor-pointer"
+              aria-label="Set status for selected work orders"
+            >
+              <option value="" disabled>Set status…</option>
+              {STATUS_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          }
+        />
+      )}
 
       {filtered.length === 0 ? (
         <EmptyState

--- a/src/lib/actions/work-orders.ts
+++ b/src/lib/actions/work-orders.ts
@@ -430,6 +430,15 @@ export async function deleteWorkOrder(id: string): Promise<void> {
   revalidatePath("/work-orders");
 }
 
+/** Apply a status to several work orders. Reuses updateWorkOrderStatus per row
+ *  so timeline events, started_at/completed_at, and the completed webhook all
+ *  fire exactly as they do for a single change. */
+export async function bulkUpdateWorkOrderStatus(ids: string[], status: WorkOrderStatus): Promise<void> {
+  for (const id of ids) {
+    await updateWorkOrderStatus(id, status);
+  }
+}
+
 export async function bulkDeleteWorkOrders(ids: string[]): Promise<void> {
   if (!ids.length) return;
   const supabase = await createClient();


### PR DESCRIPTION
Follow-up to #419. When work orders are multi-selected, the selection bar now includes a **Set status…** dropdown that applies the chosen status to every selected order (next to Delete). Each row goes through the existing `updateWorkOrderStatus`, so timeline events, start/complete timestamps and the completed webhook all fire as normal. The shared `BulkBar` gained an optional `extra` slot for this. tsc + build clean.