### PR TITLE
feat(leads): status-coloured cards + side drawer with notes log & tags

### DIFF
--- a/src/app/(dashboard)/leads/page.tsx
+++ b/src/app/(dashboard)/leads/page.tsx
@@ -1,7 +1,10 @@
-import { getLeads } from "@/lib/actions/leads";
+import { getLeads, listLeadTagPresets } from "@/lib/actions/leads";
 import { LeadsClient } from "@/components/leads/leads-client";
 
 export default async function LeadsPage() {
-  const leads = await getLeads();
-  return <LeadsClient leads={leads} />;
+  const [leads, tagPresets] = await Promise.all([
+    getLeads(),
+    listLeadTagPresets().catch(() => []),
+  ]);
+  return <LeadsClient leads={leads} tagPresets={tagPresets} />;
 }

--- a/src/components/leads/lead-card.tsx
+++ b/src/components/leads/lead-card.tsx
@@ -33,10 +33,12 @@ export function LeadCard({
 }) {
   const stage = STAGE_BY_STATUS[lead.status];
   const next = NEXT_STATUS[lead.status];
+  const tags = lead.tags ?? [];
 
   return (
     <div
-      className={`rounded-xl border border-border border-l-[3px] ${stage?.rail ?? ""} bg-card p-3 space-y-2 transition-shadow ${
+      onClick={() => handlers.onOpen(lead.id)}
+      className={`cursor-pointer rounded-xl border border-border border-l-[3px] ${stage?.rail ?? ""} ${stage?.cardBg ?? "bg-card"} p-3 space-y-2 transition-shadow ${
         dragging ? "shadow-lg rotate-[1.5deg] cursor-grabbing" : "shadow-sm hover:shadow-md"
       }`}
     >
@@ -46,7 +48,9 @@ export function LeadCard({
           <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
           <span className="font-semibold text-sm break-words">{lead.name}</span>
         </div>
-        <LeadActions lead={lead} busy={busy} handlers={handlers} />
+        <div onClick={(e) => e.stopPropagation()}>
+          <LeadActions lead={lead} busy={busy} handlers={handlers} />
+        </div>
       </div>
 
       {/* Details */}
@@ -55,6 +59,7 @@ export function LeadCard({
           <a
             href={`tel:${lead.phone.replace(/\s/g, "")}`}
             onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
             className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
           >
             <Phone className="h-3 w-3 shrink-0" />
@@ -65,6 +70,7 @@ export function LeadCard({
           <a
             href={`mailto:${lead.email}`}
             onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
             className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
           >
             <Mail className="h-3 w-3 shrink-0" />
@@ -81,6 +87,17 @@ export function LeadCard({
           <p className="text-xs text-foreground/80 break-words">{lead.service}</p>
         )}
       </div>
+
+      {/* Tags */}
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {tags.map((tag) => (
+            <span key={tag} className="inline-flex items-center rounded-full bg-background/70 border border-border px-2 py-0.5 text-[10px] font-medium text-foreground/80">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
 
       {/* Footer */}
       <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-border/60">
@@ -100,7 +117,7 @@ export function LeadCard({
               size="sm"
               className="h-7 text-[11px] px-2 gap-0.5"
               onPointerDown={(e) => e.stopPropagation()}
-              onClick={() => handlers.onMove(lead.id, next)}
+              onClick={(e) => { e.stopPropagation(); handlers.onMove(lead.id, next); }}
             >
               {next.charAt(0).toUpperCase() + next.slice(1)}
               <ChevronRight className="h-3 w-3" />

--- a/src/components/leads/lead-drawer.tsx
+++ b/src/components/leads/lead-drawer.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Phone, Mail, MapPin, Plus, X, Trash2, Clock } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Sheet, SheetContent, SheetHeader, SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  setLeadTags, createLeadTagPreset,
+  getLeadNotes, addLeadNote, deleteLeadNote, updateLeadStatus,
+} from "@/lib/actions/leads";
+import { STAGES } from "./lead-shared";
+import type { Lead, LeadStatus, LeadNote, LeadTagPreset } from "@/types/database";
+
+export function LeadDrawer({
+  lead,
+  open,
+  onOpenChange,
+  presets: presetsProp,
+  onLeadUpdated,
+  onPresetsChanged,
+}: {
+  lead: Lead | null;
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  presets: LeadTagPreset[];
+  onLeadUpdated: (id: string, patch: Partial<Lead>) => void;
+  onPresetsChanged: (presets: LeadTagPreset[]) => void;
+}) {
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
+  const [notes, setNotes] = useState<LeadNote[]>([]);
+  const [noteDraft, setNoteDraft] = useState("");
+  const [loadingNotes, setLoadingNotes] = useState(false);
+  const [savingNote, setSavingNote] = useState(false);
+
+  // Reset + load when a lead opens.
+  useEffect(() => {
+    if (!lead || !open) return;
+    setTags(lead.tags ?? []);
+    setTagInput("");
+    setNoteDraft("");
+    setLoadingNotes(true);
+    getLeadNotes(lead.id)
+      .then(setNotes)
+      .catch(() => setNotes([]))
+      .finally(() => setLoadingNotes(false));
+  }, [lead, open]);
+
+  if (!lead) return null;
+
+  const persistTags = async (next: string[]) => {
+    setTags(next);
+    try {
+      const clean = await setLeadTags(lead.id, next);
+      setTags(clean);
+      onLeadUpdated(lead.id, { tags: clean });
+    } catch {
+      toast.error("Couldn't update tags");
+    }
+  };
+
+  const addTag = (raw: string) => {
+    const t = raw.trim();
+    if (!t) return;
+    if (tags.some((x) => x.toLowerCase() === t.toLowerCase())) { setTagInput(""); return; }
+    persistTags([...tags, t]);
+    setTagInput("");
+  };
+
+  const removeTag = (t: string) => persistTags(tags.filter((x) => x !== t));
+
+  const saveAsPreset = async (label: string) => {
+    try {
+      const preset = await createLeadTagPreset(label);
+      if (!presetsProp.some((p) => p.id === preset.id)) {
+        onPresetsChanged([...presetsProp, preset].sort((a, b) => a.label.localeCompare(b.label)));
+      }
+      toast.success(`Saved "${label}" as a preset`);
+    } catch {
+      toast.error("Couldn't save preset");
+    }
+  };
+
+  const setStatus = async (status: LeadStatus) => {
+    onLeadUpdated(lead.id, { status });
+    try {
+      await updateLeadStatus(lead.id, status);
+    } catch {
+      toast.error("Couldn't update status");
+    }
+  };
+
+  const submitNote = async () => {
+    const body = noteDraft.trim();
+    if (!body) return;
+    setSavingNote(true);
+    try {
+      const note = await addLeadNote(lead.id, body);
+      setNotes((prev) => [note, ...prev]);
+      setNoteDraft("");
+    } catch {
+      toast.error("Couldn't add note");
+    }
+    setSavingNote(false);
+  };
+
+  const removeNote = async (id: string) => {
+    const before = notes;
+    setNotes((prev) => prev.filter((n) => n.id !== id));
+    try {
+      await deleteLeadNote(id);
+    } catch {
+      toast.error("Couldn't delete note");
+      setNotes(before);
+    }
+  };
+
+  // Presets not already applied, offered as quick-add chips.
+  const availablePresets = presetsProp.filter((p) => !tags.some((t) => t.toLowerCase() === p.label.toLowerCase()));
+  const canSaveInputAsPreset =
+    tagInput.trim().length > 0 && !presetsProp.some((p) => p.label.toLowerCase() === tagInput.trim().toLowerCase());
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-md overflow-y-auto p-0">
+        <SheetHeader className="border-b border-border p-5">
+          <SheetTitle className="text-lg">{lead.name}</SheetTitle>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            {lead.phone && <a href={`tel:${lead.phone.replace(/\s/g, "")}`} className="inline-flex items-center gap-1.5 hover:text-foreground"><Phone className="h-3.5 w-3.5" />{lead.phone}</a>}
+            {lead.email && <a href={`mailto:${lead.email}`} className="inline-flex items-center gap-1.5 hover:text-foreground"><Mail className="h-3.5 w-3.5" />{lead.email}</a>}
+            {lead.suburb && <span className="inline-flex items-center gap-1.5"><MapPin className="h-3.5 w-3.5" />{lead.suburb}</span>}
+          </div>
+        </SheetHeader>
+
+        <div className="space-y-6 p-5">
+          {/* Status */}
+          <section>
+            <p className="mb-2 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">Pipeline stage</p>
+            <div className="flex flex-wrap gap-1.5">
+              {STAGES.map((s) => {
+                const active = s.status === lead.status;
+                return (
+                  <button
+                    key={s.status}
+                    onClick={() => setStatus(s.status)}
+                    disabled={active}
+                    className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-semibold capitalize transition-colors ${
+                      active ? "bg-primary text-primary-foreground shadow-sm" : "border border-border bg-card hover:bg-muted"
+                    }`}
+                  >
+                    <span className={`h-2 w-2 rounded-full ${s.dot}`} />
+                    {s.label}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Tags */}
+          <section>
+            <p className="mb-2 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">Tags</p>
+            {tags.length > 0 && (
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {tags.map((t) => (
+                  <span key={t} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                    {t}
+                    <button onClick={() => removeTag(t)} className="hover:text-primary/70" aria-label={`Remove ${t}`}><X className="h-3 w-3" /></button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <Input
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addTag(tagInput); } }}
+                placeholder="Add a tag…"
+                className="h-9"
+              />
+              <Button size="sm" variant="outline" className="shrink-0" onClick={() => addTag(tagInput)} disabled={!tagInput.trim()}>
+                <Plus className="mr-1 h-3.5 w-3.5" /> Add
+              </Button>
+            </div>
+            {canSaveInputAsPreset && (
+              <button onClick={() => saveAsPreset(tagInput.trim())} className="mt-1.5 text-xs font-medium text-primary hover:underline">
+                + Save &quot;{tagInput.trim()}&quot; as a preset
+              </button>
+            )}
+            {availablePresets.length > 0 && (
+              <div className="mt-3">
+                <p className="mb-1.5 text-[11px] text-muted-foreground">Presets</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {availablePresets.map((p) => (
+                    <button
+                      key={p.id}
+                      onClick={() => addTag(p.label)}
+                      className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-xs font-medium text-muted-foreground hover:border-primary/40 hover:text-foreground"
+                    >
+                      <Plus className="h-3 w-3" /> {p.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Notes log */}
+          <section>
+            <p className="mb-2 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">Notes</p>
+            <div className="space-y-2">
+              <Textarea
+                value={noteDraft}
+                onChange={(e) => setNoteDraft(e.target.value)}
+                placeholder="Add a note about this lead…"
+                rows={3}
+              />
+              <div className="flex justify-end">
+                <Button size="sm" onClick={submitNote} disabled={!noteDraft.trim() || savingNote}>
+                  {savingNote ? "Adding…" : "Add note"}
+                </Button>
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-2.5">
+              {loadingNotes ? (
+                <p className="text-sm text-muted-foreground">Loading…</p>
+              ) : notes.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No notes yet.</p>
+              ) : (
+                notes.map((n) => (
+                  <div key={n.id} className="group rounded-lg border border-border bg-card p-3">
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">{n.body}</p>
+                    <div className="mt-1.5 flex items-center justify-between">
+                      <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                        <Clock className="h-3 w-3" />
+                        {new Date(n.created_at).toLocaleString("en-AU", { dateStyle: "medium", timeStyle: "short" })}
+                      </span>
+                      <button onClick={() => removeNote(n.id)} className="text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100" aria-label="Delete note">
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/leads/lead-shared.ts
+++ b/src/components/leads/lead-shared.ts
@@ -18,14 +18,16 @@ export interface StageDef {
   soft: string;
   /** Left-rail border colour for cards. */
   rail: string;
+  /** Soft card background tint per status. */
+  cardBg: string;
 }
 
 export const STAGES: StageDef[] = [
-  { status: "new",       label: "New",       dot: "bg-blue-500",    soft: "bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300",          rail: "border-l-blue-500" },
-  { status: "contacted", label: "Contacted", dot: "bg-amber-500",   soft: "bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",      rail: "border-l-amber-500" },
-  { status: "quoted",    label: "Quoted",    dot: "bg-violet-500",  soft: "bg-violet-50 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300",  rail: "border-l-violet-500" },
-  { status: "won",       label: "Won",       dot: "bg-emerald-500", soft: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300", rail: "border-l-emerald-500" },
-  { status: "lost",      label: "Lost",      dot: "bg-rose-500",    soft: "bg-rose-50 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300",          rail: "border-l-rose-500" },
+  { status: "new",       label: "New",       dot: "bg-blue-500",    soft: "bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300",          rail: "border-l-blue-500",    cardBg: "bg-blue-50/70 dark:bg-blue-950/20" },
+  { status: "contacted", label: "Contacted", dot: "bg-amber-500",   soft: "bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",      rail: "border-l-amber-500",   cardBg: "bg-amber-50/70 dark:bg-amber-950/20" },
+  { status: "quoted",    label: "Quoted",    dot: "bg-violet-500",  soft: "bg-violet-50 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300",  rail: "border-l-violet-500",  cardBg: "bg-violet-50/70 dark:bg-violet-950/20" },
+  { status: "won",       label: "Won",       dot: "bg-emerald-500", soft: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300", rail: "border-l-emerald-500", cardBg: "bg-emerald-50/70 dark:bg-emerald-950/20" },
+  { status: "lost",      label: "Lost",      dot: "bg-rose-500",    soft: "bg-rose-50 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300",          rail: "border-l-rose-500",    cardBg: "bg-rose-50/70 dark:bg-rose-950/20" },
 ];
 
 export const STAGE_BY_STATUS: Record<LeadStatus, StageDef> = Object.fromEntries(
@@ -79,4 +81,6 @@ export interface LeadActionHandlers {
   onDelete: (id: string) => void;
   onConvert: (id: string, target: ConvertTarget) => void;
   onAddAsContact: (id: string) => void;
+  /** Open the lead's side drawer (details + tags + notes). */
+  onOpen: (id: string) => void;
 }

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -38,13 +38,14 @@ import {
 import { LeadsBoard } from "./leads-board";
 import { LeadsList } from "./leads-list";
 import { LeadsCalendar } from "./leads-calendar";
+import { LeadDrawer } from "./lead-drawer";
 import { formatSourceLabel, type ConvertTarget, type LeadActionHandlers } from "./lead-shared";
 import {
   updateLeadStatus, deleteLead, createLead, updateLead,
   convertLeadToCustomer, convertLeadToQuote, convertLeadToWorkOrder,
 } from "@/lib/actions/leads";
 import { addLeadAsContact } from "@/lib/actions/contacts";
-import type { Lead, LeadStatus, LeadSource } from "@/types/database";
+import type { Lead, LeadStatus, LeadSource, LeadTagPreset } from "@/types/database";
 import { BUILT_IN_LEAD_SOURCES } from "@/types/database";
 
 type View = "board" | "list" | "calendar";
@@ -65,7 +66,7 @@ const EMPTY_FORM: NewLeadForm = {
   service: "", property_type: "", timing: "", notes: "", source: "manual",
 };
 
-export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
+export function LeadsClient({ leads: initial, tagPresets: initialPresets = [] }: { leads: Lead[]; tagPresets?: LeadTagPreset[] }) {
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
@@ -79,6 +80,8 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
   const [saving, setSaving] = useState(false);
   const [editLead, setEditLead] = useState<Lead | null>(null);
   const [editForm, setEditForm] = useState<Partial<Lead>>({});
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [tagPresets, setTagPresets] = useState<LeadTagPreset[]>(initialPresets);
 
   // View lives in the URL so it survives a refresh and can be linked to —
   // same pattern as the Content Studio hub.
@@ -234,7 +237,10 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
     onDelete: (id) => setDeleteId(id),
     onConvert: handleConvert,
     onAddAsContact: handleAddAsContact,
+    onOpen: (id) => setOpenId(id),
   };
+
+  const openLead = openId ? leads.find((l) => l.id === openId) ?? null : null;
 
   // ── render ────────────────────────────────────────────────────────────────
 
@@ -441,6 +447,16 @@ export function LeadsClient({ leads: initial }: { leads: Lead[] }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Lead drawer — details, tags, notes */}
+      <LeadDrawer
+        lead={openLead}
+        open={!!openLead}
+        onOpenChange={(o) => { if (!o) setOpenId(null); }}
+        presets={tagPresets}
+        onLeadUpdated={(id, patch) => setLeads((prev) => prev.map((l) => (l.id === id ? { ...l, ...patch } : l)))}
+        onPresetsChanged={setTagPresets}
+      />
 
       {/* Delete */}
       <AlertDialog open={!!deleteId} onOpenChange={(o) => { if (!o) setDeleteId(null); }}>

--- a/src/lib/actions/leads.ts
+++ b/src/lib/actions/leads.ts
@@ -7,7 +7,7 @@ import { dispatchWebhook } from "@/lib/webhooks";
 import { createCustomer } from "@/lib/actions/customers";
 import { createQuote } from "@/lib/actions/quotes";
 import { createWorkOrder } from "@/lib/actions/work-orders";
-import type { Lead, LeadStatus } from "@/types/database";
+import type { Lead, LeadStatus, LeadNote, LeadTagPreset } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -134,6 +134,125 @@ export async function updateLead(id: string, updates: Partial<Lead>): Promise<vo
   if (error) throw error;
   revalidatePath("/leads");
   revalidatePath(`/leads/${id}`);
+}
+
+// ── Tags ────────────────────────────────────────────────────────────────────
+
+/** Normalise a tag list: trim, drop empties, de-dupe (case-insensitive keep-first). */
+function cleanTags(tags: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of tags) {
+    const t = (raw ?? "").trim();
+    if (!t) continue;
+    const key = t.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
+}
+
+export async function setLeadTags(id: string, tags: string[]): Promise<string[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const clean = cleanTags(tags);
+
+  const { error } = await tbl(supabase, "leads")
+    .update({ tags: clean })
+    .eq("id", id)
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/leads");
+  revalidatePath(`/leads/${id}`);
+  return clean;
+}
+
+export async function listLeadTagPresets(): Promise<LeadTagPreset[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "lead_tag_presets")
+    .select("*")
+    .eq("business_id", businessId)
+    .order("label");
+  if (error) throw error;
+  return data as LeadTagPreset[];
+}
+
+export async function createLeadTagPreset(label: string, color?: string | null): Promise<LeadTagPreset> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const clean = label.trim();
+  if (!clean) throw new Error("A tag label is required");
+
+  const { data, error } = await tbl(supabase, "lead_tag_presets")
+    .upsert({ business_id: businessId, label: clean, color: color ?? null }, { onConflict: "business_id,label" })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/leads");
+  return data as LeadTagPreset;
+}
+
+export async function deleteLeadTagPreset(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { error } = await tbl(supabase, "lead_tag_presets")
+    .delete()
+    .eq("id", id)
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/leads");
+}
+
+// ── Notes log ───────────────────────────────────────────────────────────────
+
+export async function getLeadNotes(leadId: string): Promise<LeadNote[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "lead_notes")
+    .select("*")
+    .eq("lead_id", leadId)
+    .eq("business_id", businessId)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return data as LeadNote[];
+}
+
+export async function addLeadNote(leadId: string, body: string): Promise<LeadNote> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const clean = body.trim();
+  if (!clean) throw new Error("Note can't be empty");
+
+  const { data, error } = await tbl(supabase, "lead_notes")
+    .insert({ business_id: businessId, lead_id: leadId, user_id: user.id, body: clean })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath(`/leads/${leadId}`);
+  return data as LeadNote;
+}
+
+export async function deleteLeadNote(noteId: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { error } = await tbl(supabase, "lead_notes")
+    .delete()
+    .eq("id", noteId)
+    .eq("business_id", businessId);
+  if (error) throw error;
 }
 
 // ── Pipeline conversions ────────────────────────────────────────────────────

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -1120,6 +1120,56 @@ export function registerTools(register: ToolFn): void {
       return text({ deleted: true });
     });
 
+  tool("set_lead_tags", "Replace a lead's tags with the given list (custom labels or preset labels).",
+    { lead_id: UUID, tags: z.array(z.string()) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "leads:write");
+      const clean = Array.from(new Set(args.tags.map((s: string) => s.trim()).filter(Boolean)));
+      const { data, error } = await t(ctx, "leads").update({ tags: clean }).eq("id", args.lead_id).eq("business_id", ctx.businessId).select().single();
+      if (error) throw error;
+      return text({ updated: true, tags: clean, lead: data });
+    });
+
+  tool("list_lead_tag_presets", "List the business's preset lead tags.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "leads:read");
+      const { data, error } = await t(ctx, "lead_tag_presets").select("*").eq("business_id", ctx.businessId).order("label");
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_lead_tag_preset", "Create a preset lead tag (label + optional colour tone).",
+    { label: z.string().min(1), color: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "leads:write");
+      const { data, error } = await t(ctx, "lead_tag_presets")
+        .upsert({ business_id: ctx.businessId, label: args.label.trim(), color: args.color ?? null }, { onConflict: "business_id,label" })
+        .select().single();
+      if (error) throw error;
+      return text({ created: true, preset: data });
+    });
+
+  tool("list_lead_notes", "List the notes on a lead's follow-up log (newest first).",
+    { lead_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "leads:read");
+      const { data, error } = await t(ctx, "lead_notes").select("*").eq("lead_id", args.lead_id).eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("add_lead_note", "Add a timestamped note to a lead's follow-up log.",
+    { lead_id: UUID, body: z.string().min(1) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "leads:write");
+      const { data, error } = await t(ctx, "lead_notes")
+        .insert({ business_id: ctx.businessId, lead_id: args.lead_id, user_id: ctx.userId, body: args.body.trim() })
+        .select().single();
+      if (error) throw error;
+      return text({ added: true, note: data });
+    });
+
   tool("convert_lead_to_customer", "Create a customer from a lead and link them (sets lead status to contacted).",
     { lead_id: UUID },
     async (args, extra) => {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -875,6 +875,8 @@ export interface Lead {
   property_type: string | null;
   timing: string | null;
   notes: string | null;
+  /** Free-typed + preset tags on this lead. */
+  tags: string[];
   status: LeadStatus;
   source: LeadSource;
   utm_source: string | null;
@@ -892,6 +894,25 @@ export interface Lead {
   identity_key?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+/** A single timestamped note on a lead (append-only follow-up log). */
+export interface LeadNote {
+  id: string;
+  business_id: string;
+  lead_id: string;
+  user_id: string | null;
+  body: string;
+  created_at: string;
+}
+
+/** A business-managed preset tag for leads (label + optional colour tone). */
+export interface LeadTagPreset {
+  id: string;
+  business_id: string;
+  label: string;
+  color: string | null;
+  created_at: string;
 }
 
 // ----------------------------------------------------------------

--- a/supabase/migrations/20260730120000_lead_notes_tags.sql
+++ b/supabase/migrations/20260730120000_lead_notes_tags.sql
@@ -1,0 +1,71 @@
+-- Leads get: per-lead tags (custom + business presets) and a timestamped notes
+-- log. Card background colour is derived from status in the UI (no column).
+
+-- ── tags array on the lead ──────────────────────────────────────────────────
+ALTER TABLE public.leads
+  ADD COLUMN IF NOT EXISTS tags text[] NOT NULL DEFAULT '{}';
+
+-- ── notes log ───────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.lead_notes (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  lead_id     uuid NOT NULL REFERENCES public.leads(id) ON DELETE CASCADE,
+  user_id     uuid,
+  body        text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS lead_notes_lead_idx ON public.lead_notes (lead_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS lead_notes_business_idx ON public.lead_notes (business_id);
+
+ALTER TABLE public.lead_notes ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "lead_notes_no_workers" ON public.lead_notes;
+CREATE POLICY "lead_notes_no_workers" ON public.lead_notes
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );
+
+-- ── business-managed tag presets ────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.lead_tag_presets (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  label       text NOT NULL,
+  color       text,   -- tone key (e.g. "blue") or hex; UI decides rendering
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (business_id, label)
+);
+CREATE INDEX IF NOT EXISTS lead_tag_presets_business_idx ON public.lead_tag_presets (business_id);
+
+ALTER TABLE public.lead_tag_presets ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "lead_tag_presets_no_workers" ON public.lead_tag_presets;
+CREATE POLICY "lead_tag_presets_no_workers" ON public.lead_tag_presets
+  FOR ALL
+  USING (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  )
+  WITH CHECK (
+    business_id IN (
+      SELECT id FROM public.businesses WHERE user_id = auth.uid()
+      UNION
+      SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status = 'active'
+    )
+    AND NOT public.is_business_worker(business_id)
+  );


### PR DESCRIPTION
Adds notes, tags and a click-to-open drawer to Leads, plus status-coloured cards.

## What
- **Status-coloured cards** — each card gets a soft tint for its pipeline stage; tag chips shown on the card.
- **Click to open** — clicking a lead opens a **side drawer** (you stay on the board) with its details, stage switcher, tags and notes.
- **Notes log** — a timestamped follow-up log per lead (add / delete), not a single overwrite field.
- **Tags** — free-typed **custom** tags + **business-managed presets** (quick-add chips, "save as preset").

## Data (migration `20260730120000`, applied + recorded)
- `leads.tags text[]`
- `lead_notes` (id, business_id, lead_id, user_id, body, created_at) — the follow-up log
- `lead_tag_presets` (business_id, label, color, unique per business)
- RLS mirrors `leads_no_workers` (business members; workers excluded)

## Actions + MCP
- Actions: `setLeadTags`, `list/create/deleteLeadTagPreset`, `get/add/deleteLeadNote`
- MCP: `set_lead_tags`, `list/create_lead_tag_preset`, `list/add_lead_note`

## Verify
- `npx tsc --noEmit` ✅ · `npm run build` ✅
- Review: open /leads, note the status-tinted cards + tag chips, click a card → drawer (change stage, add/remove tags incl. a preset, add/delete notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)