### PR TITLE
fix(files): upload customer attachments direct to storage, not via a server action

### DIFF
--- a/src/components/attachments/attachments-panel.tsx
+++ b/src/components/attachments/attachments-panel.tsx
@@ -5,9 +5,13 @@ import { toast } from "sonner";
 import { FileText, Image as ImageIcon, Download, Trash2, Upload, Loader2, Paperclip } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import {
-  listAttachments, uploadAttachment, deleteAttachment, getAttachmentUrl,
+  listAttachments, deleteAttachment, getAttachmentUrl,
+  createAttachmentUpload, finalizeAttachment, discardAttachmentUpload,
 } from "@/lib/actions/attachments";
+import { createClient } from "@/lib/supabase/client";
 import type { Attachment, AttachmentEntityType } from "@/types/database";
+
+const MAX_BYTES = 25 * 1024 * 1024;
 
 function formatBytes(n: number | null): string {
   if (!n) return "";
@@ -44,19 +48,43 @@ export function AttachmentsPanel({
     return () => { cancelled = true; };
   }, [entityType, entityId]);
 
+  /**
+   * Upload straight from the browser to Supabase Storage via a signed URL.
+   * The bytes must NOT go through a server action — Vercel rejects request
+   * bodies over 4.5MB, which is well under a typical phone photo.
+   */
   const onPick = async (list: FileList | null) => {
     if (!list || list.length === 0) return;
+    const picked = Array.from(list);
+    const tooBig = picked.find((f) => f.size > MAX_BYTES);
+    if (tooBig) {
+      toast.error(`"${tooBig.name}" is over 25MB`);
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+
     setUploading(true);
+    const sb = createClient();
+    let done = 0;
     try {
-      for (const file of Array.from(list)) {
-        const fd = new FormData();
-        fd.set("file", file);
-        fd.set("entity_type", entityType);
-        fd.set("entity_id", entityId);
-        const saved = await uploadAttachment(fd);
-        setFiles((prev) => [saved, ...prev]);
+      for (const file of picked) {
+        const { path, token } = await createAttachmentUpload(entityType, entityId, file.name, file.size);
+        const { error } = await sb.storage.from("attachments").uploadToSignedUrl(path, token, file, {
+          contentType: file.type || undefined,
+        });
+        if (error) throw error;
+
+        try {
+          const saved = await finalizeAttachment(entityType, entityId, path, file.name, file.type || null, file.size);
+          setFiles((prev) => [saved, ...prev]);
+          done++;
+        } catch (e) {
+          // The object landed but the row didn't — don't leave it orphaned.
+          void discardAttachmentUpload(path);
+          throw e;
+        }
       }
-      toast.success(list.length > 1 ? `${list.length} files uploaded` : "File uploaded");
+      toast.success(done > 1 ? `${done} files uploaded` : "File uploaded");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Upload failed");
     } finally {

--- a/src/lib/actions/attachments.ts
+++ b/src/lib/actions/attachments.ts
@@ -36,44 +36,85 @@ export async function listAttachments(entityType: AttachmentEntityType, entityId
   return data as Attachment[];
 }
 
-export async function uploadAttachment(formData: FormData): Promise<Attachment> {
-  const { supabase, user, businessId } = await ctx();
-  const file = formData.get("file") as File | null;
-  const entityType = String(formData.get("entity_type") || "") as AttachmentEntityType;
-  const entityId = String(formData.get("entity_id") || "");
-  if (!file) throw new Error("No file");
-  if (!entityType || !entityId) throw new Error("Missing entity");
-  if (file.size > 25 * 1024 * 1024) throw new Error("File must be under 25MB");
+export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
-  const ext = (file.name.split(".").pop() || "bin").toLowerCase().replace(/[^a-z0-9]/g, "");
+/**
+ * Step 1 of 2 — mint a signed URL the BROWSER uploads straight to Supabase
+ * Storage with.
+ *
+ * The bytes must not travel through this server. A Next.js server action body
+ * is capped at 1MB by default, and Vercel caps any serverless request body at
+ * 4.5MB regardless of that setting — so posting a phone photo (routinely
+ * 2–8MB) through an action fails before the handler ever runs, surfacing as
+ * the opaque "An unexpected response was received from the server."
+ *
+ * Only this small token request crosses the server, so the real ceiling is the
+ * storage bucket's, not the platform's.
+ */
+export async function createAttachmentUpload(
+  entityType: AttachmentEntityType,
+  entityId: string,
+  fileName: string,
+  sizeBytes: number,
+): Promise<{ path: string; token: string }> {
+  const { businessId } = await ctx();
+  if (!entityType || !entityId) throw new Error("Missing entity");
+  if (!Number.isFinite(sizeBytes) || sizeBytes <= 0) throw new Error("Empty file");
+  if (sizeBytes > MAX_ATTACHMENT_BYTES) throw new Error("File must be under 25MB");
+
+  const ext = (fileName.split(".").pop() || "bin").toLowerCase().replace(/[^a-z0-9]/g, "");
   const path = `${businessId}/${entityType}/${entityId}/${randomUUID()}.${ext}`;
 
   const admin = createAdminClient();
-  const { error: upErr } = await admin.storage
-    .from("attachments")
-    .upload(path, file, { contentType: file.type || undefined, upsert: false });
-  if (upErr) throw upErr;
+  const { data, error } = await admin.storage.from("attachments").createSignedUploadUrl(path);
+  if (error || !data) throw error ?? new Error("Couldn't start upload");
+  return { path: data.path, token: data.token };
+}
+
+/** Step 2 of 2 — record the row once the browser has finished uploading. */
+export async function finalizeAttachment(
+  entityType: AttachmentEntityType,
+  entityId: string,
+  path: string,
+  name: string,
+  mimeType: string | null,
+  sizeBytes: number,
+): Promise<Attachment> {
+  const { supabase, user, businessId } = await ctx();
+
+  // The path is minted server-side above, but it round-trips through the
+  // client — so re-check it belongs to this business before trusting it.
+  if (!path.startsWith(`${businessId}/${entityType}/${entityId}/`)) {
+    throw new Error("Invalid upload path");
+  }
 
   const { data, error } = await tbl(supabase, "attachments")
     .insert({
       business_id: businessId,
       entity_type: entityType,
       entity_id: entityId,
-      name: file.name,
+      name,
       path,
-      mime_type: file.type || null,
-      size_bytes: file.size,
+      mime_type: mimeType || null,
+      size_bytes: sizeBytes,
       uploaded_by: user.id,
     })
     .select()
     .single();
   if (error) {
     // Best-effort cleanup so we don't orphan the object if the row insert fails.
-    await admin.storage.from("attachments").remove([path]);
+    await createAdminClient().storage.from("attachments").remove([path]);
     throw error;
   }
   revalidatePath(`/${entityType === "work_order" ? "work-orders" : entityType + "s"}/${entityId}`);
   return data as Attachment;
+}
+
+/** Drop an uploaded object whose row never got written (client-side failure). */
+export async function discardAttachmentUpload(path: string): Promise<void> {
+  const { businessId } = await ctx();
+  if (!path.startsWith(`${businessId}/`)) return;
+  await createAdminClient().storage.from("attachments").remove([path]);
 }
 
 export async function deleteAttachment(id: string): Promise<void> {


### PR DESCRIPTION
Uploading a photo to a customer's **Files** tab failed with:

> An unexpected response was received from the server.

## Cause

The panel posted the whole file through a **server action**. Two limits apply, and the file hit both:

- a Next.js server action body is capped at **1MB** by default
- Vercel caps **any** serverless request body at **4.5MB**, regardless of that setting

A phone photo is routinely 2–8MB, so the request was rejected *before the handler ever ran* — and Next surfaces that rejection as the opaque message above. The action's own `file.size > 25 MB` guard never got a chance to run, which is exactly why the limit looked like it should have been fine.

**Raising `serverActions.bodySizeLimit` would not fix this** — Vercel's 4.5MB platform cap still applies. The bytes have to skip the server.

## Fix

| | |
|---|---|
| `createAttachmentUpload()` | mints a Supabase **signed upload URL** — a few hundred bytes over the wire |
| browser | PUTs the file **straight to Storage** |
| `finalizeAttachment()` | writes the DB row |

The real ceiling is now the storage bucket's rather than the platform's, and the file no longer makes the browser → Vercel → Supabase round trip.

**Safety:** `finalizeAttachment` re-checks that the path it's handed starts with the caller's own `business/entity` prefix — the path is minted server-side but round-trips through the client, so it can't be trusted coming back. If the object lands but the row insert fails, the client calls `discardAttachmentUpload` so nothing is orphaned in the bucket.

## Same bug lives in four other places

Not touched here — flagging rather than widening this PR:

| Path | Guard claims | Actually fails at |
|---|---|---|
| `uploadReceipt` (expenses) | 10MB | **1MB** — receipt photos, same phone-camera problem |
| `uploadContractPdf` | 15MB | **1MB** |
| `uploadTemplateAsset` | 5MB | **1MB** |
| `/api/f/[slug]/upload`, `/api/portal/…/onboarding/…/upload` | 10MB | **4.5MB** (route handlers — Vercel cap only) |

The expenses receipt one will bite immediately given how photo-driven that flow is. Say the word and I'll port the same signed-URL pattern across all of them.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅

⚠️ **Not verified end-to-end** — the Files tab needs a logged-in session I don't have locally. The diagnosis is confirmed from the code path and the platform limits; the round trip itself wants a real upload on the preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)