### PR TITLE
feat(outreach): sequence builder, campaigns, tracking, sourcing + 11 seed verticals

### DIFF
--- a/src/app/(dashboard)/outreach/page.tsx
+++ b/src/app/(dashboard)/outreach/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import {
+  getOutreachSettings, getOutreachStats, listCampaigns, listSequences, listOutreachMessages,
+} from "@/lib/actions/outreach";
+import { OutreachClient } from "@/components/outreach/outreach-client";
+
+export default async function OutreachPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const settings = await getOutreachSettings();
+  const [stats, campaigns, sequences, messages] = await Promise.all([
+    getOutreachStats(),
+    listCampaigns(),
+    listSequences(),
+    listOutreachMessages({ limit: 100 }),
+  ]);
+
+  return (
+    <OutreachClient
+      settings={settings}
+      stats={stats}
+      campaigns={campaigns}
+      sequences={sequences}
+      messages={messages}
+    />
+  );
+}

--- a/src/app/(dashboard)/outreach/sequences/[id]/page.tsx
+++ b/src/app/(dashboard)/outreach/sequences/[id]/page.tsx
@@ -1,0 +1,21 @@
+import { redirect, notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getSequence } from "@/lib/actions/outreach";
+import { SequenceBuilder } from "@/components/outreach/sequence-builder";
+
+export default async function SequencePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  try {
+    const { sequence, steps } = await getSequence(id);
+    return <SequenceBuilder sequence={sequence} initialSteps={steps} />;
+  } catch {
+    notFound();
+  }
+}

--- a/src/app/api/cron/outreach/route.ts
+++ b/src/app/api/cron/outreach/route.ts
@@ -13,7 +13,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireCron } from "@/lib/cron-auth";
-import { autoEnroll, runOutreachForBusiness } from "@/lib/outreach/engine";
+import { autoEnroll, runOutreachForBusiness, withinSendWindow } from "@/lib/outreach/engine";
+import { sourceProspects } from "@/lib/outreach/sourcing";
 
 export const maxDuration = 300;
 
@@ -25,16 +26,31 @@ export async function GET(req: NextRequest) {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: settings } = await (sb as any)
-    .from("outreach_settings").select("business_id").eq("enabled", true);
+    .from("outreach_settings").select("*").eq("enabled", true);
 
-  const results: { business_id: string; enrolled: number; sent: number; failed: number }[] = [];
+  const results: { business_id: string; enrolled: number; sent: number; failed: number; sourced: number }[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   for (const s of ((settings ?? []) as any[])) {
     const businessId = s.business_id;
     let enrolled = 0;
+    let sourced = 0;
 
     try {
+      // Sourcing runs once a day rather than hourly — it burns the business's
+      // own Places quota, so it fires on the first tick inside the send window.
+      if (s.sourcing_enabled && withinSendWindow(s)) {
+        const since = new Date(Date.now() - 20 * 3600 * 1000).toISOString();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { count } = await (sb as any).from("prospects")
+          .select("id", { count: "exact", head: true })
+          .eq("business_id", businessId).eq("source", "places").gte("created_at", since);
+        if (!count) {
+          try { sourced = (await sourceProspects(sb, businessId)).created; }
+          catch (e) { console.error("outreach sourcing failed for", businessId, e); }
+        }
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data: campaigns } = await (sb as any)
         .from("outreach_campaigns").select("id")
@@ -47,9 +63,9 @@ export async function GET(req: NextRequest) {
       }
 
       const run = await runOutreachForBusiness(sb, businessId);
-      results.push({ business_id: businessId, enrolled, sent: run.sent, failed: run.failed });
+      results.push({ business_id: businessId, enrolled, sourced, sent: run.sent, failed: run.failed });
     } catch (e) {
-      results.push({ business_id: businessId, enrolled, sent: 0, failed: 0 });
+      results.push({ business_id: businessId, enrolled, sourced, sent: 0, failed: 0 });
       console.error("outreach cron failed for", businessId, e);
     }
   }
@@ -59,6 +75,7 @@ export async function GET(req: NextRequest) {
     businesses: results.length,
     sent: results.reduce((n, r) => n + r.sent, 0),
     enrolled: results.reduce((n, r) => n + r.enrolled, 0),
+    sourced: results.reduce((n, r) => n + r.sourced, 0),
     results,
   });
 }

--- a/src/components/outreach/outreach-client.tsx
+++ b/src/components/outreach/outreach-client.tsx
@@ -1,0 +1,652 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { KireiTabs } from "@/components/ui/kirei/tabs";
+import { StatTile } from "@/components/ui/kirei/stat-tile";
+import { EmptyState } from "@/components/ui/kirei/empty-state";
+import { TimePicker } from "@/components/ui/time-picker";
+import {
+  Send, Play, Pause, Plus, Trash2, Loader2, Target, MailCheck, MousePointer2, AlertCircle,
+} from "@/components/ui/icons";
+import {
+  updateOutreachSettings, seedSequence, createSequence, deleteSequence,
+  createCampaign, updateCampaign, deleteCampaign, enrollMatchingProspects,
+  runOutreachNow, runSourcingNow, setPlacesApiKey, acknowledgeCrawlerCompliance,
+} from "@/lib/actions/outreach";
+import { SEED_SEQUENCES } from "@/lib/outreach/seed-sequences";
+import type { OutreachStats } from "@/lib/actions/outreach";
+import type {
+  OutreachSettings, OutreachSequence, OutreachCampaign, OutreachMessage,
+} from "@/types/database";
+
+type Tab = "overview" | "campaigns" | "sequences" | "activity" | "settings";
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function pct(n: number, of: number): string {
+  if (!of) return "—";
+  return `${Math.round((n / of) * 100)}%`;
+}
+
+export function OutreachClient({
+  settings: initialSettings, stats, campaigns, sequences, messages,
+}: {
+  settings: OutreachSettings;
+  stats: OutreachStats;
+  campaigns: OutreachCampaign[];
+  sequences: (OutreachSequence & { step_count: number })[];
+  messages: OutreachMessage[];
+}) {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("overview");
+  const [settings, setSettings] = useState(initialSettings);
+  const [busy, startTransition] = useTransition();
+  const [running, setRunning] = useState(false);
+
+  const patch = (p: Partial<OutreachSettings>) => setSettings((s) => ({ ...s, ...p }));
+
+  const saveSettings = () => {
+    startTransition(async () => {
+      try {
+        await updateOutreachSettings({
+          enabled: settings.enabled,
+          daily_send_cap: settings.daily_send_cap,
+          send_window_start: settings.send_window_start,
+          send_window_end: settings.send_window_end,
+          send_days: settings.send_days,
+          seconds_between_sends: settings.seconds_between_sends,
+          timezone: settings.timezone,
+          from_local_part: settings.from_local_part,
+          reply_to: settings.reply_to,
+          signature_html: settings.signature_html,
+          sourcing_enabled: settings.sourcing_enabled,
+          sourcing_queries: settings.sourcing_queries,
+          sourcing_daily_quota: settings.sourcing_daily_quota,
+        });
+        toast.success("Settings saved");
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't save");
+      }
+    });
+  };
+
+  const sendNow = async () => {
+    setRunning(true);
+    try {
+      const r = await runOutreachNow(25);
+      toast.success(
+        r.sent ? `Sent ${r.sent}${r.failed ? ` · ${r.failed} failed` : ""}` : "Nothing was due to send",
+      );
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Run failed");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const activeCampaigns = campaigns.filter((c) => c.status === "running").length;
+
+  return (
+    <div>
+      <PageHeader
+        title="Outreach"
+        subtitle="Multi-step cold email over your prospect list — sequences, campaigns and delivery tracking."
+        actions={
+          <>
+            <Button variant="outline" onClick={sendNow} disabled={running || !settings.enabled}>
+              {running ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Send className="mr-1.5 h-4 w-4" />}
+              Send due now
+            </Button>
+            <Button onClick={() => setTab("campaigns")}>
+              <Plus className="mr-1.5 h-4 w-4" /> New campaign
+            </Button>
+          </>
+        }
+      />
+
+      {!settings.enabled && (
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4">
+          <div>
+            <p className="text-sm font-semibold">Outreach is switched off</p>
+            <p className="text-sm text-muted-foreground">
+              Nothing sends — not from the hourly runner, and not from &ldquo;Send due now&rdquo; — until you turn it on.
+            </p>
+          </div>
+          <Button
+            onClick={() => {
+              patch({ enabled: true });
+              startTransition(async () => {
+                await updateOutreachSettings({ enabled: true });
+                toast.success("Outreach enabled");
+                router.refresh();
+              });
+            }}
+          >
+            Turn on sending
+          </Button>
+        </div>
+      )}
+
+      <KireiTabs
+        className="mb-5"
+        value={tab}
+        onChange={setTab}
+        tabs={[
+          { value: "overview", label: "Overview" },
+          { value: "campaigns", label: "Campaigns", count: campaigns.length },
+          { value: "sequences", label: "Sequences", count: sequences.length },
+          { value: "activity", label: "Activity", count: messages.length },
+          { value: "settings", label: "Settings" },
+        ]}
+      />
+
+      {tab === "overview" && (
+        <div className="space-y-5">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <StatTile toneColor="#1f4f4a" icon={<Send className="h-4 w-4" />} label="Sent" value={String(stats.sent)}
+              sub={`${stats.delivered} delivered`} />
+            <StatTile toneColor="#2563eb" icon={<MailCheck className="h-4 w-4" />} label="Opened" value={String(stats.opened)}
+              sub={`${pct(stats.opened, stats.sent)} of sent`} />
+            <StatTile toneColor="#7c3aed" icon={<MousePointer2 className="h-4 w-4" />} label="Clicked" value={String(stats.clicked)}
+              sub={`${pct(stats.clicked, stats.sent)} of sent`} />
+            <StatTile toneColor="#dc2626" icon={<AlertCircle className="h-4 w-4" />} label="Bounced" value={String(stats.bounced)}
+              sub={`${pct(stats.bounced, stats.sent)} — keep under 2%`} />
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-xl border border-border bg-card p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">In sequence</p>
+              <p className="mt-2 text-2xl font-bold tabular-nums">{stats.active_enrollments}</p>
+              <p className="text-xs text-muted-foreground">prospects with a step still due</p>
+            </div>
+            <div className="rounded-xl border border-border bg-card p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Running campaigns</p>
+              <p className="mt-2 text-2xl font-bold tabular-nums">{activeCampaigns}</p>
+              <p className="text-xs text-muted-foreground">of {campaigns.length} total</p>
+            </div>
+            <div className="rounded-xl border border-border bg-card p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Daily cap</p>
+              <p className="mt-2 text-2xl font-bold tabular-nums">{settings.daily_send_cap}</p>
+              <p className="text-xs text-muted-foreground">
+                {settings.send_window_start.slice(0, 5)}–{settings.send_window_end.slice(0, 5)} · {settings.timezone}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-5">
+            <p className="mb-1 text-sm font-semibold">How it runs</p>
+            <p className="text-sm text-muted-foreground">
+              An hourly job checks whether the local time is inside your send window. If it is, it enrols any new
+              prospects matching each running campaign&rsquo;s filter, then sends every step that&rsquo;s due — up to
+              the daily cap. A hard bounce or a spam complaint stops that prospect&rsquo;s sequence immediately.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {tab === "campaigns" && (
+        <CampaignsTab campaigns={campaigns} sequences={sequences} onDone={() => router.refresh()} />
+      )}
+
+      {tab === "sequences" && (
+        <SequencesTab sequences={sequences} onDone={() => router.refresh()} />
+      )}
+
+      {tab === "activity" && <ActivityTab messages={messages} />}
+
+      {tab === "settings" && (
+        <SettingsTab
+          settings={settings} patch={patch} save={saveSettings} busy={busy}
+          onDone={() => router.refresh()}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Campaigns ────────────────────────────────────────────────────────────────
+
+function CampaignsTab({
+  campaigns, sequences, onDone,
+}: {
+  campaigns: OutreachCampaign[];
+  sequences: (OutreachSequence & { step_count: number })[];
+  onDone: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [seqId, setSeqId] = useState(sequences[0]?.id ?? "");
+  const [busy, setBusy] = useState(false);
+
+  const create = async () => {
+    if (!name.trim() || !seqId) { toast.error("Name and sequence are both required"); return; }
+    setBusy(true);
+    try {
+      await createCampaign({ name, sequence_id: seqId, auto_enroll: true });
+      toast.success("Campaign created as a draft — start it when you're ready");
+      setName("");
+      onDone();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't create");
+    } finally { setBusy(false); }
+  };
+
+  const setStatus = async (c: OutreachCampaign, status: OutreachCampaign["status"]) => {
+    try {
+      await updateCampaign(c.id, { status });
+      toast.success(status === "running" ? "Campaign started" : "Campaign paused");
+      onDone();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update"); }
+  };
+
+  const enrol = async (c: OutreachCampaign) => {
+    try {
+      const n = await enrollMatchingProspects(c.id);
+      toast.success(n ? `Enrolled ${n} prospect${n === 1 ? "" : "s"}` : "No new matching prospects");
+      onDone();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't enrol"); }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-border bg-card p-5">
+        <p className="mb-3 text-sm font-semibold">New campaign</p>
+        {sequences.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Create a sequence first — a campaign is just a sequence pointed at a set of prospects.
+          </p>
+        ) : (
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-[220px] flex-1">
+              <Label htmlFor="c-name">Name</Label>
+              <Input id="c-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Strata managers — Q3" />
+            </div>
+            <div className="min-w-[200px]">
+              <Label htmlFor="c-seq">Sequence</Label>
+              <select
+                id="c-seq" value={seqId} onChange={(e) => setSeqId(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-card px-3 text-sm"
+              >
+                {sequences.map((s) => (
+                  <option key={s.id} value={s.id}>{s.name} ({s.step_count} steps)</option>
+                ))}
+              </select>
+            </div>
+            <Button onClick={create} disabled={busy}>
+              {busy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
+              Create
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {campaigns.length === 0 ? (
+        <EmptyState icon={<Target className="h-6 w-6" />} title="No campaigns yet"
+          hint="A campaign enrols prospects into a sequence and sends the steps on schedule." />
+      ) : (
+        <div className="space-y-2">
+          {campaigns.map((c) => {
+            const seq = sequences.find((s) => s.id === c.sequence_id);
+            return (
+              <div key={c.id} className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card p-4">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold">{c.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {seq ? `${seq.name} · ${seq.step_count} steps` : "No sequence"}
+                    {c.auto_enroll ? " · auto-enrols new matches" : ""}
+                  </p>
+                </div>
+                <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+                  c.status === "running" ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+                  : c.status === "paused" ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                  : "bg-muted text-muted-foreground"}`}>
+                  {c.status}
+                </span>
+                <Button size="sm" variant="outline" onClick={() => enrol(c)}>Enrol matches</Button>
+                {c.status === "running" ? (
+                  <Button size="sm" variant="outline" onClick={() => setStatus(c, "paused")}>
+                    <Pause className="mr-1.5 h-3.5 w-3.5" /> Pause
+                  </Button>
+                ) : (
+                  <Button size="sm" onClick={() => setStatus(c, "running")}>
+                    <Play className="mr-1.5 h-3.5 w-3.5" /> Start
+                  </Button>
+                )}
+                <button
+                  className="text-muted-foreground hover:text-destructive"
+                  aria-label="Delete campaign"
+                  onClick={async () => {
+                    if (!confirm(`Delete "${c.name}"? Enrollments go with it.`)) return;
+                    await deleteCampaign(c.id); toast.success("Campaign deleted"); onDone();
+                  }}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sequences ────────────────────────────────────────────────────────────────
+
+function SequencesTab({
+  sequences, onDone,
+}: {
+  sequences: (OutreachSequence & { step_count: number })[];
+  onDone: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const fromSeed = async (vertical: string) => {
+    setBusy(true);
+    try {
+      await seedSequence(vertical);
+      toast.success("Sequence created from template — edit the copy before you start it");
+      onDone();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't create");
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        {sequences.length === 0 ? (
+          <EmptyState icon={<Send className="h-6 w-6" />} title="No sequences yet"
+            hint="Start from a template below, or build one from scratch." />
+        ) : sequences.map((s) => (
+          <div key={s.id} className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card p-4">
+            <div className="min-w-0 flex-1">
+              <Link href={`/outreach/sequences/${s.id}`} className="truncate text-sm font-semibold hover:underline">
+                {s.name}
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                {s.step_count} step{s.step_count === 1 ? "" : "s"}
+                {s.description ? ` · ${s.description}` : ""}
+              </p>
+            </div>
+            <Link href={`/outreach/sequences/${s.id}`}>
+              <Button size="sm" variant="outline">Edit steps</Button>
+            </Link>
+            <button
+              className="text-muted-foreground hover:text-destructive"
+              aria-label="Delete sequence"
+              onClick={async () => {
+                if (!confirm(`Delete "${s.name}"?`)) return;
+                await deleteSequence(s.id); toast.success("Sequence deleted"); onDone();
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <div>
+            <p className="text-sm font-semibold">Start from a template</p>
+            <p className="text-xs text-muted-foreground">
+              Four steps over two weeks: intro → nudge → availability → sign-off. Edit the copy before sending —
+              anything in [square brackets] is yours to fill in.
+            </p>
+          </div>
+          <Button size="sm" variant="outline" disabled={busy} onClick={async () => {
+            const name = prompt("Sequence name?");
+            if (!name?.trim()) return;
+            await createSequence({ name });
+            toast.success("Blank sequence created"); onDone();
+          }}>
+            <Plus className="mr-1.5 h-3.5 w-3.5" /> Blank
+          </Button>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {SEED_SEQUENCES.map((s) => (
+            <button
+              key={s.vertical} disabled={busy} onClick={() => fromSeed(s.vertical)}
+              className="rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-primary/40 disabled:opacity-60"
+            >
+              <p className="text-sm font-semibold">{s.name}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{s.description}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Activity ─────────────────────────────────────────────────────────────────
+
+function ActivityTab({ messages }: { messages: OutreachMessage[] }) {
+  if (!messages.length) {
+    return <EmptyState icon={<Send className="h-6 w-6" />} title="Nothing sent yet"
+      hint="Every email this agent sends shows up here with its delivery, open, click and bounce state." />;
+  }
+  return (
+    <div className="ch-table-wrap">
+      <table className="ch-table">
+        <thead>
+          <tr>
+            <th>Recipient</th><th>Subject</th><th>Step</th><th>Status</th><th>Sent</th>
+          </tr>
+        </thead>
+        <tbody>
+          {messages.map((m) => (
+            <tr key={m.id}>
+              <td className="ch-mono">{m.recipient}</td>
+              <td className="max-w-[280px] truncate">{m.subject}</td>
+              <td className="num">{m.step_order ?? "—"}</td>
+              <td>
+                <span className={`ch-pill ${
+                  m.status === "bounced" || m.status === "failed" || m.status === "complained" ? "overdue"
+                  : m.status === "clicked" || m.status === "opened" ? "paid"
+                  : m.status === "delivered" ? "sent" : "draft"}`}>
+                  {m.status}
+                </span>
+              </td>
+              <td>{new Date(m.sent_at).toLocaleString("en-AU", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Settings ─────────────────────────────────────────────────────────────────
+
+function SettingsTab({
+  settings, patch, save, busy, onDone,
+}: {
+  settings: OutreachSettings;
+  patch: (p: Partial<OutreachSettings>) => void;
+  save: () => void;
+  busy: boolean;
+  onDone: () => void;
+}) {
+  const [placesKey, setPlacesKey] = useState("");
+  const toggleDay = (d: number) => {
+    const days = settings.send_days.includes(d)
+      ? settings.send_days.filter((x) => x !== d)
+      : [...settings.send_days, d].sort();
+    patch({ send_days: days });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-border bg-card p-5">
+        <p className="mb-4 text-sm font-semibold">Sending</p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex items-center justify-between gap-3 sm:col-span-2">
+            <div>
+              <Label>Sending enabled</Label>
+              <p className="text-xs text-muted-foreground">The master switch. Off means nothing sends, ever.</p>
+            </div>
+            <Switch checked={settings.enabled} onCheckedChange={(v) => patch({ enabled: v })} />
+          </div>
+          <div>
+            <Label htmlFor="cap">Daily send cap</Label>
+            <Input id="cap" type="number" min={0} value={settings.daily_send_cap}
+              onChange={(e) => patch({ daily_send_cap: Number(e.target.value) })} />
+            <p className="mt-1 text-xs text-muted-foreground">Across all campaigns. Ramp up slowly on a new domain.</p>
+          </div>
+          <div>
+            <Label htmlFor="gap">Seconds between sends</Label>
+            <Input id="gap" type="number" min={0} value={settings.seconds_between_sends}
+              onChange={(e) => patch({ seconds_between_sends: Number(e.target.value) })} />
+            <p className="mt-1 text-xs text-muted-foreground">A small gap looks less like a blast.</p>
+          </div>
+          <div>
+            <Label>Send window opens</Label>
+            <TimePicker value={settings.send_window_start.slice(0, 5)}
+              onChange={(v) => patch({ send_window_start: v })} />
+          </div>
+          <div>
+            <Label>Send window closes</Label>
+            <TimePicker value={settings.send_window_end.slice(0, 5)}
+              onChange={(v) => patch({ send_window_end: v })} />
+          </div>
+          <div className="sm:col-span-2">
+            <Label>Send days</Label>
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
+              {DAYS.map((d, i) => (
+                <button key={d} type="button" onClick={() => toggleDay(i)}
+                  className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                    settings.send_days.includes(i)
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-card text-muted-foreground hover:border-primary/40"}`}>
+                  {d}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="tz">Timezone</Label>
+            <Input id="tz" value={settings.timezone} onChange={(e) => patch({ timezone: e.target.value })} />
+            <p className="mt-1 text-xs text-muted-foreground">The window is evaluated in this zone.</p>
+          </div>
+          <div>
+            <Label htmlFor="from">From address (local part)</Label>
+            <Input id="from" value={settings.from_local_part}
+              onChange={(e) => patch({ from_local_part: e.target.value })} />
+            <p className="mt-1 text-xs text-muted-foreground">Sends as {settings.from_local_part}@your-business-domain.</p>
+          </div>
+          <div className="sm:col-span-2">
+            <Label htmlFor="reply">Reply-to</Label>
+            <Input id="reply" type="email" value={settings.reply_to ?? ""} placeholder="info@yourbusiness.com.au"
+              onChange={(e) => patch({ reply_to: e.target.value })} />
+          </div>
+          <div className="sm:col-span-2">
+            <Label htmlFor="sig">Signature (HTML)</Label>
+            <Textarea id="sig" rows={4} value={settings.signature_html ?? ""}
+              onChange={(e) => patch({ signature_html: e.target.value })}
+              placeholder="<strong>Your Name</strong><br>Your Business<br>0400 000 000" />
+            <p className="mt-1 text-xs text-muted-foreground">Appended to every step, above the unsubscribe line.</p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <Button onClick={save} disabled={busy}>
+            {busy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />} Save settings
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-5">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">Prospect sourcing</p>
+            <p className="text-xs text-muted-foreground">
+              Find businesses via Google Places using your own API key. Places never returns email addresses, so
+              sourced prospects arrive with a website and no email.
+            </p>
+          </div>
+          <Switch checked={settings.sourcing_enabled} onCheckedChange={(v) => patch({ sourcing_enabled: v })} />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="sm:col-span-2">
+            <Label htmlFor="queries">Search terms (one per line)</Label>
+            <Textarea id="queries" rows={3} value={(settings.sourcing_queries ?? []).join("\n")}
+              onChange={(e) => patch({ sourcing_queries: e.target.value.split("\n").map((s) => s.trim()).filter(Boolean) })}
+              placeholder={"strata management\nproperty management\nfacilities management"} />
+          </div>
+          <div>
+            <Label htmlFor="quota">Daily quota</Label>
+            <Input id="quota" type="number" min={0} value={settings.sourcing_daily_quota}
+              onChange={(e) => patch({ sourcing_daily_quota: Number(e.target.value) })} />
+          </div>
+          <div>
+            <Label htmlFor="pk">Google Places API key</Label>
+            <div className="flex gap-2">
+              <Input id="pk" type="password" value={placesKey} placeholder={settings.places_api_key_enc ? "•••••• saved" : "Paste key"}
+                onChange={(e) => setPlacesKey(e.target.value)} />
+              <Button variant="outline" onClick={async () => {
+                try { await setPlacesApiKey(placesKey); setPlacesKey(""); toast.success("Key saved (encrypted)"); onDone(); }
+                catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't save key"); }
+              }}>Save</Button>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">Stored encrypted. Never shown again after saving.</p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <Button variant="outline" disabled={!settings.sourcing_enabled} onClick={async () => {
+            try {
+              const r = await runSourcingNow();
+              if (r.errors.length) toast.error(r.errors[0]);
+              else toast.success(`Found ${r.found} · added ${r.created} · skipped ${r.skipped} already known`);
+              onDone();
+            } catch (e) { toast.error(e instanceof Error ? e.message : "Sourcing failed"); }
+          }}>
+            <Target className="mr-1.5 h-4 w-4" /> Source prospects now
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">Website email crawling</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Visits a sourced business&rsquo;s own website to find a published contact address. Off by default and
+              deliberately gated: the Spam Act 2003 (s.22) prohibits sending to addresses collected by
+              address-harvesting software, so turning this on is recorded against your account with a timestamp.
+              You remain responsible for having a lawful basis to contact anyone you email.
+            </p>
+            {settings.compliance_ack_at && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Acknowledged {new Date(settings.compliance_ack_at).toLocaleString("en-AU")}
+              </p>
+            )}
+          </div>
+          <Switch
+            checked={settings.crawler_enabled}
+            onCheckedChange={async (v) => {
+              if (v && !confirm(
+                "Turning this on records your acknowledgement, with a timestamp, that you have a lawful basis to contact the addresses it finds. Continue?",
+              )) return;
+              try {
+                await acknowledgeCrawlerCompliance(v);
+                patch({ crawler_enabled: v });
+                toast.success(v ? "Crawling enabled and acknowledgement recorded" : "Crawling disabled");
+                onDone();
+              } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update"); }
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/outreach/sequence-builder.tsx
+++ b/src/components/outreach/sequence-builder.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { ArrowLeft, Plus, Trash2, Loader2, ChevronUp, ChevronDown, AlertCircle } from "@/components/ui/icons";
+import { saveSequenceSteps, updateSequence } from "@/lib/actions/outreach";
+import { unfilledPlaceholders } from "@/lib/outreach/seed-sequences";
+import type { OutreachSequence, OutreachSequenceStep } from "@/types/database";
+
+interface Draft { subject: string; body: string; delay_days: number }
+
+const MERGE_FIELDS = ["first_name", "name", "company", "title", "website"];
+
+/** Day each step lands on, counting from enrolment — delays are cumulative. */
+function dayOf(steps: Draft[], i: number): number {
+  return steps.slice(0, i + 1).reduce((n, s, idx) => n + (idx === 0 ? 0 : s.delay_days), 0);
+}
+
+export function SequenceBuilder({
+  sequence, initialSteps,
+}: {
+  sequence: OutreachSequence;
+  initialSteps: OutreachSequenceStep[];
+}) {
+  const router = useRouter();
+  const [name, setName] = useState(sequence.name);
+  const [steps, setSteps] = useState<Draft[]>(
+    initialSteps.map((s) => ({ subject: s.subject, body: s.body, delay_days: s.delay_days })),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const placeholders = useMemo(
+    () => [...new Set(steps.flatMap((s) => [...unfilledPlaceholders(s.subject), ...unfilledPlaceholders(s.body)]))],
+    [steps],
+  );
+
+  const update = (i: number, p: Partial<Draft>) =>
+    setSteps((prev) => prev.map((s, idx) => (idx === i ? { ...s, ...p } : s)));
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= steps.length) return;
+    setSteps((prev) => {
+      const next = [...prev];
+      [next[i], next[j]] = [next[j], next[i]];
+      return next;
+    });
+  };
+
+  const save = async () => {
+    if (steps.some((s) => !s.subject.trim() || !s.body.trim())) {
+      toast.error("Every step needs a subject and a body");
+      return;
+    }
+    setSaving(true);
+    try {
+      if (name.trim() && name !== sequence.name) await updateSequence(sequence.id, { name: name.trim() });
+      await saveSequenceSteps(sequence.id, steps);
+      toast.success("Sequence saved");
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't save");
+    } finally { setSaving(false); }
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2">
+            <Link href="/outreach" className="text-muted-foreground hover:text-foreground" aria-label="Back to outreach">
+              <ArrowLeft className="h-5 w-5" />
+            </Link>
+            Sequence
+          </span>
+        }
+        subtitle={sequence.description ?? "Steps send in order — each delay counts from the step before it."}
+        actions={
+          <Button onClick={save} disabled={saving}>
+            {saving && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />} Save sequence
+          </Button>
+        }
+      />
+
+      <div className="mb-4 rounded-xl border border-border bg-card p-5">
+        <Label htmlFor="seq-name">Name</Label>
+        <Input id="seq-name" value={name} onChange={(e) => setName(e.target.value)} className="max-w-md" />
+        <p className="mt-3 text-xs text-muted-foreground">
+          Merge fields: {MERGE_FIELDS.map((f) => <code key={f} className="mr-1.5 rounded bg-muted px-1 py-0.5">{`{{${f}}}`}</code>)}
+          — a missing value falls back to &ldquo;there&rdquo; for the name, or an empty string.
+        </p>
+      </div>
+
+      {placeholders.length > 0 && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <div>
+            <p className="text-sm font-semibold">This template still has blanks to fill in</p>
+            <p className="text-sm text-muted-foreground">
+              {placeholders.map((p) => `[${p}]`).join(" · ")} — these send literally if you leave them.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {steps.map((s, i) => (
+          <div key={i} className="rounded-xl border border-border bg-card p-5">
+            <div className="mb-3 flex flex-wrap items-center gap-3">
+              <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                {i + 1}
+              </span>
+              <div className="flex items-center gap-2">
+                <Label htmlFor={`d-${i}`} className="text-xs">
+                  {i === 0 ? "Sends immediately on enrolment" : "Days after previous step"}
+                </Label>
+                {i > 0 && (
+                  <Input
+                    id={`d-${i}`} type="number" min={0} className="h-8 w-20"
+                    value={s.delay_days}
+                    onChange={(e) => update(i, { delay_days: Math.max(0, Number(e.target.value) || 0) })}
+                  />
+                )}
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {i === 0 ? "day 0" : `lands on day ${dayOf(steps, i)}`}
+              </span>
+              <div className="ml-auto flex items-center gap-1">
+                <button onClick={() => move(i, -1)} disabled={i === 0} aria-label="Move up"
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-30">
+                  <ChevronUp className="h-4 w-4" />
+                </button>
+                <button onClick={() => move(i, 1)} disabled={i === steps.length - 1} aria-label="Move down"
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-30">
+                  <ChevronDown className="h-4 w-4" />
+                </button>
+                <button onClick={() => setSteps((p) => p.filter((_, idx) => idx !== i))} aria-label="Delete step"
+                  className="ml-1 text-muted-foreground hover:text-destructive">
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div>
+                <Label htmlFor={`s-${i}`}>Subject</Label>
+                <Input id={`s-${i}`} value={s.subject} onChange={(e) => update(i, { subject: e.target.value })} />
+              </div>
+              <div>
+                <Label htmlFor={`b-${i}`}>Body</Label>
+                <Textarea id={`b-${i}`} rows={10} value={s.body} onChange={(e) => update(i, { body: e.target.value })}
+                  className="font-mono text-[13px]" />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Plain text — line breaks are preserved. Your signature and the unsubscribe link are added automatically.
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Button variant="outline" className="mt-3"
+        onClick={() => setSteps((p) => [...p, { subject: "", body: "", delay_days: p.length ? 3 : 0 }])}>
+        <Plus className="mr-1.5 h-4 w-4" /> Add step
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/__tests__/outreach.test.ts
+++ b/src/lib/__tests__/outreach.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { mergeFields, withinSendWindow } from "@/lib/outreach/engine";
+import { SEED_SEQUENCES, SEEDS_BY_VERTICAL, unfilledPlaceholders } from "@/lib/outreach/seed-sequences";
+
+describe("mergeFields", () => {
+  const p = { name: "Sarah Chen", company: "Harbour Strata", title: "Manager", website: "https://x.com" };
+
+  it("uses the first token of the name for {{first_name}}", () => {
+    expect(mergeFields("Hi {{first_name}},", p)).toBe("Hi Sarah,");
+  });
+
+  it("falls back to 'there' when there's no name", () => {
+    expect(mergeFields("Hi {{first_name}},", { name: null })).toBe("Hi there,");
+    expect(mergeFields("Hi {{first_name}},", {})).toBe("Hi there,");
+  });
+
+  it("fills company / title / website, and empties unknown values", () => {
+    expect(mergeFields("{{company}} · {{title}}", p)).toBe("Harbour Strata · Manager");
+    expect(mergeFields("[{{company}}]", { name: "X" })).toBe("[]");
+  });
+
+  it("is case- and whitespace-insensitive in the tag", () => {
+    expect(mergeFields("{{ First_Name }}", p)).toBe("Sarah");
+  });
+
+  it("leaves prospect values unescaped — the engine escapes AFTER merging", () => {
+    // Regression guard: escaping the template first would let a company name
+    // like this reach the email as live markup.
+    const merged = mergeFields("Hi {{company}}", { company: "<script>x</script>" });
+    expect(merged).toContain("<script>");
+  });
+});
+
+describe("withinSendWindow", () => {
+  const base = {
+    timezone: "Australia/Sydney",
+    send_window_start: "08:00",
+    send_window_end: "17:00",
+    send_days: [1, 2, 3, 4, 5],
+  };
+  // 2026-08-03 is a Monday. 02:00Z = 12:00 Sydney (AEST, UTC+10).
+  const monMidday = new Date("2026-08-03T02:00:00Z");
+  const monMidnight = new Date("2026-08-03T14:00:00Z");   // 00:00 Tue Sydney
+  const satMidday = new Date("2026-08-08T02:00:00Z");     // Saturday
+
+  it("allows a weekday inside the window", () => {
+    expect(withinSendWindow(base, monMidday)).toBe(true);
+  });
+
+  it("blocks outside the daily window", () => {
+    expect(withinSendWindow(base, monMidnight)).toBe(false);
+  });
+
+  it("blocks a day that isn't selected", () => {
+    expect(withinSendWindow(base, satMidday)).toBe(false);
+  });
+
+  it("respects the business's timezone, not the server's", () => {
+    // Same instant is inside Sydney's 08:00-17:00 but outside London's.
+    expect(withinSendWindow({ ...base, timezone: "Europe/London" }, monMidday)).toBe(false);
+  });
+
+  it("defaults to Mon-Fri 08:00-17:00 when unset", () => {
+    expect(withinSendWindow({ timezone: "Australia/Sydney" }, monMidday)).toBe(true);
+  });
+});
+
+describe("seed sequence library", () => {
+  it("ships all 11 verticals", () => {
+    expect(SEED_SEQUENCES).toHaveLength(11);
+    expect(Object.keys(SEEDS_BY_VERTICAL)).toHaveLength(11);
+  });
+
+  it("gives every sequence a 4-step arc with step 1 sending immediately", () => {
+    for (const s of SEED_SEQUENCES) {
+      expect(s.steps, s.vertical).toHaveLength(4);
+      expect(s.steps[0].delay_days, s.vertical).toBe(0);
+      expect(s.steps.slice(1).every((st) => st.delay_days > 0), s.vertical).toBe(true);
+    }
+  });
+
+  it("has a subject and body on every step", () => {
+    for (const s of SEED_SEQUENCES) {
+      for (const [i, st] of s.steps.entries()) {
+        expect(st.subject.trim(), `${s.vertical} step ${i + 1}`).not.toBe("");
+        expect(st.body.trim(), `${s.vertical} step ${i + 1}`).not.toBe("");
+      }
+    }
+  });
+
+  it("carries no Crown Roofers identity — seeds must be business-agnostic", () => {
+    const all = JSON.stringify(SEED_SEQUENCES).toLowerCase();
+    for (const leak of ["crown", "roofer", "altamimi", "0490", "crownroofers.com.au"]) {
+      expect(all, `seed leaked "${leak}"`).not.toContain(leak);
+    }
+  });
+
+  it("contains no HTML — bodies are plain text and get escaped on send", () => {
+    for (const s of SEED_SEQUENCES) {
+      for (const st of s.steps) {
+        expect(st.body, s.vertical).not.toMatch(/<[a-z/][^>]*>/i);
+      }
+    }
+  });
+
+  it("opens every first step with a merge field so it reads personally", () => {
+    for (const s of SEED_SEQUENCES) {
+      expect(s.steps[0].body, s.vertical).toContain("{{first_name}}");
+    }
+  });
+
+  it("flags the blanks a business still has to fill in", () => {
+    expect(unfilledPlaceholders("call [your number] now")).toEqual(["your number"]);
+    expect(unfilledPlaceholders("nothing to fill")).toEqual([]);
+    // The strata seed deliberately leaves licence/insurance details blank.
+    const strata = SEEDS_BY_VERTICAL.strata.steps[0].body;
+    expect(unfilledPlaceholders(strata).length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/actions/outreach.ts
+++ b/src/lib/actions/outreach.ts
@@ -11,6 +11,8 @@ import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
 import { autoEnroll, runOutreachForBusiness, stopEnrollments } from "@/lib/outreach/engine";
+import { sourceProspects, type SourcingResult } from "@/lib/outreach/sourcing";
+import { SEEDS_BY_VERTICAL } from "@/lib/outreach/seed-sequences";
 import type {
   OutreachSettings, OutreachSequence, OutreachSequenceStep,
   OutreachCampaign, OutreachEnrollment, OutreachMessage,
@@ -151,6 +153,42 @@ export async function saveSequenceSteps(
   const { error } = await tbl(supabase, "outreach_sequence_steps").insert(rows);
   if (error) throw error;
   revalidatePath("/outreach");
+}
+
+/** Create a sequence pre-filled from the seed library (editable afterwards). */
+export async function seedSequence(vertical: string): Promise<OutreachSequence> {
+  const { supabase, businessId } = await ctx();
+  const seed = SEEDS_BY_VERTICAL[vertical];
+  if (!seed) throw new Error("Unknown template");
+
+  const { data: seq, error } = await tbl(supabase, "outreach_sequences").insert({
+    business_id: businessId, name: seed.name, description: seed.description,
+    vertical: seed.vertical, status: "draft",
+  }).select().single();
+  if (error) throw error;
+
+  const rows = seed.steps.map((s, i) => ({
+    business_id: businessId, sequence_id: seq.id, step_order: i + 1,
+    delay_days: i === 0 ? 0 : s.delay_days, subject: s.subject, body: s.body,
+  }));
+  const { error: stepErr } = await tbl(supabase, "outreach_sequence_steps").insert(rows);
+  if (stepErr) {
+    await tbl(supabase, "outreach_sequences").delete().eq("id", seq.id);
+    throw stepErr;
+  }
+  revalidatePath("/outreach");
+  return seq as OutreachSequence;
+}
+
+// ── Sourcing ─────────────────────────────────────────────────────────────────
+
+/** Run a Google Places sourcing pass now. Returns what it found/created. */
+export async function runSourcingNow(limit?: number): Promise<SourcingResult> {
+  const { supabase, businessId } = await ctx();
+  const res = await sourceProspects(supabase, businessId, { limit });
+  revalidatePath("/outreach");
+  revalidatePath("/prospects");
+  return res;
 }
 
 // ── Campaigns ────────────────────────────────────────────────────────────────

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -41,6 +41,7 @@ import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
 import { registerProspectTools } from "./tools/prospects-tools";
+import { registerOutreachTools } from "./tools/outreach-tools";
 import { registerAssistantTools } from "./tools/assistant-tools";
 import { ilikeAcross } from "@/lib/pg-filter";
 
@@ -1719,6 +1720,7 @@ export function registerTools(register: ToolFn): void {
 
   // ===== PROSPECTS =====
   registerProspectTools(tool);
+  registerOutreachTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/outreach-tools.ts
+++ b/src/lib/mcp/tools/outreach-tools.ts
@@ -1,0 +1,315 @@
+/**
+ * MCP tools for the Outreach agent. Scopes: outreach:read / outreach:write.
+ *
+ * These run as service-role via the admin client scoped by business_id (the
+ * MCP layer is API-key authed, so the cookie-bound server actions can't be
+ * reused). The engine itself is shared with the cron + the UI, so a send
+ * triggered from here obeys exactly the same caps, window and suppression list.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { autoEnroll, runOutreachForBusiness, stopEnrollments } from "@/lib/outreach/engine";
+import { sourceProspects } from "@/lib/outreach/sourcing";
+import { SEED_SEQUENCES, SEEDS_BY_VERTICAL } from "@/lib/outreach/seed-sequences";
+
+const STEP = z.object({
+  subject: z.string().min(1),
+  body: z.string().min(1),
+  delay_days: z.number().int().min(0).default(0),
+});
+
+export function registerOutreachTools(tool: ToolFn): void {
+  // ── Settings ───────────────────────────────────────────────────────────────
+
+  tool("get_outreach_settings",
+    "Outreach agent configuration: whether sending is on, the daily cap, send window/days, timezone, from address and sourcing setup. Never returns the stored API key.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      const { data } = await t(ctx, "outreach_settings").select("*").eq("business_id", ctx.businessId).maybeSingle();
+      if (!data) return text({ enabled: false, configured: false });
+      const { places_api_key_enc, ...safe } = data;
+      return text({ ...safe, places_api_key_set: Boolean(places_api_key_enc) });
+    });
+
+  tool("update_outreach_settings",
+    "Change outreach sending guardrails. Setting enabled=false stops all sending immediately.",
+    {
+      enabled: z.boolean().optional(),
+      daily_send_cap: z.number().int().min(0).max(1000).optional(),
+      send_window_start: z.string().optional(),
+      send_window_end: z.string().optional(),
+      send_days: z.array(z.number().int().min(0).max(6)).optional(),
+      seconds_between_sends: z.number().int().min(0).max(600).optional(),
+      timezone: z.string().optional(),
+      from_local_part: z.string().optional(),
+      reply_to: z.string().optional(),
+      signature_html: z.string().optional(),
+      sourcing_enabled: z.boolean().optional(),
+      sourcing_queries: z.array(z.string()).optional(),
+      sourcing_daily_quota: z.number().int().min(0).max(500).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const patch = Object.fromEntries(Object.entries(args).filter(([, v]) => v !== undefined));
+      if (!Object.keys(patch).length) return errorText("Nothing to update");
+      const { error } = await t(ctx, "outreach_settings")
+        .upsert({ business_id: ctx.businessId, ...patch }, { onConflict: "business_id" });
+      if (error) throw error;
+      return text({ updated: true, ...patch });
+    });
+
+  // ── Sequences ──────────────────────────────────────────────────────────────
+
+  tool("list_outreach_sequences", "List outreach sequences with their step counts.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      const { data, error } = await t(ctx, "outreach_sequences")
+        .select("id, name, description, vertical, status, created_at, outreach_sequence_steps(count)")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return text(((data ?? []) as any[]).map((s) => ({
+        id: s.id, name: s.name, description: s.description, vertical: s.vertical,
+        status: s.status, steps: s.outreach_sequence_steps?.[0]?.count ?? 0,
+      })));
+    });
+
+  tool("get_outreach_sequence", "Get a sequence with every step's subject, body and delay.",
+    { sequence_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      const { data: seq } = await t(ctx, "outreach_sequences").select("*")
+        .eq("id", args.sequence_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!seq) return errorText("Sequence not found");
+      const { data: steps } = await t(ctx, "outreach_sequence_steps")
+        .select("step_order, delay_days, subject, body").eq("sequence_id", args.sequence_id).order("step_order");
+      return text({ ...seq, steps: steps ?? [] });
+    });
+
+  tool("list_outreach_templates",
+    "The built-in seed sequence library — 11 verticals (strata, real estate, builders, NDIS, facilities, insurance, housing, aged care, schools, hospitality, trade partners), each a 4-step arc over two weeks. Use create_outreach_sequence with template=<vertical> to start from one.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      return text(SEED_SEQUENCES.map((s) => ({
+        vertical: s.vertical, name: s.name, description: s.description, steps: s.steps.length,
+      })));
+    });
+
+  tool("create_outreach_sequence",
+    "Create a sequence. Pass `template` to copy a seed vertical, or `steps` to write your own. Merge fields: {{first_name}} {{name}} {{company}} {{title}} {{website}}. Bodies are plain text.",
+    {
+      name: z.string().optional(),
+      description: z.string().optional(),
+      template: z.string().optional(),
+      steps: z.array(STEP).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+
+      const seed = args.template ? SEEDS_BY_VERTICAL[args.template] : undefined;
+      if (args.template && !seed) {
+        return errorText(`Unknown template "${args.template}". Call list_outreach_templates for valid verticals.`);
+      }
+      const steps = args.steps?.length ? args.steps : seed?.steps;
+      if (!steps?.length) return errorText("Provide either a template or at least one step");
+
+      const name = args.name?.trim() || seed?.name;
+      if (!name) return errorText("A sequence name is required");
+
+      const { data: seq, error } = await t(ctx, "outreach_sequences").insert({
+        business_id: ctx.businessId, name,
+        description: args.description ?? seed?.description ?? null,
+        vertical: seed?.vertical ?? null, status: "draft",
+      }).select("id").single();
+      if (error) throw error;
+
+      const rows = steps.map((s: z.infer<typeof STEP>, i: number) => ({
+        business_id: ctx.businessId, sequence_id: seq.id, step_order: i + 1,
+        delay_days: i === 0 ? 0 : (s.delay_days ?? 0), subject: s.subject, body: s.body,
+      }));
+      const { error: stepErr } = await t(ctx, "outreach_sequence_steps").insert(rows);
+      if (stepErr) {
+        await t(ctx, "outreach_sequences").delete().eq("id", seq.id);
+        throw stepErr;
+      }
+      return text({ created: true, sequence_id: seq.id, steps: rows.length });
+    });
+
+  tool("update_outreach_sequence_steps",
+    "Replace a sequence's steps wholesale. Step 1 always sends immediately on enrolment, so its delay is forced to 0.",
+    { sequence_id: UUID, steps: z.array(STEP) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const { data: owned } = await t(ctx, "outreach_sequences").select("id")
+        .eq("id", args.sequence_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!owned) return errorText("Sequence not found");
+
+      await t(ctx, "outreach_sequence_steps").delete()
+        .eq("sequence_id", args.sequence_id).eq("business_id", ctx.businessId);
+      if (!args.steps.length) return text({ updated: true, steps: 0 });
+
+      const rows = args.steps.map((s: z.infer<typeof STEP>, i: number) => ({
+        business_id: ctx.businessId, sequence_id: args.sequence_id, step_order: i + 1,
+        delay_days: i === 0 ? 0 : (s.delay_days ?? 0), subject: s.subject, body: s.body,
+      }));
+      const { error } = await t(ctx, "outreach_sequence_steps").insert(rows);
+      if (error) throw error;
+      return text({ updated: true, steps: rows.length });
+    });
+
+  tool("delete_outreach_sequence", "Delete a sequence and its steps.",
+    { sequence_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const { error } = await t(ctx, "outreach_sequences").delete()
+        .eq("id", args.sequence_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  // ── Campaigns ──────────────────────────────────────────────────────────────
+
+  tool("list_outreach_campaigns", "List outreach campaigns with status and enrolment filter.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      const { data, error } = await t(ctx, "outreach_campaigns").select("*")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_outreach_campaign",
+    "Create a campaign — a sequence pointed at the prospects matching a filter. Starts as a draft; nothing sends until you set it running.",
+    {
+      name: z.string().min(1),
+      sequence_id: UUID,
+      tags: z.array(z.string()).optional(),
+      statuses: z.array(z.string()).optional(),
+      sources: z.array(z.string()).optional(),
+      auto_enroll: z.boolean().optional(),
+      daily_cap: z.number().int().min(0).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const { data, error } = await t(ctx, "outreach_campaigns").insert({
+        business_id: ctx.businessId, name: args.name, sequence_id: args.sequence_id,
+        filter: { tags: args.tags ?? [], status: args.statuses ?? [], sources: args.sources ?? [] },
+        auto_enroll: args.auto_enroll ?? true, daily_cap: args.daily_cap ?? null,
+      }).select("id").single();
+      if (error) throw error;
+      return text({ created: true, campaign_id: data.id, status: "draft" });
+    });
+
+  tool("set_outreach_campaign_status",
+    "Start, pause or complete a campaign. 'running' is what actually lets its enrollments send.",
+    { campaign_id: UUID, status: z.enum(["draft", "running", "paused", "completed"]) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const patch: Record<string, unknown> = { status: args.status };
+      if (args.status === "running") patch.started_at = new Date().toISOString();
+      const { error } = await t(ctx, "outreach_campaigns").update(patch)
+        .eq("id", args.campaign_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true, status: args.status });
+    });
+
+  tool("delete_outreach_campaign", "Delete a campaign and its enrollments.",
+    { campaign_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const { error } = await t(ctx, "outreach_campaigns").delete()
+        .eq("id", args.campaign_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("enroll_outreach_prospects",
+    "Enrol every prospect matching a campaign's filter that isn't already in it. Returns how many were added.",
+    { campaign_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const n = await autoEnroll(ctx.sb, ctx.businessId, args.campaign_id);
+      return text({ enrolled: n });
+    });
+
+  tool("stop_outreach_for_prospect",
+    "Stop every active sequence for one prospect — use when they reply, ask to stop, or you learn the address is wrong.",
+    { prospect_id: UUID, replied: z.boolean().optional(), reason: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      await stopEnrollments(
+        ctx.sb, ctx.businessId, args.prospect_id,
+        args.replied ? "replied" : "stopped", args.reason,
+      );
+      if (args.replied) {
+        await t(ctx, "prospects").update({ status: "responded" })
+          .eq("id", args.prospect_id).eq("business_id", ctx.businessId);
+      }
+      return text({ stopped: true });
+    });
+
+  // ── Tracking + running ─────────────────────────────────────────────────────
+
+  tool("get_outreach_stats",
+    "Delivery funnel for the outreach agent: sent, delivered, opened, clicked, bounced, replied, plus how many prospects still have a step due.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      const [msgs, enr] = await Promise.all([
+        t(ctx, "outreach_messages").select("status, opened_at, clicked_at, replied_at, bounced_at")
+          .eq("business_id", ctx.businessId).limit(10000),
+        t(ctx, "outreach_enrollments").select("id", { count: "exact", head: true })
+          .eq("business_id", ctx.businessId).eq("status", "active"),
+      ]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = (msgs.data ?? []) as any[];
+      return text({
+        sent: rows.length,
+        delivered: rows.filter((r) => r.delivered_at || ["delivered", "opened", "clicked"].includes(r.status)).length,
+        opened: rows.filter((r) => r.opened_at).length,
+        clicked: rows.filter((r) => r.clicked_at).length,
+        bounced: rows.filter((r) => r.bounced_at || r.status === "bounced").length,
+        replied: rows.filter((r) => r.replied_at).length,
+        active_enrollments: enr.count ?? 0,
+      });
+    });
+
+  tool("list_outreach_messages", "Recent outreach emails with their delivery/open/click/bounce state.",
+    { campaign_id: UUID.optional(), limit: z.number().int().min(1).max(500).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      let q = t(ctx, "outreach_messages")
+        .select("id, recipient, subject, step_order, status, sent_at, delivered_at, opened_at, clicked_at, bounced_at")
+        .eq("business_id", ctx.businessId).order("sent_at", { ascending: false }).limit(args.limit ?? 100);
+      if (args.campaign_id) q = q.eq("campaign_id", args.campaign_id);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("run_outreach_now",
+    "Send whatever is due right now, ignoring the send window (the daily cap and suppression list still apply). Requires sending to be enabled.",
+    { limit: z.number().int().min(1).max(200).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const res = await runOutreachForBusiness(ctx.sb, ctx.businessId, {
+        ignoreWindow: true, limit: args.limit ?? 25,
+      });
+      return text({ sent: res.sent, skipped: res.skipped, failed: res.failed, completed: res.completed });
+    });
+
+  tool("source_prospects",
+    "Run a Google Places sourcing pass using the business's configured search terms, locations and its own API key. Places doesn't return email addresses, so new prospects arrive with a website and no email.",
+    { limit: z.number().int().min(1).max(200).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+      const res = await sourceProspects(ctx.sb, ctx.businessId, { limit: args.limit });
+      if (res.errors.length && !res.created) return errorText(res.errors[0]);
+      return text(res);
+    });
+}

--- a/src/lib/outreach/engine.ts
+++ b/src/lib/outreach/engine.ts
@@ -144,7 +144,10 @@ export async function runOutreachForBusiness(
     }
 
     const subject = mergeFields(step.subject, p);
-    const bodyHtml = mergeFields(esc(step.body), p).replace(/\n/g, "<br>");
+    // Merge FIRST, then escape — escaping the template first would leave the
+    // substituted prospect values (name/company, which can come from a CSV
+    // import or the crawler) as raw HTML in the outgoing email.
+    const bodyHtml = esc(mergeFields(step.body, p)).replace(/\n/g, "<br>");
     const unsubUrl = `${appUrl()}/unsubscribe/${token}`;
     const html =
       `<div style="font-family:system-ui,Segoe UI,sans-serif;max-width:560px;margin:0 auto;color:#0f172a;line-height:1.5">` +

--- a/src/lib/outreach/seed-sequences.ts
+++ b/src/lib/outreach/seed-sequences.ts
@@ -1,0 +1,622 @@
+/**
+ * Seed sequence library — the 11 verticals from the standalone Crown Roofers
+ * agent, generalised so any business can start from them.
+ *
+ * What was ported and what deliberately wasn't:
+ *   · the ARC — intro → nudge → availability → breakup, 0/3/7/14 days
+ *   · the per-vertical ANGLE — a strata manager cares about documentation for
+ *     committee meetings; a builder cares about not holding up the trade after
+ *     them. That insight is the valuable part and it's kept verbatim in spirit.
+ *   · NOT the Crown-specific identity — no company name, phone, licence or
+ *     logo. The sender comes from outreach_settings (from_local_part +
+ *     signature_html), so seeds must stay business-agnostic or every Kirei
+ *     business would be emailing as a Sydney roofer.
+ *
+ * Bodies are PLAIN TEXT. The engine merges fields, HTML-escapes, then converts
+ * newlines to <br> — so never put markup here, and use blank lines for spacing.
+ * Merge fields: {{first_name}} {{name}} {{company}} {{title}} {{website}}
+ *
+ * A few lines carry [square brackets] — the one or two specifics only the
+ * business can supply (licence, insurance, service area). The builder flags
+ * them so they're not accidentally sent as-is.
+ */
+
+export interface SeedStep { subject: string; body: string; delay_days: number }
+export interface SeedSequence {
+  vertical: string;
+  name: string;
+  description: string;
+  steps: SeedStep[];
+}
+
+/** Steps 2-4 follow the original 3 / 7 / 14-day cadence (delays are relative). */
+const D = [0, 3, 4, 7];
+
+export const SEED_SEQUENCES: SeedSequence[] = [
+  {
+    vertical: "strata",
+    name: "Strata managers",
+    description: "Get onto a strata portfolio's preferred-contractor list. Leads on documentation and after-hours response.",
+    steps: [
+      {
+        subject: "Preferred contractor for your strata portfolio",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I wanted to introduce ourselves to {{company}} as a contractor for your strata portfolio.
+
+Strata managers need someone they can call at any hour — and who leaves a paper trail the committee will accept. That's the part we take seriously:
+
+· Same-day emergency callouts across [your service area]
+· Inspection reports with photos, ready to table at a body corporate meeting
+· Itemised quotes, so owners see exactly what they're voting on
+· [Licence no.] · [public liability cover] · [workmanship guarantee]
+
+Would a quick 10-minute call be worth it to see if we're a fit for your preferred list?`,
+      },
+      {
+        subject: "Re: your strata portfolio",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Quick follow-up on my note last week — I know inboxes get busy.
+
+The reason strata managers keep calling us back is the documentation. You always have what you need for owners' meetings and compliance records, without chasing us for it.
+
+If there's a job coming up, or a building you'd like a second opinion on, I'm happy to come out and assess it at no cost.
+
+Worth a chat?`,
+      },
+      {
+        subject: "Current availability",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+One more note. We've got good availability right now for both urgent repairs and planned works.
+
+If anything is on the horizon — repairs, inspections, callouts or a full tender — I can turn a quote around within 24 hours.
+
+Ten minutes on the phone now usually saves a lot of back-and-forth later.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll stop reaching out after this — I don't want to clutter your inbox.
+
+If you ever need a reliable contractor for the portfolio, please keep us in mind. Happy to quote any time.
+
+All the best to the team at {{company}}.`,
+      },
+    ],
+  },
+  {
+    vertical: "real_estate",
+    name: "Real estate & property management",
+    description: "For agencies managing rentals. Leads on speed — a tenant complaint that stays open is the agency's problem.",
+    steps: [
+      {
+        subject: "Fast, reliable trades for your rental properties",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm reaching out to {{company}} because managing repairs across a rent roll is usually a scheduling problem more than a trade problem.
+
+What property managers tell us matters most:
+
+· We answer the phone, and we turn up when we said we would
+· Photos and a written report after every attendance, straight to your file
+· We deal with the tenant directly so you're not relaying messages
+· Quotes back same-day, so you can get landlord approval quickly
+
+Would it be worth a short call about your maintenance list?`,
+      },
+      {
+        subject: "Re: trades for {{company}}",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Following up briefly.
+
+The complaint we hear most about trades is silence — the tenant chases the PM, the PM chases the trade, and nobody knows what's happening. We fix that by reporting back the same day we attend, every time.
+
+If you've got a job sitting open right now, I'm happy to take a look at it.`,
+      },
+      {
+        subject: "Availability for your portfolio",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We've got capacity at the moment and can take on additional properties.
+
+If you've got a backlog of jobs, or one landlord who needs a quote before they'll approve anything, send it through and I'll come back to you within 24 hours.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+This is my last note — I won't keep following up.
+
+If your current trade ever lets you down, we're here and we answer the phone. Best of luck with the rent roll.`,
+      },
+    ],
+  },
+  {
+    vertical: "builder",
+    name: "Builders & head contractors",
+    description: "Subcontract work. Leads on not holding up the program — the builder's real fear.",
+    steps: [
+      {
+        subject: "Subcontractor availability",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm getting in touch with {{company}} about subcontract work.
+
+You already know the risk with a new sub: they hold up the trade after them. So the short version —
+
+· We give you a realistic date, not an optimistic one
+· Fully licensed and insured, all paperwork ready before we start [licence no.]
+· We clean up and hand over so the next trade can start
+· Priced off plans, no variations invented halfway through
+
+Happy to price something small first so you can see how we work.`,
+      },
+      {
+        subject: "Re: subcontract work",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Quick follow-up.
+
+If it helps, send through one job — ideally something with a tight turnaround — and let us prove it on that before you consider us for anything bigger. That's usually the easiest way to find out if a sub is any good.
+
+Any plans you'd like priced?`,
+      },
+      {
+        subject: "Availability update",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We've got a gap in the schedule coming up and can take on additional work.
+
+If you've got anything you need priced — or a sub who's let you down and left you needing someone at short notice — give me a call.`,
+      },
+      {
+        subject: "Signing off",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll leave it there so I'm not cluttering your inbox.
+
+If you're ever stuck for a sub at short notice, keep us in mind — that's often when we're most useful. All the best with the current program.`,
+      },
+    ],
+  },
+  {
+    vertical: "ndis",
+    name: "NDIS & SDA providers",
+    description: "Disability housing. Leads on compliance, worker screening and minimal disruption to residents.",
+    steps: [
+      {
+        subject: "Maintenance for NDIS & SDA properties",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm reaching out to {{company}} about maintenance across your NDIS and SDA properties.
+
+These sites need more care than a standard job, so:
+
+· Our team hold current NDIS Worker Screening and Working With Children checks
+· We work around residents — quiet hours, clear notice, minimal disruption
+· Written reports and photos suitable for your compliance records
+· Urgent response when something affects a resident's safety
+
+Would you like us to look at anything currently outstanding?`,
+      },
+      {
+        subject: "Re: your NDIS properties",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Just following up.
+
+The thing providers tell us is hardest is finding trades who understand that the resident comes first — not the schedule. We brief every person on site before they attend.
+
+Happy to do a free assessment on any property you're unsure about.`,
+      },
+      {
+        subject: "Free inspections this month",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We're offering free inspections on NDIS and SDA properties at the moment — a written condition report with photos, no obligation.
+
+If you've got a property you've been meaning to get looked at, this is an easy way to find out where it stands.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll stop here.
+
+If you ever need a screened, compliant trade team for your properties, we'd be glad to help. All the best to everyone at {{company}}.`,
+      },
+    ],
+  },
+  {
+    vertical: "facilities",
+    name: "Facilities management",
+    description: "Multi-site FM contracts. Leads on one point of contact and predictable reporting.",
+    steps: [
+      {
+        subject: "Contractor for your facilities portfolio",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'd like to introduce ourselves to {{company}} as a contractor across your managed sites.
+
+Running multiple sites, what usually goes wrong is coordination rather than the work itself. So:
+
+· One point of contact for every site, not a different number each time
+· Consistent reporting format so your records stay tidy
+· Scheduled preventative work as well as reactive callouts
+· Fully licensed and insured [licence no. · insurance]
+
+Is it worth a short call about the sites you manage?`,
+      },
+      {
+        subject: "Re: your managed sites",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Following up on last week's note.
+
+If it's easier, start us on a single site. It's a low-risk way to see whether our reporting and response times actually hold up before you'd consider us more broadly.
+
+Any site you'd like us to look at?`,
+      },
+      {
+        subject: "Capacity for new sites",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We have capacity for additional sites this quarter.
+
+If you've got a contract coming up for renewal, or a site that isn't being serviced well, I'd welcome the chance to quote.`,
+      },
+      {
+        subject: "Signing off",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+Last note from me.
+
+If a contractor ever falls through mid-contract, we're usually able to step in quickly. Keep us in mind, and all the best.`,
+      },
+    ],
+  },
+  {
+    vertical: "insurance",
+    name: "Insurance & claims",
+    description: "Assessors, brokers and claims managers. Leads on report quality and scope accuracy.",
+    steps: [
+      {
+        subject: "Licensed assessor & repairer for claims work",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm getting in touch with {{company}} about claims work.
+
+What makes or breaks a claim is the report, so that's where we put the effort:
+
+· Detailed assessment reports with photo evidence and a clear cause finding
+· Scopes that hold up — we'd rather be accurate than optimistic
+· Make-safe attendance at short notice, including after hours
+· Fully licensed and insured [licence no. · insurance]
+
+Would you like us on your panel for [your service area]?`,
+      },
+      {
+        subject: "Re: claims partnership",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Quick follow-up.
+
+If it's useful, send us one claim to assess and you can judge the report on its own merits. That tends to be more convincing than anything I can say in an email.
+
+Happy to turn it around quickly.`,
+      },
+      {
+        subject: "Storm season availability",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+Ahead of the busy period — we're keeping capacity free for make-safe and assessment work.
+
+If your usual panel gets stretched when the weather turns, it's worth having us set up beforehand rather than scrambling on the day.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll leave it there.
+
+If you're ever short an assessor or repairer at short notice, we're happy to help. All the best.`,
+      },
+    ],
+  },
+  {
+    vertical: "housing",
+    name: "Social & community housing",
+    description: "Community housing providers. Leads on tenant care, budget discipline and reporting.",
+    steps: [
+      {
+        subject: "Maintenance for social & community housing",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm reaching out to {{company}} about maintenance across your housing portfolio.
+
+We understand this work has constraints a private job doesn't:
+
+· Budgets are fixed, so our quotes are itemised and we stick to them
+· Tenants are treated respectfully, with proper notice before attendance
+· Reports and photos suitable for funding and compliance reporting
+· Responsive on urgent work that affects a tenant's safety or amenity
+
+Would a short conversation be useful?`,
+      },
+      {
+        subject: "Re: your housing portfolio",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Following up briefly.
+
+The feedback we get is that we make the reporting side easy — which matters when you're accountable for how the money was spent.
+
+Happy to assess any property at no cost so you know where it stands.`,
+      },
+      {
+        subject: "Current availability",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We've got availability for planned maintenance at the moment.
+
+If you're preparing a works program or need condition reports before you can budget, we can help with either.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll stop reaching out now.
+
+If you ever need a contractor who understands housing work specifically, we'd be glad to help. All the best to the team.`,
+      },
+    ],
+  },
+  {
+    vertical: "aged_care",
+    name: "Aged care",
+    description: "Residential aged care. Leads on resident safety, noise, screening and infection-control awareness.",
+    steps: [
+      {
+        subject: "Contractor for aged care facilities",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm getting in touch with {{company}} about maintenance at your facilities.
+
+Working in aged care isn't like a normal site, and we treat it accordingly:
+
+· Police-checked, inducted staff who understand resident privacy
+· Noise and disruption planned around residents' routines
+· Clear site management so walkways and exits stay safe
+· Documentation suitable for accreditation records
+
+Could we have a brief conversation about your facilities?`,
+      },
+      {
+        subject: "Re: your facilities",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Just a short follow-up.
+
+The most common complaint about contractors in aged care is disruption — noise at the wrong time, equipment left where it shouldn't be. We plan around that before we start, not after someone complains.
+
+Happy to walk a site with you at no cost.`,
+      },
+      {
+        subject: "Availability",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We've got capacity for planned works right now, which is the easiest time to schedule around residents.
+
+If you have anything upcoming, I can get you a quote quickly.`,
+      },
+      {
+        subject: "Signing off",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+This is my last note.
+
+If you ever need a contractor who's comfortable working around residents, please keep us in mind. All the best to everyone at {{company}}.`,
+      },
+    ],
+  },
+  {
+    vertical: "schools",
+    name: "Schools & education",
+    description: "Schools and campuses. Leads on holiday-period scheduling and child-safety compliance.",
+    steps: [
+      {
+        subject: "Maintenance for schools & campuses",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm reaching out to {{company}} about maintenance work.
+
+Schools have one constraint that dominates everything: the work has to fit around students.
+
+· All staff hold current Working With Children clearances
+· We schedule major works into term breaks and holidays
+· Sites are fenced and made safe before we leave each day
+· Written reports for your asset and compliance records
+
+Would it be worth a short call before the next break?`,
+      },
+      {
+        subject: "Re: maintenance at {{company}}",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Following up on my earlier note.
+
+If you're planning holiday works, now is usually the time to lock in a contractor — the good windows fill up fast and everyone wants the same two weeks.
+
+Happy to assess anything you're considering.`,
+      },
+      {
+        subject: "Holiday period availability",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We're holding capacity for the upcoming break.
+
+If there's work you've been deferring, this is the window. Send it through and I'll get you a quote so you can get approval in time.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll stop here so I'm not filling your inbox.
+
+If a holiday works program ever needs a contractor at short notice, keep us in mind. All the best for the term.`,
+      },
+    ],
+  },
+  {
+    vertical: "hospitality",
+    name: "Hotels & hospitality",
+    description: "Venues and hotels. Leads on working outside trading hours — downtime is lost revenue.",
+    steps: [
+      {
+        subject: "Maintenance for your venue",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm getting in touch with {{company}} about maintenance.
+
+In hospitality the cost isn't the repair, it's the closure. So we work to that:
+
+· Attendance outside trading hours where the job allows
+· Fast make-safe so you can keep operating while we plan the full fix
+· Tidy, discreet crews — guests shouldn't notice we're there
+· Quotes back quickly so approvals don't hold up the work
+
+Would a quick call be worthwhile?`,
+      },
+      {
+        subject: "Re: your venue",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Quick follow-up.
+
+If you've got something that's been nagging — a leak, a recurring fault, something you've patched twice — I'm happy to look at it and tell you honestly whether it needs fixing properly or can wait.
+
+No obligation either way.`,
+      },
+      {
+        subject: "Current availability",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We've got availability at the moment, including out-of-hours work.
+
+If there's something you've been putting off because you couldn't afford the downtime, that's exactly the kind of job we can schedule around you.`,
+      },
+      {
+        subject: "Last note",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+Last note from me.
+
+If something goes wrong at the worst possible moment — which it usually does — we're contactable and quick. All the best with the venue.`,
+      },
+    ],
+  },
+  {
+    vertical: "maintenance",
+    name: "Maintenance companies & trade partners",
+    description: "Other trades who need your speciality. Leads on being an extension of their team, not a competitor.",
+    steps: [
+      {
+        subject: "Trade partner for your maintenance team",
+        delay_days: D[0],
+        body: `Hi {{first_name}},
+
+I'm reaching out to {{company}} about working together as a trade partner.
+
+You've got the client relationship — we're not interested in taking it. We just handle the work that falls outside what your team does:
+
+· Trade rates, so there's margin left for you
+· We attend as an extension of your team, in your name if you prefer
+· Same-day or next-day response on urgent jobs
+· Reports written so you can pass them straight to your client
+
+Worth a quick chat about how it might work?`,
+      },
+      {
+        subject: "Re: trade partnership",
+        delay_days: D[1],
+        body: `Hi {{first_name}},
+
+Following up briefly.
+
+The arrangement usually works best when you've got a client asking for something you don't do in-house, and subbing it out is easier than turning it down.
+
+If that comes up, we're happy to be the call you make.`,
+      },
+      {
+        subject: "Same-day availability for trade partners",
+        delay_days: D[2],
+        body: `Hi {{first_name}},
+
+We keep capacity aside for trade partners specifically, so partner jobs don't sit behind our own.
+
+If you've got something today or this week, give me a call and I'll tell you straight away whether we can get there.`,
+      },
+      {
+        subject: "Signing off",
+        delay_days: D[3],
+        body: `Hi {{first_name}},
+
+I'll leave it there.
+
+If a client ever asks you for something outside your scope, keep us in mind rather than turning the job away. All the best.`,
+      },
+    ],
+  },
+];
+
+export const SEEDS_BY_VERTICAL: Record<string, SeedSequence> =
+  Object.fromEntries(SEED_SEQUENCES.map((s) => [s.vertical, s]));
+
+/** Lines a seed left for the business to fill in — surfaced before sending. */
+export function unfilledPlaceholders(body: string): string[] {
+  return [...body.matchAll(/\[([^\]]+)\]/g)].map((m) => m[1]);
+}

--- a/src/lib/outreach/sourcing.ts
+++ b/src/lib/outreach/sourcing.ts
@@ -1,0 +1,178 @@
+/**
+ * Prospect sourcing — the port of the standalone agent's prospector.js.
+ *
+ * Google Places Text Search finds businesses matching the configured queries
+ * inside the configured locations; each result becomes a prospect. Places does
+ * NOT return email addresses, so a sourced prospect usually arrives with a
+ * website and no email — which is what the (separate, opt-in) crawler is for.
+ *
+ * Compliance, and why the crawler is gated:
+ *   Australia's Spam Act 2003 s.22 prohibits sending to addresses collected by
+ *   address-harvesting software. Pulling a business's own published contact
+ *   address is a different thing from harvesting, but the line is thin enough
+ *   that it must be a deliberate, attributable choice — hence crawler_enabled
+ *   defaults false and records who turned it on (see acknowledgeCrawlerCompliance).
+ *
+ * Each business supplies its OWN Places key, stored encrypted. We never ship a
+ * shared key: quota and billing belong to whoever is doing the sourcing.
+ */
+import { decryptSecret } from "@/lib/crypto";
+import type { OutreachLocation } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SB = any;
+
+export interface SourcedBusiness {
+  name: string;
+  address: string | null;
+  website: string | null;
+  phone: string | null;
+  place_id: string;
+}
+
+interface PlacesResult {
+  id?: string;
+  displayName?: { text?: string };
+  formattedAddress?: string;
+  websiteUri?: string;
+  nationalPhoneNumber?: string;
+}
+
+/** One Places Text Search page (max 20 results). */
+async function placesSearch(
+  apiKey: string, query: string, loc: OutreachLocation,
+): Promise<SourcedBusiness[]> {
+  const res = await fetch("https://places.googleapis.com/v1/places:searchText", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": apiKey,
+      "X-Goog-FieldMask":
+        "places.id,places.displayName,places.formattedAddress,places.websiteUri,places.nationalPhoneNumber",
+    },
+    body: JSON.stringify({
+      textQuery: `${query} ${loc.label}`.trim(),
+      maxResultCount: 20,
+      locationBias: {
+        circle: {
+          center: { latitude: loc.lat, longitude: loc.lng },
+          radius: Math.min(50000, Math.max(1, loc.radius_m || 25000)),
+        },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Places search failed (${res.status}): ${detail.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { places?: PlacesResult[] };
+  return (json.places ?? [])
+    .filter((p) => p.id && p.displayName?.text)
+    .map((p) => ({
+      place_id: p.id!,
+      name: p.displayName!.text!,
+      address: p.formattedAddress ?? null,
+      website: p.websiteUri ?? null,
+      phone: p.nationalPhoneNumber ?? null,
+    }));
+}
+
+/** Strip a URL back to its origin so one site yields one crawl target. */
+function origin(url: string): string | null {
+  try { return new URL(url).origin; } catch { return null; }
+}
+
+export interface SourcingResult {
+  found: number; created: number; skipped: number; errors: string[];
+}
+
+/**
+ * Run one sourcing pass for a business: every query × every location, capped
+ * by the daily quota. Dedupes against existing prospects by place_id (stored
+ * in custom_fields) and by website origin.
+ */
+export async function sourceProspects(
+  sb: SB, businessId: string, opts: { limit?: number } = {},
+): Promise<SourcingResult> {
+  const out: SourcingResult = { found: 0, created: 0, skipped: 0, errors: [] };
+
+  const { data: settings } = await sb.from("outreach_settings").select("*")
+    .eq("business_id", businessId).maybeSingle();
+  if (!settings?.sourcing_enabled) return out;
+  if (!settings.places_api_key_enc) {
+    out.errors.push("No Google Places API key configured");
+    return out;
+  }
+
+  let apiKey: string;
+  try {
+    apiKey = decryptSecret(settings.places_api_key_enc);
+  } catch {
+    out.errors.push("Couldn't decrypt the Places API key — is APP_ENCRYPTION_KEY set?");
+    return out;
+  }
+
+  const queries: string[] = settings.sourcing_queries ?? [];
+  const locations: OutreachLocation[] = settings.sourcing_locations ?? [];
+  if (!queries.length || !locations.length) return out;
+
+  const quota = Math.max(0, opts.limit ?? settings.sourcing_daily_quota ?? 10);
+  if (quota === 0) return out;
+
+  // Existing prospects, so a repeat run doesn't re-add the same businesses.
+  const { data: existing } = await sb.from("prospects")
+    .select("website, custom_fields").eq("business_id", businessId).limit(10000);
+  const seenPlace = new Set<string>();
+  const seenSite = new Set<string>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const p of ((existing ?? []) as any[])) {
+    const pid = (p.custom_fields ?? {}).place_id;
+    if (pid) seenPlace.add(String(pid));
+    if (p.website) { const o = origin(p.website); if (o) seenSite.add(o); }
+  }
+
+  const rows: Record<string, unknown>[] = [];
+
+  outer:
+  for (const query of queries) {
+    for (const loc of locations) {
+      let batch: SourcedBusiness[];
+      try {
+        batch = await placesSearch(apiKey, query, loc);
+      } catch (e) {
+        out.errors.push(e instanceof Error ? e.message : "Places search failed");
+        continue;
+      }
+      out.found += batch.length;
+
+      for (const b of batch) {
+        if (rows.length >= quota) break outer;
+        const site = b.website ? origin(b.website) : null;
+        if (seenPlace.has(b.place_id) || (site && seenSite.has(site))) { out.skipped++; continue; }
+        seenPlace.add(b.place_id);
+        if (site) seenSite.add(site);
+
+        rows.push({
+          business_id: businessId,
+          company: b.name,
+          name: null,
+          email: null,                       // Places never returns one
+          phone: b.phone,
+          website: b.website,
+          source: "places",
+          status: "new",
+          tags: [query],
+          notes: b.address ? `Sourced from Google Places · ${b.address}` : "Sourced from Google Places",
+          custom_fields: { place_id: b.place_id, sourced_query: query, sourced_location: loc.label },
+        });
+      }
+    }
+  }
+
+  if (!rows.length) return out;
+  const { error } = await sb.from("prospects").insert(rows);
+  if (error) { out.errors.push(error.message); return out; }
+  out.created = rows.length;
+  return out;
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1651,6 +1651,8 @@ export type ApiScope =
   | 'assets:write'
   | 'prospects:read'
   | 'prospects:write'
+  | 'outreach:read'
+  | 'outreach:write'
   | 'attachments:read'
   | 'attachments:write'
   | 'payroll:read'
@@ -1701,6 +1703,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'assets:write',     label: 'Manage assets & equipment', group: 'Assets' },
   { value: 'prospects:read',   label: 'Read prospects', group: 'Prospects' },
   { value: 'prospects:write',  label: 'Create / edit / import prospects', group: 'Prospects' },
+  { value: 'outreach:read',    label: 'Read outreach sequences, campaigns & tracking', group: 'Outreach' },
+  { value: 'outreach:write',   label: 'Manage outreach & send cold email', group: 'Outreach' },
   { value: 'attachments:read', label: 'Read file attachments', group: 'Attachments' },
   { value: 'attachments:write', label: 'Delete file attachments', group: 'Attachments' },
   { value: 'payroll:read',     label: 'Read payroll (employees, pay runs)', group: 'Payroll' },


### PR DESCRIPTION
Finishes the outreach agent. PR1 shipped the engine with **no way to drive it** — nothing could actually send. This adds the surface, the seed library, the sourcing pass and the MCP tools.

## UI — `/outreach`

| Tab | |
|---|---|
| **Overview** | sent / opened / clicked / bounced funnel, how many prospects still have a step due, and a plain-English note on how the runner behaves |
| **Campaigns** | create, start / pause, enrol matching prospects |
| **Sequences** | seed library + blank; per-step subject / body / delay builder |
| **Activity** | every message with its delivery state |
| **Settings** | cap, window, days, timezone, from, signature, sourcing, crawler |

The sequence builder shows a cumulative **"lands on day N"** per step, so a four-step arc is readable at a glance rather than requiring you to add the delays up in your head.

## The 11 seed verticals

Strata · real estate · builders · NDIS · facilities · insurance · housing · aged care · schools · hospitality · trade partners.

**What I ported** is the arc (0/3/7/14) and the per-vertical *angle* — a strata manager cares about documentation for committee meetings; a builder cares about not holding up the trade after them. That insight is the valuable part.

**What I deliberately did not port** is Crown's identity. No company name, phone, licence or logo — the sender comes from `outreach_settings`, and every Kirei business gets this library, so a seed that emails as a Sydney roofer would be wrong for all of them. There's a test asserting no Crown identity leaked through.

The one or two specifics only a business can supply are left as `[square brackets]`, and the builder warns before they'd be sent literally.

## Sourcing

Google Places Text Search, each business using its **own** API key — quota and billing belong to whoever is doing the sourcing. Dedupes on `place_id` and website origin so repeat runs don't pile up duplicates. Places returns **no email addresses**, which is what the separate, still-opt-in crawler is for. It runs once a day from the hourly cron, on the first tick inside the send window, since it burns their quota.

## MCP

17 tools behind new `outreach:read` / `outreach:write` scopes — including `list_outreach_templates` and `create_outreach_sequence(template=…)`, so the assistant can build and start a campaign end to end. Sends route through the same engine, so the cap, window and suppression list apply identically.

## One bug fixed along the way

The engine escaped the template and **then** merged, which left prospect values — which can come from a CSV import or the crawler — as **raw HTML in the outgoing email**. Merging first and escaping after fixes it, with a regression test pinning the order.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · **17 new tests** ✅ (merge fields, send-window timezone logic, seed-library integrity)

Two notes on what I could *not* check locally:
- **The UI is unverified in a browser** — `/outreach` needs a logged-in session I don't have here. Worth a pass on the preview URL.
- `src/lib/content/__tests__/prompts.test.ts` fails **in my local Windows worktree** with a syntax error at import. It is unrelated to this change (Content Studio), it fails the same way with my work stashed, and CI has been green on it across the last several PRs — so I've left it rather than chase a local-only artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)