### PR TITLE
fix(uploads): receipts, contract PDFs and template assets no longer die at 1MB

### DIFF
--- a/src/app/api/f/[slug]/upload/route.ts
+++ b/src/app/api/f/[slug]/upload/route.ts
@@ -7,7 +7,13 @@ import type { OnboardingField } from "@/types/database";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
 
-const MAX_BYTES = 10 * 1024 * 1024;
+// Vercel rejects any serverless request body over 4.5MB, so a larger limit
+// here would be a promise the platform breaks — the caller would get an opaque
+// 413 from the edge instead of this route's message. Public uploads keep
+// travelling through the route (rather than a signed URL straight to storage)
+// because these endpoints are unauthenticated: the server-side size and type
+// check is the only gate before bytes land in the bucket.
+const MAX_BYTES = 4 * 1024 * 1024;
 const IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|heic|heif)$/i;
 
 /** Public file/image upload for a form field (slug-gated, rate-limited). */
@@ -28,7 +34,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
   const file = fd.get("file");
   const fieldId = String(fd.get("field_id") ?? "");
   if (!(file instanceof File) || !fieldId) return NextResponse.json({ error: "file and field_id required" }, { status: 400 });
-  if (file.size > MAX_BYTES) return NextResponse.json({ error: "File must be under 10 MB" }, { status: 413 });
+  if (file.size > MAX_BYTES) return NextResponse.json({ error: "File must be under 4 MB" }, { status: 413 });
 
   const field = ((form.schema ?? []) as OnboardingField[]).find((x) => x.id === fieldId);
   if (!field || (field.type !== "file" && field.type !== "image")) return NextResponse.json({ error: "Unknown upload field" }, { status: 400 });

--- a/src/app/api/portal/[token]/onboarding/[id]/upload/route.ts
+++ b/src/app/api/portal/[token]/onboarding/[id]/upload/route.ts
@@ -6,7 +6,13 @@ import type { OnboardingField } from "@/types/database";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
 
-const MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+// Vercel rejects any serverless request body over 4.5MB, so a larger limit
+// here would be a promise the platform breaks — the caller would get an opaque
+// 413 from the edge instead of this route's message. Public uploads keep
+// travelling through the route (rather than a signed URL straight to storage)
+// because these endpoints are unauthenticated: the server-side size and type
+// check is the only gate before bytes land in the bucket.
+const MAX_BYTES = 4 * 1024 * 1024;
 const IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|heic|heif)$/i;
 
 /** Customer file/image upload for an onboarding field (token-gated). */
@@ -29,7 +35,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tok
   const file = form.get("file");
   const fieldId = String(form.get("field_id") ?? "");
   if (!(file instanceof File) || !fieldId) return NextResponse.json({ error: "file and field_id are required" }, { status: 400 });
-  if (file.size > MAX_BYTES) return NextResponse.json({ error: "File must be under 10 MB" }, { status: 413 });
+  if (file.size > MAX_BYTES) return NextResponse.json({ error: "File must be under 4 MB" }, { status: 413 });
 
   // The field must exist on the form and be an upload type.
   const { data: f } = await tbl(sb, "onboarding_forms").select("schema").eq("id", request.form_id).maybeSingle();

--- a/src/components/contracts/contracts-client.tsx
+++ b/src/components/contracts/contracts-client.tsx
@@ -15,7 +15,8 @@ import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SearchableSelect } from "@/components/ui/searchable-select";
-import { createContract, uploadContractPdf } from "@/lib/actions/contracts";
+import { createContract, createContractPdfUpload } from "@/lib/actions/contracts";
+import { putSignedUpload } from "@/lib/uploads-client";
 import { CONTRACT_MERGE_FIELDS } from "@/lib/contracts/merge-fields";
 import { formatDate } from "@/lib/utils";
 import type { Contract, ContractTemplate, Customer } from "@/types/database";
@@ -60,8 +61,9 @@ export function ContractsClient({ initial, customers, templates }: Props) {
       let source_path: string | undefined;
       if (mode === "pdf") {
         if (!pdfFile) { setSaving(false); return toast.error("Choose a PDF"); }
-        const fd = new FormData(); fd.append("file", pdfFile);
-        source_path = (await uploadContractPdf(fd)).path;
+        const upload = await createContractPdfUpload(pdfFile.name, pdfFile.type, pdfFile.size);
+        await putSignedUpload("contracts", upload, pdfFile);
+        source_path = upload.path;
       } else if (!content.trim()) {
         setSaving(false); return toast.error("Write the contract content");
       }

--- a/src/components/expenses/expenses-view.tsx
+++ b/src/components/expenses/expenses-view.tsx
@@ -14,7 +14,8 @@ import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { DatePicker } from "@/components/ui/date-picker";
-import { createExpense, deleteExpense, uploadReceipt, getReceiptUrl } from "@/lib/actions/expenses";
+import { createExpense, deleteExpense, createReceiptUpload, getReceiptUrl } from "@/lib/actions/expenses";
+import { putSignedUpload } from "@/lib/uploads-client";
 import type { Expense } from "@/types/database";
 
 interface WO { id: string; number: string | null; title: string | null }
@@ -79,9 +80,9 @@ export function ExpensesView({ expenses, workOrders }: Props) {
     if (!file) return;
     setUploading(true);
     try {
-      const fd = new FormData(); fd.append("file", file);
-      const path = await uploadReceipt(fd);
-      setReceiptPath(path);
+      const upload = await createReceiptUpload(file.name, file.size);
+      await putSignedUpload("expense-receipts", upload, file);
+      setReceiptPath(upload.path);
       toast.success("Receipt attached");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Upload failed");

--- a/src/components/settings/document-templates-client.tsx
+++ b/src/components/settings/document-templates-client.tsx
@@ -16,8 +16,9 @@ import { DEFAULT_TEMPLATE_CONFIG, DEFAULT_COLUMNS, FONT_LABELS } from "@/lib/doc
 import { TEMPLATE_PRESETS } from "@/lib/documents/presets";
 import {
   createDocumentTemplate, updateDocumentTemplate, deleteDocumentTemplate,
-  setDefaultDocumentTemplate, uploadTemplateAsset,
+  setDefaultDocumentTemplate, createTemplateAssetUpload,
 } from "@/lib/actions/document-templates";
+import { putSignedUpload } from "@/lib/uploads-client";
 
 type DocType = "invoice" | "quote" | "both";
 
@@ -216,9 +217,9 @@ function TemplateEditor({ editing, setEditing, onSaved }: {
   const onUpload = async (file: File) => {
     setUploading(true);
     try {
-      const fd = new FormData(); fd.append("file", file);
-      const { url } = await uploadTemplateAsset(fd);
-      set("background_image_url", url);
+      const upload = await createTemplateAssetUpload(file.name, file.type, file.size);
+      await putSignedUpload("document-assets", upload, file);
+      set("background_image_url", upload.url);
     } catch (e) {
       alert(e instanceof Error ? e.message : "Upload failed");
     } finally { setUploading(false); }

--- a/src/lib/actions/contracts.ts
+++ b/src/lib/actions/contracts.ts
@@ -5,6 +5,7 @@ import { randomBytes } from "node:crypto";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
+import { mintUpload, assertSize, safeExt, UPLOAD_LIMITS, type SignedUpload } from "@/lib/uploads";
 import { getUser } from "@/lib/auth";
 import { renderTemplateVars } from "@/lib/emails/templates";
 import { appUrl } from "@/lib/app-url";
@@ -83,7 +84,7 @@ export interface CreateContractInput {
   customer_id: string;
   kind: "rich_text" | "pdf";
   content_html?: string | null;   // for rich_text
-  source_path?: string | null;    // for pdf (from uploadContractPdf)
+  source_path?: string | null;    // for pdf (from createContractPdfUpload)
 }
 
 export async function createContract(input: CreateContractInput): Promise<Contract> {
@@ -139,24 +140,27 @@ export async function voidContract(id: string): Promise<void> {
   revalidatePath("/contracts");
 }
 
-/** Upload a source PDF to the private contracts bucket; returns its storage path. */
-export async function uploadContractPdf(formData: FormData): Promise<{ path: string }> {
+/**
+ * Mint a signed URL the browser uploads the contract PDF straight to.
+ *
+ * A scanned contract comfortably exceeds the 1MB server-action body cap — see
+ * src/lib/uploads.ts. The path always ends `.pdf` (server-chosen), so a
+ * mis-declared content type can't change what the file is stored as.
+ */
+export async function createContractPdfUpload(
+  fileName: string, mimeType: string, sizeBytes: number,
+): Promise<SignedUpload> {
   const supabase = await createClient();
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
-  const file = formData.get("file");
-  if (!(file instanceof File)) throw new Error("No file provided");
-  if (file.type !== "application/pdf") throw new Error("Only PDF files are supported");
-  if (file.size > 15 * 1024 * 1024) throw new Error("PDF must be under 15 MB");
+  if (mimeType !== "application/pdf" && safeExt(fileName, "") !== "pdf") {
+    throw new Error("Only PDF files are supported");
+  }
+  assertSize(sizeBytes, UPLOAD_LIMITS.contractPdf, "PDF");
 
-  const admin = createAdminClient();
   const path = `${businessId}/${Date.now()}-${randomBytes(6).toString("hex")}.pdf`;
-  const bytes = Buffer.from(await file.arrayBuffer());
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (admin as any).storage.from("contracts").upload(path, bytes, { contentType: "application/pdf", upsert: false });
-  if (error) throw error;
-  return { path };
+  return mintUpload("contracts", path);
 }
 
 /** Signed URL (1h) for a contract's source or signed PDF, served from the private bucket. */

--- a/src/lib/actions/document-templates.ts
+++ b/src/lib/actions/document-templates.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getUser } from "@/lib/auth";
 import { getActiveBizId } from "@/lib/active-business";
+import { mintUpload, assertSize, safeExt, UPLOAD_LIMITS, type SignedUpload } from "@/lib/uploads";
 import type { DocumentTemplate } from "@/types/database";
 import type { TemplateConfig } from "@/lib/documents/template-config";
 import { DEFAULT_TEMPLATE_CONFIG } from "@/lib/documents/template-config";
@@ -157,29 +158,27 @@ export async function deleteDocumentTemplate(id: string): Promise<void> {
   revalidatePath("/settings/document-templates");
 }
 
-/** Upload a background/letterhead image for a template. Returns the public URL
- *  to store in config.background_image_url. */
-export async function uploadTemplateAsset(formData: FormData): Promise<{ url: string }> {
+/**
+ * Mint a signed URL the browser uploads a background/letterhead image straight
+ * to (see src/lib/uploads.ts — a letterhead scan won't fit through a server
+ * action). Returns the public URL to store in config.background_image_url; the
+ * bucket is public, so the URL is known before the bytes arrive.
+ */
+export async function createTemplateAssetUpload(
+  fileName: string, mimeType: string, sizeBytes: number,
+): Promise<SignedUpload & { url: string }> {
   const supabase = await createClient();
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
-  const file = formData.get("file");
-  if (!(file instanceof File)) throw new Error("No file provided.");
-  if (file.size > 5 * 1024 * 1024) throw new Error("Image must be under 5MB.");
-  if (!file.type.startsWith("image/")) throw new Error("Only image files are allowed.");
+  if (!mimeType.startsWith("image/")) throw new Error("Only image files are allowed.");
+  assertSize(sizeBytes, UPLOAD_LIMITS.templateAsset, "Image");
 
-  const ext = (file.name.split(".").pop() || "png").toLowerCase().replace(/[^a-z0-9]/g, "");
   // No Math.random in some sandboxes; a timestamp+size key is unique enough here.
-  const key = `${businessId}/${Date.now()}-${file.size}.${ext}`;
-
-  const { error } = await supabase.storage.from("document-assets").upload(key, file, {
-    contentType: file.type, upsert: false,
-  });
-  if (error) throw new Error(error.message);
-
+  const key = `${businessId}/${Date.now()}-${sizeBytes}.${safeExt(fileName, "png")}`;
+  const upload = await mintUpload("document-assets", key);
   const { data } = supabase.storage.from("document-assets").getPublicUrl(key);
-  return { url: data.publicUrl };
+  return { ...upload, url: data.publicUrl };
 }
 
 /** Attach (or clear, with null) a template on a specific invoice or quote. */

--- a/src/lib/actions/expenses.ts
+++ b/src/lib/actions/expenses.ts
@@ -10,6 +10,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveBizId } from "@/lib/active-business";
+import { mintUpload, assertSize, safeExt, UPLOAD_LIMITS, type SignedUpload } from "@/lib/uploads";
 import { getUser } from "@/lib/auth";
 import type { Expense, ExpenseStatus } from "@/types/database";
 
@@ -107,18 +108,18 @@ export async function deleteExpense(id: string): Promise<void> {
   revalidatePath("/expenses");
 }
 
-/** Upload a receipt image; returns the storage path (private bucket). */
-export async function uploadReceipt(formData: FormData): Promise<string> {
+/**
+ * Mint a signed URL the browser uploads the receipt straight to.
+ *
+ * Receipts are phone photos, so they routinely exceed the 1MB server-action
+ * body cap — see src/lib/uploads.ts. Returns the storage path to store on the
+ * expense once the browser has finished uploading.
+ */
+export async function createReceiptUpload(fileName: string, sizeBytes: number): Promise<SignedUpload> {
   const businessId = await biz();
-  const file = formData.get("file") as File | null;
-  if (!file) throw new Error("No file");
-  if (file.size > 10 * 1024 * 1024) throw new Error("Receipt must be under 10MB");
-  const ext = (file.name.split(".").pop() || "jpg").toLowerCase().replace(/[^a-z0-9]/g, "");
-  const path = `${businessId}/${randomUUID()}.${ext}`;
-  const admin = createAdminClient();
-  const { error } = await admin.storage.from("expense-receipts").upload(path, file, { contentType: file.type || undefined, upsert: false });
-  if (error) throw error;
-  return path;
+  assertSize(sizeBytes, UPLOAD_LIMITS.receipt, "Receipt");
+  const path = `${businessId}/${randomUUID()}.${safeExt(fileName, "jpg")}`;
+  return mintUpload("expense-receipts", path);
 }
 
 /** Signed URL for a stored receipt. */

--- a/src/lib/uploads-client.ts
+++ b/src/lib/uploads-client.ts
@@ -1,0 +1,20 @@
+import { createClient } from "@/lib/supabase/client";
+import type { SignedUpload } from "@/lib/uploads";
+
+/**
+ * Browser half of the direct-to-storage upload (see src/lib/uploads.ts for why
+ * the bytes must not go through a server action).
+ *
+ * The signed token authorises exactly the one path the server minted, so this
+ * needs no storage RLS policy of its own and can't write anywhere else.
+ */
+export async function putSignedUpload(
+  bucket: string, upload: SignedUpload, file: File,
+): Promise<void> {
+  const { error } = await createClient().storage
+    .from(bucket)
+    .uploadToSignedUrl(upload.path, upload.token, file, {
+      contentType: file.type || undefined,
+    });
+  if (error) throw error;
+}

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -1,0 +1,67 @@
+/**
+ * Direct-to-storage uploads.
+ *
+ * Why this exists: posting a file through a server action caps it at 1MB by
+ * default, and Vercel caps ANY serverless request body at 4.5MB regardless of
+ * that setting. A phone photo is routinely 2-8MB, so those uploads failed
+ * before the handler ran — surfacing as the opaque Next.js message "An
+ * unexpected response was received from the server." Several call sites had
+ * generous-looking guards (10MB, 15MB) that could never actually be reached.
+ *
+ * The fix is the same everywhere: the server mints a short-lived signed upload
+ * URL (a few hundred bytes over the wire), the browser PUTs the bytes straight
+ * to Supabase Storage, then a second small call records whatever row is needed.
+ * The real ceiling becomes the bucket's, and the file no longer makes the
+ * browser -> Vercel -> Supabase round trip.
+ *
+ * Plain module (NOT "use server") so it can export constants — a "use server"
+ * file may only export async functions.
+ */
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/** Per-domain ceilings. These are now real: nothing truncates below them. */
+export const UPLOAD_LIMITS = {
+  attachment: 25 * 1024 * 1024,
+  receipt: 10 * 1024 * 1024,
+  contractPdf: 15 * 1024 * 1024,
+  templateAsset: 5 * 1024 * 1024,
+} as const;
+
+export interface SignedUpload {
+  /** Storage path the browser must upload to (server-chosen, never client-chosen). */
+  path: string;
+  /** One-shot upload token that authorises exactly that path. */
+  token: string;
+}
+
+/** Filename extension, stripped to a-z0-9 so it can't escape the path. */
+export function safeExt(fileName: string, fallback: string): string {
+  const ext = (fileName.split(".").pop() || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  return ext || fallback;
+}
+
+export function assertSize(bytes: number, limit: number, label: string): void {
+  if (!Number.isFinite(bytes) || bytes <= 0) throw new Error("Empty file");
+  if (bytes > limit) throw new Error(`${label} must be under ${Math.round(limit / 1024 / 1024)}MB`);
+}
+
+/**
+ * Mint a signed upload URL for a server-chosen path.
+ *
+ * Callers build the path themselves so the business/entity prefix is decided
+ * server-side — a client that could name its own path could write anywhere in
+ * the bucket.
+ */
+export async function mintUpload(bucket: string, path: string): Promise<SignedUpload> {
+  const admin = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any).storage.from(bucket).createSignedUploadUrl(path);
+  if (error || !data) throw error ?? new Error("Couldn't start upload");
+  return { path: data.path, token: data.token };
+}
+
+/** Delete an object whose owning row never got written. Best effort. */
+export async function discardUpload(bucket: string, path: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (createAdminClient() as any).storage.from(bucket).remove([path]);
+}


### PR DESCRIPTION
Ports the [#432](https://github.com/maltamimi96/invoicer/pull/432) fix to the three remaining authenticated upload paths, and makes the two public ones tell the truth.

## The same defect, three more times

Each posted the file through a server action — capped at **1MB** by Next.js, and **4.5MB** by Vercel regardless. Every one carried a guard that could never be reached:

| | Guard says | Actually failed at |
|---|---|---|
| `uploadReceipt` | 10MB | **1MB** — receipt photos |
| `uploadContractPdf` | 15MB | **1MB** — scanned contracts |
| `uploadTemplateAsset` | 5MB | **1MB** — letterheads |

And it surfaced as the same opaque *"An unexpected response was received from the server"*, with no hint that size was the problem.

## Fixed once, not three more times

The mechanics now live in [`src/lib/uploads.ts`](src/lib/uploads.ts) (mint + limits + safe extension) and [`src/lib/uploads-client.ts`](src/lib/uploads-client.ts) (the browser PUT). Each domain keeps its own action so the **storage path is still chosen server-side** — a client that could name its own path could write anywhere in the bucket.

## The public endpoints are deliberately left alone

`/api/f/[slug]/upload` and the portal onboarding upload keep taking bytes through the route, and their claimed limit drops from 10MB to **4MB**.

They're **unauthenticated**. The server-side size and type check is the only gate before bytes land in the bucket, and handing out signed URLs there would remove it — anyone with a form slug could write arbitrary files. 10MB was never achievable regardless: the platform 413'd first, from the edge, without the route's own message ever reaching the caller. So this makes the promise honest rather than opening a hole.

## One trade-off worth naming

Mime validation is now **advisory** — the server sees a *declared* content type, not the bytes. Where it matters the server-chosen extension pins it: a contract is always stored as `.pdf` no matter what the client claims.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · tests 116 passed ✅

⚠️ **Not verified end-to-end** — these screens need a logged-in session I don't have locally. Worth one real receipt photo on the preview URL, since that's the flow most likely to be hit first.

(`src/lib/content/__tests__/prompts.test.ts` fails in my local Windows worktree, unrelated and pre-existing — CI has been green on it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)