### PR TITLE
fix(files): un-export a const that broke every action in attachments.ts

### DIFF
--- a/src/lib/__tests__/use-server-exports.test.ts
+++ b/src/lib/__tests__/use-server-exports.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * A "use server" file may only export async functions.
+ *
+ * Next.js enforces this at RUNTIME, not at build — so `tsc` passes, `next
+ * build` passes, CI goes green, and the first request to any page importing
+ * that file dies with "A 'use server' file can only export async functions,
+ * found number". One stray `export const` breaks EVERY export in the file.
+ *
+ * This has now shipped to production twice (a const in actions/stripe.ts, and
+ * MAX_ATTACHMENT_BYTES in actions/attachments.ts). Nothing else catches it, so
+ * this test does.
+ *
+ * Constants belong in a plain sibling module — see src/lib/uploads.ts.
+ */
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(entry)) out.push(p);
+  }
+  return out;
+}
+
+/** Exports that are legal in a "use server" file. */
+const OK = [
+  /^export\s+async\s+function\s/,   // the only real export form
+  /^export\s+type\s/,               // erased at compile time
+  /^export\s+interface\s/,          // erased at compile time
+  /^export\s*\{[^}]*\}\s*from\s+["'].*["'];?$/,   // re-export (values must be async fns)
+];
+
+describe("\"use server\" files", () => {
+  const files = walk("src").filter((f) => {
+    const head = readFileSync(f, "utf8").slice(0, 200);
+    return /^\s*["']use server["']/.test(head);
+  });
+
+  it("finds the server-action files to check", () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it("export only async functions and types", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = readFileSync(file, "utf8").split(/\r?\n/);
+      lines.forEach((line, i) => {
+        if (!/^export\s/.test(line)) return;
+        if (OK.some((rx) => rx.test(line.trim()))) return;
+        offenders.push(`${file}:${i + 1}  ${line.trim().slice(0, 90)}`);
+      });
+    }
+    expect(offenders, `Move these to a plain module — a non-async export breaks every export in the file at runtime:\n${offenders.join("\n")}`)
+      .toEqual([]);
+  });
+});

--- a/src/lib/actions/attachments.ts
+++ b/src/lib/actions/attachments.ts
@@ -36,7 +36,9 @@ export async function listAttachments(entityType: AttachmentEntityType, entityId
   return data as Attachment[];
 }
 
-export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+// NOT exported: a "use server" file may only export async functions, and a
+// non-async export breaks EVERY export in the file at runtime (not at build).
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
 /**
  * Step 1 of 2 — mint a signed URL the BROWSER uploads straight to Supabase


### PR DESCRIPTION
**Production hotfix.** Uploading a file to a customer failed with *"An error occurred in the Server Components render"*.

## What the production log said

```
Error: A "use server" file can only export async functions, found number.
routes=/customers/[id]   digest: 252607977@E352
```

## My bug, from #432

I added `export const MAX_ATTACHMENT_BYTES` to `src/lib/actions/attachments.ts`. A non-async export from a `"use server"` file **breaks every export in that file** — so `listAttachments`, `uploadAttachment`, `deleteAttachment` and `getAttachmentUrl` all died, and the customer page render died with them.

Next enforces this at **runtime, not build**. `tsc` passed, `next build` passed, CI went green, and it only surfaced on the first real request — which is why my verification didn't catch it.

CLAUDE.md already documents this trap from a previous incident in `actions/stripe.ts`. I walked into it anyway.

The constant is only used inside this file (the panel carries its own client-side limit), so it simply loses `export`.

## Closing the class, not just the instance

`src/lib/__tests__/use-server-exports.test.ts` scans every `"use server"` file and fails on any export that isn't an async function or a type. I verified it catches this exact bug by stashing the fix and watching it fail:

```
src\lib\actions\attachments.ts:39  export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
```

Nothing else in the toolchain catches this, so a test is the only place it can live.

## Note on the earlier error in the same log

The same route also shows `Error: Body exceeded 1 MB limit.` (3 occurrences, 2026-08-03 08:37) — that's the original upload bug, from **before** #432 deployed. It confirms the diagnosis in that PR.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · guard passes with the fix, fails without it ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)