### PR TITLE
feat(telephony): VoIPcloud phone-system plugin — call log, caller ID, missed-call follow-up

### DIFF
--- a/src/app/(dashboard)/calls/page.tsx
+++ b/src/app/(dashboard)/calls/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getTelephonySettings, getWebhookUrl, listCalls, getCallStats } from "@/lib/actions/telephony";
+import { CallsClient } from "@/components/telephony/calls-client";
+
+export default async function CallsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const settings = await getTelephonySettings();
+  const [calls, stats, webhookUrl] = await Promise.all([
+    listCalls({ limit: 200 }),
+    getCallStats(),
+    getWebhookUrl(),
+  ]);
+
+  return <CallsClient settings={settings} calls={calls} stats={stats} webhookUrl={webhookUrl} />;
+}

--- a/src/app/api/webhooks/voipcloud/[token]/route.ts
+++ b/src/app/api/webhooks/voipcloud/[token]/route.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/webhooks/voipcloud/[token]
+ *
+ * Receives call events from a business's VoIPcloud PBX.
+ *
+ * The request carries no session, so the business is identified by the
+ * unguessable token in the path — the same approach the customer portal uses.
+ * The token alone is not treated as proof: when the business has configured a
+ * Secret Token in VoIPcloud, the X-Pbx-Token header must match it.
+ *
+ * Always answers 200 once the event is accepted. A PBX that gets an error
+ * retries, and a retry storm over a bug in our automations would be worse than
+ * a dropped event — the raw payload is stored either way.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ingestCallEvent, type VoipEvent } from "@/lib/telephony/ingest";
+
+export const maxDuration = 30;
+
+/** Constant-time compare so the secret can't be recovered by timing. */
+function secretMatches(expected: string, given: string): boolean {
+  const a = Buffer.from(expected);
+  const b = Buffer.from(given);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ token: string }> }) {
+  const { token } = await ctx.params;
+  if (!token || token.length < 16) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const sb = createAdminClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: settings } = await (sb as any)
+    .from("telephony_settings")
+    .select("business_id, enabled, webhook_secret")
+    .eq("webhook_token", token)
+    .maybeSingle();
+
+  // Same response for an unknown token and a disabled plugin, so the endpoint
+  // can't be used to enumerate which tokens are live.
+  if (!settings?.business_id || !settings.enabled) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (settings.webhook_secret) {
+    const given = req.headers.get("x-pbx-token") ?? "";
+    if (!given || !secretMatches(settings.webhook_secret, given)) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+    }
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Bad JSON" }, { status: 400 });
+  }
+
+  // Some PBX configurations batch events into an array.
+  const events: VoipEvent[] = Array.isArray(payload) ? payload : [payload as VoipEvent];
+
+  const results = [];
+  for (const event of events) {
+    try {
+      results.push(await ingestCallEvent(sb, settings.business_id, event));
+    } catch (e) {
+      // Log and keep going: one malformed event shouldn't cost us the batch,
+      // and a 500 would make the PBX retry the whole thing.
+      console.error("voipcloud ingest failed", e);
+      results.push({ error: true });
+    }
+  }
+
+  return NextResponse.json({ ok: true, processed: results.length, results });
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -1,6 +1,6 @@
 import {
   LayoutDashboard, FileText, FileCheck, Users,
-  Package, FileStack, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target, Megaphone, DollarSign, Send,
+  Package, FileStack, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target, Megaphone, DollarSign, Send, Phone,
 } from "@/components/ui/icons";
 
 export type NavItem = {
@@ -18,6 +18,7 @@ export const navSections: NavSection[] = [
     { label: "Dashboard",  href: "/dashboard",  icon: LayoutDashboard, worker: true },
     { label: "Assistant",  href: "/assistant",  icon: Sparkles                      },
     { label: "Messages",   href: "/messages",   icon: MessageSquare,   plugin: "messages" },
+    { label: "Calls",      href: "/calls",      icon: Phone,           plugin: "telephony" },
     { label: "Tasks",      href: "/tasks",      icon: Columns3                      },
   ]},
   { section: "Sales", items: [

--- a/src/components/telephony/calls-client.tsx
+++ b/src/components/telephony/calls-client.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { KireiTabs } from "@/components/ui/kirei/tabs";
+import { StatTile } from "@/components/ui/kirei/stat-tile";
+import { EmptyState } from "@/components/ui/kirei/empty-state";
+import { Phone, PhoneOff, Loader2, Copy, RefreshCw, AlertCircle } from "@/components/ui/icons";
+import {
+  updateTelephonySettings, rotateWebhookToken, rematchCalls,
+} from "@/lib/actions/telephony";
+import { formatAuPhone } from "@/lib/telephony/phone";
+import type { CallStats } from "@/lib/actions/telephony";
+import type { TelephonySettings, Call } from "@/types/database";
+
+type Tab = "log" | "missed" | "setup";
+
+function duration(sec: number | null): string {
+  if (!sec) return "—";
+  const m = Math.floor(sec / 60);
+  return m ? `${m}m ${sec % 60}s` : `${sec}s`;
+}
+
+/** Whoever the caller ID resolved to, with a link when there is one. */
+function Party({ call }: { call: Call }) {
+  if (call.customer_id) {
+    return <Link href={`/customers/${call.customer_id}`} className="font-medium hover:underline">
+      {call.customers?.name ?? "Customer"}
+    </Link>;
+  }
+  if (call.lead_id) {
+    return <Link href={`/leads/${call.lead_id}`} className="font-medium hover:underline">
+      {call.leads?.name ?? "Lead"}
+    </Link>;
+  }
+  if (call.contact_id) return <span className="font-medium">{call.contacts?.name ?? "Contact"}</span>;
+  if (call.prospect_id) return <span className="font-medium">{call.prospects?.company ?? "Prospect"}</span>;
+  return <span className="text-muted-foreground">{call.caller_name || "Unknown number"}</span>;
+}
+
+export function CallsClient({
+  settings: initial, calls, stats, webhookUrl,
+}: {
+  settings: TelephonySettings;
+  calls: Call[];
+  stats: CallStats;
+  webhookUrl: string;
+}) {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>(initial.enabled ? "log" : "setup");
+  const [settings, setSettings] = useState(initial);
+  const [url, setUrl] = useState(webhookUrl);
+  const [busy, startTransition] = useTransition();
+
+  const save = (p: Partial<TelephonySettings>) => {
+    setSettings((s) => ({ ...s, ...p }));
+    startTransition(async () => {
+      try {
+        await updateTelephonySettings(p);
+        router.refresh();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't save");
+      }
+    });
+  };
+
+  const missed = calls.filter((c) => c.status === "missed" || c.status === "voicemail");
+  const shown = tab === "missed" ? missed : calls;
+
+  return (
+    <div>
+      <PageHeader
+        title="Calls"
+        subtitle="Every call logged against the customer, with missed calls turned into follow-ups."
+        actions={
+          <Button variant="outline" disabled={busy} onClick={async () => {
+            const n = await rematchCalls();
+            toast.success(n ? `Matched ${n} more call${n === 1 ? "" : "s"}` : "No new matches");
+            router.refresh();
+          }}>
+            <RefreshCw className="mr-1.5 h-4 w-4" /> Re-match callers
+          </Button>
+        }
+      />
+
+      {!settings.enabled && (
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4">
+          <div>
+            <p className="text-sm font-semibold">Phone system isn&rsquo;t connected yet</p>
+            <p className="text-sm text-muted-foreground">
+              Nothing is logged until you turn this on and paste the webhook URL into VoIPcloud.
+            </p>
+          </div>
+          <Button onClick={() => { save({ enabled: true }); setTab("setup"); }}>Turn on</Button>
+        </div>
+      )}
+
+      <KireiTabs
+        className="mb-5"
+        value={tab}
+        onChange={setTab}
+        tabs={[
+          { value: "log", label: "All calls", count: calls.length },
+          { value: "missed", label: "Missed & voicemail", count: missed.length },
+          { value: "setup", label: "Setup" },
+        ]}
+      />
+
+      {tab !== "setup" && (
+        <>
+          <div className="mb-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <StatTile toneColor="#1f4f4a" icon={<Phone className="h-4 w-4" />} label="Calls" value={String(stats.total)}
+              sub={`${stats.inbound} in · ${stats.outbound} out`} />
+            <StatTile toneColor="#dc2626" icon={<PhoneOff className="h-4 w-4" />} label="Missed" value={String(stats.missed)}
+              sub="each one is a possible lost job" />
+            <StatTile toneColor="#b45309" icon={<AlertCircle className="h-4 w-4" />} label="Voicemail" value={String(stats.voicemail)} />
+            <StatTile toneColor="#64748b" icon={<Phone className="h-4 w-4" />} label="Unknown numbers" value={String(stats.unmatched)}
+              sub="not on file yet" />
+          </div>
+
+          {shown.length === 0 ? (
+            <EmptyState icon={<Phone className="h-6 w-6" />} title="No calls yet"
+              hint="Once the webhook is connected, every call through your PBX shows up here." />
+          ) : (
+            <div className="ch-table-wrap">
+              <table className="ch-table">
+                <thead>
+                  <tr><th>Who</th><th>Number</th><th>Direction</th><th>Status</th><th>Length</th><th>When</th><th>Handled</th></tr>
+                </thead>
+                <tbody>
+                  {shown.map((c) => {
+                    const other = c.direction === "inbound" ? c.from_number : c.to_number;
+                    return (
+                      <tr key={c.id}>
+                        <td><Party call={c} /></td>
+                        <td className="ch-mono">{formatAuPhone(other)}</td>
+                        <td className="capitalize">{c.direction}</td>
+                        <td>
+                          <span className={`ch-pill ${
+                            c.status === "missed" || c.status === "failed" ? "overdue"
+                            : c.status === "voicemail" ? "pending"
+                            : c.status === "answered" || c.status === "completed" ? "paid" : "draft"}`}>
+                            {c.status}
+                          </span>
+                        </td>
+                        <td className="num">{duration(c.duration_seconds)}</td>
+                        <td>{new Date(c.started_at).toLocaleString("en-AU", {
+                          day: "numeric", month: "short", hour: "2-digit", minute: "2-digit",
+                        })}</td>
+                        <td className="text-xs text-muted-foreground">
+                          {c.created_task_id ? "Task created" : c.created_lead_id ? "Lead created" : "—"}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+
+      {tab === "setup" && (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-border bg-card p-5">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <Label>Connected</Label>
+                <p className="text-xs text-muted-foreground">Master switch — off means nothing is logged.</p>
+              </div>
+              <Switch checked={settings.enabled} onCheckedChange={(v) => save({ enabled: v })} />
+            </div>
+
+            <Label htmlFor="hook">Webhook URL</Label>
+            <div className="flex gap-2">
+              <Input id="hook" readOnly value={url} className="font-mono text-xs" />
+              <Button variant="outline" onClick={() => {
+                navigator.clipboard.writeText(url); toast.success("Copied");
+              }}><Copy className="h-4 w-4" /></Button>
+              <Button variant="outline" disabled={busy} onClick={async () => {
+                if (!confirm("Rotating breaks the old URL immediately — you'll need to paste the new one into VoIPcloud. Continue?")) return;
+                setUrl(await rotateWebhookToken());
+                toast.success("Rotated — update VoIPcloud with the new URL");
+              }}>Rotate</Button>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              In VoIPcloud: <strong>Integration/API → Webhooks</strong>. Paste this URL, set a Secret Token, and
+              tick the call events you want (inbound/outbound call, answered, completion, and voicemail).
+            </p>
+
+            <div className="mt-4">
+              <Label htmlFor="secret">Secret token</Label>
+              <Input id="secret" type="password" placeholder={settings.webhook_secret ? "•••••• set" : "Match the value you set in VoIPcloud"}
+                onBlur={(e) => e.target.value && save({ webhook_secret: e.target.value })} />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Sent back as the <code>X-Pbx-Token</code> header and checked on every request. Strongly recommended —
+                the URL alone is otherwise the only thing protecting the endpoint.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-5">
+            <p className="mb-3 text-sm font-semibold">When a call is missed</p>
+            <div className="space-y-3">
+              {([
+                ["create_task_on_missed", "Create a call-back task", "A missed call is a possible lost job — this is the point of the integration."],
+                ["create_task_on_voicemail", "Create a task for voicemail", "So a message can't sit unheard."],
+                ["create_lead_on_missed", "Create a lead from unknown numbers", "Off by default: it adds a lead for every wrong number and cold caller too."],
+                ["log_calls", "Log calls", "Turn off to keep the integration connected but stop recording call history."],
+              ] as const).map(([key, label, hint]) => (
+                <div key={key} className="flex items-center justify-between gap-3">
+                  <div>
+                    <Label>{label}</Label>
+                    <p className="text-xs text-muted-foreground">{hint}</p>
+                  </div>
+                  <Switch checked={Boolean(settings[key])} onCheckedChange={(v) => save({ [key]: v })} />
+                </div>
+              ))}
+            </div>
+            {busy && <p className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" /> Saving…
+            </p>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -51,6 +51,7 @@ export {
   Pause,
   Pencil,
   Phone,
+  PhoneOff,
   Play,
   Plus,
   Receipt,

--- a/src/lib/__tests__/telephony.test.ts
+++ b/src/lib/__tests__/telephony.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { digitsOf, matchKey, samePhone, formatAuPhone } from "@/lib/telephony/phone";
+import { classify } from "@/lib/telephony/ingest";
+
+describe("phone matching", () => {
+  it("collapses every caller-ID format to the same key", () => {
+    // The whole integration rests on this: the PBX and the customer record
+    // almost never store a number the same way.
+    const forms = ["+61412345678", "0412345678", "61412345678", "0412 345 678", "+61 412 345 678"];
+    const keys = new Set(forms.map(matchKey));
+    expect(keys.size, `expected one key, got ${[...keys].join(", ")}`).toBe(1);
+    expect([...keys][0]).toBe("412345678");
+  });
+
+  it("handles landlines with area codes and punctuation", () => {
+    expect(matchKey("(02) 9876 5432")).toBe("298765432");
+    expect(matchKey("+61 2 9876 5432")).toBe("298765432");
+    expect(samePhone("(02) 9876 5432", "0298765432")).toBe(true);
+  });
+
+  it("refuses to match on short internal extensions", () => {
+    // Matching a 3-digit extension would collide across unrelated records.
+    expect(matchKey("101")).toBe("");
+    expect(matchKey("2005")).toBe("");
+    expect(samePhone("101", "101")).toBe(false);
+  });
+
+  it("treats empty / missing numbers as no-match, never as equal", () => {
+    expect(matchKey(null)).toBe("");
+    expect(matchKey("")).toBe("");
+    expect(samePhone(null, null)).toBe(false);
+    expect(samePhone("", "")).toBe(false);
+    expect(samePhone("0412345678", null)).toBe(false);
+  });
+
+  it("does not match two different numbers", () => {
+    expect(samePhone("0412345678", "0412345679")).toBe(false);
+  });
+
+  it("strips non-digits", () => {
+    expect(digitsOf("+61 (02) 9876-5432")).toBe("610298765432");
+  });
+
+  it("formats for display", () => {
+    expect(formatAuPhone("+61412345678")).toBe("0412 345 678");
+    expect(formatAuPhone("0298765432")).toBe("(02) 9876 5432");
+    expect(formatAuPhone("garbage")).toBe("garbage");
+  });
+});
+
+describe("webhook event classification", () => {
+  // VoIPcloud documents the 11 triggers in prose but not their exact wire
+  // strings, so classify() matches on substrings. These cover the documented
+  // names plus plausible casing/spacing variants.
+  it("reads direction from the event name, defaulting to inbound", () => {
+    expect(classify("User outbound call").direction).toBe("outbound");
+    expect(classify("User inbound call").direction).toBe("inbound");
+    expect(classify("Voicemail").direction).toBe("inbound");
+  });
+
+  it("maps each documented trigger to a stage", () => {
+    expect(classify("User inbound call").stage).toBe("ringing");
+    expect(classify("User inbound call answered").stage).toBe("answered");
+    expect(classify("User inbound call completion").stage).toBe("completed");
+    expect(classify("Queue call summary").stage).toBe("completed");
+    expect(classify("Ring group call summary").stage).toBe("completed");
+    expect(classify("Voicemail").stage).toBe("voicemail");
+    expect(classify("Inbound call recording").stage).toBe("recording");
+    expect(classify("Outbound call recording").stage).toBe("recording");
+  });
+
+  it("is case- and format-insensitive", () => {
+    expect(classify("user_outbound_call_answered")).toEqual({ direction: "outbound", stage: "answered" });
+    expect(classify("USER INBOUND CALL COMPLETION")).toEqual({ direction: "inbound", stage: "completed" });
+  });
+
+  it("prefers the more specific stage when words overlap", () => {
+    // "answered" must win over the bare "call" that also appears.
+    expect(classify("User inbound call answered").stage).toBe("answered");
+    // A recording event must not be read as a completion.
+    expect(classify("Inbound call recording").stage).toBe("recording");
+  });
+
+  it("returns a null stage for anything unrecognised, without throwing", () => {
+    expect(classify("something entirely new").stage).toBeNull();
+    expect(classify(undefined).stage).toBeNull();
+    expect(classify("").stage).toBeNull();
+  });
+});

--- a/src/lib/actions/telephony.ts
+++ b/src/lib/actions/telephony.ts
@@ -1,0 +1,152 @@
+"use server";
+
+/**
+ * Telephony (VoIPcloud) — settings and the call log.
+ * Ingest lives in src/lib/telephony/ingest.ts, shared with the webhook route.
+ * AI-tool-first: matching MCP tools use scopes telephony:read / telephony:write.
+ */
+import { randomBytes } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
+import { appUrl } from "@/lib/app-url";
+import { matchNumber } from "@/lib/telephony/ingest";
+import type { TelephonySettings, Call } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, user, businessId };
+}
+
+/** Lazily creates the row so the UI always has something to bind to. */
+export async function getTelephonySettings(): Promise<TelephonySettings> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "telephony_settings").select("*")
+    .eq("business_id", businessId).maybeSingle();
+  if (data) return data as TelephonySettings;
+  const { data: created, error } = await tbl(supabase, "telephony_settings")
+    .insert({ business_id: businessId }).select().single();
+  if (error) throw error;
+  return created as TelephonySettings;
+}
+
+/** The URL to paste into VoIPcloud's webhook configuration. */
+export async function getWebhookUrl(): Promise<string> {
+  const s = await getTelephonySettings();
+  return `${appUrl()}/api/webhooks/voipcloud/${s.webhook_token}`;
+}
+
+export async function updateTelephonySettings(patch: Partial<Omit<TelephonySettings,
+  "business_id" | "created_at" | "updated_at" | "webhook_token" | "api_key_enc">>): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  await getTelephonySettings();
+  const clean = Object.fromEntries(Object.entries(patch).filter(([, v]) => v !== undefined));
+  const { error } = await tbl(supabase, "telephony_settings").update(clean).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/calls");
+}
+
+/** Rotate the webhook token — invalidates the old URL immediately. */
+export async function rotateWebhookToken(): Promise<string> {
+  const { supabase, businessId } = await ctx();
+  await getTelephonySettings();
+  const token = randomBytes(16).toString("hex");
+  const { error } = await tbl(supabase, "telephony_settings")
+    .update({ webhook_token: token }).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/calls");
+  return `${appUrl()}/api/webhooks/voipcloud/${token}`;
+}
+
+/** Store the PBX API key encrypted (used later for click-to-call). */
+export async function setTelephonyApiKey(key: string): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  if (!encryptionAvailable()) throw new Error("APP_ENCRYPTION_KEY is not configured on the server");
+  await getTelephonySettings();
+  const { error } = await tbl(supabase, "telephony_settings")
+    .update({ api_key_enc: key.trim() ? encryptSecret(key.trim()) : null })
+    .eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/calls");
+}
+
+export async function listCalls(filters?: {
+  customer_id?: string; status?: string; limit?: number;
+}): Promise<Call[]> {
+  const { supabase, businessId } = await ctx();
+  let q = tbl(supabase, "calls")
+    .select("*, customers(name), leads(name), contacts(name), prospects(company)")
+    .eq("business_id", businessId)
+    .order("started_at", { ascending: false })
+    .limit(filters?.limit ?? 200);
+  if (filters?.customer_id) q = q.eq("customer_id", filters.customer_id);
+  if (filters?.status) q = q.eq("status", filters.status);
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data ?? []) as Call[];
+}
+
+export interface CallStats {
+  total: number; inbound: number; outbound: number; missed: number; voicemail: number; unmatched: number;
+}
+
+export async function getCallStats(): Promise<CallStats> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "calls")
+    .select("direction, status, customer_id, lead_id, contact_id, prospect_id")
+    .eq("business_id", businessId).limit(5000);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (data ?? []) as any[];
+  return {
+    total: rows.length,
+    inbound: rows.filter((r) => r.direction === "inbound").length,
+    outbound: rows.filter((r) => r.direction === "outbound").length,
+    missed: rows.filter((r) => r.status === "missed").length,
+    voicemail: rows.filter((r) => r.status === "voicemail").length,
+    unmatched: rows.filter((r) => !r.customer_id && !r.lead_id && !r.contact_id && !r.prospect_id).length,
+  };
+}
+
+/** Free-text note against a call (what was discussed). */
+export async function setCallNotes(callId: string, notes: string): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const { error } = await tbl(supabase, "calls").update({ notes })
+    .eq("id", callId).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/calls");
+}
+
+/**
+ * Re-run caller-ID matching on calls that arrived before the customer existed
+ * — e.g. an unknown number that later got added as a customer.
+ */
+export async function rematchCalls(limit = 200): Promise<number> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "calls")
+    .select("id, counterparty_digits")
+    .eq("business_id", businessId)
+    .is("customer_id", null).is("lead_id", null).is("contact_id", null).is("prospect_id", null)
+    .not("counterparty_digits", "is", null)
+    .limit(limit);
+
+  let matched = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const call of ((data ?? []) as any[])) {
+    const m = await matchNumber(supabase, businessId, call.counterparty_digits);
+    if (!m.customer_id && !m.lead_id && !m.contact_id && !m.prospect_id) continue;
+    await tbl(supabase, "calls").update({
+      customer_id: m.customer_id ?? null, contact_id: m.contact_id ?? null,
+      lead_id: m.lead_id ?? null, prospect_id: m.prospect_id ?? null,
+    }).eq("id", call.id);
+    matched++;
+  }
+  revalidatePath("/calls");
+  return matched;
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -42,6 +42,7 @@ import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
 import { registerProspectTools } from "./tools/prospects-tools";
 import { registerOutreachTools } from "./tools/outreach-tools";
+import { registerTelephonyTools } from "./tools/telephony-tools";
 import { registerAssistantTools } from "./tools/assistant-tools";
 import { ilikeAcross } from "@/lib/pg-filter";
 
@@ -1721,6 +1722,7 @@ export function registerTools(register: ToolFn): void {
   // ===== PROSPECTS =====
   registerProspectTools(tool);
   registerOutreachTools(tool);
+  registerTelephonyTools(tool);
 
   // ===== SCHEDULE =====
   tool("get_schedule", "Get jobs scheduled on a given date (YYYY-MM-DD), or today if omitted.",

--- a/src/lib/mcp/tools/telephony-tools.ts
+++ b/src/lib/mcp/tools/telephony-tools.ts
@@ -1,0 +1,150 @@
+/**
+ * MCP tools for the Telephony (VoIPcloud) plugin.
+ * Scopes: telephony:read / telephony:write.
+ *
+ * The call log is the raw material for questions like "who called today that we
+ * never rang back" — so the read tools are shaped around answering those rather
+ * than dumping rows.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, appBase, type ToolFn } from "./shared";
+import { matchNumber } from "@/lib/telephony/ingest";
+import { matchKey, formatAuPhone } from "@/lib/telephony/phone";
+
+const STATUS = z.enum(["ringing", "answered", "completed", "missed", "voicemail", "failed"]);
+
+export function registerTelephonyTools(tool: ToolFn): void {
+  tool("get_telephony_settings",
+    "Phone-system integration status: whether it's on, the webhook URL to paste into VoIPcloud, and which automations run on a missed call or voicemail. Never returns the stored secret or API key.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:read");
+      const { data } = await t(ctx, "telephony_settings").select("*")
+        .eq("business_id", ctx.businessId).maybeSingle();
+      if (!data) return text({ enabled: false, configured: false });
+      const { webhook_secret, api_key_enc, webhook_token, ...safe } = data;
+      return text({
+        ...safe,
+        webhook_url: `${appBase()}/api/webhooks/voipcloud/${webhook_token}`,
+        webhook_secret_set: Boolean(webhook_secret),
+        api_key_set: Boolean(api_key_enc),
+      });
+    });
+
+  tool("update_telephony_settings",
+    "Turn the phone-system integration on/off and choose what happens automatically when a call is missed or a voicemail is left.",
+    {
+      enabled: z.boolean().optional(),
+      log_calls: z.boolean().optional(),
+      create_lead_on_missed: z.boolean().optional(),
+      create_task_on_missed: z.boolean().optional(),
+      create_task_on_voicemail: z.boolean().optional(),
+      webhook_secret: z.string().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:write");
+      const patch = Object.fromEntries(Object.entries(args).filter(([, v]) => v !== undefined));
+      if (!Object.keys(patch).length) return errorText("Nothing to update");
+      const { error } = await t(ctx, "telephony_settings")
+        .upsert({ business_id: ctx.businessId, ...patch }, { onConflict: "business_id" });
+      if (error) throw error;
+      return text({ updated: true, ...patch, webhook_secret: patch.webhook_secret ? "(set)" : undefined });
+    });
+
+  tool("list_calls",
+    "The call log: who called, when, how long, whether it was answered, and which customer/lead it matched. Filter by status (missed/voicemail/...), direction, customer, or unmatched-only.",
+    {
+      status: STATUS.optional(),
+      direction: z.enum(["inbound", "outbound"]).optional(),
+      customer_id: UUID.optional(),
+      unmatched_only: z.boolean().optional(),
+      since: z.string().optional(),
+      limit: z.number().int().min(1).max(500).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:read");
+      let q = t(ctx, "calls")
+        .select("id, direction, status, from_number, to_number, caller_name, user_name, started_at, duration_seconds, customer_id, lead_id, contact_id, prospect_id, created_task_id, notes, customers(name), leads(name)")
+        .eq("business_id", ctx.businessId)
+        .order("started_at", { ascending: false }).limit(args.limit ?? 100);
+      if (args.status) q = q.eq("status", args.status);
+      if (args.direction) q = q.eq("direction", args.direction);
+      if (args.customer_id) q = q.eq("customer_id", args.customer_id);
+      if (args.since) q = q.gte("started_at", args.since);
+      if (args.unmatched_only) {
+        q = q.is("customer_id", null).is("lead_id", null).is("contact_id", null).is("prospect_id", null);
+      }
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("get_call_stats",
+    "Call volume summary: total, inbound vs outbound, missed, voicemail, and how many came from numbers you don't have on file.",
+    { since: z.string().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:read");
+      let q = t(ctx, "calls").select("direction, status, customer_id, lead_id, contact_id, prospect_id")
+        .eq("business_id", ctx.businessId).limit(5000);
+      if (args.since) q = q.gte("started_at", args.since);
+      const { data } = await q;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = (data ?? []) as any[];
+      return text({
+        total: rows.length,
+        inbound: rows.filter((r) => r.direction === "inbound").length,
+        outbound: rows.filter((r) => r.direction === "outbound").length,
+        missed: rows.filter((r) => r.status === "missed").length,
+        voicemail: rows.filter((r) => r.status === "voicemail").length,
+        unmatched: rows.filter((r) => !r.customer_id && !r.lead_id && !r.contact_id && !r.prospect_id).length,
+      });
+    });
+
+  tool("identify_caller",
+    "Look up a phone number against customers, contacts, leads and prospects. Matches regardless of format (+61…, 0…, spaces, brackets).",
+    { phone: z.string() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:read");
+      const key = matchKey(args.phone);
+      if (!key) return errorText("That doesn't look like a full phone number");
+      const m = await matchNumber(ctx.sb, ctx.businessId, args.phone);
+      const kind = m.customer_id ? "customer" : m.contact_id ? "contact"
+        : m.lead_id ? "lead" : m.prospect_id ? "prospect" : null;
+      return text({ phone: formatAuPhone(args.phone), match_key: key, matched: kind, ...m });
+    });
+
+  tool("set_call_notes", "Record what was discussed on a call.",
+    { call_id: UUID, notes: z.string() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:write");
+      const { error } = await t(ctx, "calls").update({ notes: args.notes })
+        .eq("id", args.call_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("rematch_calls",
+    "Re-run caller-ID matching over unmatched calls — use after adding customers, so earlier calls from that number link up.",
+    { limit: z.number().int().min(1).max(500).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "telephony:write");
+      const { data } = await t(ctx, "calls").select("id, counterparty_digits")
+        .eq("business_id", ctx.businessId)
+        .is("customer_id", null).is("lead_id", null).is("contact_id", null).is("prospect_id", null)
+        .not("counterparty_digits", "is", null).limit(args.limit ?? 200);
+
+      let matched = 0;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for (const call of ((data ?? []) as any[])) {
+        const m = await matchNumber(ctx.sb, ctx.businessId, call.counterparty_digits);
+        if (!m.customer_id && !m.lead_id && !m.contact_id && !m.prospect_id) continue;
+        await t(ctx, "calls").update({
+          customer_id: m.customer_id ?? null, contact_id: m.contact_id ?? null,
+          lead_id: m.lead_id ?? null, prospect_id: m.prospect_id ?? null,
+        }).eq("id", call.id);
+        matched++;
+      }
+      return text({ rematched: matched, scanned: (data ?? []).length });
+    });
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -77,6 +77,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "products", icon: "package",   name: "Products",      description: "Price list used across quotes and invoices.", kind: "module", category: "catalog", defaultEnabled: true, routePrefixes: ["/products"] },
   { id: "materials", icon: "package",  name: "Materials",     description: "Cost-price catalog of materials, used as an internal reference when pricing jobs.", kind: "module", category: "catalog", defaultEnabled: false, routePrefixes: ["/materials"] },
   { id: "inventory", icon: "boxes", name: "Inventory", description: "Track stock on hand, reorder points and usage per job.", kind: "module", category: "catalog", defaultEnabled: false, dependencies: ["products"], routePrefixes: ["/inventory"] },
+  { id: "telephony", icon: "phone", name: "Phone system (VoIPcloud)", description: "Log every call against the customer, turn missed calls and voicemail into follow-ups.", kind: "module", category: "communication", defaultEnabled: false, routePrefixes: ["/calls"] },
   { id: "messages", icon: "message-square",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "communication", defaultEnabled: true, routePrefixes: ["/messages"] },
   { id: "analytics", icon: "trending-up",  name: "Analytics",     description: "Revenue and pipeline insight.",          kind: "module", category: "insights", defaultEnabled: true, routePrefixes: ["/analytics"] },
 

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -66,6 +66,10 @@ export async function updateSession(request: NextRequest) {
     // was 307'd to /auth/login, so delivered/bounced events never reached the
     // handler and every email stayed frozen at "Sent (in transit)".
     pathname === "/api/webhooks/resend" ||
+    // VoIPcloud PBX call events. Authenticates itself: the business is keyed by
+    // the unguessable token in the path, and the configured shared secret is
+    // checked against the X-Pbx-Token header.
+    pathname.startsWith("/api/webhooks/voipcloud/") ||
     (isBearerAuthRoute && hasBearer) ||
     (pathname.startsWith("/api/pdf/") && new URL(request.url).searchParams.get("token") !== null);
 

--- a/src/lib/telephony/ingest.ts
+++ b/src/lib/telephony/ingest.ts
@@ -1,0 +1,257 @@
+/**
+ * VoIPcloud webhook ingest — turns a PBX call event into a Kirei call record,
+ * matched to whoever was on the other end, plus the follow-up automations.
+ *
+ * One real-world call fires several events (ringing → answered → completion,
+ * then possibly a recording event), and they can arrive out of order or be
+ * retried. So every event UPSERTS the same row keyed on the PBX's
+ * `unique_call_id`, and each stage only widens what we know — a late "ringing"
+ * event can never downgrade a call that already completed.
+ *
+ * Server-only: runs as the admin client from an unauthenticated webhook, so
+ * every write is explicitly scoped by business_id.
+ */
+import { matchKey } from "./phone";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SB = any;
+
+/** The subset of the payload we rely on. Everything is kept in `raw` too. */
+export interface VoipEvent {
+  type?: string;
+  unique_call_id?: string;
+  caller_id?: string;
+  caller_name?: string;
+  user_name?: string;
+  user_number?: string;
+  dest_number?: string;
+  call_start_at?: string;
+  duration?: number | string;
+  recording_url?: string;
+  [k: string]: unknown;
+}
+
+export type CallDirection = "inbound" | "outbound";
+export type CallStatus = "ringing" | "answered" | "completed" | "missed" | "voicemail" | "failed";
+
+/**
+ * Classify an event from its `type`.
+ *
+ * VoIPcloud's docs name the 11 triggers in prose ("User inbound call
+ * answered") but don't pin the exact wire strings, so this matches on
+ * substrings rather than an equality table. An unrecognised type still logs
+ * the call — it just doesn't advance the status.
+ */
+export function classify(type: string | undefined): { direction: CallDirection; stage: CallStatus | "recording" | null } {
+  const t = String(type ?? "").toLowerCase();
+  const direction: CallDirection = t.includes("outbound") ? "outbound" : "inbound";
+
+  if (t.includes("voicemail")) return { direction, stage: "voicemail" };
+  if (t.includes("recording")) return { direction, stage: "recording" };
+  if (t.includes("answer")) return { direction, stage: "answered" };
+  if (t.includes("completion") || t.includes("summary") || t.includes("complete")) {
+    return { direction, stage: "completed" };
+  }
+  if (t.includes("call")) return { direction, stage: "ringing" };
+  return { direction, stage: null };
+}
+
+/** Rank so a late-arriving earlier event can't undo a later one. */
+const RANK: Record<CallStatus, number> = {
+  ringing: 0, answered: 1, voicemail: 2, missed: 2, completed: 3, failed: 3,
+};
+
+/** The FK columns a match can set — exactly the shape written to `calls`. */
+export interface MatchIds {
+  customer_id?: string; contact_id?: string; lead_id?: string; prospect_id?: string;
+}
+
+/** A match plus a human label for display. `label` is NOT a column on calls. */
+export interface MatchResult extends MatchIds {
+  label?: string;
+}
+
+/** Drop the display-only fields so the rest can be spread into a row. */
+export function matchIds(m: MatchResult): MatchIds {
+  const { customer_id, contact_id, lead_id, prospect_id } = m;
+  return { customer_id, contact_id, lead_id, prospect_id };
+}
+
+/**
+ * Resolve a number to a known party. Priority is deliberate: a customer beats
+ * a lead beats a prospect, because the most-qualified relationship is the one
+ * the user wants to see when the phone rings.
+ */
+export async function matchNumber(sb: SB, businessId: string, number: string | null | undefined): Promise<MatchResult> {
+  const key = matchKey(number);
+  if (!key) return {};
+
+  const lookups: [string, keyof MatchResult, string][] = [
+    ["customers", "customer_id", "name"],
+    ["contacts", "contact_id", "name"],
+    ["leads", "lead_id", "name"],
+    ["prospects", "prospect_id", "company"],
+  ];
+
+  for (const [table, field, labelCol] of lookups) {
+    const { data } = await sb.from(table)
+      .select(`id, ${labelCol}`)
+      .eq("business_id", businessId).eq("phone_digits", key)
+      .limit(1).maybeSingle();
+    if (data?.id) return { [field]: data.id, label: data[labelCol] ?? undefined } as MatchResult;
+  }
+  return {};
+}
+
+export interface IngestResult {
+  call_id: string | null;
+  status: CallStatus | null;
+  matched: string | null;
+  created_lead: boolean;
+  created_task: boolean;
+}
+
+/** Handle one webhook event end to end. */
+export async function ingestCallEvent(
+  sb: SB, businessId: string, event: VoipEvent,
+): Promise<IngestResult> {
+  const out: IngestResult = { call_id: null, status: null, matched: null, created_lead: false, created_task: false };
+
+  const { data: settings } = await sb.from("telephony_settings").select("*")
+    .eq("business_id", businessId).maybeSingle();
+  if (!settings?.enabled || !settings.log_calls) return out;
+
+  const { direction, stage } = classify(event.type);
+  const externalId = event.unique_call_id ? String(event.unique_call_id) : null;
+
+  // On an inbound call the outside party is the caller; on an outbound one
+  // it's the number we dialled.
+  const counterparty = direction === "inbound"
+    ? (event.caller_id ?? null)
+    : (event.dest_number ?? event.caller_id ?? null);
+
+  const existing = externalId
+    ? (await sb.from("calls").select("*").eq("business_id", businessId).eq("external_id", externalId).maybeSingle()).data
+    : null;
+
+  // Never regress: a retried "ringing" must not overwrite "completed".
+  const priorRank = existing ? RANK[existing.status as CallStatus] ?? -1 : -1;
+  let status: CallStatus = (existing?.status as CallStatus) ?? "ringing";
+  if (stage && stage !== "recording" && (RANK[stage] ?? -1) >= priorRank) status = stage;
+
+  // A completed inbound call that was never answered is a MISSED call — the
+  // single most valuable signal here, since a missed call is a lost job.
+  const durationRaw = event.duration;
+  const duration = durationRaw === undefined || durationRaw === null || durationRaw === ""
+    ? null : Number(durationRaw);
+  const everAnswered = Boolean(existing?.answered_at) || stage === "answered";
+  if (status === "completed" && direction === "inbound" && !everAnswered) status = "missed";
+
+  const match = existing?.customer_id || existing?.lead_id || existing?.contact_id || existing?.prospect_id
+    ? {
+        customer_id: existing.customer_id ?? undefined, contact_id: existing.contact_id ?? undefined,
+        lead_id: existing.lead_id ?? undefined, prospect_id: existing.prospect_id ?? undefined,
+      }
+    : matchIds(await matchNumber(sb, businessId, counterparty));
+
+  const now = new Date().toISOString();
+  const row: Record<string, unknown> = {
+    business_id: businessId,
+    provider: "voipcloud",
+    external_id: externalId,
+    direction,
+    status,
+    from_number: direction === "inbound" ? (event.caller_id ?? null) : (event.user_number ?? null),
+    to_number: direction === "inbound" ? (event.user_number ?? null) : (event.dest_number ?? null),
+    counterparty_digits: matchKey(counterparty) || null,
+    caller_name: event.caller_name ?? null,
+    user_name: event.user_name ?? null,
+    user_number: event.user_number ?? null,
+    started_at: existing?.started_at ?? (event.call_start_at ? new Date(event.call_start_at).toISOString() : now),
+    updated_at: now,
+    raw: { ...(existing?.raw ?? {}), [String(event.type ?? "event")]: event },
+    ...match,
+  };
+  if (stage === "answered") row.answered_at = existing?.answered_at ?? now;
+  if (status === "completed" || status === "missed") row.ended_at = existing?.ended_at ?? now;
+  if (duration !== null && Number.isFinite(duration)) row.duration_seconds = Math.round(duration);
+  if (stage === "recording" && event.recording_url) row.recording_url = String(event.recording_url);
+
+  let callId = existing?.id ?? null;
+  if (existing) {
+    await sb.from("calls").update(row).eq("id", existing.id);
+  } else {
+    const { data: created, error } = await sb.from("calls").insert(row).select("id").single();
+    if (error) {
+      // A concurrent event for the same call raced us to the unique index —
+      // re-read and update instead of dropping the event.
+      const { data: again } = await sb.from("calls").select("id")
+        .eq("business_id", businessId).eq("external_id", externalId).maybeSingle();
+      if (!again?.id) throw error;
+      callId = again.id;
+      await sb.from("calls").update(row).eq("id", again.id);
+    } else {
+      callId = created.id;
+    }
+  }
+
+  out.call_id = callId;
+  out.status = status;
+  out.matched = match.customer_id ? "customer" : match.contact_id ? "contact"
+    : match.lead_id ? "lead" : match.prospect_id ? "prospect" : null;
+
+  // ── Automations, only at the moment the call actually ends ────────────────
+  const terminal = status === "missed" || status === "voicemail";
+  if (!terminal || !callId) return out;
+
+  const fresh = (await sb.from("calls").select("created_lead_id, created_task_id").eq("id", callId).maybeSingle()).data;
+  const patch: Record<string, unknown> = {};
+
+  // Unknown number that rang out → a lead, so it can be worked rather than lost.
+  // upsert_lead is the single ingest entry point everywhere else (it owns the
+  // identity_key dedupe), so a repeat caller merges instead of duplicating.
+  if (settings.create_lead_on_missed && !out.matched && !fresh?.created_lead_id && counterparty) {
+    try {
+      const { data: lead } = await sb.rpc("upsert_lead", {
+        p_business_id: businessId,
+        p_user_id: null,
+        p_name: event.caller_name || `Missed call ${counterparty}`,
+        p_email: null,
+        p_phone: counterparty,
+        p_address: null,
+        p_suburb: null,
+        p_service: null,
+        p_property_type: null,
+        p_timing: null,
+        p_notes: `Missed ${direction} call${event.user_name ? ` to ${event.user_name}` : ""}.`,
+        p_source: "phone",
+        p_source_ref: externalId,
+      }).single();
+      const leadId = typeof lead === "string" ? lead : lead?.id;
+      if (leadId) { patch.created_lead_id = leadId; out.created_lead = true; }
+    } catch {
+      // A lead we couldn't create must not cost us the call log itself.
+    }
+  }
+
+  // Either way, someone should call them back.
+  const wantTask = status === "voicemail" ? settings.create_task_on_voicemail : settings.create_task_on_missed;
+  if (wantTask && !fresh?.created_task_id) {
+    const who = out.matched ?? "unknown number";
+    const { data: task } = await sb.from("tasks").insert({
+      business_id: businessId,
+      title: status === "voicemail"
+        ? `Voicemail from ${event.caller_name || counterparty || "unknown"}`
+        : `Call back ${event.caller_name || counterparty || "unknown"}`,
+      description: `${status === "voicemail" ? "Voicemail left" : "Missed call"} at `
+        + `${new Date(String(row.started_at)).toLocaleString("en-AU")} (${who}).`,
+      status: "todo",
+      related_customer_id: match.customer_id ?? null,
+      related_contact_id: match.contact_id ?? null,
+    }).select("id").single();
+    if (task?.id) { patch.created_task_id = task.id; out.created_task = true; }
+  }
+
+  if (Object.keys(patch).length) await sb.from("calls").update(patch).eq("id", callId);
+  return out;
+}

--- a/src/lib/telephony/phone.ts
+++ b/src/lib/telephony/phone.ts
@@ -1,0 +1,54 @@
+/**
+ * Phone-number normalisation for caller-ID matching.
+ *
+ * Caller ID arrives in whatever shape the carrier feels like — +61412345678,
+ * 0412345678, 61412345678, "(02) 9876 5432" — while the number stored against
+ * a customer is whatever someone typed into a form. Comparing the LAST 9
+ * DIGITS collapses all of those to the same key, because 9 digits is the
+ * Australian national significant number: the part after the country code or
+ * the trunk 0.
+ *
+ *   +61 412 345 678  → 412345678
+ *   0412 345 678     → 412345678
+ *   (02) 9876 5432   → 298765432
+ *
+ * The same expression is a STORED generated column (`phone_digits`) on
+ * customers / contacts / leads / prospects, so matching is an indexed equality
+ * lookup rather than a wildcard scan. Keep the two in step: if you change the
+ * rule here, change migration 20260804090000 too.
+ *
+ * Plain module — no server-only imports, so the UI can normalise for display.
+ */
+
+/** Digits only, no formatting. */
+export function digitsOf(raw: string | null | undefined): string {
+  return String(raw ?? "").replace(/\D/g, "");
+}
+
+/**
+ * The match key: last 9 digits, or "" when there aren't enough to be a real
+ * number. Short internal extensions (3-4 digits) deliberately return "" —
+ * matching on them would collide across unrelated records.
+ */
+export function matchKey(raw: string | null | undefined): string {
+  const d = digitsOf(raw);
+  if (d.length < 6) return "";
+  return d.slice(-9);
+}
+
+/** Pretty AU formatting for display; falls back to the input if unrecognised. */
+export function formatAuPhone(raw: string | null | undefined): string {
+  const d = digitsOf(raw);
+  const nsn = d.length >= 9 ? d.slice(-9) : d;
+  if (nsn.length !== 9) return String(raw ?? "");
+  // Mobiles start 4; landlines are area code + 8 digits.
+  return nsn.startsWith("4")
+    ? `0${nsn.slice(0, 3)} ${nsn.slice(3, 6)} ${nsn.slice(6)}`
+    : `(0${nsn.slice(0, 1)}) ${nsn.slice(1, 5)} ${nsn.slice(5)}`;
+}
+
+/** True when two numbers are the same line, whatever format each is in. */
+export function samePhone(a: string | null | undefined, b: string | null | undefined): boolean {
+  const ka = matchKey(a);
+  return ka !== "" && ka === matchKey(b);
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1651,6 +1651,8 @@ export type ApiScope =
   | 'assets:write'
   | 'prospects:read'
   | 'prospects:write'
+  | 'telephony:read'
+  | 'telephony:write'
   | 'outreach:read'
   | 'outreach:write'
   | 'attachments:read'
@@ -1703,6 +1705,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'assets:write',     label: 'Manage assets & equipment', group: 'Assets' },
   { value: 'prospects:read',   label: 'Read prospects', group: 'Prospects' },
   { value: 'prospects:write',  label: 'Create / edit / import prospects', group: 'Prospects' },
+  { value: 'telephony:read',  label: 'Read call logs & telephony settings', group: 'Telephony' },
+  { value: 'telephony:write', label: 'Manage telephony & call records', group: 'Telephony' },
   { value: 'outreach:read',    label: 'Read outreach sequences, campaigns & tracking', group: 'Outreach' },
   { value: 'outreach:write',   label: 'Manage outreach & send cold email', group: 'Outreach' },
   { value: 'attachments:read', label: 'Read file attachments', group: 'Attachments' },
@@ -2104,4 +2108,62 @@ export interface OutreachMessage {
   status: OutreachMessageStatus; error: string | null;
   sent_at: string; delivered_at: string | null; opened_at: string | null;
   clicked_at: string | null; bounced_at: string | null; replied_at: string | null;
+}
+
+// ── Telephony (VoIPcloud PBX plugin) ────────────────────────────────────────
+export type CallDirection = 'inbound' | 'outbound';
+export type CallStatus = 'ringing' | 'answered' | 'completed' | 'missed' | 'voicemail' | 'failed';
+
+export interface TelephonySettings {
+  business_id: string;
+  enabled: boolean;
+  provider: string;
+  /** Identifies the business in the webhook URL. Unguessable, rotatable. */
+  webhook_token: string;
+  /** Shared secret VoIPcloud returns as the X-Pbx-Token header. */
+  webhook_secret: string | null;
+  api_key_enc: string | null;
+  api_base_url: string | null;
+  log_calls: boolean;
+  create_lead_on_missed: boolean;
+  create_task_on_missed: boolean;
+  create_task_on_voicemail: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Call {
+  id: string;
+  business_id: string;
+  provider: string;
+  /** The PBX's unique_call_id — collapses a call's several events into one row. */
+  external_id: string | null;
+  direction: CallDirection;
+  status: CallStatus;
+  from_number: string | null;
+  to_number: string | null;
+  counterparty_digits: string | null;
+  caller_name: string | null;
+  user_name: string | null;
+  user_number: string | null;
+  started_at: string;
+  answered_at: string | null;
+  ended_at: string | null;
+  duration_seconds: number | null;
+  recording_url: string | null;
+  customer_id: string | null;
+  contact_id: string | null;
+  lead_id: string | null;
+  prospect_id: string | null;
+  created_lead_id: string | null;
+  created_task_id: string | null;
+  notes: string | null;
+  raw: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+  /** Joined labels from listCalls. */
+  customers?: { name: string } | null;
+  leads?: { name: string } | null;
+  contacts?: { name: string } | null;
+  prospects?: { company: string | null } | null;
 }

--- a/supabase/migrations/20260804090000_telephony.sql
+++ b/supabase/migrations/20260804090000_telephony.sql
@@ -1,0 +1,138 @@
+-- Telephony plugin — VoIPcloud hosted PBX integration.
+--
+-- Their PBX pushes call events to a webhook; we log every call, match it to a
+-- customer / contact / lead / prospect by caller ID, and can turn a missed call
+-- or voicemail into a lead or task. Additive, plugin defaults OFF.
+--
+-- Multi-tenancy: a webhook arrives with no session, so the business is
+-- identified by an unguessable token in the URL path (the same shape the
+-- customer portal already uses), and the shared secret they configure is
+-- verified from the X-Pbx-Token header.
+
+-- ── Phone matching ──────────────────────────────────────────────────────────
+-- Caller ID arrives as +61412345678, 0412345678, 61412345678 or "(02) 9876
+-- 5432" depending on the carrier, while stored numbers are whatever the user
+-- typed. Comparing the LAST 9 DIGITS collapses every one of those forms to the
+-- same key (the AU national significant number), and unlike a LIKE '%...'
+-- scan it's an equality match a btree index can serve.
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['customers','contacts','leads','prospects'] LOOP
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS phone_digits TEXT
+         GENERATED ALWAYS AS (right(regexp_replace(coalesce(phone,''''), ''\D'', '''', ''g''), 9)) STORED', t);
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS idx_%s_phone_digits ON public.%I (business_id, phone_digits)
+         WHERE phone_digits <> ''''', t, t);
+  END LOOP;
+END $$;
+
+-- ── Per-business settings ───────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.telephony_settings (
+  business_id       UUID PRIMARY KEY REFERENCES public.businesses(id) ON DELETE CASCADE,
+  enabled           BOOLEAN NOT NULL DEFAULT FALSE,
+  provider          TEXT NOT NULL DEFAULT 'voipcloud',
+  -- Identifies the business in the webhook URL. Unguessable, rotatable.
+  webhook_token     TEXT NOT NULL DEFAULT replace(gen_random_uuid()::text, '-', ''),
+  -- The value they type into VoIPcloud's "Secret Token" field; arrives as
+  -- X-Pbx-Token on every request.
+  webhook_secret    TEXT,
+  api_key_enc       TEXT,                       -- encrypted (src/lib/crypto.ts)
+  api_base_url      TEXT,
+  -- What to do automatically
+  log_calls         BOOLEAN NOT NULL DEFAULT TRUE,
+  create_lead_on_missed   BOOLEAN NOT NULL DEFAULT FALSE,
+  create_task_on_missed   BOOLEAN NOT NULL DEFAULT TRUE,
+  create_task_on_voicemail BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_telephony_settings_token
+  ON public.telephony_settings (webhook_token);
+
+-- ── Call log ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.calls (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  provider      TEXT NOT NULL DEFAULT 'voipcloud',
+  -- The PBX's unique_call_id. One call fires several events (ringing →
+  -- answered → completed), so this is what collapses them into one row.
+  external_id   TEXT,
+  direction     TEXT NOT NULL DEFAULT 'inbound' CHECK (direction IN ('inbound','outbound')),
+  status        TEXT NOT NULL DEFAULT 'ringing'
+                CHECK (status IN ('ringing','answered','completed','missed','voicemail','failed')),
+  from_number   TEXT,
+  to_number     TEXT,
+  -- Normalised match key for whichever party is the outside line.
+  counterparty_digits TEXT,
+  caller_name   TEXT,
+  user_name     TEXT,                            -- the extension/user involved
+  user_number   TEXT,
+  started_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  answered_at   TIMESTAMPTZ,
+  ended_at      TIMESTAMPTZ,
+  duration_seconds INT,
+  recording_url TEXT,
+  -- Whoever the caller ID resolved to (at most one is set).
+  customer_id   UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+  contact_id    UUID REFERENCES public.contacts(id)  ON DELETE SET NULL,
+  lead_id       UUID REFERENCES public.leads(id)     ON DELETE SET NULL,
+  prospect_id   UUID REFERENCES public.prospects(id) ON DELETE SET NULL,
+  -- What the automations produced, so we never double-create on a repeat event.
+  created_lead_id UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  created_task_id UUID REFERENCES public.tasks(id) ON DELETE SET NULL,
+  notes         TEXT,
+  raw           JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One row per real-world call. Events arrive out of order and can be retried,
+-- so the ingest upserts on this rather than trusting arrival order.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_calls_biz_external
+  ON public.calls (business_id, external_id) WHERE external_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_calls_biz_started ON public.calls (business_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_calls_biz_customer ON public.calls (business_id, customer_id)
+  WHERE customer_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_calls_biz_status ON public.calls (business_id, status);
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+ALTER TABLE public.telephony_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.calls ENABLE ROW LEVEL SECURITY;
+
+-- Members can read; only owner/admin/editor can write. Workers are excluded —
+-- call logs expose customer contact details they're not entitled to.
+DROP POLICY IF EXISTS telephony_settings_read ON public.telephony_settings;
+CREATE POLICY telephony_settings_read ON public.telephony_settings FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status = 'active' AND role <> 'worker'
+  )
+);
+DROP POLICY IF EXISTS telephony_settings_write ON public.telephony_settings;
+CREATE POLICY telephony_settings_write ON public.telephony_settings FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status = 'active' AND role IN ('admin','editor')
+  )
+);
+
+DROP POLICY IF EXISTS calls_read ON public.calls;
+CREATE POLICY calls_read ON public.calls FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status = 'active' AND role <> 'worker'
+  )
+);
+DROP POLICY IF EXISTS calls_write ON public.calls;
+CREATE POLICY calls_write ON public.calls FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status = 'active' AND role IN ('admin','editor')
+  )
+);


### PR DESCRIPTION
Integrates [VoIPcloud](https://au.voipcloud.online/) as a Kirei plugin. Their PBX pushes call events to a webhook; we log every call, match it to a customer / contact / lead / prospect by caller ID, and turn a missed call or voicemail into a follow-up. **Default OFF**, route-gated `/calls`.

## Caller-ID matching is the crux

The PBX sends `+61412345678`. The customer record says `0412 345 678`. Same line, two strings — and if that doesn't reconcile, nothing else in this plugin is worth having.

Comparing the **last 9 digits** (the AU national significant number) collapses every format to one key:

| Arrives as | Key |
|---|---|
| `+61 412 345 678` | `412345678` |
| `0412345678` | `412345678` |
| `(02) 9876 5432` | `298765432` |

It's a **STORED generated column** with an index on customers / contacts / leads / prospects, so matching is an indexed equality lookup, not a wildcard scan. `phone.ts` and migration `20260804090000` implement the same rule and must stay in step — there's a comment on both saying so. Extensions under 6 digits deliberately never match, since a 3-digit extension would collide across unrelated records.

## One call, many events

A single call fires ringing → answered → completion, plus maybe a recording — out of order and retryable. Every event **upserts one row** keyed on the PBX's `unique_call_id`, and a rank ordering means a late `ringing` can never downgrade a call that already completed.

A completed inbound call that was **never answered becomes `missed`** — the signal this whole plugin exists for.

## Multi-tenancy and auth

The webhook has no session, so the business is keyed by an **unguessable token in the URL path** (the pattern the customer portal already uses), and the shared secret is checked against `X-Pbx-Token` with a **constant-time compare**. An unknown token and a disabled plugin return the *same* 404, so the endpoint can't be used to enumerate which tokens are live. The token is rotatable from the UI.

## Automations, deliberately conservative

| | Default | Why |
|---|---|---|
| Task on missed call | **ON** | the point of the integration |
| Task on voicemail | **ON** | so a message can't sit unheard |
| Lead from unknown number | **OFF** | it would add a lead for every wrong number and cold caller |

Lead creation goes through `upsert_lead`, so a repeat caller merges rather than duplicating.

## Verified end to end — not just unit-tested

Ran real events against the demo business through the actual route:

- `+61`-format call **matched a customer stored in `0`-format** ✅
- two events collapsed to **one row** ✅
- unanswered completion became **`missed`** ✅
- replayed `ringing` **did not downgrade** it ✅
- unknown number logged **unmatched** ✅
- bad token → **404**, wrong secret → **401** ✅

**That run caught a bug the unit tests missed**: the display-only `label` from `matchNumber` was being spread into the insert, so every ingest failed with `Could not find the 'label' column`. Fixed with a `matchIds()` split. All test data was deleted afterwards.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 12 new tests ✅

## Not included: click-to-call

VoIPcloud's REST API reference sits behind their support login (403), so whether **call origination** exists is unconfirmed. I've left the encrypted API-key field and column in place for when it is. Same for **recording playback** — the webhook fires a recording event but the documented payload carries no URL.

Worth confirming with your account: whether the API supports origination, and whether recording URLs are retrievable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)