### PR TITLE
fix(telephony): restrict the portal address to voipcloud.online

### DIFF
--- a/src/components/telephony/calls-client.tsx
+++ b/src/components/telephony/calls-client.tsx
@@ -303,8 +303,8 @@ export function CallsClient({
                     catch (err) { toast.error(err instanceof Error ? err.message : "Invalid endpoint"); }
                   }} />
                 <p className="mt-1 text-xs text-muted-foreground">
-                  Only change this if your provider gave you a different portal — resellers run their own branded
-                  addresses. The default suits most Australian accounts.
+                  Your VoIPcloud regional portal. Only change this if yours differs (uk, nz, …) — addresses outside
+                  voipcloud.online are rejected, since this plugin connects to VoIPcloud only.
                 </p>
               </div>
 

--- a/src/lib/__tests__/telephony.test.ts
+++ b/src/lib/__tests__/telephony.test.ts
@@ -173,28 +173,34 @@ describe("E.164 for click-to-call", () => {
   });
 });
 
-describe("per-business endpoint (multi-tenant SaaS)", () => {
-  it("accepts a reseller's own branded portal", () => {
-    // VoIPcloud is white-label — the host can't be hardcoded.
+describe("per-business endpoint — VoIPcloud domains only", () => {
+  it("accepts VoIPcloud regional portals", () => {
     expect(assertSafeBaseUrl("https://au.voipcloud.online")).toBe("https://au.voipcloud.online");
-    expect(assertSafeBaseUrl("https://pbx.somereseller.com.au/")).toBe("https://pbx.somereseller.com.au");
     expect(assertSafeBaseUrl("  https://uk.voipcloud.online/api  ")).toBe("https://uk.voipcloud.online");
+    expect(assertSafeBaseUrl("https://voipcloud.online")).toBe("https://voipcloud.online");
   });
 
-  it("blocks SSRF into our own infrastructure", () => {
-    // A tenant-supplied URL that OUR server fetches is an SSRF vector: the
+  it("blocks SSRF outright — the allow-list removes the whole class", () => {
+    // A tenant-controlled URL fetched by OUR server is an SSRF vector; the
     // cloud metadata endpoint is the classic target.
-    expect(() => assertSafeBaseUrl("https://169.254.169.254")).toThrow(/hostname, not an IP/);
-    expect(() => assertSafeBaseUrl("https://127.0.0.1")).toThrow(/hostname, not an IP/);
-    expect(() => assertSafeBaseUrl("https://10.0.0.5")).toThrow(/hostname, not an IP/);
-    expect(() => assertSafeBaseUrl("https://localhost")).toThrow(/reachable/);
-    expect(() => assertSafeBaseUrl("https://vault.internal")).toThrow(/reachable/);
+    expect(() => assertSafeBaseUrl("https://169.254.169.254")).toThrow(/VoIPcloud only/);
+    expect(() => assertSafeBaseUrl("https://127.0.0.1")).toThrow(/VoIPcloud only/);
+    expect(() => assertSafeBaseUrl("https://10.0.0.5")).toThrow(/VoIPcloud only/);
+    expect(() => assertSafeBaseUrl("https://localhost")).toThrow(/VoIPcloud only/);
+    expect(() => assertSafeBaseUrl("https://vault.internal")).toThrow(/VoIPcloud only/);
+  });
+
+  it("is not fooled by lookalike domains", () => {
+    // The two classic bypasses for a naive "contains" or "endsWith" check.
+    expect(() => assertSafeBaseUrl("https://voipcloud.online.evil.com")).toThrow(/VoIPcloud only/);
+    expect(() => assertSafeBaseUrl("https://notvoipcloud.online")).toThrow(/VoIPcloud only/);
+    expect(() => assertSafeBaseUrl("https://evil.com/?x=voipcloud.online")).toThrow(/VoIPcloud only/);
   });
 
   it("requires https on the default port", () => {
     expect(() => assertSafeBaseUrl("http://au.voipcloud.online")).toThrow(/https/);
-    expect(() => assertSafeBaseUrl("file:///etc/passwd")).toThrow(/https/);
     expect(() => assertSafeBaseUrl("https://au.voipcloud.online:8080")).toThrow(/default https port/);
+    expect(() => assertSafeBaseUrl("file:///etc/passwd")).toThrow(/https/);
   });
 
   it("rejects nonsense rather than silently defaulting", () => {

--- a/src/lib/telephony/api.ts
+++ b/src/lib/telephony/api.ts
@@ -210,20 +210,23 @@ export function groupCallToEvent(row: GroupCallRow, kind: "queue" | "ringgroup")
 /**
  * Validate a business-supplied API endpoint.
  *
- * VoIPcloud is white-label: resellers run their own branded portals, so the
- * host can't be hardcoded. But a URL one tenant controls, fetched by OUR
- * server, is a server-side request forgery vector — point it at an internal
- * address and Kirei becomes a proxy into its own infrastructure. So:
+ * This plugin is VoIPcloud-only by design, so the host is restricted to
+ * VoIPcloud's own domains. That is both a scope decision and the strongest
+ * available defence: a URL one tenant controls, fetched by OUR server, is a
+ * server-side request forgery vector — an open field would let a tenant point
+ * Kirei at cloud metadata (169.254.169.254) or anything else inside our
+ * network. An allow-list removes that class of attack outright rather than
+ * trying to enumerate the bad destinations, and it closes off DNS rebinding
+ * too, since the resolved address no longer matters.
  *
- *   · https only (their portals are, and it stops h2c/file/gopher tricks)
- *   · no IP literals — a real portal is a hostname, and this is what kills
- *     the cloud-metadata endpoint (169.254.169.254) and private ranges
- *   · no loopback or internal-only names
- *   · default port only
- *
- * Residual risk: DNS rebinding to a private address needs attacker-controlled
- * DNS. Worth an egress allow-list if this ever becomes a concern.
+ * Regional portals (au / uk / nz / …) all live under voipcloud.online, so this
+ * costs nothing for a genuine VoIPcloud account. A white-label reseller on its
+ * own branded domain would be rejected — deliberately: supporting those means
+ * reopening a tenant-controlled fetch, which is a decision to make on purpose,
+ * not by accident.
  */
+export const VOIP_ALLOWED_DOMAIN = "voipcloud.online";
+
 export function assertSafeBaseUrl(raw: string): string {
   let u: URL;
   try {
@@ -236,11 +239,13 @@ export function assertSafeBaseUrl(raw: string): string {
   if (u.port && u.port !== "443") throw new Error("Use the default https port");
 
   const host = u.hostname.toLowerCase();
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(":")) {
-    throw new Error("Enter the portal's hostname, not an IP address");
-  }
-  if (host === "localhost" || host.endsWith(".local") || host.endsWith(".internal") || !host.includes(".")) {
-    throw new Error("That host isn't reachable from the internet");
+  // Exact domain or a subdomain of it — never a lookalike like
+  // "voipcloud.online.evil.com" or "notvoipcloud.online".
+  const ok = host === VOIP_ALLOWED_DOMAIN || host.endsWith(`.${VOIP_ALLOWED_DOMAIN}`);
+  if (!ok) {
+    throw new Error(
+      `This plugin connects to VoIPcloud only, so the address must be on ${VOIP_ALLOWED_DOMAIN} — for example https://au.${VOIP_ALLOWED_DOMAIN}`,
+    );
   }
 
   return u.origin;


### PR DESCRIPTION
You asked to keep this plugin VoIPcloud-only. It already was everywhere else — hardcoded provider, VoIPcloud-specific naming, no abstraction layer — so nothing needed undoing. The one place it wasn't was the portal address field, which accepted any real hostname.

## Why this is more than a scope change

A URL **one tenant controls**, fetched by **our** server, is a server-side request forgery vector. An open field lets a tenant point Kirei at cloud metadata (`169.254.169.254`) or anything else reachable from inside our network.

The previous guard enumerated bad destinations (no IP literals, no loopback, no internal names). An **allow-list removes the class outright** — and it also closes DNS rebinding, since the resolved address stops mattering.

## Cost

Regional portals (`au` / `uk` / `nz` / …) all live under `voipcloud.online`, so a genuine account is unaffected.

A **white-label reseller on its own branded domain is now rejected** — deliberately. Supporting one means reopening a tenant-controlled fetch, and that should be a decision made on purpose rather than inherited by accident.

## Bypass-resistant

Matching is exact-domain-or-subdomain, so the two classic tricks against a naive `includes`/`endsWith` both fail and are tested:

- `voipcloud.online.evil.com` ❌
- `notvoipcloud.online` ❌

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · **25 tests** ✅ (SSRF targets, lookalikes, scheme/port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)