### PR TITLE
feat(telephony): call drawer, screen pop, and create-customer-from-a-call

### DIFF
--- a/src/components/telephony/call-drawer.tsx
+++ b/src/components/telephony/call-drawer.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, Phone, UserPlus } from "@/components/ui/icons";
+import { getCallContext, setCallNotes, createCustomerFromCall, placeCall } from "@/lib/actions/telephony";
+import { formatAuPhone } from "@/lib/telephony/phone";
+import type { CallContext } from "@/lib/actions/telephony";
+
+const money = (n: unknown) => `$${(Number(n) || 0).toFixed(2)}`;
+
+/**
+ * Everything about one call: who it was, what's already open for them, their
+ * recent call history, and a place to write down what was said.
+ *
+ * This is the "screen pop" surface — the equivalent of what a CTI integration
+ * gives you, but pointed at Kirei's own jobs, quotes and invoices rather than
+ * a second system's tickets.
+ */
+export function CallDrawer({ callId, onClose }: { callId: string | null; onClose: () => void }) {
+  const router = useRouter();
+  const [ctx, setCtx] = useState<CallContext | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+
+  useEffect(() => {
+    if (!callId) { setCtx(null); return; }
+    let cancelled = false;
+    setLoading(true);
+    getCallContext(callId)
+      .then((c) => {
+        if (cancelled) return;
+        setCtx(c);
+        setNotes(c.call.notes ?? "");
+        setNewName(c.call.caller_name ?? "");
+      })
+      .catch((e) => toast.error(e instanceof Error ? e.message : "Couldn't load call"))
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [callId]);
+
+  const other = ctx?.call
+    ? (ctx.call.direction === "inbound" ? ctx.call.from_number : ctx.call.to_number)
+    : null;
+
+  return (
+    <Sheet open={Boolean(callId)} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>{ctx?.party?.name ?? ctx?.call.caller_name ?? "Call"}</SheetTitle>
+        </SheetHeader>
+
+        {loading && <p className="mt-6 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </p>}
+
+        {ctx && (
+          <div className="mt-5 space-y-5">
+            {/* Who + how to reach them */}
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-semibold break-words">
+                    {ctx.party
+                      ? <Link href={`/${ctx.party.kind === "customer" ? "customers" : ctx.party.kind === "lead" ? "leads" : "contacts"}/${ctx.party.id}`}
+                          className="hover:underline">{ctx.party.name}</Link>
+                      : <span className="text-muted-foreground">Unknown number</span>}
+                  </p>
+                  <p className="ch-mono text-sm text-muted-foreground">{formatAuPhone(other)}</p>
+                  {ctx.party?.email && <p className="text-sm text-muted-foreground break-words">{ctx.party.email}</p>}
+                  {ctx.party?.company && <p className="text-sm text-muted-foreground">{ctx.party.company}</p>}
+                </div>
+                {ctx.party && <span className="ch-pill draft capitalize">{ctx.party.kind}</span>}
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button size="sm" variant="outline" onClick={async () => {
+                  try { await placeCall(other ?? ""); toast.success("Calling — your handset will ring first"); }
+                  catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't place the call"); }
+                }}>
+                  <Phone className="mr-1.5 h-3.5 w-3.5" /> Call back
+                </Button>
+              </div>
+
+              <p className="mt-3 text-xs text-muted-foreground">
+                {ctx.call.direction} · {ctx.call.status} ·{" "}
+                {new Date(ctx.call.started_at).toLocaleString("en-AU")}
+                {ctx.call.duration_seconds ? ` · ${ctx.call.duration_seconds}s` : ""}
+                {ctx.call.user_name ? ` · handled by ${ctx.call.user_name}` : ""}
+              </p>
+            </div>
+
+            {/* Unknown caller → make them a customer, and adopt their history */}
+            {!ctx.party && (
+              <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
+                <p className="text-sm font-semibold">Not on file</p>
+                <p className="mb-3 text-xs text-muted-foreground">
+                  Save them as a customer — every past call from this number links up too.
+                </p>
+                <div className="space-y-2">
+                  <div>
+                    <Label htmlFor="cname">Name</Label>
+                    <Input id="cname" value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Their name" />
+                  </div>
+                  <div>
+                    <Label htmlFor="cemail">Email (optional)</Label>
+                    <Input id="cemail" type="email" value={newEmail} onChange={(e) => setNewEmail(e.target.value)} />
+                  </div>
+                  <Button size="sm" disabled={!newName.trim()} onClick={async () => {
+                    try {
+                      const r = await createCustomerFromCall(ctx.call.id, newName, newEmail);
+                      toast.success(r.linkedCalls > 1
+                        ? `Customer created — ${r.linkedCalls} calls linked`
+                        : "Customer created");
+                      onClose(); router.refresh();
+                    } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't create"); }
+                  }}>
+                    <UserPlus className="mr-1.5 h-3.5 w-3.5" /> Create customer
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* What's already open for them — the "active tickets" equivalent */}
+            {ctx.party?.kind === "customer" && (
+              <div className="rounded-xl border border-border bg-card p-4">
+                <p className="mb-2 text-sm font-semibold">Open for this customer</p>
+                {ctx.workOrders.length + ctx.quotes.length + ctx.invoices.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">Nothing open.</p>
+                ) : (
+                  <div className="space-y-1.5 text-sm">
+                    {ctx.workOrders.map((w) => (
+                      <Link key={w.id} href={`/work-orders/${w.id}`} className="flex justify-between gap-3 hover:underline">
+                        <span className="break-words">{w.title || w.number || "Job"}</span>
+                        <span className="shrink-0 text-xs text-muted-foreground">{w.status}</span>
+                      </Link>
+                    ))}
+                    {ctx.quotes.map((q) => (
+                      <Link key={q.id} href={`/quotes/${q.id}`} className="flex justify-between gap-3 hover:underline">
+                        <span>Quote {q.number ?? ""}</span>
+                        <span className="shrink-0 text-xs text-muted-foreground">{money(q.total)} · {q.status}</span>
+                      </Link>
+                    ))}
+                    {ctx.invoices.map((i) => (
+                      <Link key={i.id} href={`/invoices/${i.id}`} className="flex justify-between gap-3 hover:underline">
+                        <span>Invoice {i.number ?? ""}</span>
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          {money(Number(i.total) - Number(i.amount_paid))} owing
+                        </span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {ctx.recentCalls.length > 0 && (
+              <div className="rounded-xl border border-border bg-card p-4">
+                <p className="mb-2 text-sm font-semibold">Other calls from this number</p>
+                <div className="space-y-1 text-sm text-muted-foreground">
+                  {ctx.recentCalls.map((c) => (
+                    <p key={c.id}>
+                      {new Date(c.started_at).toLocaleDateString("en-AU")} · {c.direction} · {c.status}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Notes — the action existed from day one with nothing calling it */}
+            <div className="rounded-xl border border-border bg-card p-4">
+              <Label htmlFor="call-notes">What was discussed</Label>
+              <Textarea id="call-notes" rows={5} value={notes} onChange={(e) => setNotes(e.target.value)}
+                placeholder="Quoted the gutter repair, sending Thursday…" />
+              <Button size="sm" className="mt-2" disabled={saving} onClick={async () => {
+                setSaving(true);
+                try { await setCallNotes(ctx.call.id, notes); toast.success("Saved"); router.refresh(); }
+                catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't save"); }
+                finally { setSaving(false); }
+              }}>
+                {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />} Save notes
+              </Button>
+            </div>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/telephony/calls-client.tsx
+++ b/src/components/telephony/calls-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -18,6 +18,8 @@ import {
   setTelephonyApiKey, testTelephonyConnection, syncCallsNow, setTelephonyEndpoint,
 } from "@/lib/actions/telephony";
 import { formatAuPhone } from "@/lib/telephony/phone";
+import { CallDrawer } from "./call-drawer";
+import { createClient } from "@/lib/supabase/client";
 import type { CallStats } from "@/lib/actions/telephony";
 import type { TelephonySettings, Call } from "@/types/database";
 
@@ -61,6 +63,7 @@ export function CallsClient({
   const [busy, startTransition] = useTransition();
   const [syncing, setSyncing] = useState(false);
   const [apiKey, setApiKey] = useState("");
+  const [openCallId, setOpenCallId] = useState<string | null>(null);
 
   const save = (p: Partial<TelephonySettings>) => {
     setSettings((s) => ({ ...s, ...p }));
@@ -73,6 +76,34 @@ export function CallsClient({
       }
     });
   };
+
+  // Screen pop. A call log you have to refresh is a log; a call log that tells
+  // you who is ringing WHILE it rings is the point of a phone integration.
+  useEffect(() => {
+    if (!settings.enabled) return;
+    const sb = createClient();
+    const channel = sb
+      .channel("calls-live")
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "calls", filter: `business_id=eq.${settings.business_id}` },
+        (payload) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const c = payload.new as any;
+          // Only the moment it starts ringing — later stages of the same call
+          // would pop again for something you already answered.
+          if (c.direction !== "inbound" || c.status !== "ringing") return;
+          toast(c.caller_name ? `${c.caller_name} is calling` : "Incoming call", {
+            description: formatAuPhone(c.from_number),
+            action: { label: "Open", onClick: () => setOpenCallId(c.id) },
+            duration: 20000,
+          });
+          router.refresh();
+        },
+      )
+      .subscribe();
+    return () => { void sb.removeChannel(channel); };
+  }, [settings.enabled, settings.business_id, router]);
 
   const missed = calls.filter((c) => c.status === "missed" || c.status === "voicemail");
   const shown = tab === "missed" ? missed : calls;
@@ -157,7 +188,7 @@ export function CallsClient({
                   {shown.map((c) => {
                     const other = c.direction === "inbound" ? c.from_number : c.to_number;
                     return (
-                      <tr key={c.id}>
+                      <tr key={c.id} onClick={() => setOpenCallId(c.id)} className="cursor-pointer hover:bg-muted/40">
                         <td><Party call={c} /></td>
                         <td className="ch-mono">{formatAuPhone(other)}</td>
                         <td className="capitalize">{c.direction}</td>
@@ -185,6 +216,8 @@ export function CallsClient({
           )}
         </>
       )}
+
+      <CallDrawer callId={openCallId} onClose={() => setOpenCallId(null)} />
 
       {tab === "setup" && (
         <div className="space-y-4">

--- a/src/lib/actions/telephony.ts
+++ b/src/lib/actions/telephony.ts
@@ -224,3 +224,116 @@ export async function placeCall(numberToCall: string, userNumber?: string): Prom
     caller_id: data.default_caller_id || undefined,
   });
 }
+
+// ── Call context: who is this, and what's open for them ─────────────────────
+
+export interface CallContext {
+  call: Call;
+  party: { kind: "customer" | "contact" | "lead" | "prospect"; id: string; name: string;
+           email: string | null; phone: string | null; company: string | null } | null;
+  /** Open work for the matched customer — the "active tickets" equivalent. */
+  workOrders: { id: string; number: string | null; title: string | null; status: string }[];
+  quotes: { id: string; number: string | null; total: number; status: string }[];
+  invoices: { id: string; number: string | null; total: number; amount_paid: number; status: string }[];
+  recentCalls: { id: string; direction: string; status: string; started_at: string }[];
+}
+
+/**
+ * Everything worth knowing when the phone rings: who's calling and what's
+ * already open for them, so you answer informed rather than asking.
+ */
+export async function getCallContext(callId: string): Promise<CallContext> {
+  const { supabase, businessId } = await ctx();
+
+  const { data: call, error } = await tbl(supabase, "calls")
+    .select("*, customers(name,email,phone), leads(name,email,phone), contacts(name,email,phone), prospects(company,email,phone,name)")
+    .eq("id", callId).eq("business_id", businessId).single();
+  if (error) throw error;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const c = call as any;
+  let party: CallContext["party"] = null;
+  if (c.customer_id && c.customers) {
+    party = { kind: "customer", id: c.customer_id, name: c.customers.name,
+              email: c.customers.email, phone: c.customers.phone, company: null };
+  } else if (c.contact_id && c.contacts) {
+    party = { kind: "contact", id: c.contact_id, name: c.contacts.name,
+              email: c.contacts.email, phone: c.contacts.phone, company: null };
+  } else if (c.lead_id && c.leads) {
+    party = { kind: "lead", id: c.lead_id, name: c.leads.name,
+              email: c.leads.email, phone: c.leads.phone, company: null };
+  } else if (c.prospect_id && c.prospects) {
+    party = { kind: "prospect", id: c.prospect_id, name: c.prospects.name ?? c.prospects.company ?? "Prospect",
+              email: c.prospects.email, phone: c.prospects.phone, company: c.prospects.company };
+  }
+
+  const empty = { workOrders: [], quotes: [], invoices: [] };
+  // Open work only exists for a customer — a lead has nothing booked yet.
+  const related = party?.kind === "customer"
+    ? await (async () => {
+        const [wo, q, inv] = await Promise.all([
+          tbl(supabase, "work_orders").select("id, number, title, status")
+            .eq("business_id", businessId).eq("customer_id", party.id)
+            .not("status", "in", '("completed","cancelled")')
+            .order("created_at", { ascending: false }).limit(5),
+          tbl(supabase, "quotes").select("id, number, total, status")
+            .eq("business_id", businessId).eq("customer_id", party.id)
+            .order("created_at", { ascending: false }).limit(5),
+          tbl(supabase, "invoices").select("id, number, total, amount_paid, status")
+            .eq("business_id", businessId).eq("customer_id", party.id)
+            .neq("status", "paid").order("created_at", { ascending: false }).limit(5),
+        ]);
+        return { workOrders: wo.data ?? [], quotes: q.data ?? [], invoices: inv.data ?? [] };
+      })()
+    : empty;
+
+  // Their call history, so you can see "third time this week" at a glance.
+  const { data: recent } = c.counterparty_digits
+    ? await tbl(supabase, "calls").select("id, direction, status, started_at")
+        .eq("business_id", businessId).eq("counterparty_digits", c.counterparty_digits)
+        .neq("id", callId).order("started_at", { ascending: false }).limit(5)
+    : { data: [] };
+
+  return {
+    call: call as Call,
+    party,
+    ...related,
+    recentCalls: recent ?? [],
+  } as CallContext;
+}
+
+/**
+ * Turn an unknown caller into a customer, and back-link every call from that
+ * number so the history isn't stranded on the old unmatched rows.
+ */
+export async function createCustomerFromCall(
+  callId: string, name: string, email?: string,
+): Promise<{ customer_id: string; linkedCalls: number }> {
+  const { supabase, businessId, user } = await ctx();
+
+  const { data: call } = await tbl(supabase, "calls")
+    .select("id, from_number, to_number, direction, counterparty_digits")
+    .eq("id", callId).eq("business_id", businessId).maybeSingle();
+  if (!call) throw new Error("Call not found");
+  if (!name.trim()) throw new Error("A name is required");
+
+  const phone = call.direction === "inbound" ? call.from_number : call.to_number;
+  const { data: customer, error } = await tbl(supabase, "customers").insert({
+    business_id: businessId, user_id: user.id,
+    name: name.trim(), phone, email: email?.trim() || null,
+  }).select("id").single();
+  if (error) throw error;
+
+  // Link every past call from this number, not just the one in front of you.
+  let linkedCalls = 0;
+  if (call.counterparty_digits) {
+    const { data: linked } = await tbl(supabase, "calls")
+      .update({ customer_id: customer.id })
+      .eq("business_id", businessId).eq("counterparty_digits", call.counterparty_digits)
+      .is("customer_id", null).select("id");
+    linkedCalls = linked?.length ?? 0;
+  }
+
+  revalidatePath("/calls");
+  return { customer_id: customer.id, linkedCalls };
+}

--- a/supabase/migrations/20260804200000_calls_realtime.sql
+++ b/supabase/migrations/20260804200000_calls_realtime.sql
@@ -1,0 +1,13 @@
+-- Realtime must be told which tables to broadcast; without this the screen pop
+-- silently never fires.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname='supabase_realtime' AND schemaname='public' AND tablename='calls'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.calls;
+  END IF;
+END $$;
+SELECT string_agg(tablename, ', ') AS realtime_tables FROM pg_publication_tables
+WHERE pubname='supabase_realtime' AND schemaname='public' AND tablename IN ('calls','sms_messages');


### PR DESCRIPTION
The four things the VoIPcloud→Zendesk bridge offers, built into Kirei and pointed at **your own** jobs, quotes and invoices instead of a second system's tickets.

## First, a correction

I told you Kirei already did all four. **It didn't.** Checking found:

| | Claimed | Actually |
|---|---|---|
| Log calls + notes | ✅ | action + MCP tool existed, **no UI reached them** — same gap as the expenses edit |
| View customer on a call | ✅ | caller-ID matching only; no detail, no live pop |
| See open work | ✅ | **didn't exist** |
| Create customer from a call | ✅ | **didn't exist** |

## What's built

- **Call drawer** — click any row: who called, their email/company, the call's details, and a **Call back** button that rings your handset then dials them.
- **Open work** — for a matched customer: live jobs, quotes, and unpaid invoices with amounts owing, each linked. The "active tickets" equivalent.
- **Screen pop** — a realtime toast the instant an inbound call starts **ringing**, naming the caller, one click into the drawer. Fires only on the ringing event; later stages of the same call would otherwise pop again for something you'd already answered.
- **Notes** — finally reachable, with that number's recent call history beside it so *"third time this week"* is visible.
- **Create customer from an unknown caller** — and it **back-links every past call from that number**, not just the one on screen, so history isn't stranded on rows that stay unmatched.

## The migration matters more than it looks

`20260804200000` adds `calls` to the `supabase_realtime` publication. Without it the screen-pop subscription is **silently dead** — the client code looks correct and simply never fires. Applied and recorded; verified `calls` is now in the publication alongside `sms_messages`.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · migration applied + verified ✅

⚠️ Not exercised in a browser — `/calls` needs a login I don't have locally. The screen pop in particular wants a real inbound call to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)