### PR TITLE
feat(payments): Revolut saved cards + provider routing (foundation)

### DIFF
--- a/src/app/api/revolut/save-card/route.ts
+++ b/src/app/api/revolut/save-card/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { decryptSecret } from "@/lib/crypto";
+import { createRevolutSaveCardOrder, toRevolutAmount, type RevolutMode } from "@/lib/revolut";
+import { customerAllowsCard } from "@/lib/payment-methods";
+import { appUrl } from "@/lib/app-url";
+
+/**
+ * Public, token-gated. Sends the customer to Revolut's hosted checkout to put a
+ * card on file, mirroring the Stripe save-card route.
+ *
+ * Revolut has no zero-amount setup equivalent to a Stripe SetupIntent — a card
+ * is saved during a real payment. So this takes a genuine amount, defaulting to
+ * a small verification charge, and the amount is shown to the customer before
+ * they confirm. Storing the token happens in the webhook, not here: only a
+ * completed order proves the card is good.
+ */
+export const dynamic = "force-dynamic";
+
+/** Verification amount when there's no invoice to attach the save to. */
+const VERIFY_AMOUNT = 1.0;
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  const invoiceId = url.searchParams.get("invoice");
+  if (!token) return NextResponse.json({ error: "Missing token" }, { status: 400 });
+
+  const sb = createAdminClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: link } = await (sb as any).from("customer_portal_tokens")
+    .select("business_id, customer_id, expires_at, revoked_at")
+    .eq("token", token).maybeSingle();
+  if (!link || link.revoked_at) return NextResponse.json({ error: "Invalid token" }, { status: 404 });
+  if (link.expires_at && new Date(link.expires_at) < new Date()) {
+    return NextResponse.json({ error: "Token expired" }, { status: 404 });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: business } = await (sb as any).from("businesses")
+    .select("name, currency, revolut_enabled, revolut_mode, revolut_secret_enc")
+    .eq("id", link.business_id).single();
+  if (!business?.revolut_enabled || !business.revolut_secret_enc) {
+    return NextResponse.json({ error: "Card payments aren't enabled for this business" }, { status: 400 });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: customer } = await (sb as any).from("customers")
+    .select("id, name, email, allowed_payment_methods")
+    .eq("id", link.customer_id).eq("business_id", link.business_id).maybeSingle();
+  if (!customer) return NextResponse.json({ error: "Customer not found" }, { status: 404 });
+  if (!customerAllowsCard(customer)) {
+    return NextResponse.json({ error: "This customer isn't set up for card payments" }, { status: 400 });
+  }
+
+  let secret: string;
+  try {
+    secret = decryptSecret(business.revolut_secret_enc);
+  } catch {
+    return NextResponse.json({ error: "Payment configuration error" }, { status: 500 });
+  }
+
+  // If an invoice was given, save the card while taking that actual payment —
+  // no separate verification charge for the customer to query.
+  let amount = VERIFY_AMOUNT;
+  if (invoiceId) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: inv } = await (sb as any).from("invoices")
+      .select("total, amount_paid").eq("id", invoiceId).eq("business_id", link.business_id).maybeSingle();
+    const owing = inv ? Number(inv.total) - Number(inv.amount_paid) : 0;
+    if (owing > 0) amount = owing;
+  }
+
+  try {
+    const order = await createRevolutSaveCardOrder({
+      secret,
+      mode: (business.revolut_mode ?? "sandbox") as RevolutMode,
+      amountMinor: toRevolutAmount(amount),
+      currency: business.currency ?? "AUD",
+      customerEmail: customer.email,
+      customerName: customer.name,
+      reference: `savecard:${link.business_id}:${customer.id}`,
+      redirectUrl: `${appUrl()}/portal/${token}`,
+      description: invoiceId ? "Payment — card saved for future invoices" : "Card verification",
+    });
+
+    if (!order.checkout_url) {
+      return NextResponse.json({ error: "Revolut didn't return a checkout link" }, { status: 502 });
+    }
+
+    // Remember what this order was for, so the webhook knows to store the token
+    // rather than treating it as an ordinary payment.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sb as any).from("revolut_orders").insert({
+      order_id: order.id,
+      business_id: link.business_id,
+      customer_id: customer.id,
+      invoice_id: invoiceId ?? null,
+      amount,
+      currency: business.currency ?? "AUD",
+      portal_token: token,
+      purpose: "save_card",
+    });
+
+    return NextResponse.redirect(order.checkout_url);
+  } catch (e) {
+    // Surface Revolut's own message — a rejected field or an unsupported
+    // currency needs to be readable, not swallowed into a generic 500.
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Couldn't start the card setup" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/revolut/webhook/route.ts
+++ b/src/app/api/revolut/webhook/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
     const t = (n: string) => (sb as any).from(n);
 
     const { data: map } = await t("revolut_orders")
-      .select("business_id, invoice_id, amount, portal_token").eq("order_id", orderId).maybeSingle();
+      .select("business_id, invoice_id, amount, portal_token, customer_id, purpose").eq("order_id", orderId).maybeSingle();
     if (!map) return NextResponse.json({ ok: true }); // unknown order — not ours
 
     const { data: biz } = await t("businesses")
@@ -50,6 +50,36 @@ export async function POST(req: NextRequest) {
     const mode = (biz.revolut_mode as RevolutMode) ?? "sandbox";
     const order = await retrieveRevolutOrder(secret, mode, orderId);
     if (!revolutOrderIsPaid(order.state)) return NextResponse.json({ ok: true }); // not paid (yet)
+
+    // A save-card order also yields a reusable token. Store it BEFORE recording
+    // the payment: if the payment write failed we'd still rather have the card
+    // on file than lose it, since the customer has already been charged and
+    // won't be asked again.
+    if (map.purpose === "save_card" && map.customer_id) {
+      // Revolut reports the stored method on the order once it completes. The
+      // exact key isn't pinned in the public guides, so accept the shapes their
+      // examples use and record nothing rather than guessing wrong.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const o = order as any;
+      const pm = o.payment_method ?? o.saved_payment_method ?? o.payments?.[0]?.payment_method ?? null;
+      const pmId = pm?.id ?? o.payment_method_id ?? null;
+
+      if (pmId) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (sb as any).from("customers").update({
+          revolut_customer_id: o.customer?.id ?? o.customer_id ?? null,
+          revolut_payment_method_id: pmId,
+          revolut_pm_brand: pm?.brand ?? pm?.card?.brand ?? null,
+          revolut_pm_last4: pm?.last4 ?? pm?.card?.last4 ?? null,
+          autopay_enabled: true,
+        }).eq("id", map.customer_id).eq("business_id", map.business_id);
+      } else {
+        // Loud, because the customer paid expecting the card to be kept.
+        console.error("[revolut/webhook] save_card order completed with no payment method on it", {
+          orderId, keys: Object.keys(o ?? {}),
+        });
+      }
+    }
 
     await recordRevolutPayment(sb, {
       businessId: map.business_id,

--- a/src/lib/__tests__/card-provider.test.ts
+++ b/src/lib/__tests__/card-provider.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { resolveCardProvider, stripeReady, revolutReady, cardProviderProblem } from "@/lib/card-provider";
+
+const stripeLive = { stripe_account_id: "acct_1", stripe_charges_enabled: true };
+const stripePending = { stripe_account_id: "acct_1", stripe_charges_enabled: false };
+const revolutLive = { revolut_enabled: true, revolut_secret_enc: "enc" };
+
+describe("stripeReady", () => {
+  it("requires charges to actually be enabled, not just an account", () => {
+    // The real state on this account: details submitted, charges disabled.
+    // Treating that as "connected" is why payments appeared to work and didn't.
+    expect(stripeReady(stripeLive)).toBe(true);
+    expect(stripeReady(stripePending)).toBe(false);
+    expect(stripeReady({})).toBe(false);
+  });
+});
+
+describe("revolutReady", () => {
+  it("needs both the toggle and a stored key", () => {
+    expect(revolutReady(revolutLive)).toBe(true);
+    expect(revolutReady({ revolut_enabled: true })).toBe(false);
+    expect(revolutReady({ revolut_secret_enc: "enc" })).toBe(false);
+  });
+});
+
+describe("resolveCardProvider", () => {
+  it("prefers Stripe on auto when it is genuinely ready", () => {
+    expect(resolveCardProvider({ ...stripeLive, ...revolutLive })).toBe("stripe");
+  });
+
+  it("falls through to Revolut when Stripe is connected but not enabled", () => {
+    // The exact situation that prompted this: an account Stripe hasn't approved.
+    expect(resolveCardProvider({ ...stripePending, ...revolutLive })).toBe("revolut");
+  });
+
+  it("returns null when neither can take a payment", () => {
+    expect(resolveCardProvider({})).toBeNull();
+    expect(resolveCardProvider(stripePending)).toBeNull();
+  });
+
+  it("honours an explicit choice even when that provider isn't ready", () => {
+    // Silently charging through the OTHER provider would put the money in an
+    // account the user didn't choose. Better to honour it and report why.
+    expect(resolveCardProvider({ card_provider: "revolut", ...stripeLive })).toBe("revolut");
+    expect(resolveCardProvider({ card_provider: "stripe", ...stripePending, ...revolutLive })).toBe("stripe");
+  });
+
+  it("treats auto as the default when unset", () => {
+    expect(resolveCardProvider({ card_provider: null, ...revolutLive })).toBe("revolut");
+  });
+});
+
+describe("cardProviderProblem", () => {
+  it("says nothing when a provider is ready", () => {
+    expect(cardProviderProblem(stripeLive)).toBeNull();
+    expect(cardProviderProblem(revolutLive)).toBeNull();
+  });
+
+  it("names the Stripe pending-verification case specifically", () => {
+    const msg = cardProviderProblem({ card_provider: "stripe", ...stripePending });
+    expect(msg).toMatch(/hasn't enabled charges/);
+  });
+
+  it("tells an unconnected business what to do", () => {
+    expect(cardProviderProblem({})).toMatch(/Connect Stripe or Revolut/);
+  });
+});

--- a/src/lib/card-provider.ts
+++ b/src/lib/card-provider.ts
@@ -1,0 +1,72 @@
+/**
+ * Which provider takes a business's card payments.
+ *
+ * Kirei supports Stripe and Revolut side by side rather than one at a time.
+ * That matters because saved cards are NOT portable: a token stored with
+ * Stripe cannot be charged through Revolut, or vice versa. If switching
+ * provider silently repointed everything, every card already on file would
+ * quietly stop working — and you'd only find out when an autopay run failed.
+ *
+ * So a customer can hold a card with each, and a charge uses whichever token
+ * matches the provider being used.
+ *
+ * Plain module — safe to import from actions, routes and crons.
+ */
+
+export type CardProvider = "stripe" | "revolut";
+
+export interface ProviderState {
+  /** The business's explicit choice: 'auto' | 'stripe' | 'revolut'. */
+  card_provider?: string | null;
+  stripe_account_id?: string | null;
+  stripe_charges_enabled?: boolean | null;
+  revolut_enabled?: boolean | null;
+  revolut_secret_enc?: string | null;
+}
+
+/** Is Stripe genuinely able to take a payment right now? */
+export function stripeReady(b: ProviderState): boolean {
+  // details_submitted is not enough — Stripe can hold an account with details
+  // in and charges still disabled, which is exactly the state that looks
+  // connected in the UI while every payment fails.
+  return Boolean(b.stripe_account_id && b.stripe_charges_enabled);
+}
+
+export function revolutReady(b: ProviderState): boolean {
+  return Boolean(b.revolut_enabled && b.revolut_secret_enc);
+}
+
+/**
+ * The provider to use, or null when the business can't take cards at all.
+ *
+ * 'auto' prefers Stripe when it's genuinely ready, so nothing changes for
+ * businesses already running on it; it falls through to Revolut otherwise.
+ * An explicit choice is honoured even if that provider isn't ready — the
+ * caller then reports why, rather than silently charging through the other
+ * one, which would land the money in an account the user didn't expect.
+ */
+export function resolveCardProvider(b: ProviderState): CardProvider | null {
+  const choice = (b.card_provider ?? "auto").toLowerCase();
+  if (choice === "stripe") return "stripe";
+  if (choice === "revolut") return "revolut";
+  if (stripeReady(b)) return "stripe";
+  if (revolutReady(b)) return "revolut";
+  return null;
+}
+
+/** A sentence explaining why cards aren't available, for the UI. */
+export function cardProviderProblem(b: ProviderState): string | null {
+  const provider = resolveCardProvider(b);
+  if (!provider) {
+    return "No card provider is connected. Connect Stripe or Revolut in Settings → Payments.";
+  }
+  if (provider === "stripe" && !stripeReady(b)) {
+    return b.stripe_account_id
+      ? "Stripe has your details but hasn't enabled charges yet — check your Stripe dashboard for a verification request."
+      : "Stripe isn't connected yet.";
+  }
+  if (provider === "revolut" && !revolutReady(b)) {
+    return "Revolut isn't connected yet — add your Merchant API key in Settings → Payments.";
+  }
+  return null;
+}

--- a/src/lib/revolut.ts
+++ b/src/lib/revolut.ts
@@ -181,3 +181,114 @@ export function revolutOrderIsPaid(state: string | undefined): boolean {
   const s = (state ?? "").toLowerCase();
   return s === "completed" || s === "paid" || s === "authorised" || s === "authorized";
 }
+
+// ── Saved cards (card-on-file) ──────────────────────────────────────────────
+//
+// ⚠️ FIELD NAMES NEED CONFIRMING AGAINST REVOLUT'S REFERENCE BEFORE LIVE USE.
+// developer.revolut.com returns 403 to unauthenticated fetches, so the field
+// names below come from Revolut's public guides rather than the API reference
+// I could read directly. The CAPABILITY is documented — save a payment method
+// for the merchant, then charge it off-session (MIT) — but an exact key could
+// differ. Everything uncertain is confined to the three functions below and
+// each one surfaces Revolut's own error text verbatim, so a wrong field name
+// shows up as a clear API message on the first sandbox run rather than a
+// silent failure. Run it in sandbox before switching a business to live.
+
+/** Create a hosted-checkout order that ALSO stores the card for later use. */
+export async function createRevolutSaveCardOrder(input: {
+  secret: string;
+  mode: RevolutMode;
+  /** Revolut requires an amount; a small verification charge is the usual
+   *  pattern. Pass the real first payment when there is one. */
+  amountMinor: number;
+  currency: string;
+  customerEmail?: string | null;
+  customerName?: string | null;
+  reference: string;
+  redirectUrl: string;
+  description?: string;
+}): Promise<RevolutOrder> {
+  const body = {
+    amount: input.amountMinor,
+    currency: input.currency.toUpperCase(),
+    description: input.description ?? "Save card for future payments",
+    ...(input.customerEmail
+      ? { customer: { email: input.customerEmail, ...(input.customerName ? { full_name: input.customerName } : {}) } }
+      : {}),
+    // "merchant" = we can charge later without the customer present, which is
+    // the whole point. "customer" would only speed up their next checkout.
+    save_payment_method_for: "merchant",
+    merchant_order_data: { reference: input.reference },
+    redirect_url: input.redirectUrl,
+  };
+  const res = await revolutFetch(input.secret, input.mode, "/api/orders", {
+    method: "POST", body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Revolut save-card order failed (${res.status}): ${txt.slice(0, 300)}`);
+  }
+  return (await res.json()) as RevolutOrder;
+}
+
+/** Every payment method Revolut holds for a customer. */
+export async function listRevolutPaymentMethods(
+  secret: string, mode: RevolutMode, customerId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any[]> {
+  const res = await revolutFetch(secret, mode, `/api/customers/${customerId}/payment-methods`);
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Revolut payment-method lookup failed (${res.status}): ${txt.slice(0, 300)}`);
+  }
+  const json = await res.json();
+  return Array.isArray(json) ? json : (json?.payment_methods ?? []);
+}
+
+export interface RevolutChargeResult { orderId: string; state: string }
+
+/**
+ * Charge a stored card with the customer absent (merchant-initiated).
+ *
+ * Two steps, mirroring how their hosted flow works: create the order, then
+ * confirm it against the saved payment method. Any failure throws with
+ * Revolut's own message so a decline, an expired card and a wrong field name
+ * are all distinguishable rather than a generic "charge failed".
+ */
+export async function chargeRevolutSavedCard(input: {
+  secret: string;
+  mode: RevolutMode;
+  amountMinor: number;
+  currency: string;
+  paymentMethodId: string;
+  reference: string;
+  description?: string;
+}): Promise<RevolutChargeResult> {
+  const created = await revolutFetch(input.secret, input.mode, "/api/orders", {
+    method: "POST",
+    body: JSON.stringify({
+      amount: input.amountMinor,
+      currency: input.currency.toUpperCase(),
+      description: input.description,
+      merchant_order_data: { reference: input.reference },
+    }),
+  });
+  if (!created.ok) {
+    const txt = await created.text().catch(() => "");
+    throw new Error(`Revolut order failed (${created.status}): ${txt.slice(0, 300)}`);
+  }
+  const order = (await created.json()) as RevolutOrder;
+
+  const confirmed = await revolutFetch(input.secret, input.mode, `/api/orders/${order.id}/confirm`, {
+    method: "POST",
+    body: JSON.stringify({
+      saved_payment_method: { id: input.paymentMethodId, initiator: "merchant" },
+    }),
+  });
+  if (!confirmed.ok) {
+    const txt = await confirmed.text().catch(() => "");
+    throw new Error(`Revolut charge declined or failed (${confirmed.status}): ${txt.slice(0, 300)}`);
+  }
+  const result = (await confirmed.json()) as RevolutOrder;
+  return { orderId: order.id, state: result.state ?? "unknown" };
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -62,6 +62,8 @@ export async function updateSession(request: NextRequest) {
     // Revolut payment provider — signed webhook + token-gated hosted checkout.
     pathname === "/api/revolut/webhook" ||
     pathname === "/api/revolut/checkout" ||
+    // Customer-facing card setup — gated by a portal token, not a session.
+    pathname === "/api/revolut/save-card" ||
     // Resend delivery webhook (verifies its own Svix signature). Without this it
     // was 307'd to /auth/login, so delivered/bounced events never reached the
     // handler and every email stayed frozen at "Sent (in transit)".

--- a/supabase/migrations/20260805090000_revolut_saved_cards.sql
+++ b/supabase/migrations/20260805090000_revolut_saved_cards.sql
@@ -1,0 +1,26 @@
+-- Revolut saved cards — a card-on-file path that doesn't depend on Stripe.
+--
+-- Mirrors the existing stripe_* columns rather than generalising them: the two
+-- providers' tokens are not interchangeable, and a business may have both
+-- connected during a migration. Keeping them side by side means switching
+-- provider never destroys the other one's saved cards.
+ALTER TABLE public.customers
+  ADD COLUMN IF NOT EXISTS revolut_customer_id       TEXT,
+  ADD COLUMN IF NOT EXISTS revolut_payment_method_id TEXT,
+  ADD COLUMN IF NOT EXISTS revolut_pm_brand          TEXT,
+  ADD COLUMN IF NOT EXISTS revolut_pm_last4          TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_customers_revolut_pm
+  ON public.customers (business_id, revolut_payment_method_id)
+  WHERE revolut_payment_method_id IS NOT NULL;
+
+-- Which provider a business takes card payments through. 'auto' picks whichever
+-- is actually connected, preferring Stripe when both are — so nothing changes
+-- for businesses already on Stripe.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS card_provider TEXT NOT NULL DEFAULT 'auto';
+ALTER TABLE public.businesses
+  DROP CONSTRAINT IF EXISTS businesses_card_provider_ck;
+ALTER TABLE public.businesses
+  ADD CONSTRAINT businesses_card_provider_ck
+  CHECK (card_provider IN ('auto', 'stripe', 'revolut'));

--- a/supabase/migrations/20260805100000_revolut_order_purpose.sql
+++ b/supabase/migrations/20260805100000_revolut_order_purpose.sql
@@ -1,0 +1,16 @@
+-- revolut_orders needs to remember WHY an order was created.
+--
+-- Until now every Revolut order was an invoice payment, so the webhook could
+-- assume that. A save-card order is a payment too, but it additionally yields a
+-- reusable payment-method token — and the webhook can only know to store that
+-- if the order says so. Without `purpose` a saved card would be silently
+-- dropped and the customer would have paid for nothing.
+ALTER TABLE public.revolut_orders
+  ADD COLUMN IF NOT EXISTS customer_id UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS purpose     TEXT NOT NULL DEFAULT 'invoice';
+
+ALTER TABLE public.revolut_orders
+  DROP CONSTRAINT IF EXISTS revolut_orders_purpose_ck;
+ALTER TABLE public.revolut_orders
+  ADD CONSTRAINT revolut_orders_purpose_ck
+  CHECK (purpose IN ('invoice', 'save_card'));


### PR DESCRIPTION
## What "Stripe doesn't work" actually is

Checked against production rather than assumed:

| Business | Stripe |
|---|---|
| **Connected Studio** | account exists, details **submitted**, charges **disabled** |
| **Crown Roofers** | no Stripe account at all |

Connected Studio's pattern — details in, charges off — is **Stripe holding the account pending verification**, not a Kirei bug. There's usually an unread request for ID or business documents in the Stripe dashboard, and that's the fastest fix if it applies. But either way there needs to be a path that doesn't depend on Stripe.

## This PR

Revolut was already integrated for one-off payment links, and **credentials are already stored for both businesses**. Their Merchant API also supports saving a payment method for the merchant and charging it off-session — exactly the missing piece.

- **Migration** — `revolut_customer_id` / `payment_method_id` / `brand` / `last4` on customers, plus `businesses.card_provider`.
  Deliberately **not** generalising the `stripe_*` columns: tokens aren't portable between providers, so keeping them side by side means switching provider never silently invalidates cards already on file. You'd only discover that when an autopay run failed.
- **[`card-provider.ts`](src/lib/card-provider.ts)** — resolves which provider to use. `auto` prefers Stripe when it's **genuinely** ready (account *and* `charges_enabled` — `details_submitted` alone is precisely the state that looks connected while every payment fails) and falls through to Revolut. An explicit choice is honoured even when unready, so we report why rather than quietly charging through the other provider and depositing money in an account you didn't pick.
- **`revolut.ts`** — `createRevolutSaveCardOrder`, `listRevolutPaymentMethods`, `chargeRevolutSavedCard`.

## ⚠️ Read this before going live

`developer.revolut.com` **403s unauthenticated fetches**, so the field names in those three functions come from Revolut's public guides, not the API reference I could read directly. The *capability* is documented; an exact key may not be.

Everything uncertain is confined to those three functions, and each surfaces **Revolut's own error text verbatim** — so a wrong field name shows up as a clear API message on the first sandbox call rather than a silent failure. **Run it in sandbox before switching a business to live.**

If you can open the Revolut developer docs while logged in, paste me the "create order" and "charge saved payment method" pages and I'll pin the field names exactly — that's what caught the real bug in the VoIPcloud work.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · **10 tests** ✅ (including the pending-Stripe fallthrough) · migration applied + recorded ✅

## Next
Save-card link route, webhook storage of the token, and pointing autopay / recurring billing at the resolved provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)