### PR TITLE
feat(customers): industry-aware client fields, overridable per business

### DIFF
--- a/src/app/(dashboard)/settings/client-fields/page.tsx
+++ b/src/app/(dashboard)/settings/client-fields/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getClientFieldConfig } from "@/lib/actions/client-fields";
+import { ClientFieldsSettings } from "@/components/settings/client-fields-settings";
+
+export default async function ClientFieldsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await getActiveBizId(supabase as any, user.id);
+
+  const config = await getClientFieldConfig();
+  return <ClientFieldsSettings config={config} />;
+}

--- a/src/components/customers/client-fields.tsx
+++ b/src/components/customers/client-fields.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { DatePicker } from "@/components/ui/date-picker";
+import { TimePicker } from "@/components/ui/time-picker";
+import type { OnboardingField } from "@/types/database";
+
+/**
+ * Renders a business's client-profile fields.
+ *
+ * One component for both the add-customer form and the customer detail, so the
+ * two can't drift into rendering the same field differently. Types not handled
+ * here fall back to a text input rather than disappearing — a field the user
+ * configured must always be fillable, even if we don't have a bespoke control
+ * for it yet.
+ */
+export function ClientFields({
+  fields, values, onChange, disabled,
+}: {
+  fields: OnboardingField[];
+  values: Record<string, unknown>;
+  onChange: (id: string, value: unknown) => void;
+  disabled?: boolean;
+}) {
+  if (fields.length === 0) return null;
+
+  const str = (id: string) => {
+    const v = values[id];
+    return v === null || v === undefined ? "" : String(v);
+  };
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {fields.map((f) => {
+        // Layout-only types span the row and render no control.
+        if (f.type === "heading") {
+          return <h3 key={f.id} className="sm:col-span-2 mt-2 text-sm font-semibold">{f.label}</h3>;
+        }
+        if (f.type === "divider") {
+          return <hr key={f.id} className="sm:col-span-2 border-border" />;
+        }
+        if (f.type === "instructions") {
+          return <p key={f.id} className="sm:col-span-2 text-sm text-muted-foreground">{f.label}</p>;
+        }
+
+        const wide = f.type === "long_text" || f.type === "address";
+        const control = (() => {
+          switch (f.type) {
+            case "long_text":
+            case "address":
+              return <Textarea id={f.id} rows={3} value={str(f.id)} disabled={disabled}
+                placeholder={f.placeholder} onChange={(e) => onChange(f.id, e.target.value)} />;
+
+            case "yes_no":
+            case "consent":
+              return (
+                <div className="flex h-9 items-center">
+                  <Switch checked={Boolean(values[f.id])} disabled={disabled}
+                    onCheckedChange={(v) => onChange(f.id, v)} />
+                </div>
+              );
+
+            case "dropdown":
+            case "radio":
+              return (
+                <select id={f.id} value={str(f.id)} disabled={disabled}
+                  onChange={(e) => onChange(f.id, e.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-card px-3 text-sm">
+                  <option value="">—</option>
+                  {(f.options ?? []).map((o) => <option key={o} value={o}>{o}</option>)}
+                </select>
+              );
+
+            case "date":
+              return <DatePicker id={f.id} value={str(f.id)} clearable disabled={disabled}
+                onChange={(v) => onChange(f.id, v)} />;
+
+            case "time":
+              return <TimePicker id={f.id} value={str(f.id)} clearable disabled={disabled}
+                onChange={(v) => onChange(f.id, v)} />;
+
+            case "number":
+            case "rating":
+              return <Input id={f.id} type="number" value={str(f.id)} disabled={disabled}
+                onChange={(e) => onChange(f.id, e.target.value === "" ? "" : Number(e.target.value))} />;
+
+            case "currency":
+              return (
+                <div className="relative">
+                  <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+                  <Input id={f.id} type="number" step="0.01" className="pl-6" value={str(f.id)} disabled={disabled}
+                    onChange={(e) => onChange(f.id, e.target.value === "" ? "" : Number(e.target.value))} />
+                </div>
+              );
+
+            case "email":
+              return <Input id={f.id} type="email" value={str(f.id)} disabled={disabled}
+                placeholder={f.placeholder} onChange={(e) => onChange(f.id, e.target.value)} />;
+
+            case "url":
+              return <Input id={f.id} type="url" value={str(f.id)} disabled={disabled}
+                placeholder={f.placeholder ?? "https://"} onChange={(e) => onChange(f.id, e.target.value)} />;
+
+            case "phone":
+              return <Input id={f.id} type="tel" value={str(f.id)} disabled={disabled}
+                placeholder={f.placeholder} onChange={(e) => onChange(f.id, e.target.value)} />;
+
+            default:
+              // Unknown / not-yet-specialised types stay fillable as text.
+              return <Input id={f.id} value={str(f.id)} disabled={disabled}
+                placeholder={f.placeholder} onChange={(e) => onChange(f.id, e.target.value)} />;
+          }
+        })();
+
+        return (
+          <div key={f.id} className={wide ? "sm:col-span-2" : undefined}>
+            <Label htmlFor={f.id}>{f.label}{f.required ? " *" : ""}</Label>
+            {control}
+            {f.help_text && <p className="mt-1 text-xs text-muted-foreground">{f.help_text}</p>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Read-only summary for the customer detail page. */
+export function ClientFieldsSummary({
+  fields, values,
+}: {
+  fields: OnboardingField[];
+  values: Record<string, unknown>;
+}) {
+  const shown = fields.filter(
+    (f) => !["heading", "divider", "instructions"].includes(f.type)
+      && values[f.id] !== undefined && values[f.id] !== null && values[f.id] !== "",
+  );
+  if (shown.length === 0) return null;
+
+  return (
+    <dl className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+      {shown.map((f) => {
+        const v = values[f.id];
+        const display = typeof v === "boolean" ? (v ? "Yes" : "No") : String(v);
+        const isLink = f.type === "url" && /^https?:\/\//i.test(display);
+        return (
+          <div key={f.id}>
+            <dt className="text-xs text-muted-foreground">{f.label}</dt>
+            <dd className="text-sm break-words">
+              {isLink
+                ? <a href={display} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">{display}</a>
+                : display}
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}

--- a/src/components/settings/client-fields-settings.tsx
+++ b/src/components/settings/client-fields-settings.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, Trash2, ChevronUp, ChevronDown, Loader2, RefreshCw } from "@/components/ui/icons";
+import { saveClientFields, resetClientFieldsToPreset, type ClientFieldConfig } from "@/lib/actions/client-fields";
+import { ClientFields } from "@/components/customers/client-fields";
+import type { OnboardingField, OnboardingFieldType } from "@/types/database";
+
+/** Types that make sense on a client profile. `secure` is deliberately absent —
+ *  a profile is visible to everyone who can see the customer. */
+const TYPES: { value: OnboardingFieldType; label: string }[] = [
+  { value: "short_text", label: "Text" },
+  { value: "long_text", label: "Long text" },
+  { value: "number", label: "Number" },
+  { value: "currency", label: "Money" },
+  { value: "dropdown", label: "Dropdown" },
+  { value: "yes_no", label: "Yes / no" },
+  { value: "date", label: "Date" },
+  { value: "email", label: "Email" },
+  { value: "phone", label: "Phone" },
+  { value: "url", label: "Link" },
+  { value: "address", label: "Address" },
+  { value: "heading", label: "Section heading" },
+];
+
+const HAS_OPTIONS = new Set(["dropdown", "radio", "multi_select", "checkboxes"]);
+const slug = (s: string) =>
+  s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 40) || "field";
+
+export function ClientFieldsSettings({ config }: { config: ClientFieldConfig }) {
+  const router = useRouter();
+  const [fields, setFields] = useState<OnboardingField[]>(config.fields);
+  const [preview, setPreview] = useState<Record<string, unknown>>({});
+  const [saving, setSaving] = useState(false);
+
+  const update = (i: number, patch: Partial<OnboardingField>) =>
+    setFields((prev) => prev.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= fields.length) return;
+    setFields((prev) => {
+      const next = [...prev];
+      [next[i], next[j]] = [next[j], next[i]];
+      return next;
+    });
+  };
+
+  const add = () => setFields((prev) => [
+    ...prev,
+    { id: `field_${prev.length + 1}_${Date.now().toString(36)}`, type: "short_text", label: "New field" },
+  ]);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const res = await saveClientFields(fields);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success(`Saved — ${res.count} field${res.count === 1 ? "" : "s"} on the client form`);
+      router.refresh();
+    } finally { setSaving(false); }
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="Client fields"
+        subtitle="What you record about a client, beyond name and contact details."
+        actions={
+          <>
+            <Button variant="outline" disabled={saving} onClick={async () => {
+              if (!confirm("Reset to your industry's defaults? Any fields you've added here are removed — answers already saved on clients stay in the database but stop being shown.")) return;
+              const res = await resetClientFieldsToPreset();
+              if (!res.ok) { toast.error(res.error); return; }
+              toast.success("Back to the preset defaults");
+              router.refresh();
+            }}>
+              <RefreshCw className="mr-1.5 h-4 w-4" /> Reset to preset
+            </Button>
+            <Button onClick={save} disabled={saving}>
+              {saving && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />} Save
+            </Button>
+          </>
+        }
+      />
+
+      <div className="mb-5 rounded-xl border border-border bg-card p-4">
+        <p className="text-sm">
+          {config.usingPresetDefaults
+            ? <>These are the defaults for <strong>{config.industryPreset ?? "your business"}</strong>. Change anything and it becomes yours — the preset stops applying.</>
+            : <>You&rsquo;ve customised these. <em>Reset to preset</em> puts back your industry&rsquo;s defaults.</>}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Name, email, phone, company and address are always present and aren&rsquo;t listed here. Credentials belong
+          in an onboarding form, not a client profile — anyone who can see the client can see these.
+        </p>
+      </div>
+
+      <div className="grid gap-5 lg:grid-cols-2">
+        <div className="space-y-3">
+          {fields.length === 0 && (
+            <p className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+              No extra fields. Clients will show just the standard contact details.
+            </p>
+          )}
+
+          {fields.map((f, i) => (
+            <div key={f.id} className="rounded-xl border border-border bg-card p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <Input value={f.label} className="flex-1"
+                  onChange={(e) => {
+                    const label = e.target.value;
+                    // Keep the id stable once answers may exist — regenerating it
+                    // would orphan every answer already saved under the old one.
+                    const isFresh = /^field_\d+_/.test(f.id);
+                    update(i, isFresh ? { label, id: slug(label) || f.id } : { label });
+                  }} />
+                <select value={f.type}
+                  onChange={(e) => update(i, { type: e.target.value as OnboardingFieldType })}
+                  className="h-9 rounded-md border border-input bg-card px-2 text-sm">
+                  {TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+                </select>
+                <button onClick={() => move(i, -1)} disabled={i === 0} aria-label="Move up"
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-30">
+                  <ChevronUp className="h-4 w-4" />
+                </button>
+                <button onClick={() => move(i, 1)} disabled={i === fields.length - 1} aria-label="Move down"
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-30">
+                  <ChevronDown className="h-4 w-4" />
+                </button>
+                <button onClick={() => setFields((p) => p.filter((_, idx) => idx !== i))} aria-label="Remove"
+                  className="text-muted-foreground hover:text-destructive">
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+
+              {HAS_OPTIONS.has(f.type) && (
+                <div>
+                  <Label htmlFor={`opt-${f.id}`} className="text-xs">Options (one per line)</Label>
+                  <textarea id={`opt-${f.id}`} rows={3} value={(f.options ?? []).join("\n")}
+                    onChange={(e) => update(i, { options: e.target.value.split("\n").map((s) => s.trim()).filter(Boolean) })}
+                    className="w-full rounded-md border border-input bg-card p-2 text-sm" />
+                </div>
+              )}
+
+              <p className="mt-2 text-[11px] text-muted-foreground">
+                Stored as <code>{f.id}</code>
+              </p>
+            </div>
+          ))}
+
+          <Button variant="outline" onClick={add}>
+            <Plus className="mr-1.5 h-4 w-4" /> Add field
+          </Button>
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            How it looks on a client
+          </p>
+          <div className="rounded-xl border border-border bg-card p-5">
+            <ClientFields fields={fields} values={preview}
+              onChange={(id, v) => setPreview((p) => ({ ...p, [id]: v }))} />
+            {fields.length === 0 && (
+              <p className="text-sm text-muted-foreground">Nothing extra to show.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/settings-client.tsx
+++ b/src/components/settings/settings-client.tsx
@@ -269,6 +269,21 @@ export function SettingsClient({ business: initial, apiKeys, emailConfig, webhoo
         {/* ── Business tab ── */}
         <TabsContent value="business" className="space-y-4 mt-6">
           <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Client fields</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between gap-4">
+              <p className="text-sm text-muted-foreground">
+                What you record about a client beyond their contact details. Starts from your industry&rsquo;s
+                defaults — a trades business gets site access and property type, an agency gets retainer and socials.
+              </p>
+              <Button asChild variant="outline" className="shrink-0">
+                <a href="/settings/client-fields">Edit fields</a>
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
             <CardHeader className="flex flex-row items-center gap-2.5 space-y-0">
               <GradientTile gradient="violet" size={28} radius={8}><Palette className="w-3.5 h-3.5" /></GradientTile>
               <CardTitle className="text-base">Logo</CardTitle>

--- a/src/lib/__tests__/client-fields.test.ts
+++ b/src/lib/__tests__/client-fields.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveCustomerFields, isUsingPresetDefaults, pruneAnswers,
+  PRESET_CUSTOMER_FIELDS, GENERIC_CUSTOMER_FIELDS,
+} from "@/lib/customers/field-schema";
+import { INDUSTRY_PRESETS } from "@/lib/plugins/presets";
+import type { OnboardingField } from "@/types/database";
+
+describe("preset field sets", () => {
+  it("gives a trades business site fields and an agency retainer fields", () => {
+    // The whole point: the same screen must read correctly for both.
+    const trades = PRESET_CUSTOMER_FIELDS.trades.map((f) => f.id);
+    const agency = PRESET_CUSTOMER_FIELDS.agency.map((f) => f.id);
+    expect(trades).toContain("property_type");
+    expect(trades).toContain("access_notes");
+    expect(agency).toContain("monthly_retainer");
+    expect(agency).toContain("instagram");
+    // And crucially, neither leaks into the other.
+    expect(agency).not.toContain("property_type");
+    expect(trades).not.toContain("monthly_retainer");
+  });
+
+  it("covers every industry preset that ships", () => {
+    // A preset with no field set would silently fall back to generic, which
+    // looks like a bug to whoever picked that industry.
+    for (const preset of INDUSTRY_PRESETS) {
+      expect(PRESET_CUSTOMER_FIELDS[preset.id], `no client fields for preset "${preset.id}"`).toBeDefined();
+    }
+  });
+
+  it("uses unique ids within each preset", () => {
+    // Duplicate ids would make one answer overwrite another.
+    for (const [preset, fields] of Object.entries(PRESET_CUSTOMER_FIELDS)) {
+      const ids = fields.map((f) => f.id);
+      expect(new Set(ids).size, `duplicate id in "${preset}"`).toBe(ids.length);
+    }
+  });
+
+  it("never puts a secure field on a client profile", () => {
+    // A profile is visible to anyone who can see the customer — the wrong home
+    // for a credential, regardless of whether the key is configured.
+    for (const fields of Object.values(PRESET_CUSTOMER_FIELDS)) {
+      expect(fields.some((f) => f.type === "secure")).toBe(false);
+    }
+  });
+});
+
+describe("resolveCustomerFields", () => {
+  it("falls back to the preset when nothing is stored", () => {
+    expect(resolveCustomerFields(null, "agency")).toEqual(PRESET_CUSTOMER_FIELDS.agency);
+    expect(resolveCustomerFields(undefined, "trades")).toEqual(PRESET_CUSTOMER_FIELDS.trades);
+  });
+
+  it("falls back to generic for an unknown or missing preset", () => {
+    expect(resolveCustomerFields(null, null)).toEqual(GENERIC_CUSTOMER_FIELDS);
+    expect(resolveCustomerFields(null, "not-a-preset")).toEqual(GENERIC_CUSTOMER_FIELDS);
+  });
+
+  it("lets a stored schema override the preset", () => {
+    const custom: OnboardingField[] = [{ id: "x", type: "short_text", label: "X" }];
+    expect(resolveCustomerFields(custom, "agency")).toEqual(custom);
+  });
+
+  it("treats an empty array as a deliberate choice, NOT as unset", () => {
+    // Falling back to the preset here would make "no extra fields" impossible
+    // to configure — you'd clear them and they'd come straight back.
+    expect(resolveCustomerFields([], "trades")).toEqual([]);
+    expect(isUsingPresetDefaults([])).toBe(false);
+    expect(isUsingPresetDefaults(null)).toBe(true);
+  });
+});
+
+describe("pruneAnswers", () => {
+  const fields: OnboardingField[] = [
+    { id: "keep", type: "short_text", label: "Keep" },
+    { id: "also", type: "number", label: "Also" },
+  ];
+
+  it("drops answers whose field no longer exists", () => {
+    // An orphan is invisible in the UI but would resurface if the id were
+    // reused — showing one client's data under a different label.
+    expect(pruneAnswers({ keep: "a", removed: "b", also: 2 }, fields))
+      .toEqual({ keep: "a", also: 2 });
+  });
+
+  it("preserves falsy answers, which are real values", () => {
+    // 0, "" and false must survive — dropping them would silently lose data.
+    expect(pruneAnswers({ keep: "", also: 0 }, fields)).toEqual({ keep: "", also: 0 });
+  });
+
+  it("handles null and undefined input", () => {
+    expect(pruneAnswers(null, fields)).toEqual({});
+    expect(pruneAnswers(undefined, fields)).toEqual({});
+  });
+
+  it("returns nothing when the schema is empty", () => {
+    expect(pruneAnswers({ a: 1 }, [])).toEqual({});
+  });
+});

--- a/src/lib/actions/client-fields.ts
+++ b/src/lib/actions/client-fields.ts
@@ -1,0 +1,126 @@
+"use server";
+
+/**
+ * Per-business client profile fields.
+ *
+ * The industry preset supplies defaults; a business can override them. See
+ * src/lib/customers/field-schema.ts for why this exists rather than a fixed
+ * set of columns.
+ *
+ * Expected failures are RETURNED, not thrown. Next.js masks thrown
+ * server-action messages in production, so anything the user can act on has to
+ * come back as data — learned the hard way from the onboarding send bug.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { resolveCustomerFields, pruneAnswers, isUsingPresetDefaults } from "@/lib/customers/field-schema";
+import type { OnboardingField } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+const ALLOWED_TYPES = new Set([
+  "short_text", "long_text", "instructions", "email", "phone", "url", "address",
+  "abn", "company", "dropdown", "multi_select", "radio", "checkboxes", "yes_no",
+  "number", "currency", "date", "time", "file", "image", "rating", "consent",
+  "heading", "divider",
+]);
+
+export interface ClientFieldConfig {
+  fields: OnboardingField[];
+  /** True when nothing has been customised — the preset's defaults are in use. */
+  usingPresetDefaults: boolean;
+  industryPreset: string | null;
+}
+
+export async function getClientFieldConfig(): Promise<ClientFieldConfig> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data } = await tbl(supabase, "businesses")
+    .select("customer_field_schema, industry_preset").eq("id", businessId).maybeSingle();
+
+  return {
+    fields: resolveCustomerFields(data?.customer_field_schema, data?.industry_preset),
+    usingPresetDefaults: isUsingPresetDefaults(data?.customer_field_schema),
+    industryPreset: data?.industry_preset ?? null,
+  };
+}
+
+export type SaveFieldsResult = { ok: true; count: number } | { ok: false; error: string };
+
+/** Replace the business's client fields. An empty array is valid — it means none. */
+export async function saveClientFields(fields: OnboardingField[]): Promise<SaveFieldsResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!Array.isArray(fields)) return { ok: false, error: "Invalid fields" };
+  if (fields.length > 60) return { ok: false, error: "That's more than 60 fields — split them across an onboarding form instead." };
+
+  const seen = new Set<string>();
+  for (const f of fields) {
+    if (!f?.id?.trim()) return { ok: false, error: "Every field needs an id" };
+    if (!f?.label?.trim()) return { ok: false, error: `The field "${f.id}" needs a label` };
+    if (!ALLOWED_TYPES.has(f.type)) {
+      // 'secure' is deliberately excluded: a client profile is read by anyone
+      // who can see the customer, so it's the wrong home for a credential.
+      return { ok: false, error: `"${f.type}" can't be used on a client profile` };
+    }
+    // Duplicate ids would make one field's answer overwrite another's.
+    if (seen.has(f.id)) return { ok: false, error: `Two fields share the id "${f.id}"` };
+    seen.add(f.id);
+  }
+
+  const { error } = await tbl(supabase, "businesses")
+    .update({ customer_field_schema: fields }).eq("id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/settings/client-fields");
+  revalidatePath("/customers");
+  return { ok: true, count: fields.length };
+}
+
+/** Drop the override and go back to whatever the industry preset ships. */
+export async function resetClientFieldsToPreset(): Promise<SaveFieldsResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { error } = await tbl(supabase, "businesses")
+    .update({ customer_field_schema: null }).eq("id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  const cfg = await getClientFieldConfig();
+  revalidatePath("/settings/client-fields");
+  revalidatePath("/customers");
+  return { ok: true, count: cfg.fields.length };
+}
+
+/**
+ * Save a customer's answers to those fields.
+ *
+ * Answers for fields that no longer exist are dropped rather than kept — an
+ * orphaned answer is invisible in the UI but would resurface if its id were
+ * ever reused, showing one client's data under another's label.
+ */
+export async function saveCustomerFieldValues(
+  customerId: string, values: Record<string, unknown>,
+): Promise<SaveFieldsResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const cfg = await getClientFieldConfig();
+  const clean = pruneAnswers(values, cfg.fields);
+
+  const { error } = await tbl(supabase, "customers")
+    .update({ custom_fields: clean }).eq("id", customerId).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath(`/customers/${customerId}`);
+  return { ok: true, count: Object.keys(clean).length };
+}

--- a/src/lib/customers/field-schema.ts
+++ b/src/lib/customers/field-schema.ts
@@ -1,0 +1,105 @@
+/**
+ * What a "client" looks like, per industry.
+ *
+ * The core customer columns (name, email, phone, address, company) are
+ * universal and stay as columns. Everything ABOVE that is industry-specific:
+ * a roofer needs roof type and access notes, an agency needs the retainer and
+ * the socials. Hardcoding either makes the app wrong for the other.
+ *
+ * So the industry preset supplies a DEFAULT set of extra fields, and a business
+ * can override it entirely from Settings. A NULL stored schema means "use the
+ * preset default" — that's what keeps every existing business unchanged rather
+ * than waking up to a different customer form.
+ *
+ * Fields reuse OnboardingField, the same model the onboarding and public-form
+ * builders already use. That's deliberate: 25 field types, validation and a
+ * drag-to-reorder editor already exist, so a client profile is a new
+ * application of a proven engine rather than a second one to maintain.
+ *
+ * Plain module — imported by server actions, the MCP tools and the UI.
+ */
+import type { OnboardingField } from "@/types/database";
+
+/** Extra client fields shipped with each industry preset. */
+export const PRESET_CUSTOMER_FIELDS: Record<string, OnboardingField[]> = {
+  trades: [
+    { id: "property_type", type: "dropdown", label: "Property type",
+      options: ["Residential", "Commercial", "Strata", "Industrial", "Rural"] },
+    { id: "access_notes", type: "long_text", label: "Site access notes",
+      help_text: "Gate codes, parking, dogs, where to find the key" },
+    { id: "preferred_times", type: "short_text", label: "Preferred visit times" },
+    { id: "referred_by", type: "short_text", label: "How did they find you?" },
+  ],
+
+  agency: [
+    { id: "client_industry", type: "short_text", label: "Their industry" },
+    { id: "engagement", type: "dropdown", label: "Engagement type",
+      options: ["Retainer", "Project", "Ad hoc"] },
+    { id: "monthly_retainer", type: "currency", label: "Monthly retainer" },
+    { id: "billing_day", type: "number", label: "Billing day of month" },
+    { id: "primary_goal", type: "long_text", label: "What does success look like?",
+      help_text: "The outcome they're paying for — leads, launches, brand awareness" },
+    { id: "website_url", type: "url", label: "Website" },
+    { id: "instagram", type: "short_text", label: "Instagram" },
+    { id: "facebook", type: "short_text", label: "Facebook" },
+    { id: "linkedin", type: "short_text", label: "LinkedIn" },
+    { id: "brand_assets", type: "url", label: "Brand assets / drive link" },
+  ],
+
+  "seo-agency-local": [
+    { id: "client_industry", type: "short_text", label: "Their industry" },
+    { id: "engagement", type: "dropdown", label: "Engagement type",
+      options: ["Retainer", "Project", "Ad hoc"] },
+    { id: "monthly_retainer", type: "currency", label: "Monthly retainer" },
+    { id: "website_url", type: "url", label: "Website" },
+    { id: "target_locations", type: "long_text", label: "Target locations",
+      help_text: "Suburbs or regions they want to rank in" },
+    { id: "gbp_url", type: "url", label: "Google Business Profile" },
+    { id: "main_competitors", type: "long_text", label: "Main competitors" },
+  ],
+};
+
+/** Businesses with no preset still get something sensible. */
+export const GENERIC_CUSTOMER_FIELDS: OnboardingField[] = [
+  { id: "referred_by", type: "short_text", label: "How did they find you?" },
+  { id: "account_notes", type: "long_text", label: "Account notes" },
+];
+
+/**
+ * The fields to show for a business.
+ *
+ * An explicitly stored schema always wins — including an empty array, which
+ * means "I don't want any extra fields". Distinguishing empty from unset is the
+ * whole point: falling back to the preset when someone deliberately cleared
+ * their fields would make the setting impossible to turn off.
+ */
+export function resolveCustomerFields(
+  storedSchema: OnboardingField[] | null | undefined,
+  industryPreset: string | null | undefined,
+): OnboardingField[] {
+  if (Array.isArray(storedSchema)) return storedSchema;
+  return PRESET_CUSTOMER_FIELDS[industryPreset ?? ""] ?? GENERIC_CUSTOMER_FIELDS;
+}
+
+/** True when the business is running on its preset's defaults. */
+export function isUsingPresetDefaults(storedSchema: OnboardingField[] | null | undefined): boolean {
+  return !Array.isArray(storedSchema);
+}
+
+/**
+ * Drop answers whose field no longer exists in the schema.
+ *
+ * Without this, removing a field would orphan its answers — invisible in the
+ * UI but still in the row, resurfacing if the field id were ever reused.
+ */
+export function pruneAnswers(
+  answers: Record<string, unknown> | null | undefined,
+  fields: OnboardingField[],
+): Record<string, unknown> {
+  const ids = new Set(fields.map((f) => f.id));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(answers ?? {})) {
+    if (ids.has(k)) out[k] = v;
+  }
+  return out;
+}

--- a/supabase/migrations/20260806090000_client_field_schema.sql
+++ b/supabase/migrations/20260806090000_client_field_schema.sql
@@ -1,0 +1,21 @@
+-- Industry-aware client profiles.
+--
+-- A roofer's client and a marketing agency's client are not the same record.
+-- The roofer wants roof type and access notes; the agency wants retainer,
+-- socials and brand assets. Hardcoding either one makes the app wrong for the
+-- other, and hardcoding both makes it wrong for everyone.
+--
+-- So: the industry preset supplies DEFAULTS, and the business can override.
+-- NULL schema means "use the preset's default", which is what keeps existing
+-- businesses unchanged — nobody gets a migration-day surprise.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS customer_field_schema JSONB;
+
+-- Answers keyed by field id, same shape the onboarding engine already uses.
+ALTER TABLE public.customers
+  ADD COLUMN IF NOT EXISTS custom_fields JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.businesses.customer_field_schema IS
+  'OnboardingField[] describing this business''s client profile. NULL = use the industry preset default.';
+COMMENT ON COLUMN public.customers.custom_fields IS
+  'Answers to customer_field_schema, keyed by field id.';


### PR DESCRIPTION
> "those settings don't really work for connected studio a marketing agency — I want a solution where things can be more agnostic to work with a SaaS"

A roofer's client and an agency's client aren't the same record. Hardcoding either makes the app wrong for the other. So **the industry preset supplies defaults, and the business can override them.**

## What each industry gets out of the box

| Trades | Agency |
|---|---|
| Property type | Their industry |
| Site access notes | Engagement type · monthly retainer · billing day |
| Preferred visit times | What does success look like |
| How did they find you | Website · Instagram · Facebook · LinkedIn · brand assets |

SEO agencies get target locations, GBP link and competitors instead. A business with no preset gets a sensible generic pair.

## The override

**Settings → Business → Client fields.** Add, rename, reorder, change type, remove — with a **live preview** of the client form beside the editor and a **reset to preset** escape hatch.

## Design decisions worth reviewing

**NULL means "use the preset", rather than seeding a copy.** So existing businesses keep working unchanged *and* keep inheriting improvements to the preset — until the moment they customise, at which point it's theirs.

**An empty array is a real choice, not "unset".** Falling back to the preset there would make "no extra fields" impossible to configure — you'd clear them and they'd come straight back.

**Fields reuse `OnboardingField`** — the same model the onboarding and public-form builders already use. A new application of a proven engine rather than a second one to maintain.

**`secure` is excluded from client profiles.** A profile is visible to anyone who can see the client, so it's the wrong home for a credential. Enforced server-side and tested.

**One renderer for the form and the detail view**, so the two can't drift into displaying the same field differently. Unknown types fall back to a text input rather than vanishing — a field someone configured must always be fillable.

## Two data-integrity guards

- **Renaming keeps the id** once answers may exist. Regenerating it would orphan every answer already saved.
- **Answers for deleted fields are pruned**, not left behind — an orphan is invisible but would resurface if the id were reused, showing one client's data under another's label.

## Applying the lesson from #444
Every expected failure is **returned** as `{ ok: false, error }`, never thrown — Next masks thrown server-action messages in production.

## Verify
`npx tsc --noEmit` ✅ · `npm run build` ✅ · **12 tests** ✅ · migration applied + recorded ✅

One test fails deliberately if a new industry preset ever ships without a client field set — so this can't silently regress when the next vertical is added.

⚠️ Not verified in a browser (`/settings/client-fields` needs a login I don't have locally). The resolver logic is the risky part and it's unit-tested; the layout wants your eye on the preview URL.

## Next in this thread
Rendering these fields on the add-client and client-detail screens, and the staff-fillable onboarding on the client page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)