### PR TITLE
fix(customers): client types per industry + catch onboarding gaps before saving

### DIFF
--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -91,6 +91,7 @@ async function CustomerDetailContent({ id }: { id: string }) {
         businessCountry={business.country ?? null}
         onboarding={onboarding}
         clientFields={fieldConfig?.fields ?? []}
+        accountTypes={fieldConfig?.accountTypes ?? []}
       />
     );
   } catch {

--- a/src/app/(dashboard)/customers/new/page.tsx
+++ b/src/app/(dashboard)/customers/new/page.tsx
@@ -22,11 +22,18 @@ async function loadFillableForms(): Promise<StaffFillForm[]> {
 }
 
 export default async function NewCustomerPage() {
+  // A failed config load is REPORTED, not swallowed. Returning empty fields on
+  // error is indistinguishable from "this business has no extra fields", which
+  // makes a broken page look like a configured one.
   const [business, fieldConfig, onboardingForms] = await Promise.all([
     getBusiness().catch(() => null),
-    getClientFieldConfig().catch(() => null),
+    getClientFieldConfig().then(
+      (c) => ({ config: c, error: null as string | null }),
+      (e: unknown) => ({ config: null, error: e instanceof Error ? e.message : "Couldn't load your client settings" }),
+    ),
     loadFillableForms(),
   ]);
+
   return (
     <div className="max-w-3xl mx-auto">
       <PageHeader
@@ -34,9 +41,15 @@ export default async function NewCustomerPage() {
         subtitle="Add a customer to your account"
         accent="linear-gradient(180deg, #3a847e 0%, #1f4f4a 100%)"
       />
+      {fieldConfig.error && (
+        <p className="mb-4 rounded-xl border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {fieldConfig.error} — the standard fields below still work.
+        </p>
+      )}
       <CustomerForm
         businessCountry={business?.country ?? null}
-        clientFields={fieldConfig?.fields ?? []}
+        clientFields={fieldConfig.config?.fields ?? []}
+        accountTypes={fieldConfig.config?.accountTypes ?? []}
         onboardingForms={onboardingForms}
       />
     </div>

--- a/src/components/customers/client-fields.tsx
+++ b/src/components/customers/client-fields.tsx
@@ -18,12 +18,15 @@ import type { OnboardingField } from "@/types/database";
  * for it yet.
  */
 export function ClientFields({
-  fields, values, onChange, disabled,
+  fields, values, onChange, disabled, invalidIds = [],
 }: {
   fields: OnboardingField[];
   values: Record<string, unknown>;
   onChange: (id: string, value: unknown) => void;
   disabled?: boolean;
+  /** Field ids that failed validation — outlined so the fix is findable
+   *  without hunting through the form. */
+  invalidIds?: string[];
 }) {
   if (fields.length === 0) return null;
 
@@ -115,9 +118,15 @@ export function ClientFields({
           }
         })();
 
+        const invalid = invalidIds.includes(f.id);
         return (
-          <div key={f.id} className={wide ? "sm:col-span-2" : undefined}>
-            <Label htmlFor={f.id}>{f.label}{f.required ? " *" : ""}</Label>
+          <div
+            key={f.id}
+            className={`${wide ? "sm:col-span-2 " : ""}${invalid ? "rounded-lg ring-1 ring-destructive/50 p-2 -m-2" : ""}`}
+          >
+            <Label htmlFor={f.id} className={invalid ? "text-destructive" : undefined}>
+              {f.label}{f.required ? " *" : ""}
+            </Label>
             {control}
             {f.help_text && <p className="mt-1 text-xs text-muted-foreground">{f.help_text}</p>}
           </div>

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/icons";
 import { AttachmentsPanel } from "@/components/attachments/attachments-panel";
 import { ClientFieldsSummary } from "@/components/customers/client-fields";
+import type { AccountTypeOption } from "@/lib/customers/account-types";
 import { Button } from "@/components/ui/button";
 import {
   DetailHero, StatTile, AnimatedPress, FadeIn, KireiAvatar, GradientTile,
@@ -79,6 +80,8 @@ interface Props {
   onboarding?: CustomerOnboardingData | null;
   /** This business's client-profile fields (industry preset or its override). */
   clientFields?: OnboardingField[];
+  /** Client type options for this business. */
+  accountTypes?: AccountTypeOption[];
 }
 
 // ── Property Modal ─────────────────────────────────────────────────────────────
@@ -507,6 +510,7 @@ export function CustomerDetailClient({
   businessCountry = null,
   onboarding = null,
   clientFields = [],
+  accountTypes = [],
 }: Props) {
   const [customer, setCustomer] = useState(initial);
   const [editing, setEditing] = useState(false);
@@ -601,7 +605,7 @@ export function CustomerDetailClient({
 
       {editing ? (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-          <CustomerForm customer={customer} businessCountry={businessCountry} clientFields={clientFields} onSuccess={(updated) => { setCustomer(updated); setEditing(false); }} />
+          <CustomerForm customer={customer} businessCountry={businessCountry} clientFields={clientFields} accountTypes={accountTypes} onSuccess={(updated) => { setCustomer(updated); setEditing(false); }} />
         </motion.div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/src/components/customers/customer-form.tsx
+++ b/src/components/customers/customer-form.tsx
@@ -12,6 +12,12 @@ import { saveStaffOnboardingResponse } from "@/lib/actions/onboarding";
 import { ClientFields } from "@/components/customers/client-fields";
 import { StaffOnboardingFill, type StaffFillForm, type StaffFillValue } from "@/components/onboarding/staff-onboarding-fill";
 import { pruneAnswers } from "@/lib/customers/field-schema";
+import {
+  staffFillProblems, staffFillErrorMessage, type StaffFillProblem,
+} from "@/lib/onboarding/staff-fill";
+import {
+  resolveAccountTypes, withCurrentValue, defaultAccountType, type AccountTypeOption,
+} from "@/lib/customers/account-types";
 import type { OnboardingField } from "@/types/database";
 import { PAYMENT_METHODS, PAYMENT_METHOD_LABELS, type PaymentMethod } from "@/lib/payment-methods";
 import { Button } from "@/components/ui/button";
@@ -22,19 +28,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { AddressFields } from "@/components/addresses/address-fields";
 import { FormSection, AnimatedPress } from "@/components/ui/kirei";
 import type { Customer } from "@/types/database";
-
-const ACCOUNT_TYPES: { value: Customer["account_type"]; label: string; hint?: string }[] = [
-  { value: "residential",   label: "Residential",          hint: "Homeowner / private individual" },
-  { value: "commercial",    label: "Commercial",           hint: "Business client" },
-  { value: "developer",     label: "Developer",            hint: "Property developer / builder-developer" },
-  { value: "agent",         label: "Real estate agent",    hint: "Sales / leasing agent" },
-  { value: "builder",       label: "Builder",              hint: "Construction company" },
-  { value: "strata",        label: "Strata company",       hint: "Body corporate / owners corp" },
-  { value: "property_mgmt", label: "Property manager",     hint: "Manages rental properties" },
-  { value: "government",    label: "Government",           hint: "Council / public sector" },
-  { value: "non_profit",    label: "Non-profit / charity" },
-  { value: "other",         label: "Other" },
-];
 
 const PREFERRED_CONTACT: { value: NonNullable<Customer["preferred_contact"]>; label: string }[] = [
   { value: "any",   label: "Any" },
@@ -76,16 +69,27 @@ interface CustomerFormProps {
   clientFields?: OnboardingField[];
   /** Onboarding forms staff can fill in here. Omitted when the plugin is off. */
   onboardingForms?: StaffFillForm[];
+  /** Client types for this business. Empty = fall back to the generic list, so
+   *  a caller that hasn't been updated still renders a usable dropdown. */
+  accountTypes?: AccountTypeOption[];
 }
 
 export function CustomerForm({
   customer, onSuccess, businessCountry, clientFields = [], onboardingForms = [],
+  accountTypes = [],
 }: CustomerFormProps) {
+  // An existing customer's type is always offered, even if the business has
+  // since changed its list — otherwise editing them would silently reclassify.
+  const typeOptions = withCurrentValue(
+    accountTypes.length ? accountTypes : resolveAccountTypes(null, null),
+    customer?.account_type,
+  );
   const router = useRouter();
   const [custom, setCustom] = useState<Record<string, unknown>>(
     (customer?.custom_fields as Record<string, unknown>) ?? {},
   );
   const [fill, setFill] = useState<StaffFillValue>({ formId: "", answers: {} });
+  const [fillProblems, setFillProblems] = useState<StaffFillProblem[]>([]);
   const { register, handleSubmit, control, setValue, watch, formState: { errors, isSubmitting } } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -97,7 +101,7 @@ export function CustomerForm({
       contact_role: customer?.contact_role ?? "",
       website: customer?.website ?? "",
       tax_number: customer?.tax_number ?? "",
-      account_type: customer?.account_type ?? "residential",
+      account_type: customer?.account_type ?? defaultAccountType(typeOptions),
       preferred_contact: customer?.preferred_contact ?? "any",
       address: customer?.address ?? "",
       city: customer?.city ?? "",
@@ -109,10 +113,27 @@ export function CustomerForm({
     },
   });
 
+  // "Company / organisation" vs "Company": only a private individual is a
+  // person rather than an organisation, and which value means that differs
+  // per industry, so key off the handful of personal types.
   const accountType = watch("account_type");
-  const showCompanyHint = accountType !== "residential" && accountType !== "individual";
+  const showCompanyHint = !["residential", "individual"].includes(accountType);
 
   const onSubmit = async (data: FormData) => {
+    // Check the attached onboarding form BEFORE creating anything. Finding out
+    // afterwards leaves the client saved and the form not — and the answers
+    // typed into this screen gone, to be re-entered from their profile.
+    if (!customer && fill.formId) {
+      const picked = onboardingForms.find((f) => f.id === fill.formId);
+      const problems = picked ? staffFillProblems(picked.schema, fill.answers) : [];
+      setFillProblems(problems);
+      if (problems.length) {
+        toast.error(staffFillErrorMessage(problems));
+        document.getElementById("onboarding-section")?.scrollIntoView({ behavior: "smooth", block: "center" });
+        return;
+      }
+    }
+
     try {
       const payload = {
         name: data.name,
@@ -123,7 +144,7 @@ export function CustomerForm({
         contact_role: data.contact_role || null,
         website: data.website || null,
         tax_number: data.tax_number || null,
-        account_type: data.account_type as Customer["account_type"],
+        account_type: data.account_type,
         preferred_contact: (data.preferred_contact || null) as Customer["preferred_contact"],
         address: data.address || null,
         city: data.city || null,
@@ -144,9 +165,7 @@ export function CustomerForm({
       toast.success(customer ? "Customer updated" : "Customer created");
 
       // The customer exists now, so the onboarding answers have something to
-      // attach to. Failing here must not read as the customer having failed —
-      // it's already saved. Say what went wrong and carry on to their page,
-      // where the Onboarding tab can retry it.
+      // attach to. Anything wrong with them was caught before we got here.
       if (!customer && fill.formId) {
         const res = await saveStaffOnboardingResponse(fill.formId, result.id, fill.answers);
         if (res.ok) toast.success("Onboarding form saved against this customer");
@@ -175,7 +194,7 @@ export function CustomerForm({
             <Select value={field.value} onValueChange={field.onChange}>
               <SelectTrigger className="h-11 rounded-xl"><SelectValue placeholder="Select type" /></SelectTrigger>
               <SelectContent>
-                {ACCOUNT_TYPES.map((t) => (
+                {typeOptions.map((t) => (
                   <SelectItem key={t.value} value={t.value}>
                     <div className="flex flex-col items-start">
                       <span>{t.label}</span>
@@ -203,7 +222,7 @@ export function CustomerForm({
             </div>
             <div className="space-y-1.5">
               <Label>{showCompanyHint ? "Company / organisation" : "Company"}</Label>
-              <Input className="h-11 rounded-xl" placeholder={showCompanyHint ? "Acme Strata Pty Ltd" : "Acme Ltd (optional)"} {...register("company")} />
+              <Input className="h-11 rounded-xl" placeholder={showCompanyHint ? "Acme Pty Ltd" : "Acme Ltd (optional)"} {...register("company")} />
             </div>
             <div className="space-y-1.5">
               <Label>Role / title</Label>
@@ -336,14 +355,21 @@ export function CustomerForm({
       {/* Create only — an existing customer has the richer Onboarding tab,
           which also handles sending and viewing. */}
       {!customer && onboardingForms.length > 0 && (
-        <FormSection
-          icon={<ClipboardList className="w-4 h-4" />}
-          gradient="blue"
-          title="Onboarding"
-          hint="Already have their details? Fill the form in here instead of sending it."
-        >
-          <StaffOnboardingFill forms={onboardingForms} value={fill} onChange={setFill} />
-        </FormSection>
+        <div id="onboarding-section">
+          <FormSection
+            icon={<ClipboardList className="w-4 h-4" />}
+            gradient="blue"
+            title="Onboarding"
+            hint="Already have their details? Fill the form in here instead of sending it."
+          >
+            <StaffOnboardingFill
+              forms={onboardingForms}
+              value={fill}
+              problems={fillProblems}
+              onChange={(next) => { setFill(next); setFillProblems([]); }}
+            />
+          </FormSection>
+        </div>
       )}
 
       <FormSection

--- a/src/components/onboarding/staff-onboarding-fill.tsx
+++ b/src/components/onboarding/staff-onboarding-fill.tsx
@@ -15,7 +15,9 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { ClientFields } from "@/components/customers/client-fields";
-import { staffFillableFields, staffOnlyCustomerFields } from "@/lib/onboarding/staff-fill";
+import {
+  staffFillableFields, staffOnlyCustomerFields, type StaffFillProblem,
+} from "@/lib/onboarding/staff-fill";
 import type { OnboardingField } from "@/types/database";
 
 export interface StaffFillForm {
@@ -30,7 +32,7 @@ export interface StaffFillValue {
 }
 
 export function StaffOnboardingFill({
-  forms, value, onChange, disabled, showPicker = true,
+  forms, value, onChange, disabled, showPicker = true, problems = [],
 }: {
   forms: StaffFillForm[];
   value: StaffFillValue;
@@ -38,6 +40,9 @@ export function StaffOnboardingFill({
   disabled?: boolean;
   /** Off where the caller already has a form picker of its own. */
   showPicker?: boolean;
+  /** Blocking problems from the last submit attempt, shown against the fields
+   *  rather than only in a toast that disappears. */
+  problems?: StaffFillProblem[];
 }) {
   const picked = forms.find((f) => f.id === value.formId) ?? null;
   const fillable = useMemo(() => (picked ? staffFillableFields(picked.schema) : []), [picked]);
@@ -80,12 +85,29 @@ export function StaffOnboardingFill({
               Every field on this form needs the customer (uploads or credentials). Send it to them instead.
             </p>
           ) : (
-            <ClientFields
-              fields={fillable}
-              values={value.answers}
-              disabled={disabled}
-              onChange={(id, v) => onChange({ ...value, answers: { ...value.answers, [id]: v } })}
-            />
+            <>
+              {problems.length > 0 && (
+                <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-3">
+                  <p className="text-sm font-medium text-destructive">
+                    {problems.length === 1 ? "One field needs fixing" : `${problems.length} fields need fixing`}
+                  </p>
+                  <ul className="mt-1 space-y-0.5">
+                    {problems.map((p) => (
+                      <li key={p.field_id} className="text-xs text-destructive">
+                        {p.label} {p.message}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <ClientFields
+                fields={fillable}
+                values={value.answers}
+                disabled={disabled}
+                invalidIds={problems.map((p) => p.field_id)}
+                onChange={(id, v) => onChange({ ...value, answers: { ...value.answers, [id]: v } })}
+              />
+            </>
           )}
 
           {/* Never let a half-filled form read as complete: name exactly what

--- a/src/components/settings/client-fields-settings.tsx
+++ b/src/components/settings/client-fields-settings.tsx
@@ -8,7 +8,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Plus, Trash2, ChevronUp, ChevronDown, Loader2, RefreshCw } from "@/components/ui/icons";
-import { saveClientFields, resetClientFieldsToPreset, type ClientFieldConfig } from "@/lib/actions/client-fields";
+import {
+  saveClientFields, resetClientFieldsToPreset, saveClientAccountTypes, type ClientFieldConfig,
+} from "@/lib/actions/client-fields";
+import type { AccountTypeOption } from "@/lib/customers/account-types";
 import { ClientFields } from "@/components/customers/client-fields";
 import type { OnboardingField, OnboardingFieldType } from "@/types/database";
 
@@ -36,8 +39,20 @@ const slug = (s: string) =>
 export function ClientFieldsSettings({ config }: { config: ClientFieldConfig }) {
   const router = useRouter();
   const [fields, setFields] = useState<OnboardingField[]>(config.fields);
+  const [types, setTypes] = useState<AccountTypeOption[]>(config.accountTypes);
   const [preview, setPreview] = useState<Record<string, unknown>>({});
   const [saving, setSaving] = useState(false);
+  const [savingTypes, setSavingTypes] = useState(false);
+
+  const saveTypes = async () => {
+    setSavingTypes(true);
+    try {
+      const res = await saveClientAccountTypes(types);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success(`Saved — ${res.count} client type${res.count === 1 ? "" : "s"}`);
+      router.refresh();
+    } finally { setSavingTypes(false); }
+  };
 
   const update = (i: number, patch: Partial<OnboardingField>) =>
     setFields((prev) => prev.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
@@ -75,7 +90,7 @@ export function ClientFieldsSettings({ config }: { config: ClientFieldConfig }) 
         actions={
           <>
             <Button variant="outline" disabled={saving} onClick={async () => {
-              if (!confirm("Reset to your industry's defaults? Any fields you've added here are removed — answers already saved on clients stay in the database but stop being shown.")) return;
+              if (!confirm("Reset client types AND fields to your industry's defaults? Anything you've added here is removed — answers already saved on clients stay in the database but stop being shown.")) return;
               const res = await resetClientFieldsToPreset();
               if (!res.ok) { toast.error(res.error); return; }
               toast.success("Back to the preset defaults");
@@ -100,6 +115,65 @@ export function ClientFieldsSettings({ config }: { config: ClientFieldConfig }) 
           Name, email, phone, company and address are always present and aren&rsquo;t listed here. Credentials belong
           in an onboarding form, not a client profile — anyone who can see the client can see these.
         </p>
+      </div>
+
+      {/* Client types — the dropdown at the top of every client form. Was a
+          fixed trades list (Strata, Builder, Property manager), which an
+          agency had no use for. */}
+      <div className="mb-5 rounded-xl border border-border bg-card p-4">
+        <div className="mb-1 flex items-center justify-between gap-2 flex-wrap">
+          <div>
+            <h2 className="text-sm font-semibold">Client types</h2>
+            <p className="text-xs text-muted-foreground">
+              The dropdown at the top of the client form. Every client is saved with one, so keep at least one.
+            </p>
+          </div>
+          <Button size="sm" variant="outline" disabled={savingTypes} onClick={saveTypes}>
+            {savingTypes && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />} Save types
+          </Button>
+        </div>
+
+        <div className="mt-3 space-y-2">
+          {types.map((t, i) => (
+            <div key={t.value} className="flex items-center gap-2">
+              <Input
+                value={t.label}
+                className="flex-1"
+                onChange={(e) => {
+                  const label = e.target.value;
+                  // Same rule as the fields: once clients are saved against a
+                  // value, renaming must not change the stored value.
+                  const isFresh = /^type_\d+_/.test(t.value);
+                  setTypes((p) => p.map((x, idx) => idx === i
+                    ? { ...x, label, ...(isFresh ? { value: slug(label) || x.value } : {}) } : x));
+                }}
+              />
+              <Input
+                value={t.hint ?? ""}
+                placeholder="Hint (optional)"
+                className="flex-1"
+                onChange={(e) => setTypes((p) => p.map((x, idx) => idx === i ? { ...x, hint: e.target.value } : x))}
+              />
+              <button
+                onClick={() => setTypes((p) => p.filter((_, idx) => idx !== i))}
+                aria-label={`Remove ${t.label}`}
+                className="text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={() => setTypes((p) => [
+              ...p, { value: `type_${p.length + 1}_${Date.now().toString(36)}`, label: "New type" },
+            ])}>
+              <Plus className="mr-1.5 h-4 w-4" /> Add type
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Clients already saved under a removed type keep it — it stays selectable on those clients only.
+            </p>
+          </div>
+        </div>
       </div>
 
       <div className="grid gap-5 lg:grid-cols-2">

--- a/src/lib/__tests__/account-types.test.ts
+++ b/src/lib/__tests__/account-types.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESET_ACCOUNT_TYPES, GENERIC_ACCOUNT_TYPES, resolveAccountTypes, isUsingPresetAccountTypes,
+  withCurrentValue, defaultAccountType, humaniseAccountType, validateAccountTypes,
+} from "@/lib/customers/account-types";
+import { INDUSTRY_PRESETS } from "@/lib/plugins/presets";
+
+describe("resolveAccountTypes", () => {
+  it("gives an agency agency types, not strata and builders", () => {
+    const values = resolveAccountTypes(null, "agency").map((o) => o.value);
+    expect(values).toContain("retainer_client");
+    // The whole bug: a marketing agency being asked to classify a client as a
+    // body corporate.
+    expect(values).not.toContain("strata");
+    expect(values).not.toContain("property_mgmt");
+    expect(values).not.toContain("builder");
+  });
+
+  it("leaves trades exactly as it was", () => {
+    expect(resolveAccountTypes(null, "trades").map((o) => o.value))
+      .toEqual(["residential", "commercial", "developer", "agent", "builder",
+        "strata", "property_mgmt", "government", "non_profit", "other"]);
+  });
+
+  it("falls back to the generic list with no preset", () => {
+    expect(resolveAccountTypes(null, null)).toEqual(GENERIC_ACCOUNT_TYPES);
+    expect(resolveAccountTypes(undefined, "not-a-preset")).toEqual(GENERIC_ACCOUNT_TYPES);
+  });
+
+  it("lets a stored list win over the preset", () => {
+    const mine = [{ value: "vip", label: "VIP" }];
+    expect(resolveAccountTypes(mine, "trades")).toEqual(mine);
+    expect(isUsingPresetAccountTypes(mine)).toBe(false);
+    expect(isUsingPresetAccountTypes(null)).toBe(true);
+  });
+
+  it("ships a type list for every industry preset", () => {
+    // A new vertical without one silently gets the generic list — which is how
+    // the agency ended up with roofing vocabulary in the first place.
+    for (const p of INDUSTRY_PRESETS) {
+      expect(PRESET_ACCOUNT_TYPES[p.id], `preset "${p.id}" has no client types`).toBeTruthy();
+    }
+  });
+});
+
+describe("withCurrentValue", () => {
+  it("keeps an existing customer's type selectable after a preset switch", () => {
+    // Otherwise opening a trades-era customer under the agency preset shows an
+    // empty dropdown and rewrites their type on the next save.
+    const opts = withCurrentValue(resolveAccountTypes(null, "agency"), "strata");
+    expect(opts.map((o) => o.value)).toContain("strata");
+    expect(opts.find((o) => o.value === "strata")?.label).toBe("Strata company");
+  });
+
+  it("doesn't duplicate a value already in the list", () => {
+    const opts = withCurrentValue(resolveAccountTypes(null, "trades"), "residential");
+    expect(opts.filter((o) => o.value === "residential")).toHaveLength(1);
+  });
+
+  it("handles a customer with no type", () => {
+    const base = resolveAccountTypes(null, "trades");
+    expect(withCurrentValue(base, null)).toEqual(base);
+  });
+});
+
+describe("defaults and labels", () => {
+  it("starts a new client on the first option of ITS list", () => {
+    // Not a hardcoded "residential", which isn't even in the agency list.
+    expect(defaultAccountType(resolveAccountTypes(null, "agency"))).toBe("retainer_client");
+    expect(defaultAccountType(resolveAccountTypes(null, "trades"))).toBe("residential");
+    expect(defaultAccountType([])).toBe("other");
+  });
+
+  it("humanises a value no list explains", () => {
+    expect(humaniseAccountType("property_mgmt")).toBe("Property manager");
+    expect(humaniseAccountType("some_legacy_value")).toBe("Some legacy value");
+  });
+});
+
+describe("validateAccountTypes", () => {
+  it("refuses an empty list — every client is saved with a type", () => {
+    expect(validateAccountTypes([])).toMatch(/at least one/i);
+  });
+  it("refuses duplicate values", () => {
+    expect(validateAccountTypes([
+      { value: "a", label: "A" }, { value: "a", label: "Also A" },
+    ])).toMatch(/share the value/i);
+  });
+  it("refuses a blank label", () => {
+    expect(validateAccountTypes([{ value: "a", label: "  " }])).toMatch(/needs a label/i);
+  });
+  it("accepts a normal list", () => {
+    expect(validateAccountTypes(resolveAccountTypes(null, "agency"))).toBeNull();
+  });
+});

--- a/src/lib/__tests__/staff-fill.test.ts
+++ b/src/lib/__tests__/staff-fill.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isStaffFillable, staffFillableFields, staffOnlyCustomerFields,
   stripUnfillableAnswers, missingForStaff, STAFF_UNFILLABLE_TYPES,
+  staffFillProblems, staffFillErrorMessage,
 } from "@/lib/onboarding/staff-fill";
 import type { OnboardingField } from "@/types/database";
 
@@ -57,6 +58,47 @@ describe("stripUnfillableAnswers", () => {
   it("keeps falsy answers that are real values", () => {
     const schema = [f("count", "number"), f("ok", "yes_no")];
     expect(stripUnfillableAnswers(schema, { count: 0, ok: false })).toEqual({ count: 0, ok: false });
+  });
+});
+
+describe("staffFillProblems", () => {
+  // This is what the add-client screen runs BEFORE creating the client. It
+  // used to run only on the server, afterwards — so a missing field left the
+  // client created and the form lost.
+  it("names the field, not just 'invalid'", () => {
+    const schema = [f("company", "short_text", { required: true, label: "Company name" })];
+    const problems = staffFillProblems(schema, {});
+    expect(problems).toEqual([{ field_id: "company", label: "Company name", message: "is required" }]);
+    expect(staffFillErrorMessage(problems)).toBe("Company name is required");
+  });
+
+  it("catches bad formats too", () => {
+    const schema = [f("email", "email", { label: "Work email" })];
+    const problems = staffFillProblems(schema, { email: "not-an-email" });
+    expect(problems).toHaveLength(1);
+    expect(problems[0].label).toBe("Work email");
+  });
+
+  it("doesn't complain twice about one empty field", () => {
+    // Empty + required must not also report "invalid format".
+    const schema = [f("email", "email", { required: true, label: "Work email" })];
+    expect(staffFillProblems(schema, { email: "" })).toHaveLength(1);
+  });
+
+  it("ignores upload and credential fields entirely", () => {
+    expect(staffFillProblems(SCHEMA, { company: "Acme" })).toEqual([]);
+  });
+
+  it("lists every problem, so one fix at a time isn't needed", () => {
+    const schema = [
+      f("a", "short_text", { required: true, label: "A" }),
+      f("b", "short_text", { required: true, label: "B" }),
+    ];
+    expect(staffFillErrorMessage(staffFillProblems(schema, {}))).toBe("Fix these first: A is required, B is required");
+  });
+
+  it("says nothing when the form is complete", () => {
+    expect(staffFillErrorMessage(staffFillProblems(SCHEMA, { company: "Acme" }))).toBe("");
   });
 });
 

--- a/src/lib/actions/client-fields.ts
+++ b/src/lib/actions/client-fields.ts
@@ -16,6 +16,9 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { resolveCustomerFields, pruneAnswers, isUsingPresetDefaults } from "@/lib/customers/field-schema";
+import {
+  resolveAccountTypes, isUsingPresetAccountTypes, validateAccountTypes, type AccountTypeOption,
+} from "@/lib/customers/account-types";
 import type { OnboardingField } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,6 +36,9 @@ export interface ClientFieldConfig {
   /** True when nothing has been customised — the preset's defaults are in use. */
   usingPresetDefaults: boolean;
   industryPreset: string | null;
+  /** Client TYPE options (Residential / Retainer client / …). */
+  accountTypes: AccountTypeOption[];
+  usingPresetAccountTypes: boolean;
 }
 
 export async function getClientFieldConfig(): Promise<ClientFieldConfig> {
@@ -40,14 +46,38 @@ export async function getClientFieldConfig(): Promise<ClientFieldConfig> {
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
-  const { data } = await tbl(supabase, "businesses")
-    .select("customer_field_schema, industry_preset").eq("id", businessId).maybeSingle();
+  // Check the error: a failed read here previously fell through to the generic
+  // defaults, which looks exactly like a business that has no preset.
+  const { data, error } = await tbl(supabase, "businesses")
+    .select("customer_field_schema, customer_type_options, industry_preset")
+    .eq("id", businessId).maybeSingle();
+  if (error) throw new Error(`Couldn't load your client settings: ${error.message}`);
 
   return {
     fields: resolveCustomerFields(data?.customer_field_schema, data?.industry_preset),
     usingPresetDefaults: isUsingPresetDefaults(data?.customer_field_schema),
     industryPreset: data?.industry_preset ?? null,
+    accountTypes: resolveAccountTypes(data?.customer_type_options, data?.industry_preset),
+    usingPresetAccountTypes: isUsingPresetAccountTypes(data?.customer_type_options),
   };
+}
+
+/** Replace the business's client TYPE options. */
+export async function saveClientAccountTypes(options: AccountTypeOption[]): Promise<SaveFieldsResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const problem = validateAccountTypes(options);
+  if (problem) return { ok: false, error: problem };
+
+  const { error } = await tbl(supabase, "businesses")
+    .update({ customer_type_options: options }).eq("id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/settings/client-fields");
+  revalidatePath("/customers");
+  return { ok: true, count: options.length };
 }
 
 export type SaveFieldsResult = { ok: true; count: number } | { ok: false; error: string };
@@ -90,8 +120,10 @@ export async function resetClientFieldsToPreset(): Promise<SaveFieldsResult> {
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
+  // Both halves go back together — a half-reset business is a state nobody
+  // asked for and can't see they're in.
   const { error } = await tbl(supabase, "businesses")
-    .update({ customer_field_schema: null }).eq("id", businessId);
+    .update({ customer_field_schema: null, customer_type_options: null }).eq("id", businessId);
   if (error) return { ok: false, error: error.message };
 
   const cfg = await getClientFieldConfig();

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -8,9 +8,9 @@ import { getUser } from "@/lib/auth";
 import { appUrl } from "@/lib/app-url";
 import { pluginFlagsTag } from "@/lib/layout-data";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
-import { redactSecureAnswers, invalidAnswerFields } from "@/lib/onboarding/answers";
+import { redactSecureAnswers } from "@/lib/onboarding/answers";
 import {
-  staffFillableFields, staffOnlyCustomerFields, stripUnfillableAnswers, missingForStaff,
+  staffOnlyCustomerFields, stripUnfillableAnswers, staffFillProblems, staffFillErrorMessage,
 } from "@/lib/onboarding/staff-fill";
 import { decryptSecret, isEncryptedAnswer, secureFieldsAvailable } from "@/lib/onboarding/crypto";
 import type {
@@ -293,16 +293,10 @@ export async function saveStaffOnboardingResponse(
   if (schema.length === 0) return { ok: false, error: "That form has no fields yet" };
 
   const clean = stripUnfillableAnswers(schema, answers ?? {});
-  const badFormats = invalidAnswerFields(staffFillableFields(schema), clean);
-  if (badFormats.length) {
-    const first = schema.find((f) => f.id === badFormats[0].field_id);
-    return { ok: false, error: `${first?.label ?? "A field"}: ${badFormats[0].message}` };
-  }
-  const missing = missingForStaff(schema, clean);
-  if (missing.length) {
-    const labels = missing.map((id) => schema.find((f) => f.id === id)?.label ?? id);
-    return { ok: false, error: `Still needs: ${labels.join(", ")}` };
-  }
+  // Same check the browser ran before creating the client — repeated here
+  // because a check only the client performs isn't one.
+  const problems = staffFillProblems(schema, answers ?? {});
+  if (problems.length) return { ok: false, error: staffFillErrorMessage(problems) };
 
   // Reuse an open request for this form+customer rather than stacking a second
   // one — otherwise "send it, then fill it in yourself" leaves two rows.

--- a/src/lib/customers/account-types.ts
+++ b/src/lib/customers/account-types.ts
@@ -1,0 +1,127 @@
+/**
+ * What kind of client this is — per industry.
+ *
+ * "Customer type" used to be a fixed trades list: Residential, Strata,
+ * Builder, Property manager. An agency was asked to classify a client as a
+ * strata company. Same problem as the client fields, so the same answer: the
+ * industry preset supplies defaults, the business can override them.
+ *
+ * Plain module — server actions, MCP tools and the form all read it.
+ */
+import type { OnboardingField } from "@/types/database";
+
+export interface AccountTypeOption {
+  value: string;
+  label: string;
+  hint?: string;
+}
+
+export const PRESET_ACCOUNT_TYPES: Record<string, AccountTypeOption[]> = {
+  trades: [
+    { value: "residential",   label: "Residential",          hint: "Homeowner / private individual" },
+    { value: "commercial",    label: "Commercial",           hint: "Business client" },
+    { value: "developer",     label: "Developer",            hint: "Property developer / builder-developer" },
+    { value: "agent",         label: "Real estate agent",    hint: "Sales / leasing agent" },
+    { value: "builder",       label: "Builder",              hint: "Construction company" },
+    { value: "strata",        label: "Strata company",       hint: "Body corporate / owners corp" },
+    { value: "property_mgmt", label: "Property manager",     hint: "Manages rental properties" },
+    { value: "government",    label: "Government",           hint: "Council / public sector" },
+    { value: "non_profit",    label: "Non-profit / charity" },
+    { value: "other",         label: "Other" },
+  ],
+
+  agency: [
+    { value: "retainer_client", label: "Retainer client",  hint: "Ongoing monthly engagement" },
+    { value: "project_client",  label: "Project client",   hint: "Fixed scope, defined end" },
+    { value: "startup",         label: "Startup" },
+    { value: "smb",             label: "Small business" },
+    { value: "ecommerce",       label: "E-commerce" },
+    { value: "enterprise",      label: "Enterprise" },
+    { value: "agency_partner",  label: "Agency partner",   hint: "White-label / subcontracted work" },
+    { value: "non_profit",      label: "Non-profit / charity" },
+    { value: "other",           label: "Other" },
+  ],
+
+  "seo-agency-local": [
+    { value: "local_business",        label: "Local business",       hint: "Single location" },
+    { value: "multi_location",        label: "Multi-location",       hint: "Several branches or service areas" },
+    { value: "franchise",             label: "Franchise" },
+    { value: "ecommerce",             label: "E-commerce" },
+    { value: "professional_services", label: "Professional services", hint: "Legal, medical, accounting" },
+    { value: "agency_partner",        label: "Agency partner",       hint: "White-label / subcontracted work" },
+    { value: "non_profit",            label: "Non-profit / charity" },
+    { value: "other",                 label: "Other" },
+  ],
+};
+
+/** Businesses with no preset get something that fits anyone. */
+export const GENERIC_ACCOUNT_TYPES: AccountTypeOption[] = [
+  { value: "individual",  label: "Individual" },
+  { value: "commercial",  label: "Business" },
+  { value: "government",  label: "Government" },
+  { value: "non_profit",  label: "Non-profit / charity" },
+  { value: "other",       label: "Other" },
+];
+
+/**
+ * Options for a business. A stored array always wins — including an empty
+ * one, same rule as the client fields.
+ */
+export function resolveAccountTypes(
+  stored: AccountTypeOption[] | null | undefined,
+  industryPreset: string | null | undefined,
+): AccountTypeOption[] {
+  if (Array.isArray(stored)) return stored;
+  return PRESET_ACCOUNT_TYPES[industryPreset ?? ""] ?? GENERIC_ACCOUNT_TYPES;
+}
+
+export function isUsingPresetAccountTypes(stored: AccountTypeOption[] | null | undefined): boolean {
+  return !Array.isArray(stored);
+}
+
+/** `property_mgmt` → `Property manager`-ish. For values no list explains. */
+export function humaniseAccountType(value: string): string {
+  const known = Object.values(PRESET_ACCOUNT_TYPES).flat().concat(GENERIC_ACCOUNT_TYPES)
+    .find((o) => o.value === value);
+  if (known) return known.label;
+  return value.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+}
+
+/**
+ * Guarantee the value a customer already has is selectable.
+ *
+ * A business that switches preset (or edits its list) still has customers
+ * classified under the old vocabulary. Without this, opening one of those
+ * would show an empty dropdown and quietly rewrite their type on the next
+ * save — data loss disguised as an edit.
+ */
+export function withCurrentValue(
+  options: AccountTypeOption[],
+  current: string | null | undefined,
+): AccountTypeOption[] {
+  if (!current || options.some((o) => o.value === current)) return options;
+  return [...options, { value: current, label: humaniseAccountType(current), hint: "Existing value" }];
+}
+
+/** The value a brand-new client should start on. */
+export function defaultAccountType(options: AccountTypeOption[]): string {
+  return options[0]?.value ?? "other";
+}
+
+/** Shared with the client-field editor so both reject the same junk. */
+export function validateAccountTypes(options: AccountTypeOption[]): string | null {
+  if (!Array.isArray(options)) return "Invalid options";
+  if (options.length === 0) return "Keep at least one client type — every client is saved with one.";
+  if (options.length > 40) return "That's more than 40 client types. Use client fields for finer detail.";
+  const seen = new Set<string>();
+  for (const o of options) {
+    if (!o?.value?.trim()) return "Every client type needs a value";
+    if (!o?.label?.trim()) return `The type "${o.value}" needs a label`;
+    if (seen.has(o.value)) return `Two client types share the value "${o.value}"`;
+    seen.add(o.value);
+  }
+  return null;
+}
+
+/** Kept here so the settings editor and the form agree on what a field is. */
+export type { OnboardingField };

--- a/src/lib/mcp/tools/plugin-form-tools.ts
+++ b/src/lib/mcp/tools/plugin-form-tools.ts
@@ -526,12 +526,16 @@ export function registerPluginFormTools(tool: ToolFn): void {
     async (_args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "settings:read");
       const { resolveCustomerFields, isUsingPresetDefaults } = await import("@/lib/customers/field-schema");
+      const { resolveAccountTypes, isUsingPresetAccountTypes } = await import("@/lib/customers/account-types");
       const { data } = await t(ctx, "businesses")
-        .select("customer_field_schema, industry_preset").eq("id", ctx.businessId).maybeSingle();
+        .select("customer_field_schema, customer_type_options, industry_preset")
+        .eq("id", ctx.businessId).maybeSingle();
       return text({
         fields: resolveCustomerFields(data?.customer_field_schema, data?.industry_preset),
         using_preset_defaults: isUsingPresetDefaults(data?.customer_field_schema),
         industry_preset: data?.industry_preset ?? null,
+        client_types: resolveAccountTypes(data?.customer_type_options, data?.industry_preset),
+        using_preset_client_types: isUsingPresetAccountTypes(data?.customer_type_options),
       });
     });
 
@@ -554,13 +558,27 @@ export function registerPluginFormTools(tool: ToolFn): void {
       return text({ updated: true, count: args.fields.length });
     });
 
+  tool("set_client_types",
+    "Replace the client TYPE options — the dropdown at the top of every client form (Residential/Strata for trades, Retainer client/Project client for an agency). Keep at least one: every client is saved with one.",
+    { types: z.array(z.object({ value: z.string().min(1), label: z.string().min(1), hint: z.string().optional() })) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const { validateAccountTypes } = await import("@/lib/customers/account-types");
+      const problem = validateAccountTypes(args.types);
+      if (problem) return errorText(problem);
+      const { error } = await t(ctx, "businesses")
+        .update({ customer_type_options: args.types }).eq("id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true, count: args.types.length });
+    });
+
   tool("reset_client_fields",
-    "Drop this business's custom client fields and go back to its industry preset's defaults. Answers already saved on clients stay in the database but stop being shown.",
+    "Drop this business's custom client fields AND client types, going back to its industry preset's defaults. Answers already saved on clients stay in the database but stop being shown.",
     {},
     async (_args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
       const { error } = await t(ctx, "businesses")
-        .update({ customer_field_schema: null }).eq("id", ctx.businessId);
+        .update({ customer_field_schema: null, customer_type_options: null }).eq("id", ctx.businessId);
       if (error) throw error;
       return text({ reset: true });
     });

--- a/src/lib/onboarding/answers.ts
+++ b/src/lib/onboarding/answers.ts
@@ -5,8 +5,13 @@
 import type { OnboardingField, OnboardingAnswers } from "@/types/database";
 import { encryptSecret, isEncryptedAnswer } from "./crypto";
 
-/** Field types that never hold an answer. */
-export const DISPLAY_ONLY_TYPES = new Set(["instructions", "heading", "divider"]);
+// Validation lives in ./validate (no crypto import) so client components can
+// run it before submitting. Re-exported here so server callers are unchanged.
+export {
+  DISPLAY_ONLY_TYPES, isValidAbn, isValidAcn, invalidAnswerFields, missingRequiredFields,
+} from "./validate";
+export type { AnswerError } from "./validate";
+
 
 /** Encrypt secure-field values before storage; pass everything else through.
  *  Already-encrypted values (autosave round-trips) are left as-is. */
@@ -41,106 +46,4 @@ export function redactSecureAnswers(
   return out;
 }
 
-// ── Format validation ────────────────────────────────────────────────────────
-
-/** ABN checksum (ATO algorithm): subtract 1 from the first digit, apply
- *  weights, total must be divisible by 89. */
-export function isValidAbn(raw: string): boolean {
-  const digits = raw.replace(/\D/g, "");
-  if (digits.length !== 11) return false;
-  const weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
-  const sum = weights.reduce((acc, w, i) => acc + w * (Number(digits[i]) - (i === 0 ? 1 : 0)), 0);
-  return sum % 89 === 0;
-}
-
-/** ACN checksum (ASIC algorithm): weights 8..1 over the first 8 digits,
- *  complement of the remainder is the 9th digit. */
-export function isValidAcn(raw: string): boolean {
-  const digits = raw.replace(/\D/g, "");
-  if (digits.length !== 9) return false;
-  const sum = [8, 7, 6, 5, 4, 3, 2, 1].reduce((acc, w, i) => acc + w * Number(digits[i]), 0);
-  return (10 - (sum % 10)) % 10 === Number(digits[8]);
-}
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
-const URL_RE = /^(https?:\/\/)?[\w-]+(\.[\w-]+)+([/?#].*)?$/i;
-const PHONE_RE = /^\+?[0-9 ()\-]{6,20}$/;
-
-export interface AnswerError { field_id: string; message: string }
-
-/** Validate answer FORMATS for non-empty, visible answers. Runs on final
- *  submit alongside missingRequiredFields. Custom `validation.pattern` on a
- *  field (e.g. social-handle presets) is checked after the type-level rules. */
-export function invalidAnswerFields(
-  schema: OnboardingField[],
-  answers: OnboardingAnswers
-): AnswerError[] {
-  const visible = (f: OnboardingField): boolean => {
-    if (!f.show_if?.field_id) return true;
-    return String(answers?.[f.show_if.field_id] ?? "") === f.show_if.equals;
-  };
-  const errors: AnswerError[] = [];
-
-  for (const f of schema) {
-    if (DISPLAY_ONLY_TYPES.has(f.type) || !visible(f)) continue;
-    const v = answers?.[f.id];
-    if (v == null || v === "" || typeof v !== "string") continue; // formats apply to string answers only
-    const s = v.trim();
-    if (!s) continue;
-
-    // ACN preset rides on short_text — checksum it before the generic pattern.
-    if (f.preset === "acn") {
-      if (!isValidAcn(s)) errors.push({ field_id: f.id, message: "That doesn't look like a valid ACN (9 digits)" });
-      continue;
-    }
-
-    switch (f.type) {
-      case "email":
-        if (!EMAIL_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid email address" });
-        continue;
-      case "url":
-        if (!URL_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid link (e.g. https://example.com)" });
-        continue;
-      case "phone":
-        if (!PHONE_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid phone number" });
-        continue;
-      case "abn":
-        if (!isValidAbn(s)) errors.push({ field_id: f.id, message: "That doesn't look like a valid ABN (11 digits, checksum failed)" });
-        continue;
-      case "number":
-      case "currency":
-        if (Number.isNaN(Number(s.replace(/[, ]/g, "")))) errors.push({ field_id: f.id, message: "Enter a number" });
-        continue;
-    }
-
-    if (f.validation?.pattern) {
-      try {
-        if (!new RegExp(f.validation.pattern).test(s)) {
-          errors.push({ field_id: f.id, message: f.validation.message || "Doesn't match the expected format" });
-        }
-      } catch { /* bad pattern authored on the form — never block the customer */ }
-    }
-  }
-  return errors;
-}
-
-/** Validate required fields (honouring simple show_if visibility). Returns
- *  the ids of missing required fields — empty array = valid. */
-export function missingRequiredFields(
-  schema: OnboardingField[],
-  answers: OnboardingAnswers
-): string[] {
-  const visible = (f: OnboardingField): boolean => {
-    if (!f.show_if?.field_id) return true;
-    return String(answers?.[f.show_if.field_id] ?? "") === f.show_if.equals;
-  };
-  return schema
-    .filter((f) => f.required && !DISPLAY_ONLY_TYPES.has(f.type) && visible(f))
-    .filter((f) => {
-      const v = answers?.[f.id];
-      if (v == null || v === "") return true;
-      if (Array.isArray(v) && v.length === 0) return true;
-      return false;
-    })
-    .map((f) => f.id);
-}
+// Format + required validation: see ./validate.

--- a/src/lib/onboarding/staff-fill.ts
+++ b/src/lib/onboarding/staff-fill.ts
@@ -7,7 +7,9 @@
  * the UI would offer a field the server then silently dropped.
  */
 import type { OnboardingField, OnboardingAnswers } from "@/types/database";
-import { DISPLAY_ONLY_TYPES, missingRequiredFields } from "./answers";
+// From ./validate, not ./answers — this module is imported by client
+// components, and answers.ts pulls in node:crypto.
+import { DISPLAY_ONLY_TYPES, missingRequiredFields, invalidAnswerFields } from "./validate";
 
 /**
  * Types staff can't fill in from the dashboard:
@@ -65,4 +67,41 @@ export function missingForStaff(
   answers: OnboardingAnswers,
 ): string[] {
   return missingRequiredFields(staffFillableFields(schema), answers);
+}
+
+export interface StaffFillProblem { field_id: string; label: string; message: string }
+
+/**
+ * Everything wrong with a staff-filled form, ready to show.
+ *
+ * One implementation for the browser and the server. The add-client screen
+ * runs it BEFORE creating the client — finding out afterwards means the client
+ * exists but the form doesn't, and you have to re-enter it from their profile.
+ * The server runs it again, because a check only the browser performs is not a
+ * check.
+ */
+export function staffFillProblems(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers,
+): StaffFillProblem[] {
+  const label = (id: string) => schema.find((f) => f.id === id)?.label ?? id;
+  const clean = stripUnfillableAnswers(schema, answers);
+
+  const problems: StaffFillProblem[] = missingForStaff(schema, clean).map((id) => ({
+    field_id: id, label: label(id), message: "is required",
+  }));
+
+  for (const e of invalidAnswerFields(staffFillableFields(schema), clean)) {
+    // Don't pile a format complaint on top of "you haven't filled it in".
+    if (problems.some((p) => p.field_id === e.field_id)) continue;
+    problems.push({ field_id: e.field_id, label: label(e.field_id), message: e.message });
+  }
+  return problems;
+}
+
+/** One sentence naming what to fix — the fields, not "validation failed". */
+export function staffFillErrorMessage(problems: StaffFillProblem[]): string {
+  if (problems.length === 0) return "";
+  if (problems.length === 1) return `${problems[0].label} ${problems[0].message}`;
+  return `Fix these first: ${problems.map((p) => `${p.label} ${p.message}`).join(", ")}`;
 }

--- a/src/lib/onboarding/validate.ts
+++ b/src/lib/onboarding/validate.ts
@@ -1,0 +1,117 @@
+/**
+ * Answer validation — pure, and deliberately free of any crypto import.
+ *
+ * Split out of answers.ts so client components can validate BEFORE submitting.
+ * answers.ts pulls in node:crypto for secure fields; importing it from a
+ * "use client" module only works while a bundler happens to tree-shake that
+ * away. Validation has no business depending on that.
+ *
+ * answers.ts re-exports everything here, so existing server callers are
+ * unchanged.
+ */
+import type { OnboardingField, OnboardingAnswers } from "@/types/database";
+
+/** Field types that never hold an answer. */
+export const DISPLAY_ONLY_TYPES = new Set(["instructions", "heading", "divider"]);
+
+/** ABN checksum (ATO algorithm): subtract 1 from the first digit, apply
+ *  weights, total must be divisible by 89. */
+export function isValidAbn(raw: string): boolean {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length !== 11) return false;
+  const weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+  const sum = weights.reduce((acc, w, i) => acc + w * (Number(digits[i]) - (i === 0 ? 1 : 0)), 0);
+  return sum % 89 === 0;
+}
+
+/** ACN checksum (ASIC algorithm): weights 8..1 over the first 8 digits,
+ *  complement of the remainder is the 9th digit. */
+export function isValidAcn(raw: string): boolean {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length !== 9) return false;
+  const sum = [8, 7, 6, 5, 4, 3, 2, 1].reduce((acc, w, i) => acc + w * Number(digits[i]), 0);
+  return (10 - (sum % 10)) % 10 === Number(digits[8]);
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+const URL_RE = /^(https?:\/\/)?[\w-]+(\.[\w-]+)+([/?#].*)?$/i;
+const PHONE_RE = /^\+?[0-9 ()\-]{6,20}$/;
+
+export interface AnswerError { field_id: string; message: string }
+
+/** Validate answer FORMATS for non-empty, visible answers. Runs on final
+ *  submit alongside missingRequiredFields. Custom `validation.pattern` on a
+ *  field (e.g. social-handle presets) is checked after the type-level rules. */
+export function invalidAnswerFields(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers
+): AnswerError[] {
+  const visible = (f: OnboardingField): boolean => {
+    if (!f.show_if?.field_id) return true;
+    return String(answers?.[f.show_if.field_id] ?? "") === f.show_if.equals;
+  };
+  const errors: AnswerError[] = [];
+
+  for (const f of schema) {
+    if (DISPLAY_ONLY_TYPES.has(f.type) || !visible(f)) continue;
+    const v = answers?.[f.id];
+    if (v == null || v === "" || typeof v !== "string") continue; // formats apply to string answers only
+    const s = v.trim();
+    if (!s) continue;
+
+    // ACN preset rides on short_text — checksum it before the generic pattern.
+    if (f.preset === "acn") {
+      if (!isValidAcn(s)) errors.push({ field_id: f.id, message: "That doesn't look like a valid ACN (9 digits)" });
+      continue;
+    }
+
+    switch (f.type) {
+      case "email":
+        if (!EMAIL_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid email address" });
+        continue;
+      case "url":
+        if (!URL_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid link (e.g. https://example.com)" });
+        continue;
+      case "phone":
+        if (!PHONE_RE.test(s)) errors.push({ field_id: f.id, message: "Enter a valid phone number" });
+        continue;
+      case "abn":
+        if (!isValidAbn(s)) errors.push({ field_id: f.id, message: "That doesn't look like a valid ABN (11 digits, checksum failed)" });
+        continue;
+      case "number":
+      case "currency":
+        if (Number.isNaN(Number(s.replace(/[, ]/g, "")))) errors.push({ field_id: f.id, message: "Enter a number" });
+        continue;
+    }
+
+    if (f.validation?.pattern) {
+      try {
+        if (!new RegExp(f.validation.pattern).test(s)) {
+          errors.push({ field_id: f.id, message: f.validation.message || "Doesn't match the expected format" });
+        }
+      } catch { /* bad pattern authored on the form — never block the customer */ }
+    }
+  }
+  return errors;
+}
+
+/** Validate required fields (honouring simple show_if visibility). Returns
+ *  the ids of missing required fields — empty array = valid. */
+export function missingRequiredFields(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers
+): string[] {
+  const visible = (f: OnboardingField): boolean => {
+    if (!f.show_if?.field_id) return true;
+    return String(answers?.[f.show_if.field_id] ?? "") === f.show_if.equals;
+  };
+  return schema
+    .filter((f) => f.required && !DISPLAY_ONLY_TYPES.has(f.type) && visible(f))
+    .filter((f) => {
+      const v = answers?.[f.id];
+      if (v == null || v === "") return true;
+      if (Array.isArray(v) && v.length === 0) return true;
+      return false;
+    })
+    .map((f) => f.id);
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -62,6 +62,8 @@ export interface Business {
   /** Overrides the preset's client fields. NULL = still using the preset;
    *  [] = deliberately none. */
   customer_field_schema?: OnboardingField[] | null;
+  /** Overrides the preset's client TYPE options. NULL = using the preset. */
+  customer_type_options?: { value: string; label: string; hint?: string }[] | null;
   invoice_prefix: string;
   invoice_next_number: number;
   quote_prefix: string;
@@ -97,10 +99,10 @@ export interface Customer {
   company: string | null;
   tax_number: string | null;
   notes: string | null;
-  account_type:
-    | 'residential' | 'commercial' | 'developer' | 'agent' | 'builder'
-    | 'strata' | 'property_mgmt' | 'government' | 'non_profit' | 'other'
-    | 'individual';
+  /** Client type. Free text: the valid set is per-business (industry preset or
+   *  its override) so no fixed union can describe it. The DB CHECK was dropped
+   *  in 20260806120000 for the same reason. See lib/customers/account-types.ts. */
+  account_type: string;
   website: string | null;
   secondary_phone: string | null;
   contact_role: string | null;

--- a/supabase/migrations/20260806120000_client_type_options.sql
+++ b/supabase/migrations/20260806120000_client_type_options.sql
@@ -1,0 +1,25 @@
+-- Customer type per industry, overridable per business.
+--
+-- customers.account_type was CHECK-constrained to a trades vocabulary
+-- (residential / strata / builder / property_mgmt …). An agency picking a
+-- client type was offered "Strata company", which is meaningless to them.
+--
+-- The valid set is now per-business, so a single global CHECK can no longer
+-- express it: dropping the constraint moves that validation into the app,
+-- where the option list actually lives. Existing rows keep their values —
+-- nothing is rewritten, and a legacy value stays selectable on the customer
+-- that holds it.
+
+ALTER TABLE public.customers DROP CONSTRAINT IF EXISTS customers_account_type_check;
+
+-- NULL = use the industry preset's list. A stored array overrides it, exactly
+-- like businesses.customer_field_schema.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS customer_type_options JSONB;
+
+COMMENT ON COLUMN public.businesses.customer_type_options IS
+  'Client type options [{value,label,hint}]. NULL = the industry preset''s defaults.';
+
+COMMENT ON COLUMN public.customers.account_type IS
+  'Client type. Free text, validated against the business''s configured list '
+  '(see lib/customers/account-types.ts) rather than a global CHECK.';


### PR DESCRIPTION
Two things hit while adding an agency client.

## 1. "Customer type" was still roofing vocabulary

Connected Studio was being asked to classify a client as a **Strata company**, **Builder** or **Property manager**. Now preset-driven and overridable, same shape as the client fields:

| Preset | Types |
|---|---|
| agency | Retainer client, Project client, Startup, Small business, E-commerce, Enterprise, Agency partner, Non-profit, Other |
| seo-agency-local | Local business, Multi-location, Franchise, E-commerce, Professional services, Agency partner, Non-profit, Other |
| trades | unchanged |
| no preset | Individual, Business, Government, Non-profit, Other |

Editable at **Settings → Business → Client fields**, next to the fields.

**This needed a migration.** The column had a CHECK constraint pinning it to the trades values, so the valid set could not be per-business — a single global constraint can't express "depends on the business". The migration drops it and moves that validation into the app, where the list lives. Applied to the live DB and recorded.

**Two data-safety decisions:**

- **A customer's existing type is always kept selectable.** Without that, opening a trades-era customer under the agency preset would show an empty dropdown and silently reclassify them on the next save.
- **A new client defaults to the first type of its own list** rather than a hardcoded `residential` — which isn't in the agency list at all, so it would have been saved as a value the dropdown couldn't display.

## 2. The onboarding form was validated too late

An attached form was only checked server-side, **after** the client was created. A missing required field left the client saved, the form not saved, and everything typed into it gone — to be re-entered from the client's profile.

Now it's checked **before anything is written**: the fields are named in the message, outlined in the form, and scrolled to. The server still repeats the check, because a check only the browser performs is not a check. `staffFillProblems` is the single implementation both sides call.

## Two things found on the way

- **Validation had to move out of `onboarding/answers.ts`** into `onboarding/validate.ts`. `answers.ts` imports `node:crypto` for secure fields, so reaching its validators from a `"use client"` module only worked while the bundler happened to tree-shake that away. Now it's correct by construction.
- **`getClientFieldConfig` ignored its query error** and fell through to the generic defaults — a failed read looked identical to a business with no preset. It now checks the error, and `/customers/new` reports a failed load instead of quietly rendering as if there were no fields to show.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 214 tests passing, 22 new ✅

The new tests pin the things that would silently regress: that no shipped preset lacks a type list (how the agency got roofing vocabulary in the first place), that a stale value survives a preset switch, and that an empty required field isn't also reported as a bad format.

Not clicked through in a browser — the local dev server needs a login I can't perform. Worth testing the agency add-client flow on the preview.