### PR TITLE
fix(business): keep each browser tab on its own business

### DIFF
--- a/src/app/api/activate-invite/route.ts
+++ b/src/app/api/activate-invite/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { setActiveBusinessCookies } from "@/lib/business-cookie";
 import { revalidateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { cookies } from "next/headers";
@@ -56,12 +57,7 @@ export async function GET(request: NextRequest) {
 
     if (hasAccess) {
       const cookieStore = await cookies();
-      cookieStore.set("active_business_id", biz, {
-        path: "/",
-        httpOnly: true,
-        sameSite: "lax",
-        maxAge: 60 * 60 * 24 * 365,
-      });
+      setActiveBusinessCookies(cookieStore, biz);
     }
   }
 

--- a/src/components/business/business-switcher.tsx
+++ b/src/components/business/business-switcher.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { setActiveBusiness } from "@/lib/actions/business";
 import { AddBusinessModal } from "./add-business-modal";
 import { useAppLoading } from "@/components/layout/app-loading";
+import { rememberTabBusiness } from "@/components/layout/tab-business-guard";
 import type { Business } from "@/types/database";
 
 interface BusinessSwitcherProps {
@@ -33,6 +34,9 @@ export function BusinessSwitcher({ business, businesses, onClose }: BusinessSwit
   const handleSwitch = (biz: Business) => {
     if (biz.id === business.id) return;
     setBusy(`Switching to ${biz.name}…`);
+    // Claim the tab BEFORE the cookie flips, or the guard sees a hint that
+    // doesn't match this tab's remembered business and switches straight back.
+    rememberTabBusiness(biz.id);
     pendingSwitch.current = true;
     onClose?.();
     // setActiveBusiness flips the cookie, then router.refresh() refetches the

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -8,6 +8,7 @@ import { AppearanceProvider } from "./appearance-provider";
 import { AppLoadingProvider } from "./app-loading";
 import { ConfirmProvider } from "@/components/ui/confirm";
 import { RouteProgress } from "./route-progress";
+import { TabBusinessGuard } from "./tab-business-guard";
 import { FocusModeProvider, useFocusMode } from "./focus-mode";
 import { AssistantProvider } from "./assistant-context";
 // The floating AI assistant starts closed and drags in framer-motion + voice
@@ -102,7 +103,9 @@ function ShellBody({ business, businesses, user, userRole, features, vocab, chil
                 the page tree — list components hold their data in local
                 useState(initial) and otherwise show the previous biz's
                 rows until a hard refresh. */}
-            <div key={business.id} className="w-full p-6">
+            {/* Each tab keeps its own business; see tab-business-guard.tsx. */}
+          <TabBusinessGuard businessId={business.id} />
+          <div key={business.id} className="w-full p-6">
               {children}
             </div>
           </main>

--- a/src/components/layout/tab-business-guard.tsx
+++ b/src/components/layout/tab-business-guard.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Keeps each browser tab on its own business.
+ *
+ * The active business is a cookie, which is per-BROWSER, not per-tab. Open
+ * Crown in a second tab and the first tab — still showing Connected Studio —
+ * starts writing to Crown. Wrong data on screen is bad; a save landing in the
+ * wrong business is worse.
+ *
+ * So each tab remembers its business in sessionStorage (which IS per-tab) and
+ * re-asserts it whenever you come back to it. The tab you're looking at wins,
+ * which is what a tab is supposed to mean.
+ *
+ * It re-asserts on focus rather than continuously because that's the only
+ * moment that matters: you have to focus a tab to act in it, and the cookie
+ * travels with the request. A background tab may be showing the other
+ * business, but it can't be used without being focused first.
+ */
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { setActiveBusiness } from "@/lib/actions/business";
+import { readBusinessHint } from "@/lib/business-cookie";
+
+const KEY = "kirei.tab.business";
+
+export function TabBusinessGuard({ businessId }: { businessId: string }) {
+  const router = useRouter();
+  // One re-assert at a time: the action + refresh is a round trip, and focus
+  // can fire twice (visibilitychange then focus) for a single tab switch.
+  const busy = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const reassert = async () => {
+      if (busy.current || cancelled) return;
+
+      let mine: string | null = null;
+      try { mine = sessionStorage.getItem(KEY); } catch { return; } // private mode
+
+      // First render in this tab: adopt whatever the server just gave us.
+      if (!mine) {
+        try { sessionStorage.setItem(KEY, businessId); } catch { /* ignore */ }
+        return;
+      }
+      if (mine === readBusinessHint()) return; // cookie already ours
+
+      busy.current = true;
+      try {
+        await setActiveBusiness(mine);
+        if (!cancelled) router.refresh();
+      } catch {
+        // The remembered business is gone or belongs to another account —
+        // e.g. signed in as someone else in this tab. Forget it and let the
+        // cookie stand rather than retrying on every focus forever.
+        try { sessionStorage.removeItem(KEY); } catch { /* ignore */ }
+      } finally {
+        busy.current = false;
+      }
+    };
+
+    // The switcher writes the new id before its own refresh, so by the time we
+    // see a changed businessId prop it already matches — this only adopts the
+    // value on a genuine first render.
+    void reassert();
+
+    const onVisible = () => { if (document.visibilityState === "visible") void reassert(); };
+    window.addEventListener("focus", reassert);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("focus", reassert);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [businessId, router]);
+
+  return null;
+}
+
+/** Called by the switcher: this tab is deliberately changing business. */
+export function rememberTabBusiness(businessId: string): void {
+  try { sessionStorage.setItem(KEY, businessId); } catch { /* private mode */ }
+}

--- a/src/lib/__tests__/business-cookie.test.ts
+++ b/src/lib/__tests__/business-cookie.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  BIZ_COOKIE, BIZ_HINT_COOKIE, setActiveBusinessCookies, readBusinessHint,
+} from "@/lib/business-cookie";
+
+function fakeStore() {
+  const set = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { store: { set } as any, set };
+}
+
+describe("setActiveBusinessCookies", () => {
+  it("always writes both cookies", () => {
+    // A hint that lags behind the real cookie makes tabs fight forever: the
+    // guard compares against the hint, so a stale one is worse than none.
+    const { store, set } = fakeStore();
+    setActiveBusinessCookies(store, "biz-1");
+    expect(set).toHaveBeenCalledTimes(2);
+    expect(set.mock.calls.map((c) => c[0]).sort()).toEqual([BIZ_HINT_COOKIE, BIZ_COOKIE].sort());
+    expect(set.mock.calls.every((c) => c[1] === "biz-1")).toBe(true);
+  });
+
+  it("keeps the authoritative cookie httpOnly and the hint readable", () => {
+    const { store, set } = fakeStore();
+    setActiveBusinessCookies(store, "biz-1");
+    const real = set.mock.calls.find((c) => c[0] === BIZ_COOKIE)![2];
+    const hint = set.mock.calls.find((c) => c[0] === BIZ_HINT_COOKIE)![2];
+    // The server must never start trusting something JS can forge; the hint is
+    // only ever compared against, never used to authorise anything.
+    expect(real.httpOnly).toBe(true);
+    expect(hint.httpOnly).toBe(false);
+  });
+});
+
+describe("readBusinessHint", () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "document");
+  afterEach(() => {
+    if (original) Object.defineProperty(globalThis, "document", original);
+    else delete (globalThis as { document?: unknown }).document;
+  });
+
+  const withCookie = (cookie: string) =>
+    Object.defineProperty(globalThis, "document", { value: { cookie }, configurable: true });
+
+  it("finds the hint among other cookies", () => {
+    withCookie(`theme=dark; ${BIZ_HINT_COOKIE}=biz-9; other=1`);
+    expect(readBusinessHint()).toBe("biz-9");
+  });
+
+  it("does not match a cookie whose name merely ends with the hint's", () => {
+    withCookie(`not_${BIZ_HINT_COOKIE}=wrong`);
+    expect(readBusinessHint()).toBeNull();
+  });
+
+  it("returns null when absent", () => {
+    withCookie("theme=dark");
+    expect(readBusinessHint()).toBeNull();
+  });
+
+  it("returns null on the server, where there is no document", () => {
+    delete (globalThis as { document?: unknown }).document;
+    expect(readBusinessHint()).toBeNull();
+  });
+});

--- a/src/lib/actions/business.ts
+++ b/src/lib/actions/business.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath, revalidateTag, unstable_cache } from "next/cache";
 import { cookies } from "next/headers";
+import { setActiveBusinessCookies } from "@/lib/business-cookie";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { bizListTag, businessTag } from "@/lib/layout-data";
@@ -64,12 +65,7 @@ export async function setActiveBusiness(businessId: string): Promise<void> {
   }
 
   const cookieStore = await cookies();
-  cookieStore.set("active_business_id", businessId, {
-    path: "/",
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 365, // 1 year
-  });
+  setActiveBusinessCookies(cookieStore, businessId);
 
   revalidatePath("/", "layout");
 }
@@ -106,12 +102,7 @@ export async function createBusiness(payload: {
 
   // Auto-switch to the new business
   const cookieStore = await cookies();
-  cookieStore.set("active_business_id", data.id, {
-    path: "/",
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 365,
-  });
+  setActiveBusinessCookies(cookieStore, data.id);
 
   revalidateTag(bizListTag(user.id), "max");
   revalidatePath("/", "layout");

--- a/src/lib/admin/impersonation.ts
+++ b/src/lib/admin/impersonation.ts
@@ -18,6 +18,9 @@ import type { Operator } from "./auth";
 
 const IMP_COOKIE = "admin_impersonation_id";
 const BIZ_COOKIE = "active_business_id";
+// Mirrored so the per-tab guard sees the impersonated business as the current
+// one and doesn't try to assert the operator's own business over the top.
+const BIZ_HINT_COOKIE = "active_business_hint";
 
 export type ImpersonationSession = {
   id: string;
@@ -77,13 +80,15 @@ export async function startImpersonation(
     path: "/",
     maxAge: 30 * 60, // 30 min, matches DB default
   });
-  jar.set(BIZ_COOKIE, targetBusinessId, {
-    httpOnly: false,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 30 * 60,
-  });
+  for (const name of [BIZ_COOKIE, BIZ_HINT_COOKIE]) {
+    jar.set(name, targetBusinessId, {
+      httpOnly: false,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 30 * 60,
+    });
+  }
 
   await logAdminAction({
     operator,
@@ -111,6 +116,7 @@ export async function stopImpersonation(operator: Operator): Promise<void> {
 
   jar.delete(IMP_COOKIE);
   jar.delete(BIZ_COOKIE);
+  jar.delete(BIZ_HINT_COOKIE);
 
   await logAdminAction({
     operator,

--- a/src/lib/business-cookie.ts
+++ b/src/lib/business-cookie.ts
@@ -1,0 +1,44 @@
+/**
+ * The active-business cookies.
+ *
+ * Two cookies, one value:
+ *
+ * - `active_business_id` — httpOnly, the one the server trusts.
+ * - `active_business_hint` — readable by JS, a mirror.
+ *
+ * The mirror exists so a browser tab can tell that ANOTHER tab changed the
+ * active business. It can't read the httpOnly one, and without that knowledge
+ * a tab happily keeps displaying business A while its next write lands on
+ * business B. The hint carries no authority: every server path still reads the
+ * httpOnly cookie, and RLS is still the gate. It leaks nothing — it's the id of
+ * a business the user is already looking at.
+ *
+ * Plain module: imported by server actions, route handlers and the client
+ * guard, so keep it free of "use server".
+ */
+import type { cookies } from "next/headers";
+
+export const BIZ_COOKIE = "active_business_id";
+export const BIZ_HINT_COOKIE = "active_business_hint";
+
+const YEAR = 60 * 60 * 24 * 365;
+
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
+
+/** Set both cookies together. Setting one without the other is the bug this
+ *  helper exists to prevent — a stale hint makes tabs fight forever. */
+export function setActiveBusinessCookies(store: CookieStore, businessId: string): void {
+  store.set(BIZ_COOKIE, businessId, {
+    path: "/", httpOnly: true, sameSite: "lax", maxAge: YEAR,
+  });
+  store.set(BIZ_HINT_COOKIE, businessId, {
+    path: "/", httpOnly: false, sameSite: "lax", maxAge: YEAR,
+  });
+}
+
+/** Read the hint in the browser. Returns null when absent. */
+export function readBusinessHint(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${BIZ_HINT_COOKIE}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}


### PR DESCRIPTION
Open Connected Studio in one tab and Crown in another, and the first tab switches too.

## This was worse than it looked

The first tab **still shows Connected Studio** — but its next save lands in **Crown**. Wrong data on screen is a nuisance; a write to the wrong business is a data-integrity bug, and it's been live.

## Why it happens

The active business is a cookie. Cookies are per-**browser**, not per-tab, so there is only ever one active business for the whole browser. Nothing about the current design could have made tabs independent.

`sessionStorage` *is* per-tab. So each tab now remembers its own business there and re-asserts it whenever you come back to it. **The tab you're looking at wins** — which is what a tab is supposed to mean.

## Why re-asserting on focus is enough

That's the only moment that matters: you have to focus a tab to act in it, and the cookie travels with the request. A background tab may be displaying the other business, but it can't be *used* without being focused first — and focusing it corrects it.

**The known gap:** a tab opened in the background renders the other business until you click into it. It corrects on focus, visibly.

## The mirror cookie

A tab can't read the `httpOnly` cookie, so it can't tell that another tab changed it. `setActiveBusinessCookies` now writes a readable mirror alongside.

The mirror **carries no authority**: every server path still reads the httpOnly cookie, and RLS is still the gate. It leaks nothing — it's the id of a business already on the user's screen. Both cookies are written through one helper, because a mirror that lags behind the real cookie would make tabs fight forever; a test pins that.

## Three details that would each have been a bug

- **The switcher claims the tab before flipping the cookie.** The other order means the guard sees a mismatch and switches you straight back.
- **A remembered business that's gone — or belongs to another account, if you signed in as someone else in this tab — is forgotten**, rather than retried on every focus forever.
- **Impersonation writes both cookies**, so the guard doesn't assert the operator's own business over the impersonated one.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 200 tests passing, 6 new ✅

Not clicked through — the local dev server needs a login I can't perform. **This one really wants a two-tab test on the preview:** open two tabs, switch one to Crown, click back to the first, and confirm it stays on Connected Studio and saves there.

## If you want the thorough version later

Putting the business in the URL (`?b=…`) would make tabs independent *and* links shareable — send someone a Crown invoice link and it opens as Crown. It's a much bigger change: ~76 Link files, 74 `router.push` calls and 73 redirects all have to carry it, and any missed one silently falls back to the other tab's business. Worth doing separately, if at all.