### PR TITLE
fix(onboarding): stop dropping answers silently; edit a submitted response

### DIFF
--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -30,6 +30,7 @@ async function loadOnboarding(customerId: string): Promise<CustomerOnboardingDat
     return {
       requests,
       responses,
+      allowSecureFill: secureOk,
       activeForms: forms
         .filter((f) => f.status !== "archived" && f.schema.length > 0)
         .map((f) => ({

--- a/src/app/(dashboard)/customers/new/page.tsx
+++ b/src/app/(dashboard)/customers/new/page.tsx
@@ -1,7 +1,7 @@
 import { CustomerForm } from "@/components/customers/customer-form";
 import { getBusiness } from "@/lib/actions/business";
 import { getClientFieldConfig } from "@/lib/actions/client-fields";
-import { getOnboardingSettings, getOnboardingForms } from "@/lib/actions/onboarding";
+import { getOnboardingSettings, getOnboardingForms, getSecureFieldsAvailable } from "@/lib/actions/onboarding";
 import { staffFillableFields } from "@/lib/onboarding/staff-fill";
 import { PageHeader } from "@/components/layout/page-header";
 import type { StaffFillForm } from "@/components/onboarding/staff-onboarding-fill";
@@ -25,13 +25,14 @@ export default async function NewCustomerPage() {
   // A failed config load is REPORTED, not swallowed. Returning empty fields on
   // error is indistinguishable from "this business has no extra fields", which
   // makes a broken page look like a configured one.
-  const [business, fieldConfig, onboardingForms] = await Promise.all([
+  const [business, fieldConfig, onboardingForms, allowSecureFill] = await Promise.all([
     getBusiness().catch(() => null),
     getClientFieldConfig().then(
       (c) => ({ config: c, error: null as string | null }),
       (e: unknown) => ({ config: null, error: e instanceof Error ? e.message : "Couldn't load your client settings" }),
     ),
     loadFillableForms(),
+    getSecureFieldsAvailable().catch(() => false),
   ]);
 
   return (
@@ -51,6 +52,7 @@ export default async function NewCustomerPage() {
         clientFields={fieldConfig.config?.fields ?? []}
         accountTypes={fieldConfig.config?.accountTypes ?? []}
         onboardingForms={onboardingForms}
+        allowSecureFill={allowSecureFill}
       />
     </div>
   );

--- a/src/app/(dashboard)/onboarding-forms/[id]/page.tsx
+++ b/src/app/(dashboard)/onboarding-forms/[id]/page.tsx
@@ -23,9 +23,10 @@ export default async function OnboardingFormBuilderPage({ params, searchParams }
 
   // ?response=<requestId> → show the submitted answers instead of the builder.
   if (responseRequestId) {
-    const [response, requests] = await Promise.all([
+    const [response, requests, allowSecureFill] = await Promise.all([
       getOnboardingResponse(responseRequestId),
       getOnboardingRequests({ form_id: id }),
+      getSecureFieldsAvailable(),
     ]);
     const request = requests.find((r) => r.id === responseRequestId);
     if (response && request) {
@@ -36,6 +37,7 @@ export default async function OnboardingFormBuilderPage({ params, searchParams }
           response={response}
           customerName={request.customers?.name ?? "Customer"}
           customerId={request.customer_id}
+          allowSecureFill={allowSecureFill}
         />
       );
     }

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -61,6 +61,8 @@ export interface CustomerOnboardingData {
   /** `blocked` explains why a form can't be sent — computed server-side so the
    *  picker can say so before you try. `schema` powers filling it in yourself. */
   activeForms: (Pick<OnboardingForm, "id" | "name" | "schema"> & { blocked?: string | null })[];
+  /** Credential fields fillable from the dashboard (server has a key). */
+  allowSecureFill?: boolean;
 }
 
 interface Props {
@@ -759,6 +761,7 @@ export function CustomerDetailClient({
                     requests={onboarding.requests}
                     responses={onboarding.responses}
                     activeForms={onboarding.activeForms}
+                    allowSecureFill={onboarding.allowSecureFill ?? false}
                   />
                 </TabsContent>
               )}

--- a/src/components/customers/customer-form.tsx
+++ b/src/components/customers/customer-form.tsx
@@ -72,11 +72,13 @@ interface CustomerFormProps {
   /** Client types for this business. Empty = fall back to the generic list, so
    *  a caller that hasn't been updated still renders a usable dropdown. */
   accountTypes?: AccountTypeOption[];
+  /** Whether credential fields can be staff-filled (server has a key). */
+  allowSecureFill?: boolean;
 }
 
 export function CustomerForm({
   customer, onSuccess, businessCountry, clientFields = [], onboardingForms = [],
-  accountTypes = [],
+  accountTypes = [], allowSecureFill = false,
 }: CustomerFormProps) {
   // An existing customer's type is always offered, even if the business has
   // since changed its list — otherwise editing them would silently reclassify.
@@ -125,7 +127,7 @@ export function CustomerForm({
     // typed into this screen gone, to be re-entered from their profile.
     if (!customer && fill.formId) {
       const picked = onboardingForms.find((f) => f.id === fill.formId);
-      const problems = picked ? staffFillProblems(picked.schema, fill.answers) : [];
+      const problems = picked ? staffFillProblems(picked.schema, fill.answers, { allowSecure: allowSecureFill }) : [];
       setFillProblems(problems);
       if (problems.length) {
         toast.error(staffFillErrorMessage(problems));
@@ -366,6 +368,7 @@ export function CustomerForm({
               forms={onboardingForms}
               value={fill}
               problems={fillProblems}
+              allowSecure={allowSecureFill}
               onChange={(next) => { setFill(next); setFillProblems([]); }}
             />
           </FormSection>

--- a/src/components/onboarding/customer-onboarding-card.tsx
+++ b/src/components/onboarding/customer-onboarding-card.tsx
@@ -40,9 +40,11 @@ interface Props {
   /** `blocked` explains why a form can't be sent, so the picker can say so
    *  before you try rather than after. `schema` powers filling it in yourself. */
   activeForms: (Pick<OnboardingForm, "id" | "name" | "schema"> & { blocked?: string | null })[];
+  /** Credential fields fillable here (server has an encryption key). */
+  allowSecureFill?: boolean;
 }
 
-export function CustomerOnboardingCard({ customerId, requests, responses, activeForms }: Props) {
+export function CustomerOnboardingCard({ customerId, requests, responses, activeForms, allowSecureFill = false }: Props) {
   const blockedForms = activeForms.filter((f) => f.blocked);
   const router = useRouter();
   const [pickedForm, setPickedForm] = useState("");
@@ -52,7 +54,7 @@ export function CustomerOnboardingCard({ customerId, requests, responses, active
   const responseByRequest = new Map(responses.map((r) => [r.request_id, r]));
   const picked = activeForms.find((f) => f.id === pickedForm) ?? null;
   // A form of nothing but uploads/credentials can't be staff-filled at all.
-  const canFill = Boolean(picked && !picked.blocked && staffFillableFields(picked.schema).length > 0);
+  const canFill = Boolean(picked && !picked.blocked && staffFillableFields(picked.schema, { allowSecure: allowSecureFill }).length > 0);
 
   const saveFill = async () => {
     if (!picked) return;
@@ -133,6 +135,7 @@ export function CustomerOnboardingCard({ customerId, requests, responses, active
             value={{ formId: picked.id, answers: fillAnswers }}
             onChange={(next) => setFillAnswers(next.answers)}
             showPicker={false}
+            allowSecure={allowSecureFill}
             disabled={busy}
           />
           <div className="flex justify-end">

--- a/src/components/onboarding/response-viewer-client.tsx
+++ b/src/components/onboarding/response-viewer-client.tsx
@@ -9,12 +9,18 @@
 import { useState } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
-import { ArrowLeft, Eye, EyeOff, Download, Loader2, Lock, Check } from "@/components/ui/icons";
+import { ArrowLeft, Eye, EyeOff, Download, Loader2, Lock, Check, PenLine, Trash2, Send } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
-import { revealSecureAnswer, getOnboardingUploadUrl } from "@/lib/actions/onboarding";
+import { useRouter } from "next/navigation";
+import {
+  revealSecureAnswer, getOnboardingUploadUrl, updateOnboardingResponse,
+  deleteOnboardingRequest, sendOnboardingRequest,
+} from "@/lib/actions/onboarding";
+import { ClientFields } from "@/components/customers/client-fields";
+import { staffFillableFields, staffOnlyCustomerFields, isStaffFillable } from "@/lib/onboarding/staff-fill";
 import { socialProfileUrl } from "@/lib/onboarding/presets";
 import { AnswerImageThumb } from "@/components/onboarding/answer-image-thumb";
 import { formatDate } from "@/lib/utils";
@@ -29,12 +35,71 @@ interface Props {
   response: OnboardingResponse;
   customerName: string;
   customerId: string;
+  /** Credential fields editable here (server has an encryption key). */
+  allowSecureFill?: boolean;
 }
 
-export function ResponseViewerClient({ formId, formName, response, customerName, customerId }: Props) {
-  const fields = (response.schema_snapshot ?? []).filter(
-    (f) => !["instructions", "heading", "divider"].includes(f.type)
-  );
+export function ResponseViewerClient({
+  formId, formName, response, customerName, customerId, allowSecureFill = false,
+}: Props) {
+  const router = useRouter();
+  const schema = (response.schema_snapshot ?? []) as OnboardingField[];
+  const fields = schema.filter((f) => !["instructions", "heading", "divider"].includes(f.type));
+  const opts = { allowSecure: allowSecureFill };
+  const editable = staffFillableFields(schema, opts).filter(
+    (f) => !["heading", "divider", "instructions"].includes(f.type));
+  const needsCustomer = staffOnlyCustomerFields(schema, opts);
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<Record<string, unknown>>({});
+  const [busy, setBusy] = useState(false);
+
+  const startEdit = () => {
+    // Secure answers arrive redacted, so they start blank. Blank means "keep
+    // what is stored", never "wipe it".
+    const seed: Record<string, unknown> = {};
+    for (const f of editable) {
+      if (f.type === "secure") continue;
+      const v = response.answers?.[f.id];
+      if (v !== undefined) seed[f.id] = v;
+    }
+    setDraft(seed);
+    setEditing(true);
+  };
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      const res = await updateOnboardingResponse(response.request_id, draft);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success("Answers updated");
+      setEditing(false);
+      router.refresh();
+    } finally { setBusy(false); }
+  };
+
+  const remove = async () => {
+    if (!confirm("Delete this response and the request behind it? The answers are gone for good \u2014 you can send the form again afterwards.")) return;
+    setBusy(true);
+    try {
+      await deleteOnboardingRequest(response.request_id);
+      toast.success("Response deleted");
+      router.push(`/customers/${customerId}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't delete");
+    } finally { setBusy(false); }
+  };
+
+  const sendFresh = async () => {
+    setBusy(true);
+    try {
+      const res = await sendOnboardingRequest(formId, customerId, { email: false });
+      if (!res.ok) { toast.error(res.error); return; }
+      await navigator.clipboard.writeText(res.url).catch(() => {});
+      toast.success("New blank form created \u2014 link copied");
+      router.push(`/customers/${customerId}`);
+    } finally { setBusy(false); }
+  };
 
   return (
     <div>
@@ -52,29 +117,85 @@ export function ResponseViewerClient({ formId, formName, response, customerName,
         }
         accent="linear-gradient(180deg, #2dd4bf 0%, #0e7490 100%)"
         actions={
-          <Button variant="outline" asChild>
-            <Link href={`/onboarding-forms/${formId}`}>Edit form</Link>
-          </Button>
+          editing ? (
+            <>
+              <Button variant="outline" disabled={busy} onClick={() => setEditing(false)}>Cancel</Button>
+              <Button disabled={busy} onClick={save}>
+                {busy && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />} Save answers
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" disabled={busy} onClick={startEdit}>
+                <PenLine className="w-4 h-4 mr-1.5" /> Edit answers
+              </Button>
+              <Button variant="outline" disabled={busy} onClick={sendFresh}>
+                <Send className="w-4 h-4 mr-1.5" /> Send a fresh one
+              </Button>
+              <Button variant="outline" disabled={busy} onClick={remove}
+                className="text-destructive hover:text-destructive">
+                <Trash2 className="w-4 h-4 mr-1.5" /> Delete
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href={`/onboarding-forms/${formId}`}>Edit form</Link>
+              </Button>
+            </>
+          )
         }
       />
 
-      <Card className="max-w-2xl">
-        <CardContent className="p-6 divide-y divide-border/60">
-          {fields.map((f) => (
-            <div key={f.id} className="py-3 first:pt-0 last:pb-0">
-              <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold mb-1">{f.label}</p>
-              <AnswerValue field={f} value={response.answers?.[f.id]} responseId={response.id} />
+      <Card className="max-w-3xl mx-auto">
+        <CardContent className="p-6">
+          {editing ? (
+            <div className="space-y-5">
+              <ClientFields
+                fields={editable}
+                values={draft}
+                disabled={busy}
+                onChange={(id, v) => setDraft((prev) => ({ ...prev, [id]: v }))}
+              />
+              {editable.some((f) => f.type === "secure") && (
+                <p className="text-xs text-muted-foreground">
+                  Leave a credential blank to keep what&rsquo;s already stored &mdash; the editor can&rsquo;t show it back to you.
+                </p>
+              )}
+              {needsCustomer.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {needsCustomer.map((f) => f.label).join(", ")} can only be provided by the customer through
+                  their own link, so {needsCustomer.length === 1 ? "it isn't" : "they aren't"} editable here.
+                </p>
+              )}
             </div>
-          ))}
+          ) : (
+            <div className="divide-y divide-border/60">
+              {fields.map((f) => (
+                <div key={f.id} className="py-3 first:pt-0 last:pb-0">
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold mb-1">{f.label}</p>
+                  <AnswerValue
+                    field={f}
+                    value={response.answers?.[f.id]}
+                    responseId={response.id}
+                    staffFillable={isStaffFillable(f, opts)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>
   );
 }
 
-function AnswerValue({ field: f, value, responseId }: { field: OnboardingField; value: unknown; responseId: string }) {
+function AnswerValue({
+  field: f, value, responseId, staffFillable = true,
+}: { field: OnboardingField; value: unknown; responseId: string; staffFillable?: boolean }) {
   if (value == null || value === "" || (Array.isArray(value) && value.length === 0)) {
-    return <p className="text-sm text-muted-foreground italic">Not answered</p>;
+    // "Not answered" is only honest if it COULD have been answered here. For an
+    // upload, or a credential with no key, say whose it is to provide.
+    return staffFillable
+      ? <p className="text-sm text-muted-foreground italic">Not answered</p>
+      : <p className="text-sm text-muted-foreground italic">Needs the customer &mdash; only they can submit this, through their own link</p>;
   }
 
   switch (f.type) {

--- a/src/components/onboarding/staff-onboarding-fill.tsx
+++ b/src/components/onboarding/staff-onboarding-fill.tsx
@@ -32,7 +32,7 @@ export interface StaffFillValue {
 }
 
 export function StaffOnboardingFill({
-  forms, value, onChange, disabled, showPicker = true, problems = [],
+  forms, value, onChange, disabled, showPicker = true, problems = [], allowSecure = false,
 }: {
   forms: StaffFillForm[];
   value: StaffFillValue;
@@ -43,10 +43,13 @@ export function StaffOnboardingFill({
   /** Blocking problems from the last submit attempt, shown against the fields
    *  rather than only in a toast that disappears. */
   problems?: StaffFillProblem[];
+  /** Whether credential fields can be filled here — true when the server has
+   *  an encryption key. Decided server-side; the browser is only told. */
+  allowSecure?: boolean;
 }) {
   const picked = forms.find((f) => f.id === value.formId) ?? null;
-  const fillable = useMemo(() => (picked ? staffFillableFields(picked.schema) : []), [picked]);
-  const customerOnly = useMemo(() => (picked ? staffOnlyCustomerFields(picked.schema) : []), [picked]);
+  const fillable = useMemo(() => (picked ? staffFillableFields(picked.schema, { allowSecure }) : []), [picked, allowSecure]);
+  const customerOnly = useMemo(() => (picked ? staffOnlyCustomerFields(picked.schema, { allowSecure }) : []), [picked, allowSecure]);
 
   if (forms.length === 0) {
     return (
@@ -117,8 +120,7 @@ export function StaffOnboardingFill({
               <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
               <p className="text-xs text-muted-foreground">
                 {customerOnly.length === 1 ? "One field needs" : `${customerOnly.length} fields need`} the
-                customer — {customerOnly.map((f) => f.label).join(", ")}. Uploads and credentials can only be
-                submitted through their own link. Send them the form for those.
+                customer — {customerOnly.map((f) => f.label).join(", ")}. Those can only be submitted through their own link. Send them the form for those.
               </p>
             </div>
           )}

--- a/src/lib/__tests__/staff-fill.test.ts
+++ b/src/lib/__tests__/staff-fill.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isStaffFillable, staffFillableFields, staffOnlyCustomerFields,
-  stripUnfillableAnswers, missingForStaff, STAFF_UNFILLABLE_TYPES,
+  stripUnfillableAnswers, missingForStaff, STAFF_UPLOAD_TYPES,
   staffFillProblems, staffFillErrorMessage,
 } from "@/lib/onboarding/staff-fill";
 import type { OnboardingField } from "@/types/database";
@@ -18,46 +18,69 @@ const SCHEMA: OnboardingField[] = [
   f("wifi", "secure", { required: true }),
 ];
 
+const WITH_KEY = { allowSecure: true };
+
 describe("what staff can fill", () => {
-  it("blocks uploads and credentials, allows the rest", () => {
+  it("never allows uploads — there is no dashboard upload path", () => {
     expect(isStaffFillable(f("a", "short_text"))).toBe(true);
-    expect(isStaffFillable(f("a", "file"))).toBe(false);
-    expect(isStaffFillable(f("a", "image"))).toBe(false);
-    expect(isStaffFillable(f("a", "secure"))).toBe(false);
+    expect(STAFF_UPLOAD_TYPES.has("file")).toBe(true);
+    expect(STAFF_UPLOAD_TYPES.has("image")).toBe(true);
+    // True even with a key: allowSecure is about credentials, not uploads.
+    expect(isStaffFillable(f("a", "file"), WITH_KEY)).toBe(false);
+    expect(isStaffFillable(f("a", "image"), WITH_KEY)).toBe(false);
   });
 
-  it("keeps a credential field off the staff form no matter what", () => {
-    // The whole point of `secure` is that the value comes from its owner. If
-    // this ever passes, staff are typing customers' passwords into a dashboard.
-    expect(STAFF_UNFILLABLE_TYPES.has("secure")).toBe(true);
-    expect(staffFillableFields(SCHEMA).some((x) => x.type === "secure")).toBe(false);
+  it("allows a credential only when there's a key to encrypt it with", () => {
+    // Staff legitimately hold details a client handed over (a BSB, an account
+    // number). Without a key there is nothing to encrypt with, and a
+    // credential is never stored in the clear.
+    expect(isStaffFillable(f("a", "secure"))).toBe(false);
+    expect(isStaffFillable(f("a", "secure"), WITH_KEY)).toBe(true);
   });
 
   it("splits the schema into fillable and still-needs-the-customer", () => {
     expect(staffFillableFields(SCHEMA).map((x) => x.id)).toEqual(["heading", "company", "abn"]);
     expect(staffOnlyCustomerFields(SCHEMA).map((x) => x.id)).toEqual(["logo", "contract", "wifi"]);
+
+    expect(staffFillableFields(SCHEMA, WITH_KEY).map((x) => x.id)).toEqual(["heading", "company", "abn", "wifi"]);
+    expect(staffOnlyCustomerFields(SCHEMA, WITH_KEY).map((x) => x.id)).toEqual(["logo", "contract"]);
   });
 });
 
 describe("stripUnfillableAnswers", () => {
-  it("drops answers to upload and credential fields", () => {
+  it("drops what it can't keep AND reports it", () => {
+    // The silent version of this lost an account number and the response page
+    // said "Not answered". Dropping is fine; dropping quietly is not.
     const out = stripUnfillableAnswers(SCHEMA, {
       company: "Acme", logo: { path: "x" }, wifi: "hunter2",
     });
-    expect(out).toEqual({ company: "Acme" });
+    expect(out.clean).toEqual({ company: "Acme" });
+    expect(out.dropped.sort()).toEqual(["logo", "wifi"]);
   });
 
-  it("drops answers to fields that aren't on the form", () => {
-    expect(stripUnfillableAnswers(SCHEMA, { company: "Acme", ghost: "?" })).toEqual({ company: "Acme" });
+  it("keeps a credential when there's a key", () => {
+    const out = stripUnfillableAnswers(SCHEMA, { wifi: "hunter2" }, WITH_KEY);
+    expect(out.clean).toEqual({ wifi: "hunter2" });
+    expect(out.dropped).toEqual([]);
+  });
+
+  it("doesn't report a field that was left empty anyway", () => {
+    expect(stripUnfillableAnswers(SCHEMA, { logo: "" }).dropped).toEqual([]);
+  });
+
+  it("drops answers to fields that aren't on the form, silently", () => {
+    const out = stripUnfillableAnswers(SCHEMA, { company: "Acme", ghost: "?" });
+    expect(out.clean).toEqual({ company: "Acme" });
+    expect(out.dropped).toEqual([]);
   });
 
   it("drops display-only fields — a heading holds no answer", () => {
-    expect(stripUnfillableAnswers(SCHEMA, { heading: "oops" })).toEqual({});
+    expect(stripUnfillableAnswers(SCHEMA, { heading: "oops" }).clean).toEqual({});
   });
 
   it("keeps falsy answers that are real values", () => {
     const schema = [f("count", "number"), f("ok", "yes_no")];
-    expect(stripUnfillableAnswers(schema, { count: 0, ok: false })).toEqual({ count: 0, ok: false });
+    expect(stripUnfillableAnswers(schema, { count: 0, ok: false }).clean).toEqual({ count: 0, ok: false });
   });
 });
 
@@ -85,8 +108,15 @@ describe("staffFillProblems", () => {
     expect(staffFillProblems(schema, { email: "" })).toHaveLength(1);
   });
 
-  it("ignores upload and credential fields entirely", () => {
+  it("ignores upload and credential fields left empty", () => {
     expect(staffFillProblems(SCHEMA, { company: "Acme" })).toEqual([]);
+  });
+
+  it("refuses to save silently when an answer can't be kept", () => {
+    const problems = staffFillProblems(SCHEMA, { company: "Acme", wifi: "hunter2" });
+    expect(problems).toHaveLength(1);
+    expect(problems[0].label).toBe("wifi");
+    expect(problems[0].message).toMatch(/wasn't saved/);
   });
 
   it("lists every problem, so one fix at a time isn't needed", () => {

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -8,7 +8,7 @@ import { getUser } from "@/lib/auth";
 import { appUrl } from "@/lib/app-url";
 import { pluginFlagsTag } from "@/lib/layout-data";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
-import { redactSecureAnswers } from "@/lib/onboarding/answers";
+import { redactSecureAnswers, processAnswersForStorage } from "@/lib/onboarding/answers";
 import {
   staffOnlyCustomerFields, stripUnfillableAnswers, staffFillProblems, staffFillErrorMessage,
 } from "@/lib/onboarding/staff-fill";
@@ -292,11 +292,15 @@ export async function saveStaffOnboardingResponse(
   const schema = (form.schema ?? []) as OnboardingField[];
   if (schema.length === 0) return { ok: false, error: "That form has no fields yet" };
 
-  const clean = stripUnfillableAnswers(schema, answers ?? {});
+  // Credentials are fillable here only when there's a key to encrypt them
+  // with — never stored in the clear.
+  const opts = { allowSecure: secureFieldsAvailable() };
+  const { clean } = stripUnfillableAnswers(schema, answers ?? {}, opts);
   // Same check the browser ran before creating the client — repeated here
   // because a check only the client performs isn't one.
-  const problems = staffFillProblems(schema, answers ?? {});
+  const problems = staffFillProblems(schema, answers ?? {}, opts);
   if (problems.length) return { ok: false, error: staffFillErrorMessage(problems) };
+  const stored = processAnswersForStorage(schema, clean);
 
   // Reuse an open request for this form+customer rather than stacking a second
   // one — otherwise "send it, then fill it in yourself" leaves two rows.
@@ -335,7 +339,60 @@ export async function saveStaffOnboardingResponse(
     ok: true,
     request_id: requestId,
     saved: Object.keys(clean).length,
-    needs_customer: staffOnlyCustomerFields(schema).length,
+    needs_customer: staffOnlyCustomerFields(schema, opts).length,
+  };
+}
+
+/**
+ * Correct a submitted response.
+ *
+ * Customers mistype things, and staff fill these in from a phone call. Before
+ * this, a wrong answer could only be fixed by deleting the whole thing and
+ * sending the form again.
+ *
+ * A blank secure field KEEPS the stored value rather than wiping it: the
+ * editor can't show what's there (that's the point of a credential), so an
+ * empty box means "leave it", not "delete it".
+ */
+export async function updateOnboardingResponse(
+  requestId: string, answers: Record<string, unknown>,
+): Promise<StaffFillResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: existing } = await tbl(supabase, "onboarding_responses")
+    .select("id, form_id, customer_id, answers, schema_snapshot")
+    .eq("request_id", requestId).eq("business_id", businessId).maybeSingle();
+  if (!existing) return { ok: false, error: "No response to edit yet" };
+
+  const schema = (existing.schema_snapshot ?? []) as OnboardingField[];
+  const opts = { allowSecure: secureFieldsAvailable() };
+  const { clean } = stripUnfillableAnswers(schema, answers ?? {}, opts);
+
+  // Uploads and (keyless) credentials aren't editable here, so carry the
+  // existing values through instead of validating against a blank.
+  const merged: Record<string, unknown> = { ...(existing.answers ?? {}) };
+  for (const [id, v] of Object.entries(clean)) {
+    const isSecure = schema.find((f) => f.id === id)?.type === "secure";
+    if (isSecure && (v === "" || v == null)) continue; // blank = keep what's stored
+    merged[id] = v;
+  }
+
+  const problems = staffFillProblems(schema, merged, opts);
+  if (problems.length) return { ok: false, error: staffFillErrorMessage(problems) };
+
+  const { error } = await tbl(supabase, "onboarding_responses")
+    .update({ answers: processAnswersForStorage(schema, merged), draft: false })
+    .eq("id", existing.id).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/onboarding-forms");
+  revalidatePath(`/customers/${existing.customer_id}`);
+  return {
+    ok: true, request_id: requestId,
+    saved: Object.keys(merged).length,
+    needs_customer: staffOnlyCustomerFields(schema, opts).length,
   };
 }
 

--- a/src/lib/mcp/tools/plugin-form-tools.ts
+++ b/src/lib/mcp/tools/plugin-form-tools.ts
@@ -603,13 +603,14 @@ export function registerPluginFormTools(tool: ToolFn): void {
     });
 
   tool("fill_onboarding_form",
-    "Fill in an onboarding form on a customer's behalf, for details you already have — records it as completed without sending them anything. Upload and credential fields are ignored: only the customer can provide those, through their own link.",
+    "Fill in an onboarding form on a customer's behalf, for details you already have — records it as completed without sending them anything. Uploads can only come from the customer through their own link; credential fields work only when the server has an encryption key. Answering something that can't be stored is an error, not a silent drop.",
     { form_id: UUID, customer_id: UUID, answers: z.record(z.string(), z.unknown()) },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
-      const { stripUnfillableAnswers, missingForStaff, staffFillableFields, staffOnlyCustomerFields } =
+      const { stripUnfillableAnswers, staffFillProblems, staffFillErrorMessage, staffOnlyCustomerFields } =
         await import("@/lib/onboarding/staff-fill");
-      const { invalidAnswerFields } = await import("@/lib/onboarding/answers");
+      const { processAnswersForStorage } = await import("@/lib/onboarding/answers");
+      const { secureFieldsAvailable } = await import("@/lib/onboarding/crypto");
 
       const [{ data: form }, { data: customer }] = await Promise.all([
         t(ctx, "onboarding_forms").select("id, schema").eq("id", args.form_id).eq("business_id", ctx.businessId).maybeSingle(),
@@ -620,13 +621,12 @@ export function registerPluginFormTools(tool: ToolFn): void {
       const schema = form.schema ?? [];
       if (schema.length === 0) return errorText("That form has no fields yet");
 
-      const clean = stripUnfillableAnswers(schema, args.answers);
-      const bad = invalidAnswerFields(staffFillableFields(schema), clean);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const label = (id: string) => (schema as any[]).find((f) => f.id === id)?.label ?? id;
-      if (bad.length) return errorText(`${label(bad[0].field_id)}: ${bad[0].message}`);
-      const missing = missingForStaff(schema, clean);
-      if (missing.length) return errorText(`Still needs: ${missing.map(label).join(", ")}`);
+      // Credentials only when there's a key to encrypt them with.
+      const opts = { allowSecure: secureFieldsAvailable() };
+      const { clean } = stripUnfillableAnswers(schema, args.answers, opts);
+      const problems = staffFillProblems(schema, args.answers, opts);
+      if (problems.length) return errorText(staffFillErrorMessage(problems));
+      const stored = processAnswersForStorage(schema, clean);
 
       const { data: openReq } = await t(ctx, "onboarding_requests")
         .select("id").eq("business_id", ctx.businessId).eq("form_id", args.form_id)
@@ -649,7 +649,7 @@ export function registerPluginFormTools(tool: ToolFn): void {
       }
       const { error: respErr } = await t(ctx, "onboarding_responses").upsert({
         business_id: ctx.businessId, request_id: requestId, form_id: args.form_id,
-        customer_id: args.customer_id, answers: clean, schema_snapshot: schema,
+        customer_id: args.customer_id, answers: stored, schema_snapshot: schema,
         draft: false, submitted_at: now,
       }, { onConflict: "request_id" });
       if (respErr) throw respErr;
@@ -657,7 +657,7 @@ export function registerPluginFormTools(tool: ToolFn): void {
       return text({
         saved: true, request_id: requestId,
         answered: Object.keys(clean).length,
-        still_needs_customer: staffOnlyCustomerFields(schema).map((f) => f.label),
+        still_needs_customer: staffOnlyCustomerFields(schema, opts).map((f) => f.label),
       });
     });
 }

--- a/src/lib/onboarding/staff-fill.ts
+++ b/src/lib/onboarding/staff-fill.ts
@@ -4,7 +4,7 @@
  *
  * Plain module (no "use server") so the server action, the MCP tool and the
  * client form all share one definition of what's fillable. If they disagreed,
- * the UI would offer a field the server then silently dropped.
+ * the UI would offer a field the server then dropped.
  */
 import type { OnboardingField, OnboardingAnswers } from "@/types/database";
 // From ./validate, not ./answers — this module is imported by client
@@ -12,61 +12,89 @@ import type { OnboardingField, OnboardingAnswers } from "@/types/database";
 import { DISPLAY_ONLY_TYPES, missingRequiredFields, invalidAnswerFields } from "./validate";
 
 /**
- * Types staff can't fill in from the dashboard:
- *
- * - `file` / `image` — uploads go through the token-gated portal route; there
- *   is no dashboard equivalent, so offering the field would be a dead end.
- * - `secure` — a credential is the customer's to enter. Typed in by staff it
- *   loses that meaning, and the encryption key may not even be configured.
- *   Stripped server-side too, so a plaintext credential can't reach the
- *   database via a hand-rolled request.
+ * Uploads can never be staff-filled: the only upload path is the token-gated
+ * portal route, so offering the field from the dashboard is a dead end.
  */
-export const STAFF_UNFILLABLE_TYPES = new Set(["file", "image", "secure"]);
+export const STAFF_UPLOAD_TYPES = new Set(["file", "image"]);
 
-export function isStaffFillable(f: OnboardingField): boolean {
-  return !STAFF_UNFILLABLE_TYPES.has(f.type);
+export interface StaffFillOptions {
+  /**
+   * Whether credential (`secure`) fields can be filled here — true only when
+   * the server has an encryption key.
+   *
+   * Staff legitimately hold details a client has handed over: a BSB and
+   * account number for a direct debit, say. Refusing those outright just loses
+   * the data. Without a key there is nothing to encrypt with, and a credential
+   * is never stored in the clear, so the answer depends on the environment
+   * rather than being fixed.
+   */
+  allowSecure?: boolean;
+}
+
+export function isStaffFillable(f: OnboardingField, opts: StaffFillOptions = {}): boolean {
+  if (STAFF_UPLOAD_TYPES.has(f.type)) return false;
+  if (f.type === "secure") return Boolean(opts.allowSecure);
+  return true;
 }
 
 /** The fields to render in a staff-fill form (display-only types included —
  *  headings and instructions still give the form its shape). */
-export function staffFillableFields(schema: OnboardingField[]): OnboardingField[] {
-  return (schema ?? []).filter(isStaffFillable);
+export function staffFillableFields(
+  schema: OnboardingField[], opts: StaffFillOptions = {},
+): OnboardingField[] {
+  return (schema ?? []).filter((f) => isStaffFillable(f, opts));
 }
 
 /** Fields that still need the customer — surfaced so staff know what's left
  *  rather than believing a half-filled form is complete. */
-export function staffOnlyCustomerFields(schema: OnboardingField[]): OnboardingField[] {
-  return (schema ?? []).filter((f) => !isStaffFillable(f));
+export function staffOnlyCustomerFields(
+  schema: OnboardingField[], opts: StaffFillOptions = {},
+): OnboardingField[] {
+  return (schema ?? []).filter((f) => !isStaffFillable(f, opts));
 }
 
-/** Drop answers to fields staff aren't allowed to fill, and to fields that
- *  aren't on the form at all. */
+export interface StripResult {
+  clean: OnboardingAnswers;
+  /**
+   * Labels of answers that were thrown away.
+   *
+   * Never drop these silently. A value typed in and discarded without a word
+   * is how an account number vanished and the response page said "Not
+   * answered" — the one failure mode worse than refusing outright.
+   */
+  dropped: string[];
+}
+
 export function stripUnfillableAnswers(
-  schema: OnboardingField[],
-  answers: OnboardingAnswers,
-): OnboardingAnswers {
-  const allowed = new Set(
-    (schema ?? []).filter((f) => isStaffFillable(f) && !DISPLAY_ONLY_TYPES.has(f.type)).map((f) => f.id),
-  );
-  const out: OnboardingAnswers = {};
+  schema: OnboardingField[], answers: OnboardingAnswers, opts: StaffFillOptions = {},
+): StripResult {
+  const byId = new Map((schema ?? []).map((f) => [f.id, f]));
+  const clean: OnboardingAnswers = {};
+  const dropped: string[] = [];
+
   for (const [id, value] of Object.entries(answers ?? {})) {
-    if (allowed.has(id)) out[id] = value;
+    const field = byId.get(id);
+    // Not on this form, or a type that holds no answer — nothing the user
+    // could act on, so drop it quietly.
+    if (!field || DISPLAY_ONLY_TYPES.has(field.type)) continue;
+
+    if (isStaffFillable(field, opts)) { clean[id] = value; continue; }
+    if (value !== undefined && value !== null && value !== "") dropped.push(field.label || id);
   }
-  return out;
+  return { clean, dropped };
 }
 
 /**
  * Required fields staff still have to answer.
  *
- * Deliberately ignores required upload/credential fields: staff physically
- * can't provide those, so counting them would make the form unsubmittable.
- * They show up as "still needs the customer" instead.
+ * Ignores required fields staff physically can't provide (uploads, and
+ * credentials with no key) — counting them would make the form unsubmittable.
+ * Those surface as "still needs the customer" instead.
  */
 export function missingForStaff(
-  schema: OnboardingField[],
-  answers: OnboardingAnswers,
+  schema: OnboardingField[], answers: OnboardingAnswers, opts: StaffFillOptions = {},
 ): string[] {
-  return missingRequiredFields(staffFillableFields(schema), answers);
+  return missingRequiredFields(staffFillableFields(schema, opts), answers);
 }
 
 export interface StaffFillProblem { field_id: string; label: string; message: string }
@@ -81,20 +109,27 @@ export interface StaffFillProblem { field_id: string; label: string; message: st
  * check.
  */
 export function staffFillProblems(
-  schema: OnboardingField[],
-  answers: OnboardingAnswers,
+  schema: OnboardingField[], answers: OnboardingAnswers, opts: StaffFillOptions = {},
 ): StaffFillProblem[] {
   const label = (id: string) => schema.find((f) => f.id === id)?.label ?? id;
-  const clean = stripUnfillableAnswers(schema, answers);
+  const { clean, dropped } = stripUnfillableAnswers(schema, answers, opts);
 
-  const problems: StaffFillProblem[] = missingForStaff(schema, clean).map((id) => ({
+  const problems: StaffFillProblem[] = missingForStaff(schema, clean, opts).map((id) => ({
     field_id: id, label: label(id), message: "is required",
   }));
 
-  for (const e of invalidAnswerFields(staffFillableFields(schema), clean)) {
+  for (const e of invalidAnswerFields(staffFillableFields(schema, opts), clean)) {
     // Don't pile a format complaint on top of "you haven't filled it in".
     if (problems.some((p) => p.field_id === e.field_id)) continue;
     problems.push({ field_id: e.field_id, label: label(e.field_id), message: e.message });
+  }
+
+  // Answered something that can't be kept: say so instead of saving without it.
+  for (const label of dropped) {
+    problems.push({
+      field_id: `__dropped_${label}`, label,
+      message: "can only be provided by the customer, through their own link — it wasn't saved",
+    });
   }
   return problems;
 }


### PR DESCRIPTION
The account number you entered was never stored — I checked the row, and there's no value for it at all. Not a display bug.

## Why it vanished

That response came from **"Fill in myself"**, and `saveStaffOnboardingResponse` stripped the `secure` field and said nothing. Two things were wrong with that, both mine from #446.

**1. It dropped the answer silently.** A value typed in and discarded without a word is worse than refusing it — the data is gone *and* the page implies you never entered it. Dropping is now reported: `stripUnfillableAnswers` returns what it threw away, and that becomes a blocking error naming the field.

**2. The blanket rule was wrong for this.** I excluded credentials reasoning that `secure` means a password, which is the customer's to type. But a client's BSB and account number, given to you to set up a direct debit, is ordinary business data — refusing it just loses it.

Credentials are now fillable from the dashboard **when the server has an encryption key**, and encrypted through the same path the customer portal uses. No key, not fillable — never stored in the clear. Uploads stay customer-only regardless: there's no dashboard upload path.

## On the response page — the rest of what you asked for

- **Edit answers** after submission, for typos and phone-call corrections
- **Delete** the response, and **Send a fresh one**
- **"Not answered" only where an answer was possible.** A field only the customer can provide now says so.
- **Centering fixed** — the card was `max-w-2xl` with no `mx-auto`, so it hugged the left with dead space beside it

**One decision worth checking:** a blank credential in the editor **keeps** the stored value rather than wiping it. The editor can't show you what's there — that's the point of a credential — so an empty box has to mean "leave it alone", or every edit would silently erase it.

## A trap worth recording

`StripResult` is structurally assignable to `OnboardingAnswers`, so passing the whole `{clean, dropped}` object where answers belong **compiles cleanly** and corrupts the row at runtime. The MCP tool did exactly that after the signature change and `tsc` reported nothing. Found by reading the call sites, not by the compiler.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests passing ✅

Tests pin the new rules: that a dropped answer is reported rather than swallowed, that a credential is fillable only with a key, and that uploads stay customer-only even with one.

Not clicked through — local dev needs a login I can't perform. **Worth re-testing your exact case:** fill the form yourself with an account number and confirm it's stored and revealable, then edit the response and confirm the credential survives an edit where you leave it blank.

## Still outstanding from your message

The app-wide layout inconsistency. This PR fixes the page you screenshotted, but the general rule — which screens cap width and centre, which fill — is a separate decision I'd rather make with you than guess at.