### PR TITLE
feat(email): the business's logo on client emails + a note per send

### DIFF
--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -595,7 +595,7 @@ export function InvoiceDetailClient({
         defaultSmsBody={`Hi${customer?.name ? " " + customer.name.split(" ")[0] : ""}, invoice ${invoice.number} from ${business.name} is ready. Amount due: ${(invoice.total - invoice.amount_paid).toFixed(2)}.`}
         onSend={async (r) => {
           if (r.channel === "email") {
-            await sendInvoiceEmail(invoice.id, { recipients: r.recipients, subject: r.subject });
+            await sendInvoiceEmail(invoice.id, { recipients: r.recipients, subject: r.subject, message: r.message });
             toast.success(`Invoice sent to ${(r.recipients ?? []).join(", ")}`);
           } else {
             await sendInvoiceSms(invoice.id, { to: r.to!, body: r.body });

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -277,7 +277,7 @@ export function QuoteDetailClient({ quote: initial, customers, products, materia
         defaultSmsBody={`Hi${customer?.name ? " " + customer.name.split(" ")[0] : ""}, your quote ${quote.number} from ${business.name} is ready.`}
         onSend={async (r) => {
           if (r.channel === "email") {
-            await sendQuoteEmail(quote.id, { recipients: r.recipients, subject: r.subject });
+            await sendQuoteEmail(quote.id, { recipients: r.recipients, subject: r.subject, message: r.message });
             toast.success(`Quote sent to ${(r.recipients ?? []).join(", ")}`);
           } else {
             await sendQuoteSms(quote.id, { to: r.to!, body: r.body });

--- a/src/components/send/send-document-modal.tsx
+++ b/src/components/send/send-document-modal.tsx
@@ -16,6 +16,8 @@ export interface SendDocumentResult {
   channel: Channel;
   recipients?: string[];
   subject?: string;
+  /** Covering note for THIS send, above the document details. */
+  message?: string;
   to?: string;
   body?: string;
 }
@@ -62,6 +64,7 @@ export function SendDocumentModal({
   const [emails, setEmails] = useState<string[]>(defaultEmails);
   const [emailInput, setEmailInput] = useState("");
   const [subject, setSubject] = useState(defaultSubject);
+  const [message, setMessage] = useState("");
   const [phone, setPhone] = useState(defaultPhone ?? "");
   const [smsBody, setSmsBody] = useState(defaultSmsBody ?? "");
   const [sending, setSending] = useState(false);
@@ -108,7 +111,7 @@ export function SendDocumentModal({
     }
 
     const result: SendDocumentResult = channel === "email"
-      ? { channel: "email", recipients: emails, subject: subject.trim() }
+      ? { channel: "email", recipients: emails, subject: subject.trim(), message: message.trim() || undefined }
       : { channel: "sms", to: phone.trim(), body: smsBody.trim() };
 
     let sendAtIso: string | null = null;
@@ -207,6 +210,18 @@ export function SendDocumentModal({
             <div className="space-y-1.5">
               <Label>Subject</Label>
               <Input value={subject} onChange={(e) => setSubject(e.target.value)} />
+              <div className="mt-3 space-y-1.5">
+                <Label>Message <span className="text-muted-foreground font-normal">(optional)</span></Label>
+                <Textarea
+                  rows={4}
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder={"Hi Sarah, as discussed — here's the invoice for the work last week. Any questions, just reply."}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Added to the top of this email only. Your saved template wording stays as it is.
+                </p>
+              </div>
             </div>
 
             <p className="text-xs text-muted-foreground">

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -502,7 +502,7 @@ export async function getDashboardStats() {
   };
 }
 
-export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[]; subject?: string }): Promise<void> {
+export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[]; subject?: string; message?: string }): Promise<void> {
   const supabase = await createClient();
   const user = await getUser();
 
@@ -611,7 +611,8 @@ export async function sendInvoiceEmail(id: string, opts?: { recipients?: string[
   await sendEmail({
     to: recipients,
     subject: opts?.subject ?? invoiceEmailSubject({ invoice: invoiceData, customer, business: businessData }, emailTemplate),
-    html: invoiceEmailHtml({ invoice: invoiceData, customer, business: businessData, lineItems, portalUrl, pdfUrl, payUrl, revolutPayUrl, template: emailTemplate }),
+    html: invoiceEmailHtml({
+    message: opts?.message ?? null, invoice: invoiceData, customer, business: businessData, lineItems, portalUrl, pdfUrl, payUrl, revolutPayUrl, template: emailTemplate }),
     attachments: [{ filename: `${invoiceData.number}.pdf`, content: pdfBuffer }],
     from: buildBusinessFrom({ name: businessData.name, localPart: "invoices" }),
     replyTo: businessData.email || undefined,

--- a/src/lib/actions/quotes.ts
+++ b/src/lib/actions/quotes.ts
@@ -191,7 +191,7 @@ export async function convertQuoteToInvoice(quoteId: string): Promise<Invoice> {
   return invoice as Invoice;
 }
 
-export async function sendQuoteEmail(id: string, opts?: { recipients?: string[]; subject?: string }): Promise<void> {
+export async function sendQuoteEmail(id: string, opts?: { recipients?: string[]; subject?: string; message?: string }): Promise<void> {
   const supabase = await createClient();
   const user = await getUser();
 
@@ -265,7 +265,8 @@ export async function sendQuoteEmail(id: string, opts?: { recipients?: string[];
   await sendEmail({
     to: recipients,
     subject: opts?.subject ?? quoteEmailSubject({ quote: quoteData, customer, business: businessData }, emailTemplate),
-    html: quoteEmailHtml({ quote: quoteData, customer, business: businessData, lineItems, acceptUrl, pdfUrl, template: emailTemplate }),
+    html: quoteEmailHtml({
+    message: opts?.message ?? null, quote: quoteData, customer, business: businessData, lineItems, acceptUrl, pdfUrl, template: emailTemplate }),
     attachments: [{ filename: `${quoteData.number}.pdf`, content: pdfBuffer }],
     from: buildBusinessFrom({ name: businessData.name, localPart: "quotes" }),
     replyTo: businessData.email || undefined,

--- a/src/lib/emails/base.ts
+++ b/src/lib/emails/base.ts
@@ -2,8 +2,37 @@
 const LOGO_URL =
   (process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://kireihq.com") + "/kirei-logo.png";
 
+/** The sending business, for the header. Without this an email goes out
+ *  carrying Kirei's brand to someone who has never heard of Kirei. */
+export interface EmailBrand {
+  name: string;
+  logoUrl?: string | null;
+}
+
+/** Escape a value going into an HTML attribute or text node. */
+function esc(v: string): string {
+  return v.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/**
+ * Header identifying the sender.
+ *
+ * Falls back to the business NAME when there's no logo — never to Kirei's
+ * logo. The customer is dealing with the business, not the platform.
+ */
+function brandHeader(brand: EmailBrand | undefined, accentColor: string): string {
+  if (!brand) return "";
+  const inner = brand.logoUrl
+    ? `<img src="${esc(brand.logoUrl)}" alt="${esc(brand.name)}" height="36"
+         style="display:block;max-height:36px;max-width:180px;border:0;outline:none;text-decoration:none;" />`
+    : `<span style="font-size:17px;font-weight:700;color:${accentColor};letter-spacing:-0.01em;">${esc(brand.name)}</span>`;
+  return `<tr><td style="padding:24px 32px 0;">${inner}</td></tr>`;
+}
+
 /** Shared wrapper so all emails look consistent. */
-export function emailBase(title: string, body: string, accentColor = "#3b82f6"): string {
+export function emailBase(
+  title: string, body: string, accentColor = "#3b82f6", brand?: EmailBrand,
+): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,9 +45,15 @@ export function emailBase(title: string, body: string, accentColor = "#3b82f6"):
     <tr><td align="center">
       <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
         <!-- Header -->
-        <tr><td style="background:${accentColor};padding:24px 32px;">
-          <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;">${title}</p>
-        </td></tr>
+        ${brandHeader(brand, accentColor)}
+        ${brand
+          ? `<tr><td style="padding:12px 32px 0;">
+               <p style="margin:0;font-size:20px;font-weight:700;color:#18181b;letter-spacing:-0.01em;">${title}</p>
+               <div style="height:3px;width:44px;background:${accentColor};border-radius:2px;margin-top:10px;"></div>
+             </td></tr>`
+          : `<tr><td style="background:${accentColor};padding:24px 32px;">
+               <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;">${title}</p>
+             </td></tr>`}
         <!-- Body -->
         <tr><td style="padding:32px;">
           ${body}
@@ -28,8 +63,9 @@ export function emailBase(title: string, body: string, accentColor = "#3b82f6"):
           <table cellpadding="0" cellspacing="0" style="width:100%;">
             <tr>
               <td style="vertical-align:middle;">
-                <img src="${LOGO_URL}" alt="Kirei" width="20" height="20" style="display:inline-block;vertical-align:middle;border-radius:4px;" />
-                <span style="font-size:12px;color:#71717a;margin-left:6px;vertical-align:middle;">Sent via Kirei · Please do not reply to this email.</span>
+                ${brand ? `<p style="margin:0 0 4px;font-size:13px;font-weight:600;color:#3f3f46;">${brand.name}</p>` : ""}
+                <img src="${LOGO_URL}" alt="Kirei" width="16" height="16" style="display:inline-block;vertical-align:middle;border-radius:4px;opacity:0.6;" />
+                <span style="font-size:11px;color:#a1a1aa;margin-left:6px;vertical-align:middle;">Sent via Kirei · Please do not reply to this email.</span>
               </td>
             </tr>
           </table>

--- a/src/lib/emails/invoice.ts
+++ b/src/lib/emails/invoice.ts
@@ -7,6 +7,11 @@ import {
 import type { Business, Customer, Invoice, LineItem } from "@/types/database";
 
 /** Variables available to the invoice template + subject line. */
+/** The message is typed by a user and dropped into HTML — escape it. */
+function escapeHtml(v: string): string {
+  return v.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 export function invoiceEmailVars({
   invoice,
   customer,
@@ -57,6 +62,7 @@ export function invoiceEmailHtml({
   payUrl,
   revolutPayUrl,
   template,
+  message,
 }: {
   invoice: Invoice;
   customer: Customer | null;
@@ -74,6 +80,9 @@ export function invoiceEmailHtml({
    *  button, independent of Stripe. */
   revolutPayUrl?: string | null;
   /** Per-business template override; defaults when omitted. */
+  /** Free text typed in the send dialog for THIS send — appears above the
+   *  document details, where a covering note belongs. */
+  message?: string | null;
   template?: ResolvedEmailTemplate;
 }): string {
   // Coerce numbers — Postgres returns numeric columns as strings via PostgREST,
@@ -102,12 +111,15 @@ export function invoiceEmailHtml({
 
   // Full custom body override — wrapper + subject still apply.
   if (t.custom_html) {
-    return emailBase(subjectLine, renderTemplateVars(t.custom_html, vars), accent);
+    return emailBase(subjectLine, renderTemplateVars(t.custom_html, vars), accent, { name: business.name, logoUrl: business.logo_url });
   }
 
   const body = `
     ${t.greeting ? `<p style="margin:0 0 4px;font-size:14px;color:#71717a;">${renderTemplateVars(t.greeting, vars)}</p>` : ""}
     ${t.intro ? `<p style="margin:0 0 24px;font-size:14px;color:#71717a;">${renderTemplateVars(t.intro, vars)}</p>` : ""}
+    ${message && message.trim() ? `<div style="margin:0 0 24px;padding:14px 16px;background:#fafaf9;border-left:3px solid ${accent};border-radius:0 8px 8px 0;">
+      <p style="margin:0;font-size:14px;line-height:1.6;color:#3f3f46;white-space:pre-wrap;">${escapeHtml(message.trim())}</p>
+    </div>` : ""}
 
     <!-- Invoice summary card -->
     <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border-radius:8px;padding:20px;margin-bottom:24px;">
@@ -163,5 +175,5 @@ export function invoiceEmailHtml({
     <p style="margin:24px 0 0;font-size:13px;color:#71717a;">Questions? Contact us at ${business.email ?? business.phone ?? "—"}</p>
   `;
 
-  return emailBase(subjectLine, body, accent);
+  return emailBase(subjectLine, body, accent, { name: business.name, logoUrl: business.logo_url });
 }

--- a/src/lib/emails/quote.ts
+++ b/src/lib/emails/quote.ts
@@ -7,6 +7,11 @@ import {
 import type { Business, Customer, LineItem, Quote } from "@/types/database";
 
 /** Variables available to the quote template + subject line. */
+/** The message is typed by a user and dropped into HTML — escape it. */
+function escapeHtml(v: string): string {
+  return v.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 export function quoteEmailVars({
   quote,
   customer,
@@ -53,6 +58,7 @@ export function quoteEmailHtml({
   acceptUrl,
   pdfUrl,
   template,
+  message,
 }: {
   quote: Quote;
   customer: Customer | null;
@@ -62,6 +68,9 @@ export function quoteEmailHtml({
   /** Direct PDF download link (tokenised). */
   pdfUrl?: string | null;
   /** Per-business template override; defaults when omitted. */
+  /** Free text typed in the send dialog for THIS send — appears above the
+   *  document details, where a covering note belongs. */
+  message?: string | null;
   template?: ResolvedEmailTemplate;
 }): string {
   const fmt = (n: number) =>
@@ -77,12 +86,15 @@ export function quoteEmailHtml({
 
   // Full custom body override — wrapper + subject still apply.
   if (t.custom_html) {
-    return emailBase(subjectLine, renderTemplateVars(t.custom_html, vars), accent);
+    return emailBase(subjectLine, renderTemplateVars(t.custom_html, vars), accent, { name: business.name, logoUrl: business.logo_url });
   }
 
   const body = `
     ${t.greeting ? `<p style="margin:0 0 4px;font-size:14px;color:#71717a;">${renderTemplateVars(t.greeting, vars)}</p>` : ""}
     ${t.intro ? `<p style="margin:0 0 24px;font-size:14px;color:#71717a;">${renderTemplateVars(t.intro, vars)}</p>` : ""}
+    ${message && message.trim() ? `<div style="margin:0 0 24px;padding:14px 16px;background:#fafaf9;border-left:3px solid ${accent};border-radius:0 8px 8px 0;">
+      <p style="margin:0;font-size:14px;line-height:1.6;color:#3f3f46;white-space:pre-wrap;">${escapeHtml(message.trim())}</p>
+    </div>` : ""}
 
     <!-- Quote summary card -->
     <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border-radius:8px;padding:20px;margin-bottom:24px;">
@@ -134,5 +146,5 @@ export function quoteEmailHtml({
     <p style="margin:24px 0 0;font-size:13px;color:#71717a;">Questions? Contact us at ${business.email ?? business.phone ?? "—"}</p>
   `;
 
-  return emailBase(subjectLine, body, accent);
+  return emailBase(subjectLine, body, accent, { name: business.name, logoUrl: business.logo_url });
 }


### PR DESCRIPTION
## 1. Your emails were branded Kirei, not you

`emailBase` — used by invoice, quote, receipt and team-invite emails — hardcoded the Kirei logo and a generic blue. `businesses.logo_url` existed and was **never read**. A Connected Studio client opened an invoice branded by a company they've never heard of.

Now the header carries **your logo**, falling back to **your business name in your accent colour** when there's no logo — never Kirei's. The "Sent via Kirei" line stays in the footer, smaller, beneath your business name.

Set your logo in Settings → Business if it isn't already; the fallback is decent, but the logo is the point.

## 2. A note on this send

The send dialog gains an optional **Message** box. Whatever you type appears above the invoice details in an accented block:

> Hi Sarah, as discussed — here's the invoice for the work last week. Any questions, just reply.

**It applies to that one email only.** Your saved template wording is untouched, so a note for one client doesn't become every invoice's intro.

The note is user-typed text going into an HTML email, so it's escaped, not interpolated raw.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 220 tests ✅

**Not seen in a real inbox** — I can't send mail from here, and email clients are where HTML goes wrong. Worth sending one invoice to yourself on the preview before merging: check the logo renders (some clients block images until you allow them), and that the note appears where you'd expect.

## One thing I did not change

`emailBase` still uses a fixed 600px table layout. It's sound and renders everywhere, but it's not a redesign — if the templates still look plain to you once your logo is on them, say so and I'll do the layout properly as its own piece.