### PR TITLE
fix(payments): stop the card toggle claiming Stripe is the only provider

### DIFF
--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -93,6 +93,10 @@ async function CustomerDetailContent({ id }: { id: string }) {
         onboarding={onboarding}
         clientFields={fieldConfig?.fields ?? []}
         accountTypes={fieldConfig?.accountTypes ?? []}
+        cardProviders={{
+          stripeEnabled: !!business?.stripe_charges_enabled,
+          revolutEnabled: !!business?.revolut_enabled,
+        }}
       />
     );
   } catch {

--- a/src/app/(dashboard)/customers/new/page.tsx
+++ b/src/app/(dashboard)/customers/new/page.tsx
@@ -53,6 +53,10 @@ export default async function NewCustomerPage() {
         accountTypes={fieldConfig.config?.accountTypes ?? []}
         onboardingForms={onboardingForms}
         allowSecureFill={allowSecureFill}
+        cardProviders={{
+          stripeEnabled: !!business?.stripe_charges_enabled,
+          revolutEnabled: !!business?.revolut_enabled,
+        }}
       />
     </div>
   );

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -84,6 +84,8 @@ interface Props {
   clientFields?: OnboardingField[];
   /** Client type options for this business. */
   accountTypes?: AccountTypeOption[];
+  /** Connected card providers, so the payment toggle names the real one. */
+  cardProviders?: { stripeEnabled: boolean; revolutEnabled: boolean };
 }
 
 // ── Property Modal ─────────────────────────────────────────────────────────────
@@ -513,6 +515,7 @@ export function CustomerDetailClient({
   onboarding = null,
   clientFields = [],
   accountTypes = [],
+  cardProviders,
 }: Props) {
   const [customer, setCustomer] = useState(initial);
   const [editing, setEditing] = useState(false);
@@ -607,7 +610,7 @@ export function CustomerDetailClient({
 
       {editing ? (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-          <CustomerForm customer={customer} businessCountry={businessCountry} clientFields={clientFields} accountTypes={accountTypes} onSuccess={(updated) => { setCustomer(updated); setEditing(false); }} />
+          <CustomerForm customer={customer} businessCountry={businessCountry} clientFields={clientFields} accountTypes={accountTypes} cardProviders={cardProviders} onSuccess={(updated) => { setCustomer(updated); setEditing(false); }} />
         </motion.div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">

--- a/src/components/customers/customer-form.tsx
+++ b/src/components/customers/customer-form.tsx
@@ -19,7 +19,7 @@ import {
   resolveAccountTypes, withCurrentValue, defaultAccountType, type AccountTypeOption,
 } from "@/lib/customers/account-types";
 import type { OnboardingField } from "@/types/database";
-import { PAYMENT_METHODS, PAYMENT_METHOD_LABELS, type PaymentMethod } from "@/lib/payment-methods";
+import { PAYMENT_METHODS, PAYMENT_METHOD_LABELS, cardProvidersLabel, type PaymentMethod } from "@/lib/payment-methods";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -64,6 +64,9 @@ interface CustomerFormProps {
   onSuccess?: (customer: Customer) => void;
   /** Country of the active business — drives address-field labels + states. */
   businessCountry?: string | null;
+  /** Which card providers are connected, so the card toggle names the one that
+   *  will actually serve the payment instead of assuming Stripe. */
+  cardProviders?: { stripeEnabled: boolean; revolutEnabled: boolean };
   /** Extra profile fields for this business (industry preset, or its override).
    *  Empty array is a real answer: this business wants none. */
   clientFields?: OnboardingField[];
@@ -78,7 +81,7 @@ interface CustomerFormProps {
 
 export function CustomerForm({
   customer, onSuccess, businessCountry, clientFields = [], onboardingForms = [],
-  accountTypes = [], allowSecureFill = false,
+  accountTypes = [], allowSecureFill = false, cardProviders,
 }: CustomerFormProps) {
   // An existing customer's type is always offered, even if the business has
   // since changed its list — otherwise editing them would silently reclassify.
@@ -324,13 +327,20 @@ export function CustomerForm({
                         onChange={(e) => toggle(m, e.target.checked)}
                         className="w-4 h-4 rounded accent-primary"
                       />
-                      <span className="text-sm font-medium">{PAYMENT_METHOD_LABELS[m]}</span>
+                      <span className="min-w-0">
+                        <span className="block text-sm font-medium">{PAYMENT_METHOD_LABELS[m]}</span>
+                        {m === "card" && cardProviders && (
+                          <span className="block text-xs text-muted-foreground">
+                            {cardProvidersLabel(cardProviders)}
+                          </span>
+                        )}
+                      </span>
                     </label>
                   );
                 })}
                 <p className="text-xs text-muted-foreground">
                   {selected.length === 0
-                    ? "All supported methods offered (card if Stripe is connected, bank transfer if bank details are set)."
+                    ? "All supported methods offered — card if a card provider is connected, bank transfer if your bank details are set."
                     : `Only the ticked method${selected.length > 1 ? "s" : ""} will be offered to this customer.`}
                 </p>
               </div>

--- a/src/lib/payment-methods.ts
+++ b/src/lib/payment-methods.ts
@@ -14,10 +14,29 @@ export const PAYMENT_METHODS = ["card", "bank_transfer", "cash"] as const;
 export type PaymentMethod = (typeof PAYMENT_METHODS)[number];
 
 export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
-  card: "Card (Stripe)",
+  // NOT "Card (Stripe)". This one permission governs every card provider the
+  // business has connected — Stripe, Revolut, or both. Naming one of them made
+  // it look as though Revolut couldn't be offered to a customer at all.
+  card: "Card / online payment",
   bank_transfer: "Bank transfer",
   cash: "Cash / in person",
 };
+
+/** Which provider will actually serve a card payment — so the toggle says what
+ *  it does instead of leaving the business to guess. */
+export function cardProvidersLabel(opts: {
+  stripeEnabled: boolean;
+  revolutEnabled?: boolean;
+}): string {
+  const names = [
+    opts.stripeEnabled ? "Stripe" : null,
+    opts.revolutEnabled ? "Revolut" : null,
+  ].filter(Boolean) as string[];
+  if (names.length === 0) {
+    return "No card provider is connected yet — connect Stripe or Revolut under Settings → Payments.";
+  }
+  return `Card payments go through ${names.join(" and ")}.`;
+}
 
 export interface OfferedPaymentMethods {
   /** Stripe card checkout. */

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -59,6 +59,10 @@ export interface Business {
   sidebar_theme: string;
   /** Industry preset id (src/lib/plugins/presets.ts); null = no preset applied. */
   industry_preset?: string | null;
+  /** Card-provider state. In the DB since the Stripe/Revolut work; the type
+   *  never caught up, so pages reading them failed to compile. */
+  stripe_charges_enabled?: boolean | null;
+  revolut_enabled?: boolean | null;
   /** Overrides the preset's client fields. NULL = still using the preset;
    *  [] = deliberately none. */
   customer_field_schema?: OnboardingField[] | null;


### PR DESCRIPTION
You reported two bugs — no Revolut option when editing a client, and no payment option for old clients. **They're the same bug, and it's a label.**

## What I found

`card` is **one permission covering every card provider you've connected**. `resolveOfferedMethods` already gates Stripe and Revolut separately (`card` vs `revolut`) while sharing that permission, and:

- the **portal** renders `offered.revolut` independently of Stripe ✅
- the **invoice email** sets `revolutPayUrl` whenever `revolut_enabled`, with no Stripe condition ✅
- **Connected Studio has `revolut_enabled = true`** in the database ✅

So the plumbing works. What didn't was the label: **"Card (Stripe)"**. With Stripe banned and Revolut live, the client editor read as though card payments were off the table — and old clients (whose `allowed_payment_methods` is NULL) looked like they had no card option, when they had one all along.

## What changed

- **"Card (Stripe)" → "Card / online payment"**, with a line naming the provider that will actually serve it: *"Card payments go through Revolut."* Or, when neither is connected, it says so and points at Settings → Payments rather than implying Stripe.
- The summary under the list said the same wrong thing ("card if Stripe is connected") — fixed with it.
- `stripe_charges_enabled` and `revolut_enabled` were **missing from the `Business` type**. In the database since the payments work, never added, so any page reading them failed to compile — which is why this took a type fix to land.

**No change to what's offered.** The permission was already provider-agnostic; this makes the screen tell the truth about it.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 220 tests ✅

**Please confirm on the preview**: open an existing client and check the card row now reads "Card payments go through Revolut", then send yourself an invoice and confirm the Revolut button appears in the email.

## Still to do for Revolut

**[#443](https://github.com/maltamimi96/invoicer/pull/443) — saved cards + provider routing.** It's BEHIND main and needs a rebase. That's what card-on-file and autopay need in order to charge through Revolut instead of Stripe; without it, recurring billing still assumes Stripe.

And you mentioned Revolut is "buggy" — I'd rather hear the specific symptom before touching that code, since it decides whether the fault is in checkout, the webhook, or how the payment gets recorded.