### PR TITLE
fix(payments): don't show a Pay button to someone who just paid

### DIFF
--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import { ArrowLeft, FileText, Download, CreditCard } from "@/components/ui/icons";
 import { resolveOfferedMethods } from "@/lib/payment-methods";
+import { PaymentConfirming } from "@/components/customer-portal/payment-confirming";
 import { computeSurcharge, surchargeNote } from "@/lib/stripe";
 import type { LineItem } from "@/types/database";
 
@@ -14,8 +15,14 @@ export const dynamic = "force-dynamic";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => sb.from(name);
 
-export default async function PortalInvoicePage({ params }: { params: Promise<{ token: string; id: string }> }) {
+export default async function PortalInvoicePage({ params, searchParams }: {
+  params: Promise<{ token: string; id: string }>;
+  searchParams: Promise<{ paid?: string }>;
+}) {
   const { token, id } = await params;
+  // Set by the provider's redirect after a successful payment. The webhook
+  // that records it is a separate call and usually lands a moment later.
+  const justPaid = (await searchParams)?.paid === "1";
   const sb = createAdminClient();
 
   const { data: link } = await tbl(sb, "customer_portal_tokens")
@@ -47,6 +54,10 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
   const lineItems: LineItem[] = invoice.line_items || [];
   const balance = Math.max(0, Number(invoice.total) - Number(invoice.amount_paid ?? 0));
   const isPaid = invoice.status === "paid" || balance < 0.01;
+  // They've paid but we haven't recorded it yet. Treat it like paid for the
+  // purpose of hiding the Pay buttons — showing one now is how a customer
+  // ends up paying twice.
+  const awaitingConfirmation = justPaid && !isPaid;
 
   // Which payment methods this customer may use (per-customer allow-list).
   const hasBankDetails = !!(business?.bank_account_name || business?.bank_account_number || business?.bank_iban);
@@ -181,7 +192,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
         )}
 
         {/* How to pay — bank transfer details */}
-        {!isPaid && balance > 0 && offered.bank_transfer && (
+        {!isPaid && !awaitingConfirmation && balance > 0 && offered.bank_transfer && (
           <Card className="p-5 space-y-3 border-primary/20 bg-primary/5">
             <div className="flex items-baseline justify-between gap-3">
               <p className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">How to pay</p>
@@ -236,16 +247,19 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
               </p>
             </>
           )}
-          {!isPaid && balance > 0 && offered.cash && (
+          {!isPaid && !awaitingConfirmation && balance > 0 && offered.cash && (
             <p className="text-sm text-muted-foreground">
               This invoice is payable by cash / in person. Please contact us to arrange payment.
             </p>
           )}
-          {!isPaid && balance > 0 && offered.card && cardNote && (
+          {awaitingConfirmation && (
+            <PaymentConfirming businessPhone={business?.phone} businessEmail={business?.email} />
+          )}
+          {!isPaid && !awaitingConfirmation && balance > 0 && offered.card && cardNote && (
             <p className="text-xs text-muted-foreground">{cardNote}</p>
           )}
           <div className="flex items-center justify-center gap-2 flex-wrap">
-            {!isPaid && balance > 0 && offered.card && (
+            {!isPaid && !awaitingConfirmation && balance > 0 && offered.card && (
               <a
                 href={`/api/stripe/checkout?invoice=${invoice.id}&token=${token}`}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity shadow-sm"
@@ -256,7 +270,7 @@ export default async function PortalInvoicePage({ params }: { params: Promise<{ 
                   : `Pay ${formatCurrency(balance, currency)} with card`}
               </a>
             )}
-            {!isPaid && balance > 0 && offered.revolut && (
+            {!isPaid && !awaitingConfirmation && balance > 0 && offered.revolut && (
               <a
                 href={`/api/revolut/checkout?invoice=${invoice.id}&token=${token}`}
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-[#0666EB] text-white text-sm font-semibold hover:opacity-90 transition-opacity shadow-sm"

--- a/src/components/customer-portal/payment-confirming.tsx
+++ b/src/components/customer-portal/payment-confirming.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * "We're confirming your payment" — the gap between paying and the webhook.
+ *
+ * The card provider redirects the browser back the moment the payment is
+ * authorised, but the webhook that records it is a separate server-to-server
+ * call that usually lands a beat later. In between, the invoice row still says
+ * unpaid.
+ *
+ * Rendering the normal unpaid view there is worse than ugly: it shows a Pay
+ * button to someone who has just paid, and some of them will pay twice.
+ *
+ * So we hold this state briefly and re-check. If it's still not through by the
+ * end, we say so plainly rather than silently reverting to "unpaid" — the
+ * payment is almost certainly fine and the customer should not pay again.
+ */
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, Check } from "@/components/ui/icons";
+
+/** ~18s total. Long enough for a slow webhook, short enough not to strand. */
+const CHECKS = [1500, 2000, 2500, 3000, 4000, 5000];
+
+export function PaymentConfirming({ businessPhone, businessEmail }: {
+  businessPhone?: string | null;
+  businessEmail?: string | null;
+}) {
+  const router = useRouter();
+  const [attempt, setAttempt] = useState(0);
+  const gaveUp = attempt >= CHECKS.length;
+
+  useEffect(() => {
+    if (gaveUp) return;
+    const t = setTimeout(() => {
+      // A refresh re-runs the server component; if the webhook has landed, the
+      // page renders as paid and this component is gone.
+      router.refresh();
+      setAttempt((n) => n + 1);
+    }, CHECKS[attempt]);
+    return () => clearTimeout(t);
+  }, [attempt, gaveUp, router]);
+
+  if (gaveUp) {
+    return (
+      <div className="rounded-xl border border-amber-500/40 bg-amber-500/5 p-5">
+        <p className="text-sm font-semibold">Your payment went through</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          We haven&rsquo;t had the confirmation from the payment provider yet, so this page still shows a
+          balance. That usually settles within a few minutes.{" "}
+          <strong>Please don&rsquo;t pay again.</strong>
+        </p>
+        {(businessPhone || businessEmail) && (
+          <p className="mt-2 text-sm text-muted-foreground">
+            If it hasn&rsquo;t updated shortly, contact us
+            {businessPhone ? <> on <span className="font-medium text-foreground">{businessPhone}</span></> : null}
+            {businessPhone && businessEmail ? " or" : null}
+            {businessEmail ? <> at <span className="font-medium text-foreground">{businessEmail}</span></> : null}.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-5">
+      <p className="flex items-center gap-2 text-sm font-semibold">
+        <Loader2 className="h-4 w-4 animate-spin text-primary" />
+        Confirming your payment&hellip;
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        <Check className="mr-1 inline h-3.5 w-3.5 text-emerald-600" />
+        Your card has been charged. We&rsquo;re just waiting for the receipt from the payment provider &mdash;
+        this page will update on its own. No need to pay again.
+      </p>
+    </div>
+  );
+}

--- a/src/lib/revolut-payments.ts
+++ b/src/lib/revolut-payments.ts
@@ -18,6 +18,23 @@ interface RecordOpts {
   portalToken?: string | null;
 }
 
+/**
+ * Drop cached renders of anything that shows this invoice's balance.
+ *
+ * Without this the dashboard keeps serving a paid invoice as unpaid until
+ * something else happens to revalidate — which is what "I had to refresh"
+ * looks like. Best-effort: a webhook must never fail because a cache tag
+ * didn't clear, or the provider retries a payment we already recorded.
+ */
+async function revalidateInvoiceViews(invoiceId: string): Promise<void> {
+  try {
+    const { revalidatePath } = await import("next/cache");
+    revalidatePath(`/invoices/${invoiceId}`);
+    revalidatePath("/invoices");
+    revalidatePath("/dashboard");
+  } catch { /* not in a revalidatable context — nothing to do */ }
+}
+
 export async function recordRevolutPayment(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sb: any,
@@ -59,6 +76,7 @@ export async function recordRevolutPayment(
 
   await recomputeInvoice(sb, businessId, invoiceId, invoice.total);
   if (invoice.parent_invoice_id) await recomputeParent(sb, businessId, invoice.parent_invoice_id);
+  await revalidateInvoiceViews(invoiceId);
 
   try {
     dispatchWebhook(businessId, "payment.received", {

--- a/src/lib/stripe-payments.ts
+++ b/src/lib/stripe-payments.ts
@@ -71,6 +71,23 @@ async function lookupFees(
  * the invoice + any parent rollup, fire the merchant webhook, and email the
  * customer a receipt. Returns true if a new payment row was written.
  */
+/**
+ * Drop cached renders of anything that shows this invoice's balance.
+ *
+ * Without this the dashboard keeps serving a paid invoice as unpaid until
+ * something else happens to revalidate — which is what "I had to refresh"
+ * looks like. Best-effort: a webhook must never fail because a cache tag
+ * didn't clear, or the provider retries a payment we already recorded.
+ */
+async function revalidateInvoiceViews(invoiceId: string): Promise<void> {
+  try {
+    const { revalidatePath } = await import("next/cache");
+    revalidatePath(`/invoices/${invoiceId}`);
+    revalidatePath("/invoices");
+    revalidatePath("/dashboard");
+  } catch { /* not in a revalidatable context — nothing to do */ }
+}
+
 export async function recordStripePayment(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sb: any,
@@ -118,6 +135,7 @@ export async function recordStripePayment(
 
   await recomputeInvoice(sb, businessId, invoiceId, invoice.total);
   if (invoice.parent_invoice_id) await recomputeParent(sb, businessId, invoice.parent_invoice_id);
+  await revalidateInvoiceViews(invoiceId);
 
   try {
     dispatchWebhook(businessId, "payment.received", {


### PR DESCRIPTION
You paid with Revolut and the invoice still showed unpaid until you refreshed.

## There's a worse version of this than the one you saw

The provider redirects the browser back the **instant** the payment is authorised. The webhook that records it is a separate server-to-server call that lands a beat later. The portal page ignored the `?paid=1` the provider appends and rendered whatever the row said — so a customer returns to their invoice **still showing a balance, with the Pay button live**.

Some of them will pay twice. You saw the stale-dashboard half; the double-payment risk is the same bug pointed at your customer.

## What changed

**The portal recognises that in-between state.** It hides every pay option, says the card has been charged and we're waiting on the receipt, and re-checks for about 18 seconds — the page updates itself.

**If it still hasn't landed**, it says so plainly and tells them **not to pay again**, with your phone and email. That's deliberate: silently reverting to the unpaid view is what causes the second payment.

**Both payment recorders now revalidate the invoice views.** Neither webhook ever called `revalidatePath`, so a recorded payment could sit behind a cached render until something else cleared it — that's the "I had to refresh" half. Best-effort by design: a webhook must never fail because a cache tag didn't clear, or the provider retries a payment we already took.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests ✅

One test failed on the first run — `booking-db`, a concurrency test that hits the live Supabase. It passed on a clean re-run and touches nothing in this change. Flaky, not related.

**Worth a real test:** pay another small invoice through Revolut and watch the return page — you should get "Confirming your payment…" and see it flip to paid on its own, without touching the browser.