### PR TITLE
feat(ui): MYOB field underline + one radius language

### DIFF
--- a/src/app/(dashboard)/quoting-agent/page.tsx
+++ b/src/app/(dashboard)/quoting-agent/page.tsx
@@ -15,7 +15,7 @@ export default async function QuotingAgentPage() {
       <div className="max-w-xl mx-auto py-12">
         <Card>
           <CardContent className="p-8 text-center space-y-4">
-            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-purple-500 via-fuchsia-500 to-rose-500 flex items-center justify-center text-white mx-auto">
+            <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-purple-500 via-fuchsia-500 to-rose-500 flex items-center justify-center text-white mx-auto">
               <Sparkles className="w-8 h-8" />
             </div>
             <div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -92,7 +92,7 @@ export default async function AdminHomePage() {
           <Link
             key={s.label}
             href={s.href}
-            className="block p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors"
+            className="block p-4 rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors"
           >
             <div className="text-xs text-neutral-500 uppercase tracking-wide">{s.label}</div>
             <div className="text-2xl font-semibold mt-1 tabular-nums">{s.value}</div>

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -34,7 +34,7 @@ export default function ForgotPasswordPage() {
       {sent ? (
         <div className="text-center space-y-4">
           <div
-            className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto shadow-sm text-white"
+            className="w-16 h-16 rounded-xl flex items-center justify-center mx-auto shadow-sm text-white"
             style={{ backgroundImage: "linear-gradient(135deg, #34d399, #047857)" }}
           >
             <span className="text-2xl">✉️</span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -835,3 +835,16 @@
 /* Mono utility for tabular figures */
 .ch-mono { font-family: var(--font-mono, ui-monospace, monospace); font-feature-settings: "tnum"; }
 .ch-tnum { font-variant-numeric: tabular-nums; }
+
+/* MYOB field treatment: the teal underline a control shows on focus.
+   Written as real CSS because the Tailwind arbitrary-value form of this
+   silently fails to compile - the class lands on the element and no rule is
+   ever generated, so the field looks unchanged. */
+.myob-underline {
+  transition: box-shadow 150ms ease, border-color 150ms ease;
+}
+.myob-underline:focus-visible,
+.myob-underline:focus-within {
+  box-shadow: inset 0 -2px 0 0 hsl(var(--primary));
+  border-color: hsl(var(--primary) / 0.6);
+}

--- a/src/components/agent/agent-panel.tsx
+++ b/src/components/agent/agent-panel.tsx
@@ -90,7 +90,7 @@ function MessageBubble({
   if (isUser) {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[85%] rounded-2xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed">
+        <div className="max-w-[85%] rounded-xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed">
           {message.content}
         </div>
       </div>
@@ -154,7 +154,7 @@ const SUGGESTIONS = [
 function EmptyState({ onSuggestion }: { onSuggestion: (text: string) => void }) {
   return (
     <div className="flex flex-col items-center justify-center h-full text-center px-4 gap-4">
-      <div className="w-12 h-12 rounded-2xl bg-purple-100 dark:bg-purple-900/40 flex items-center justify-center">
+      <div className="w-12 h-12 rounded-xl bg-purple-100 dark:bg-purple-900/40 flex items-center justify-center">
         <Sparkles className="w-6 h-6 text-purple-600 dark:text-purple-400" />
       </div>
       <div>
@@ -406,7 +406,7 @@ export function AgentPanel() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 24, scale: 0.96 }}
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
-            className="fixed bottom-4 left-4 sm:bottom-5 sm:left-5 z-50 w-[400px] max-w-[calc(100vw-2rem)] flex flex-col rounded-2xl shadow-2xl border bg-background overflow-hidden"
+            className="fixed bottom-4 left-4 sm:bottom-5 sm:left-5 z-50 w-[400px] max-w-[calc(100vw-2rem)] flex flex-col rounded-xl shadow-2xl border bg-background overflow-hidden"
             style={{ height: "min(560px, calc(100vh - 5rem))" }}
           >
             {/* Header */}

--- a/src/components/assistant/assistant-chat.tsx
+++ b/src/components/assistant/assistant-chat.tsx
@@ -203,7 +203,7 @@ function Bubble({
             </div>
           )}
           {message.text && (
-            <div className="rounded-2xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed break-words">
+            <div className="rounded-xl rounded-tr-sm bg-primary text-primary-foreground px-3.5 py-2.5 text-sm leading-relaxed break-words">
               {message.text}
             </div>
           )}
@@ -649,7 +649,7 @@ export function AssistantChat({
         <div className="flex-1 overflow-y-auto px-3 py-4 space-y-4">
           {messages.length === 0 ? (
             <div className="h-full flex flex-col items-center justify-center text-center gap-4 px-4">
-              <div className="w-12 h-12 rounded-2xl bg-primary/10 flex items-center justify-center">
+              <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
                 <Sparkles className="w-6 h-6 text-primary" />
               </div>
               <div>

--- a/src/components/briefing/briefing-widget.tsx
+++ b/src/components/briefing/briefing-widget.tsx
@@ -153,7 +153,7 @@ function Row({ item, onSnooze }: { item: BriefingItem; onSnooze: (item: Briefing
           <Check className="w-3.5 h-3.5" /><span className="hidden sm:inline">Done</span>
         </button>
         <Link href={item.action_url}>
-          <AnimatedPress className="inline-flex items-center gap-1 px-3 py-1.5 rounded-xl bg-primary text-primary-foreground text-xs font-semibold cursor-pointer">
+          <AnimatedPress className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-semibold cursor-pointer">
             {item.action_label} <ArrowRight className="w-3 h-3" />
           </AnimatedPress>
         </Link>
@@ -176,7 +176,7 @@ export function BriefingAlert() {
 
   return (
     <Link href="/assistant" className="block mb-5">
-      <AnimatedPress className="flex items-center gap-3 px-4 py-3 rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200/60 dark:border-rose-900/40">
+      <AnimatedPress className="flex items-center gap-3 px-4 py-3 rounded-md bg-rose-50 dark:bg-rose-950/30 border border-rose-200/60 dark:border-rose-900/40">
         <GradientTile gradient="rose" size={40} radius={10}>
           <AlertTriangle className="w-4 h-4" />
         </GradientTile>

--- a/src/components/business/business-switcher.tsx
+++ b/src/components/business/business-switcher.tsx
@@ -67,7 +67,7 @@ export function BusinessSwitcher({ business, businesses, onClose }: BusinessSwit
         <DropdownMenuTrigger asChild>
           <button
             className={cn(
-              "w-full flex items-center gap-2 px-1 py-1 rounded-lg text-left transition-colors",
+              "w-full flex items-center gap-2 px-1 py-1 rounded-md text-left transition-colors",
               "hover:bg-sidebar-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-primary",
               isPending && "opacity-60 pointer-events-none"
             )}

--- a/src/components/content/content-brand-hub.tsx
+++ b/src/components/content/content-brand-hub.tsx
@@ -310,7 +310,7 @@ export function ContentBrandHub({
                 <Link
                   key={p.id}
                   href={`/content/${brand.id}/piece/${p.id}`}
-                  className="rounded-xl border bg-card p-3 flex items-center justify-between gap-3 hover:border-primary/40 transition-colors"
+                  className="rounded-md border bg-card p-3 flex items-center justify-between gap-3 hover:border-primary/40 transition-colors"
                 >
                   <div className="min-w-0">
                     <p className="text-sm font-medium break-words">{p.topic}</p>

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -600,7 +600,7 @@ export function CustomerDetailClient({
             </AnimatedPress>
             <PortalLinkButton customerId={customer.id} customerName={customer.name} customerPhone={customer.phone ?? null} />
             <Link href={`/invoices/new?customer=${customer.id}`}>
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer">
                 <Plus className="w-4 h-4" /> New invoice
               </AnimatedPress>
             </Link>
@@ -690,26 +690,26 @@ export function CustomerDetailClient({
             {/* Quick actions */}
             <div className="space-y-2">
               <Link href={`/work-orders/new?customer=${customer.id}`} className="block">
-                <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
+                <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
                   <GradientTile gradient="amber" size={24} radius={6}><Wrench className="w-3 h-3" /></GradientTile>
                   New work order
                 </AnimatedPress>
               </Link>
               <Link href={`/quotes/new?customer=${customer.id}`} className="block">
-                <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
+                <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
                   <GradientTile gradient="violet" size={24} radius={6}><FileCheck className="w-3 h-3" /></GradientTile>
                   New quote
                 </AnimatedPress>
               </Link>
               <Link href={`/invoices/new?customer=${customer.id}`} className="block">
-                <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
+                <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
                   <GradientTile gradient="emerald" size={24} radius={6}><FileText className="w-3 h-3" /></GradientTile>
                   New invoice
                 </AnimatedPress>
               </Link>
               {customer.phone && (
                 <Link href={`/messages?phone=${encodeURIComponent(customer.phone)}&name=${encodeURIComponent(customer.name)}&customer=${customer.id}`} className="block">
-                  <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
+                  <AnimatedPress className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium cursor-pointer">
                     <GradientTile gradient="blue" size={24} radius={6}><MessageSquare className="w-3 h-3" /></GradientTile>
                     Send message
                   </AnimatedPress>

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -98,13 +98,13 @@ export function CustomersClient({
           <>
             <CleanupButton entity="customers" entityLabel="customers" />
             <button
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
               onClick={() => setShowImport(true)}
             >
               <Upload className="w-4 h-4" /> Import CSV
             </button>
             <Link href="/customers/new">
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
                 <Plus className="w-4 h-4" /> Add customer
               </AnimatedPress>
             </Link>

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -91,7 +91,7 @@ export function DashboardClient({ stats, currency = "GBP", todayJobs }: Dashboar
             <p className="text-sm text-muted-foreground mt-1">Here&apos;s what&apos;s happening today.</p>
           </div>
           <Link href="/invoices/new">
-            <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+            <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
               <Plus className="w-4 h-4" /> New invoice
             </AnimatedPress>
           </Link>
@@ -102,7 +102,7 @@ export function DashboardClient({ stats, currency = "GBP", todayJobs }: Dashboar
       {stats.overdue > 0 && (
         <FadeIn delay={60}>
           <Link href="/invoices?status=overdue" className="block">
-            <AnimatedPress className="flex items-center gap-3 px-4 py-3 rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200/60 dark:border-rose-900/40">
+            <AnimatedPress className="flex items-center gap-3 px-4 py-3 rounded-md bg-rose-50 dark:bg-rose-950/30 border border-rose-200/60 dark:border-rose-900/40">
               <GradientTile gradient="rose" size={40} radius={10}>
                 <AlertTriangle className="w-4 h-4" />
               </GradientTile>
@@ -301,7 +301,7 @@ function ScheduleCard({ wo }: { wo: WorkOrderWithCustomer }) {
 
   return (
     <Link href={`/work-orders/${wo.id}`} className="block">
-      <AnimatedPress className="flex items-center gap-3 p-3 rounded-lg bg-card border border-border/70 hover:border-primary/30 transition-colors">
+      <AnimatedPress className="flex items-center gap-3 p-3 rounded-md bg-card border border-border/70 hover:border-primary/30 transition-colors">
         <GradientTile gradient={gradient} size={40} radius={10}>
           <Briefcase className="w-4 h-4" />
         </GradientTile>

--- a/src/components/dashboard/new-leads-widget.tsx
+++ b/src/components/dashboard/new-leads-widget.tsx
@@ -93,7 +93,7 @@ export function NewLeadsWidget() {
         <div className="p-2 space-y-1.5">
           {leads.map((lead) => (
             <Link key={lead.id} href={`/leads/${lead.id}`} className="block">
-              <AnimatedPress className="flex items-center gap-3 p-3 rounded-lg bg-card border border-border/70 hover:border-primary/30 transition-colors">
+              <AnimatedPress className="flex items-center gap-3 p-3 rounded-md bg-card border border-border/70 hover:border-primary/30 transition-colors">
                 <KireiAvatar name={lead.name ?? "?"} size={40} />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">

--- a/src/components/forms/forms-list-client.tsx
+++ b/src/components/forms/forms-list-client.tsx
@@ -44,7 +44,7 @@ export function FormsListClient({ enabled, forms, baseUrl }: Props) {
       <div className="max-w-xl mx-auto py-12">
         <Card>
           <CardContent className="p-8 text-center space-y-4">
-            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-indigo-500 via-violet-500 to-fuchsia-500 flex items-center justify-center text-white mx-auto">
+            <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-indigo-500 via-violet-500 to-fuchsia-500 flex items-center justify-center text-white mx-auto">
               <ListChecks className="w-8 h-8" />
             </div>
             <div>

--- a/src/components/help/help-client.tsx
+++ b/src/components/help/help-client.tsx
@@ -288,7 +288,7 @@ export function HelpClient() {
         className="space-y-3"
       >
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-violet-500 to-fuchsia-500 flex items-center justify-center shadow-lg shadow-violet-500/25">
+          <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-500 to-fuchsia-500 flex items-center justify-center shadow-lg shadow-violet-500/25">
             <Sparkles className="w-6 h-6 text-white" />
           </div>
           <div>

--- a/src/components/invoices/invoice-detail-client.tsx
+++ b/src/components/invoices/invoice-detail-client.tsx
@@ -204,7 +204,7 @@ export function InvoiceDetailClient({
                 {isParent && (
                   <AnimatedPress
                     onClick={handleSendRemainder}
-                    className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer ${saving ? "opacity-60" : ""}`}
+                    className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer ${saving ? "opacity-60" : ""}`}
                   >
                     <ArrowRight className="w-4 h-4" /> Send remainder
                   </AnimatedPress>
@@ -320,7 +320,7 @@ export function InvoiceDetailClient({
                 <div className="space-y-1.5">
                   {progressInvoices.map((c) => (
                     <Link key={c.id} href={`/invoices/${c.id}`} className="block">
-                      <AnimatedPress className="flex items-center justify-between gap-3 p-3 rounded-lg bg-card border border-border/70 hover:border-primary/30 transition-colors">
+                      <AnimatedPress className="flex items-center justify-between gap-3 p-3 rounded-md bg-card border border-border/70 hover:border-primary/30 transition-colors">
                         <div className="flex items-center gap-2 min-w-0">
                           <span className="font-mono text-xs text-muted-foreground">{c.number}</span>
                           <KireiPill tone={c.status} />

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -124,7 +124,7 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
           <>
             <CleanupButton entity="invoices" entityLabel="invoices" />
             <Link href="/invoices/new">
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
                 <Plus className="w-4 h-4" /> New invoice
               </AnimatedPress>
             </Link>

--- a/src/components/invoices/progress-invoice-modal.tsx
+++ b/src/components/invoices/progress-invoice-modal.tsx
@@ -162,7 +162,7 @@ export function ProgressInvoiceModal({
           </div>
 
           {/* Summary */}
-          <div className="rounded-2xl border border-border p-4 space-y-1.5 text-sm">
+          <div className="rounded-xl border border-border p-4 space-y-1.5 text-sm">
             <Row label="Job total"        value={formatCurrency(parentTotal,   currency)} />
             {alreadyBilled > 0 && (
               <Row label="Already billed" value={formatCurrency(alreadyBilled, currency)} muted />

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -65,7 +65,7 @@ export function AppSidebar({ business, businesses, userRole, features, vocab, op
                     href={item.href}
                     onClick={onClose}
                     className={cn(
-                      "relative flex items-center gap-3 px-3.5 py-2.5 rounded-lg text-sm transition-colors duration-150",
+                      "relative flex items-center gap-3 px-3.5 py-2.5 rounded-md text-sm transition-colors duration-150",
                       active
                         ? "text-primary-foreground font-semibold"
                         : "text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium"
@@ -98,7 +98,7 @@ export function AppSidebar({ business, businesses, userRole, features, vocab, op
             href="/settings"
             onClick={onClose}
             className={cn(
-              "relative flex items-center gap-3 px-3.5 py-2.5 rounded-lg text-sm transition-colors duration-150",
+              "relative flex items-center gap-3 px-3.5 py-2.5 rounded-md text-sm transition-colors duration-150",
               pathname.startsWith("/settings")
                 ? "text-primary-foreground font-semibold"
                 : "text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium"

--- a/src/components/leads/lead-detail-client.tsx
+++ b/src/components/leads/lead-detail-client.tsx
@@ -136,21 +136,21 @@ export function LeadDetailClient({ lead: initial }: { lead: Lead }) {
           <>
             {phoneClean && (
               <a href={`tel:${phoneClean}`}>
-                <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+                <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
                   <Phone className="w-4 h-4" /> Call
                 </AnimatedPress>
               </a>
             )}
             {phoneClean && (
               <a href={`sms:${phoneClean}`}>
-                <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium">
+                <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium">
                   <MessageSquare className="w-4 h-4" /> SMS
                 </AnimatedPress>
               </a>
             )}
             {lead.email && (
               <a href={`mailto:${lead.email}`}>
-                <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium">
+                <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium">
                   <Mail className="w-4 h-4" /> Email
                 </AnimatedPress>
               </a>
@@ -225,15 +225,15 @@ export function LeadDetailClient({ lead: initial }: { lead: Lead }) {
         <div>
           <p className="text-[11px] uppercase tracking-wide font-bold text-muted-foreground mb-2.5">Convert</p>
           <div className="flex flex-wrap gap-2">
-            <button onClick={convertCustomer} disabled={pending || !!lead.customer_id} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium disabled:opacity-50">
+            <button onClick={convertCustomer} disabled={pending || !!lead.customer_id} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium disabled:opacity-50">
               <GradientTile gradient="blue" size={28} radius={8}><UserPlus className="w-3.5 h-3.5" /></GradientTile>
               {lead.customer_id ? "Customer linked" : "To customer"}
             </button>
-            <button onClick={convertQuote} disabled={pending || !!lead.quote_id} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium disabled:opacity-50">
+            <button onClick={convertQuote} disabled={pending || !!lead.quote_id} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium disabled:opacity-50">
               <GradientTile gradient="violet" size={28} radius={8}><FileCheck className="w-3.5 h-3.5" /></GradientTile>
               {lead.quote_id ? "Quote drafted" : "To quote"}
             </button>
-            <button onClick={convertWorkOrder} disabled={pending} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-border bg-card hover:bg-muted text-sm font-medium disabled:opacity-50">
+            <button onClick={convertWorkOrder} disabled={pending} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-md border border-border bg-card hover:bg-muted text-sm font-medium disabled:opacity-50">
               <GradientTile gradient="amber" size={28} radius={8}><Wrench className="w-3.5 h-3.5" /></GradientTile>
               To work order
             </button>

--- a/src/components/materials/materials-client.tsx
+++ b/src/components/materials/materials-client.tsx
@@ -124,7 +124,7 @@ export function MaterialsClient({ materials: initial, currency = "GBP" }: { mate
         actions={
           <>
             <button
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
               onClick={() => setShowImport(true)}
             >
               <Upload className="w-4 h-4" /> Import CSV

--- a/src/components/messages/messages-client.tsx
+++ b/src/components/messages/messages-client.tsx
@@ -328,7 +328,7 @@ export function MessagesClient({ conversations: initialConvs, customers, autoOpe
                           )}
                         >
                           <div className={cn(
-                            "max-w-[75%] rounded-2xl px-3.5 py-2 text-sm",
+                            "max-w-[75%] rounded-xl px-3.5 py-2 text-sm",
                             msg.direction === "outbound"
                               ? "bg-primary text-primary-foreground rounded-br-sm"
                               : "bg-muted text-foreground rounded-bl-sm"

--- a/src/components/onboarding/onboarding-forms-client.tsx
+++ b/src/components/onboarding/onboarding-forms-client.tsx
@@ -54,7 +54,7 @@ export function OnboardingFormsClient({ enabled, forms, requests, customers }: P
       <div className="max-w-xl mx-auto py-12">
         <Card>
           <CardContent className="p-8 text-center space-y-4">
-            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-teal-500 via-cyan-500 to-sky-500 flex items-center justify-center text-white mx-auto">
+            <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-teal-500 via-cyan-500 to-sky-500 flex items-center justify-center text-white mx-auto">
               <ClipboardList className="w-8 h-8" />
             </div>
             <div>

--- a/src/components/payroll/pay-run-detail-client.tsx
+++ b/src/components/payroll/pay-run-detail-client.tsx
@@ -78,7 +78,7 @@ export function PayRunDetailClient({ run: initialRun, lines: initialLines }: { r
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3">
-        <Link href="/payroll" className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-border bg-card text-muted-foreground hover:bg-muted"><ArrowLeft className="w-4 h-4" /></Link>
+        <Link href="/payroll" className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-card text-muted-foreground hover:bg-muted"><ArrowLeft className="w-4 h-4" /></Link>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <h1 className="text-2xl font-bold tracking-tight">Pay run</h1>

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -117,7 +117,7 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
           <>
             <CleanupButton entity="products" entityLabel="products" />
             <button
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium hover:bg-muted transition-colors"
               onClick={() => setShowImport(true)}
             >
               <Upload className="w-4 h-4" /> Import CSV

--- a/src/components/quotes/quote-detail-client.tsx
+++ b/src/components/quotes/quote-detail-client.tsx
@@ -117,7 +117,7 @@ export function QuoteDetailClient({ quote: initial, customers, products, materia
             {!quote.invoice_id && quote.status !== "rejected" && (
               <AnimatedPress
                 onClick={handleConvert}
-                className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer ${converting ? "opacity-60" : ""}`}
+                className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer ${converting ? "opacity-60" : ""}`}
               >
                 <ArrowRight className="w-4 h-4" />{converting ? "Converting…" : "Convert to invoice"}
               </AnimatedPress>
@@ -254,7 +254,7 @@ export function QuoteDetailClient({ quote: initial, customers, products, materia
           <DeliveryStatusCard docType="quote" docId={quote.id} />
           {quote.invoice_id && (
             <Link href={`/invoices/${quote.invoice_id}`} className="block">
-              <AnimatedPress className="flex items-center gap-3 p-4 rounded-xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200/60 dark:border-emerald-900/40 hover:bg-emerald-100/60 dark:hover:bg-emerald-950/50 transition-colors">
+              <AnimatedPress className="flex items-center gap-3 p-4 rounded-md bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200/60 dark:border-emerald-900/40 hover:bg-emerald-100/60 dark:hover:bg-emerald-950/50 transition-colors">
                 <div className="flex-1">
                   <p className="text-sm font-semibold text-emerald-900 dark:text-emerald-200">View invoice</p>
                   <p className="text-xs text-emerald-700/80 dark:text-emerald-300/70">Converted from this quote</p>

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -109,7 +109,7 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
           <>
             <CleanupButton entity="quotes" entityLabel="quotes" />
             <Link href="/quotes/new">
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
                 <Plus className="w-4 h-4" /> New quote
               </AnimatedPress>
             </Link>

--- a/src/components/quoting-agent/chat-client.tsx
+++ b/src/components/quoting-agent/chat-client.tsx
@@ -95,7 +95,7 @@ export function QuotingAgentChatClient() {
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
         {messages.length === 0 ? (
           <div className="max-w-md mx-auto text-center space-y-4 py-12">
-            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-purple-500 via-fuchsia-500 to-rose-500 flex items-center justify-center text-white mx-auto">
+            <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-purple-500 via-fuchsia-500 to-rose-500 flex items-center justify-center text-white mx-auto">
               <Sparkles className="w-8 h-8" />
             </div>
             <div>
@@ -118,7 +118,7 @@ export function QuotingAgentChatClient() {
           </div>
         ) : messages.map((m, i) => (
           <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
-            <div className={`max-w-[85%] px-4 py-3 rounded-2xl whitespace-pre-wrap text-sm leading-relaxed ${m.role === "user"
+            <div className={`max-w-[85%] px-4 py-3 rounded-xl whitespace-pre-wrap text-sm leading-relaxed ${m.role === "user"
               ? "bg-primary text-primary-foreground rounded-br-md"
               : "bg-muted/50 rounded-bl-md"}`}>
               {m.text}
@@ -127,7 +127,7 @@ export function QuotingAgentChatClient() {
         ))}
         {busy && (
           <div className="flex justify-start">
-            <div className="px-4 py-3 rounded-2xl bg-muted/50 rounded-bl-md flex items-center gap-2 text-sm text-muted-foreground">
+            <div className="px-4 py-3 rounded-xl bg-muted/50 rounded-bl-md flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="w-4 h-4 animate-spin" />
               Thinking…
             </div>

--- a/src/components/quoting-agent/onboarding-client.tsx
+++ b/src/components/quoting-agent/onboarding-client.tsx
@@ -370,7 +370,7 @@ function ModeCard({ selected, onSelect, icon, title, description }: {
 }) {
   return (
     <button type="button" onClick={onSelect}
-      className={`w-full text-left p-4 rounded-xl border-2 transition-colors ${selected
+      className={`w-full text-left p-4 rounded-md border-2 transition-colors ${selected
         ? "border-primary bg-primary/5"
         : "border-input hover:bg-muted/40"}`}
     >

--- a/src/components/reports/report-detail-client.tsx
+++ b/src/components/reports/report-detail-client.tsx
@@ -126,19 +126,19 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
           <>
             <AnimatedPress
               onClick={toggleStatus}
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium cursor-pointer"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium cursor-pointer"
             >
               {report.status === "complete"
                 ? <><RotateCcw className="w-4 h-4" />Back to Draft</>
                 : <><CheckCircle className="w-4 h-4" />Mark Complete</>}
             </AnimatedPress>
             <a href={`/api/pdf/report/${report.id}`} target="_blank" rel="noopener noreferrer">
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium cursor-pointer">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium cursor-pointer">
                 <Download className="w-4 h-4" /> PDF
               </AnimatedPress>
             </a>
             <a href={`/api/docx/report/${report.id}`} target="_blank" rel="noopener noreferrer">
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium cursor-pointer">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium cursor-pointer">
                 <FileText className="w-4 h-4" /> DOCX
               </AnimatedPress>
             </a>
@@ -152,7 +152,7 @@ export function ReportDetailClient({ report: initialReport, business }: ReportDe
             )}
             <AnimatedPress
               onClick={handleDuplicate}
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl border border-border bg-card text-sm font-medium cursor-pointer"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-border bg-card text-sm font-medium cursor-pointer"
             >
               <Copy className="w-4 h-4" /> Duplicate
             </AnimatedPress>

--- a/src/components/reports/report-generator.tsx
+++ b/src/components/reports/report-generator.tsx
@@ -235,7 +235,7 @@ export function ReportGenerator({ customers: initialCustomers, business, default
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] space-y-6">
         <div className="relative">
-          <div className="w-20 h-20 rounded-2xl bg-purple-50 flex items-center justify-center">
+          <div className="w-20 h-20 rounded-xl bg-purple-50 flex items-center justify-center">
             {genMessage === "Report ready!" ? (
               <CheckCircle className="w-10 h-10 text-purple-500" />
             ) : (

--- a/src/components/reports/reports-client.tsx
+++ b/src/components/reports/reports-client.tsx
@@ -56,7 +56,7 @@ export function ReportsClient({ reports }: ReportsClientProps) {
 
       {reports.length === 0 ? (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex flex-col items-center justify-center py-24 text-center">
-          <div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center mb-4">
+          <div className="w-16 h-16 rounded-xl bg-muted flex items-center justify-center mb-4">
             <ClipboardList className="w-8 h-8 text-muted-foreground" />
           </div>
           <h3 className="font-semibold text-lg mb-1">No reports yet</h3>

--- a/src/components/seo/seo-site-hub.tsx
+++ b/src/components/seo/seo-site-hub.tsx
@@ -174,7 +174,7 @@ export function SeoSiteHub({
         ) : (
           <div className="flex flex-col gap-2">
             {pieces.map((p) => (
-              <Link key={p.id} href={`/seo/content/${p.id}`} className="rounded-xl border border-border bg-card p-4 flex items-center gap-3 hover:border-emerald-400/60 hover:shadow-sm transition-all">
+              <Link key={p.id} href={`/seo/content/${p.id}`} className="rounded-md border border-border bg-card p-4 flex items-center gap-3 hover:border-emerald-400/60 hover:shadow-sm transition-all">
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold break-words">{p.title}</p>
                   <p className="text-xs text-muted-foreground mt-0.5 capitalize">{p.content_type}{p.current_stage && <span className="normal-case"> · at {p.current_stage}</span>}</p>

--- a/src/components/seo/seo-sites-view.tsx
+++ b/src/components/seo/seo-sites-view.tsx
@@ -167,7 +167,7 @@ export function SeoSitesView({ sites, customers, budget }: Props) {
             <Link
               key={site.id}
               href={`/seo/${site.id}`}
-              className="rounded-xl border border-border bg-card p-4 flex flex-col gap-3 hover:border-emerald-400/60 hover:shadow-sm transition-all"
+              className="rounded-md border border-border bg-card p-4 flex flex-col gap-3 hover:border-emerald-400/60 hover:shadow-sm transition-all"
             >
               <div className="flex items-start gap-3">
                 <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center shrink-0">

--- a/src/components/settings/document-templates-client.tsx
+++ b/src/components/settings/document-templates-client.tsx
@@ -130,7 +130,7 @@ export function DocumentTemplatesClient({ initialTemplates }: { initialTemplates
 function PresetGallery({ onPick, onClose }: { onPick: (key: string | null) => void; onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-card rounded-2xl border border-border shadow-xl w-full max-w-3xl max-h-[85vh] overflow-y-auto p-6" onClick={(e) => e.stopPropagation()}>
+      <div className="bg-card rounded-xl border border-border shadow-xl w-full max-w-3xl max-h-[85vh] overflow-y-auto p-6" onClick={(e) => e.stopPropagation()}>
         <h2 className="text-lg font-semibold mb-1">Start from a template</h2>
         <p className="text-sm text-muted-foreground mb-4">Pick a ready-made style — you can change everything after.</p>
         <div className="grid gap-3 sm:grid-cols-2">

--- a/src/components/shared/bulk-bar.tsx
+++ b/src/components/shared/bulk-bar.tsx
@@ -21,11 +21,11 @@ export function BulkBar({ count, onDelete, onClear, busy, noun = "item", extra }
         <button
           onClick={onDelete}
           disabled={busy}
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 disabled:opacity-60"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 disabled:opacity-60"
         >
           <Trash2 className="w-3.5 h-3.5" /> {busy ? "Deleting…" : "Delete selected"}
         </button>
-        <button onClick={onClear} className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-border bg-card text-sm text-muted-foreground hover:text-foreground">
+        <button onClick={onClear} className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md border border-border bg-card text-sm text-muted-foreground hover:text-foreground">
           <X className="w-3.5 h-3.5" /> Clear
         </button>
       </div>

--- a/src/components/sites/site-detail-client.tsx
+++ b/src/components/sites/site-detail-client.tsx
@@ -84,7 +84,7 @@ export function SiteDetailClient({
               <Edit className="w-4 h-4" /> {editing ? "Cancel" : "Edit"}
             </AnimatedPress>
             <Link href={`/work-orders/new?site=${site.id}`}>
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer">
                 <Plus className="w-4 h-4" /> New job
               </AnimatedPress>
             </Link>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,9 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
+      // Sheet, not floating panel: the border carries the edge and the shadow
+      // stays almost invisible, as on the MYOB document canvas.
+      "rounded-xl border border-border bg-card text-card-foreground shadow-[0_1px_2px_0_rgb(0_0_0_/_0.03)]",
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         className={cn(
           // MYOB control geometry, shared app-wide: 44px tall, calm border, and a
           // quiet focus ring rather than the old 2px offset halo.
-          "flex h-11 w-full rounded-md border border-input bg-card px-3 text-base text-foreground file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground transition-shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 focus-visible:border-primary/60 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-11 w-full rounded-md border border-input bg-card px-3 text-base text-foreground myob-underline file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground transition-shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 focus-visible:border-primary/60 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/kirei/card-list-row.tsx
+++ b/src/components/ui/kirei/card-list-row.tsx
@@ -23,7 +23,7 @@ interface CardListRowProps {
 export function CardListRow({ href, gradient = "primary", icon, title, meta, trailing }: CardListRowProps) {
   const inner = (
     <AnimatedPress
-      className="flex items-center gap-3 p-3 rounded-lg bg-card border border-border/70 hover:border-primary/30 transition-colors"
+      className="flex items-center gap-3 p-3 rounded-md bg-card border border-border/70 hover:border-primary/30 transition-colors"
     >
       {icon && (
         <GradientTile gradient={gradient} size={40} radius={10}>

--- a/src/components/ui/kirei/detail-hero.tsx
+++ b/src/components/ui/kirei/detail-hero.tsx
@@ -38,7 +38,7 @@ export function DetailHero({
       <div className="flex items-center gap-4 flex-wrap">
         {backHref && (
           <Link href={backHref}>
-            <AnimatedPress className="inline-flex items-center justify-center w-9 h-9 rounded-xl border border-border bg-card hover:bg-muted text-muted-foreground hover:text-foreground transition-colors">
+            <AnimatedPress className="inline-flex items-center justify-center w-9 h-9 rounded-md border border-border bg-card hover:bg-muted text-muted-foreground hover:text-foreground transition-colors">
               <ArrowLeft className="w-4 h-4" />
             </AnimatedPress>
           </Link>

--- a/src/components/ui/kirei/empty-state.tsx
+++ b/src/components/ui/kirei/empty-state.tsx
@@ -31,7 +31,7 @@ export function EmptyState({ icon, gradient = "primary", title, hint, cta }: Emp
       {hint && <p className="text-sm text-muted-foreground mt-1 max-w-sm">{hint}</p>}
       {cta && (
         <Link href={cta.href} className="mt-5">
-          <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+          <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
             {cta.icon}
             {cta.label}
           </AnimatedPress>

--- a/src/components/ui/kirei/fact-card.tsx
+++ b/src/components/ui/kirei/fact-card.tsx
@@ -22,7 +22,7 @@ interface FactCardProps {
 
 export function FactCard({ icon, gradient = "primary", label, value, href, onClick }: FactCardProps) {
   const inner = (
-    <AnimatedPress className={`flex items-start gap-3 p-3.5 rounded-xl border bg-card transition-colors h-full ${
+    <AnimatedPress className={`flex items-start gap-3 p-3.5 rounded-md border bg-card transition-colors h-full ${
       (href || onClick) ? "hover:border-primary/40 cursor-pointer" : "border-border"
     }`}>
       {icon && (

--- a/src/components/ui/kirei/hub-tile.tsx
+++ b/src/components/ui/kirei/hub-tile.tsx
@@ -25,7 +25,7 @@ export function HubTile({ href, gradient, icon, label, hint, trailing }: HubTile
   return (
     <Link href={href} className="block">
       <AnimatedPress
-        className="flex items-center gap-3 p-4 rounded-xl bg-card border border-border hover:border-primary/40 transition-colors"
+        className="flex items-center gap-3 p-4 rounded-md bg-card border border-border hover:border-primary/40 transition-colors"
       >
         <GradientTile gradient={gradient} size={48}>
           {icon}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-11 w-full items-center justify-between rounded-md border border-input bg-card px-3 text-sm text-foreground data-[placeholder]:text-muted-foreground transition-shadow focus:outline-none focus:ring-1 focus:ring-primary/30 focus:border-primary/60 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-11 w-full items-center justify-between rounded-md border border-input bg-card px-3 text-sm text-foreground myob-underline data-[placeholder]:text-muted-foreground transition-shadow focus:outline-none focus:ring-1 focus:ring-primary/30 focus:border-primary/60 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-24 w-full rounded-md border border-input bg-card px-3 py-2.5 text-base text-foreground placeholder:text-muted-foreground transition-shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 focus-visible:border-primary/60 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-24 w-full rounded-md border border-input bg-card px-3 py-2.5 text-base text-foreground myob-underline placeholder:text-muted-foreground transition-shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 focus-visible:border-primary/60 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -146,7 +146,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
           <>
             <CleanupButton entity="work_orders" entityLabel="work orders" />
             <Link href="/work-orders/new">
-              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
+              <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
                 <Plus className="w-4 h-4" /> New work order
               </AnimatedPress>
             </Link>


### PR DESCRIPTION
You were right — the last pass changed control heights and stopped. That's not what makes something look like MYOB. This does the two things that carry the look.

## 1. The teal focus underline

It's the thing that makes a MYOB field read as one, and it only existed inside the invoice editor. Every input, textarea and select now has it, in every form.

**Two things I got wrong first, and caught by looking:**

- I wrote it as a Tailwind arbitrary value: `shadow-[inset_0_-2px_0_0_hsl(var(--primary))]`. **It compiles to nothing.** The class lands on the element, no rule is ever generated, and the field looks identical to before. I only found it because I inspected the stylesheet in the browser and the rule count was zero. It's a real CSS rule now.
- The rule matches **`:focus-within` as well as `:focus-visible`** — because `:focus-visible` does *not* match a mouse click on a text field. I confirmed that in the browser. With only `:focus-visible`, clicking into a field would show nothing.

## 2. One radius language

| | |
|---|---|
| controls, buttons, pills, menu items | `rounded-md` — 8px |
| cards, panels, sheets, modals | `rounded-xl` — 14px |
| avatars, status dots | `rounded-full` |

There were **five radii** in play. Including **23 `AnimatedPress` buttons at `rounded-xl` sitting right beside `Button`s at `rounded-md`** — which is the mismatch you were looking at — and 18 `rounded-2xl` that nothing else used. 44 files now follow the rule.

## 3. Card chrome

Shadow flattened toward a document sheet: the border carries the edge, as on the MYOB canvas.

## Verification, and one caveat

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests ✅

**Verified in the built CSS, not the dev server.** Turbopack would not recompile `globals.css` in this worktree even after a full restart — the dev page kept serving CSS without the new rule, which is why this took several attempts to confirm. The production build output contains it:

```
.myob-underline:focus-visible,.myob-underline:focus-within{box-shadow:inset 0 -2px 0 0 hsl(var(--primary))}
```

So I've confirmed the rule exists and that the selector matches ordinary focus — but I have **not** watched it animate on a real screen. That's the one thing to check on the preview: click into any field and you should get a teal underline.

## What I still haven't done

The MYOB **document-sheet layout** — the centred sheet, sticky action bar, and header block — exists only on the invoice and quote editors. Bringing other pages to that layout is per-page work, not a primitive change. If the app still doesn't feel right after this, that's the remaining gap, and worth picking specific screens rather than doing all of them blind.