### PR TITLE
feat(leads): onboarding forms on a lead + fix plaintext credential storage

### DIFF
--- a/src/app/(dashboard)/leads/[id]/page.tsx
+++ b/src/app/(dashboard)/leads/[id]/page.tsx
@@ -1,12 +1,40 @@
 import { notFound } from "next/navigation";
 import { getLead } from "@/lib/actions/leads";
 import { LeadDetailClient } from "@/components/leads/lead-detail-client";
+import {
+  getOnboardingSettings, getOnboardingForms, getOnboardingResponsesForLead, getSecureFieldsAvailable,
+} from "@/lib/actions/onboarding";
+import { staffFillableFields } from "@/lib/onboarding/staff-fill";
+import type { LeadOnboardingData } from "@/components/leads/lead-onboarding-card";
+
+/** Onboarding data for a lead — only when the plugin is on. Never break the
+ *  page over it: a lead is useful without its forms. */
+async function loadLeadOnboarding(leadId: string): Promise<LeadOnboardingData | null> {
+  try {
+    const settings = await getOnboardingSettings();
+    if (!settings.enabled) return null;
+    const [forms, responses, allowSecureFill] = await Promise.all([
+      getOnboardingForms(),
+      getOnboardingResponsesForLead(leadId),
+      getSecureFieldsAvailable(),
+    ]);
+    return {
+      forms: forms
+        .filter((f) => f.status !== "archived" && staffFillableFields(f.schema).length > 0)
+        .map((f) => ({ id: f.id, name: f.name, schema: f.schema })),
+      responses,
+      allowSecureFill,
+    };
+  } catch {
+    return null;
+  }
+}
 
 export default async function LeadDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
-    const lead = await getLead(id);
-    return <LeadDetailClient lead={lead} />;
+    const [lead, onboarding] = await Promise.all([getLead(id), loadLeadOnboarding(id)]);
+    return <LeadDetailClient lead={lead} onboarding={onboarding} />;
   } catch {
     notFound();
   }

--- a/src/components/leads/lead-detail-client.tsx
+++ b/src/components/leads/lead-detail-client.tsx
@@ -18,6 +18,7 @@ import {
   DetailHero, FactCard, AnimatedPress, FadeIn, KireiAvatar, GradientTile,
 } from "@/components/ui/kirei";
 import type { GradientName } from "@/components/ui/kirei";
+import { LeadOnboardingCard, type LeadOnboardingData } from "@/components/leads/lead-onboarding-card";
 import type { Lead, LeadStatus } from "@/types/database";
 
 const STATUSES: LeadStatus[] = ["new", "contacted", "quoted", "won", "lost"];
@@ -48,7 +49,11 @@ const SOURCE_LABELS: Record<string, string> = {
 const fmtSource = (s: string | null) =>
   !s ? "—" : (SOURCE_LABELS[s] ?? s.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()));
 
-export function LeadDetailClient({ lead: initial }: { lead: Lead }) {
+export function LeadDetailClient({ lead: initial, onboarding }: {
+  lead: Lead;
+  /** Onboarding forms for this lead; absent when the plugin is off. */
+  onboarding?: LeadOnboardingData | null;
+}) {
   const router = useRouter();
   const [lead, setLead] = useState<Lead>(initial);
   const [pending, startTransition] = useTransition();
@@ -219,6 +224,8 @@ export function LeadDetailClient({ lead: initial }: { lead: Lead }) {
           </div>
         </FadeIn>
       )}
+
+      {onboarding && <LeadOnboardingCard leadId={lead.id} data={onboarding} />}
 
       {/* Convert actions */}
       <FadeIn delay={260}>

--- a/src/components/leads/lead-onboarding-card.tsx
+++ b/src/components/leads/lead-onboarding-card.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * Onboarding forms filled in against a LEAD.
+ *
+ * Qualifying a lead means asking the same questions you'd ask a client, and
+ * before this there was nowhere to put the answers until the lead converted.
+ *
+ * Fill-in only — no "send to them". Portal links are minted against a
+ * customer, so a lead has no address to send to. Convert first if you want
+ * them to fill it in themselves.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { toast } from "sonner";
+import { ClipboardList, Loader2, PenLine, Eye, ChevronDown } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { GradientTile, FadeIn } from "@/components/ui/kirei";
+import { StaffOnboardingFill } from "@/components/onboarding/staff-onboarding-fill";
+import { saveLeadOnboardingResponse } from "@/lib/actions/onboarding";
+import { staffFillableFields } from "@/lib/onboarding/staff-fill";
+import { formatDate } from "@/lib/utils";
+import type { OnboardingForm, OnboardingResponse, OnboardingField } from "@/types/database";
+
+export interface LeadOnboardingData {
+  forms: Pick<OnboardingForm, "id" | "name" | "schema">[];
+  responses: OnboardingResponse[];
+  allowSecureFill: boolean;
+}
+
+export function LeadOnboardingCard({
+  leadId, data, delay = 230,
+}: { leadId: string; data: LeadOnboardingData; delay?: number }) {
+  const router = useRouter();
+  const [picked, setPicked] = useState("");
+  const [answers, setAnswers] = useState<Record<string, unknown>>({});
+  const [busy, setBusy] = useState(false);
+
+  const opts = { allowSecure: data.allowSecureFill };
+  const fillable = data.forms.filter((f) => staffFillableFields(f.schema, opts).length > 0);
+
+  const save = async () => {
+    if (!picked) return;
+    setBusy(true);
+    try {
+      const res = await saveLeadOnboardingResponse(picked, leadId, answers);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success("Saved against this lead");
+      setPicked(""); setAnswers({});
+      router.refresh();
+    } finally { setBusy(false); }
+  };
+
+  if (fillable.length === 0 && data.responses.length === 0) return null;
+
+  return (
+    <FadeIn delay={delay}>
+      <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+        <div className="flex items-center gap-2.5">
+          <GradientTile gradient="blue" size={28} radius={8}>
+            <ClipboardList className="w-3.5 h-3.5" />
+          </GradientTile>
+          <p className="text-sm font-semibold">Onboarding</p>
+        </div>
+
+        {data.responses.map((r) => (
+          <FilledForm key={r.id} response={r} formName={
+            data.forms.find((f) => f.id === r.form_id)?.name ?? "Form"
+          } />
+        ))}
+
+        {fillable.length > 0 && (
+          <div className="space-y-3 border-t border-border/60 pt-4">
+            <StaffOnboardingFill
+              forms={fillable.map((f) => ({ id: f.id, name: f.name, schema: f.schema }))}
+              value={{ formId: picked, answers }}
+              onChange={(next) => { setPicked(next.formId); setAnswers(next.answers); }}
+              allowSecure={data.allowSecureFill}
+              disabled={busy}
+            />
+            {picked && (
+              <div className="flex justify-end">
+                <Button size="sm" disabled={busy} onClick={save}>
+                  {busy ? <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+                        : <PenLine className="w-3.5 h-3.5 mr-1.5" />}
+                  Save answers
+                </Button>
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Filled in by you. To have them fill it in themselves, convert the lead to a customer first &mdash;
+              the form link is sent to a customer.
+            </p>
+          </div>
+        )}
+      </div>
+    </FadeIn>
+  );
+}
+
+function FilledForm({ response, formName }: { response: OnboardingResponse; formName: string }) {
+  const [open, setOpen] = useState(false);
+  const fields = (response.schema_snapshot ?? []).filter(
+    (f: OnboardingField) => !["heading", "divider", "instructions"].includes(f.type),
+  );
+
+  return (
+    <div className="rounded-md border border-border/60 p-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <button onClick={() => setOpen((v) => !v)} className="flex items-center gap-1.5 text-sm font-medium">
+          <ChevronDown className={`w-3.5 h-3.5 transition-transform ${open ? "" : "-rotate-90"}`} />
+          {formName}
+          <span className="text-xs font-normal text-muted-foreground">
+            {response.submitted_at ? formatDate(response.submitted_at) : "draft"}
+          </span>
+        </button>
+        <Button size="sm" variant="outline" className="h-7 text-xs" asChild>
+          <Link href={`/onboarding-forms/${response.form_id}?response=${response.request_id}`}>
+            <Eye className="w-3 h-3 mr-1" /> View
+          </Link>
+        </Button>
+      </div>
+      {open && (
+        <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {fields.map((f: OnboardingField) => {
+            const v = response.answers?.[f.id];
+            const empty = v == null || v === "" || (Array.isArray(v) && v.length === 0);
+            return (
+              <div key={f.id} className="min-w-0">
+                <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{f.label}</dt>
+                <dd className="text-sm break-words">
+                  {empty
+                    ? <span className="italic text-muted-foreground">&mdash;</span>
+                    : typeof v === "object"
+                      ? <span className="text-muted-foreground">hidden</span>
+                      : String(v)}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      )}
+    </div>
+  );
+}

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -274,20 +274,43 @@ export type StaffFillResult =
  * lib/onboarding/staff-fill.ts) — staff can't provide those, and a
  * credential typed by someone other than its owner isn't one.
  */
+/** Who a form is about. Exactly one of these, enforced by a CHECK in the DB. */
+export type OnboardingSubject =
+  | { kind: "customer"; id: string }
+  | { kind: "lead"; id: string };
+
 export async function saveStaffOnboardingResponse(
   formId: string, customerId: string, answers: Record<string, unknown>,
+): Promise<StaffFillResult> {
+  return saveStaffOnboardingFor(formId, { kind: "customer", id: customerId }, answers);
+}
+
+/** Same thing for a lead — qualifying one means asking the same questions. */
+export async function saveLeadOnboardingResponse(
+  formId: string, leadId: string, answers: Record<string, unknown>,
+): Promise<StaffFillResult> {
+  return saveStaffOnboardingFor(formId, { kind: "lead", id: leadId }, answers);
+}
+
+async function saveStaffOnboardingFor(
+  formId: string, subject: OnboardingSubject, answers: Record<string, unknown>,
 ): Promise<StaffFillResult> {
   const supabase = await createClient();
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
-  const [{ data: form }, { data: customer }] = await Promise.all([
+  const subjectTable = subject.kind === "customer" ? "customers" : "leads";
+  const [{ data: form }, { data: subjectRow }] = await Promise.all([
     tbl(supabase, "onboarding_forms").select("id, schema").eq("id", formId).eq("business_id", businessId).maybeSingle(),
-    tbl(supabase, "customers").select("id").eq("id", customerId).eq("business_id", businessId).maybeSingle(),
+    tbl(supabase, subjectTable).select("id").eq("id", subject.id).eq("business_id", businessId).maybeSingle(),
   ]);
   // Returned, not thrown — Next masks thrown server-action messages in prod.
   if (!form) return { ok: false, error: "Form not found" };
-  if (!customer) return { ok: false, error: "Customer not found" };
+  if (!subjectRow) return { ok: false, error: subject.kind === "customer" ? "Customer not found" : "Lead not found" };
+  // Exactly one of these is set, matching the DB CHECK.
+  const subjectCols = subject.kind === "customer"
+    ? { customer_id: subject.id, lead_id: null }
+    : { customer_id: null, lead_id: subject.id };
 
   const schema = (form.schema ?? []) as OnboardingField[];
   if (schema.length === 0) return { ok: false, error: "That form has no fields yet" };
@@ -302,11 +325,12 @@ export async function saveStaffOnboardingResponse(
   if (problems.length) return { ok: false, error: staffFillErrorMessage(problems) };
   const stored = processAnswersForStorage(schema, clean);
 
-  // Reuse an open request for this form+customer rather than stacking a second
+  // Reuse an open request for this form+subject rather than stacking a second
   // one — otherwise "send it, then fill it in yourself" leaves two rows.
+  const subjectCol = subject.kind === "customer" ? "customer_id" : "lead_id";
   const { data: openReq } = await tbl(supabase, "onboarding_requests")
     .select("id").eq("business_id", businessId).eq("form_id", formId)
-    .eq("customer_id", customerId).neq("status", "completed")
+    .eq(subjectCol, subject.id).neq("status", "completed")
     .order("created_at", { ascending: false }).limit(1).maybeSingle();
 
   const now = new Date().toISOString();
@@ -317,7 +341,7 @@ export async function saveStaffOnboardingResponse(
     if (error) return { ok: false, error: error.message };
   } else {
     const { data: created, error } = await tbl(supabase, "onboarding_requests").insert({
-      business_id: businessId, form_id: formId, customer_id: customerId,
+      business_id: businessId, form_id: formId, ...subjectCols,
       status: "completed", completed_at: now,
     }).select("id").single();
     if (error) return { ok: false, error: error.message };
@@ -328,13 +352,16 @@ export async function saveStaffOnboardingResponse(
   // viewer should show the upload fields as unanswered rather than pretend
   // they were never asked for.
   const { error: respErr } = await tbl(supabase, "onboarding_responses").upsert({
-    business_id: businessId, request_id: requestId, form_id: formId, customer_id: customerId,
-    answers: clean, schema_snapshot: schema, draft: false, submitted_at: now,
+    business_id: businessId, request_id: requestId, form_id: formId, ...subjectCols,
+    // `stored`, not `clean`: secure answers must be encrypted before they land.
+    // This said `clean` from #449 onward — the encrypted value was computed and
+    // thrown away, so a staff-filled credential went into the row in plaintext.
+    answers: stored, schema_snapshot: schema, draft: false, submitted_at: now,
   }, { onConflict: "request_id" });
   if (respErr) return { ok: false, error: respErr.message };
 
   revalidatePath("/onboarding-forms");
-  revalidatePath(`/customers/${customerId}`);
+  revalidatePath(subject.kind === "customer" ? `/customers/${subject.id}` : `/leads/${subject.id}`);
   return {
     ok: true,
     request_id: requestId,
@@ -401,7 +428,7 @@ export interface OnboardingRequestRow extends OnboardingRequest {
   onboarding_forms?: { name: string } | null;
 }
 
-export async function getOnboardingRequests(filter: { form_id?: string; customer_id?: string } = {}): Promise<OnboardingRequestRow[]> {
+export async function getOnboardingRequests(filter: { form_id?: string; customer_id?: string; lead_id?: string } = {}): Promise<OnboardingRequestRow[]> {
   const supabase = await createClient();
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
@@ -410,6 +437,7 @@ export async function getOnboardingRequests(filter: { form_id?: string; customer
     .eq("business_id", businessId).order("created_at", { ascending: false }).limit(200);
   if (filter.form_id) q = q.eq("form_id", filter.form_id);
   if (filter.customer_id) q = q.eq("customer_id", filter.customer_id);
+  if (filter.lead_id) q = q.eq("lead_id", filter.lead_id);
   const { data, error } = await q;
   if (error) throw error;
   return (data ?? []) as OnboardingRequestRow[];
@@ -437,6 +465,21 @@ export async function getOnboardingResponse(requestId: string): Promise<(Onboard
   if (!data) return null;
   const schema = (data.schema_snapshot ?? []) as OnboardingField[];
   return { ...data, answers: redactSecureAnswers(schema, data.answers ?? {}), redacted: true };
+}
+
+/** All of a LEAD's responses (secure answers redacted). */
+export async function getOnboardingResponsesForLead(leadId: string): Promise<OnboardingResponse[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "onboarding_responses")
+    .select("*").eq("lead_id", leadId).eq("business_id", businessId)
+    .order("created_at", { ascending: false });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((data ?? []) as any[]).map((r) => ({
+    ...r,
+    answers: redactSecureAnswers((r.schema_snapshot ?? []) as OnboardingField[], r.answers ?? {}),
+  })) as OnboardingResponse[];
 }
 
 /** All of a customer's responses (secure answers redacted) — for the profile tab. */

--- a/src/lib/mcp/tools/plugin-form-tools.ts
+++ b/src/lib/mcp/tools/plugin-form-tools.ts
@@ -604,7 +604,12 @@ export function registerPluginFormTools(tool: ToolFn): void {
 
   tool("fill_onboarding_form",
     "Fill in an onboarding form on a customer's behalf, for details you already have — records it as completed without sending them anything. Uploads can only come from the customer through their own link; credential fields work only when the server has an encryption key. Answering something that can't be stored is an error, not a silent drop.",
-    { form_id: UUID, customer_id: UUID, answers: z.record(z.string(), z.unknown()) },
+    {
+      form_id: UUID,
+      customer_id: UUID.optional().describe("The customer this form is about. Give exactly one of customer_id or lead_id."),
+      lead_id: UUID.optional().describe("The lead this form is about, for qualifying before they convert."),
+      answers: z.record(z.string(), z.unknown()),
+    },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
       const { stripUnfillableAnswers, staffFillProblems, staffFillErrorMessage, staffOnlyCustomerFields } =
@@ -612,12 +617,21 @@ export function registerPluginFormTools(tool: ToolFn): void {
       const { processAnswersForStorage } = await import("@/lib/onboarding/answers");
       const { secureFieldsAvailable } = await import("@/lib/onboarding/crypto");
 
-      const [{ data: form }, { data: customer }] = await Promise.all([
+      // Exactly one subject, matching the DB CHECK.
+      if (!args.customer_id === !args.lead_id) {
+        return errorText("Give exactly one of customer_id or lead_id — a form is about one or the other.");
+      }
+      const isLead = Boolean(args.lead_id);
+      const subjectId = (args.lead_id ?? args.customer_id) as string;
+      const [{ data: form }, { data: subjectRow }] = await Promise.all([
         t(ctx, "onboarding_forms").select("id, schema").eq("id", args.form_id).eq("business_id", ctx.businessId).maybeSingle(),
-        t(ctx, "customers").select("id").eq("id", args.customer_id).eq("business_id", ctx.businessId).maybeSingle(),
+        t(ctx, isLead ? "leads" : "customers").select("id").eq("id", subjectId).eq("business_id", ctx.businessId).maybeSingle(),
       ]);
       if (!form) return errorText("Form not found");
-      if (!customer) return errorText("Customer not found");
+      if (!subjectRow) return errorText(isLead ? "Lead not found" : "Customer not found");
+      const subjectCols = isLead
+        ? { customer_id: null, lead_id: subjectId }
+        : { customer_id: subjectId, lead_id: null };
       const schema = form.schema ?? [];
       if (schema.length === 0) return errorText("That form has no fields yet");
 
@@ -630,7 +644,7 @@ export function registerPluginFormTools(tool: ToolFn): void {
 
       const { data: openReq } = await t(ctx, "onboarding_requests")
         .select("id").eq("business_id", ctx.businessId).eq("form_id", args.form_id)
-        .eq("customer_id", args.customer_id).neq("status", "completed")
+        .eq(isLead ? "lead_id" : "customer_id", subjectId).neq("status", "completed")
         .order("created_at", { ascending: false }).limit(1).maybeSingle();
 
       const now = new Date().toISOString();
@@ -641,7 +655,7 @@ export function registerPluginFormTools(tool: ToolFn): void {
         if (error) throw error;
       } else {
         const { data: created, error } = await t(ctx, "onboarding_requests").insert({
-          business_id: ctx.businessId, form_id: args.form_id, customer_id: args.customer_id,
+          business_id: ctx.businessId, form_id: args.form_id, ...subjectCols,
           status: "completed", completed_at: now,
         }).select("id").single();
         if (error) throw error;
@@ -649,7 +663,7 @@ export function registerPluginFormTools(tool: ToolFn): void {
       }
       const { error: respErr } = await t(ctx, "onboarding_responses").upsert({
         business_id: ctx.businessId, request_id: requestId, form_id: args.form_id,
-        customer_id: args.customer_id, answers: stored, schema_snapshot: schema,
+        ...subjectCols, answers: stored, schema_snapshot: schema,
         draft: false, submitted_at: now,
       }, { onConflict: "request_id" });
       if (respErr) throw respErr;

--- a/supabase/migrations/20260807090000_onboarding_for_leads.sql
+++ b/supabase/migrations/20260807090000_onboarding_for_leads.sql
@@ -1,0 +1,41 @@
+-- Onboarding forms against a LEAD, not just a customer.
+--
+-- Qualifying a lead means asking the same questions you'd ask a client, and
+-- until now that information had nowhere to live until the lead converted.
+--
+-- customer_id becomes nullable and lead_id joins it, with a CHECK that exactly
+-- one is set. A row belonging to both would be ambiguous everywhere it's read;
+-- a row belonging to neither is an orphan. The constraint makes both
+-- impossible rather than leaving it to the callers to remember.
+
+ALTER TABLE public.onboarding_requests
+  ADD COLUMN IF NOT EXISTS lead_id UUID REFERENCES public.leads(id) ON DELETE CASCADE;
+ALTER TABLE public.onboarding_requests
+  ALTER COLUMN customer_id DROP NOT NULL;
+
+ALTER TABLE public.onboarding_responses
+  ADD COLUMN IF NOT EXISTS lead_id UUID REFERENCES public.leads(id) ON DELETE CASCADE;
+ALTER TABLE public.onboarding_responses
+  ALTER COLUMN customer_id DROP NOT NULL;
+
+ALTER TABLE public.onboarding_requests
+  DROP CONSTRAINT IF EXISTS onboarding_requests_subject_check;
+ALTER TABLE public.onboarding_requests
+  ADD CONSTRAINT onboarding_requests_subject_check
+  CHECK ((customer_id IS NOT NULL) <> (lead_id IS NOT NULL));
+
+ALTER TABLE public.onboarding_responses
+  DROP CONSTRAINT IF EXISTS onboarding_responses_subject_check;
+ALTER TABLE public.onboarding_responses
+  ADD CONSTRAINT onboarding_responses_subject_check
+  CHECK ((customer_id IS NOT NULL) <> (lead_id IS NOT NULL));
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_requests_lead
+  ON public.onboarding_requests (lead_id);
+CREATE INDEX IF NOT EXISTS idx_onboarding_responses_lead
+  ON public.onboarding_responses (lead_id);
+
+COMMENT ON COLUMN public.onboarding_requests.lead_id IS
+  'Set instead of customer_id when the form belongs to a lead. Exactly one of the two is non-null.';
+COMMENT ON COLUMN public.onboarding_responses.lead_id IS
+  'Set instead of customer_id when the form belongs to a lead. Exactly one of the two is non-null.';


### PR DESCRIPTION
## The feature you asked for

Leads get the same onboarding forms clients have. The lead detail page has an **Onboarding** card: pick from the same forms list, fill it in, and see what's already been filled with the answers expandable inline.

**Migration `20260807090000`** — applied and recorded. `lead_id` on `onboarding_requests` and `onboarding_responses`, `customer_id` becomes nullable, and a CHECK enforces **exactly one** of the two. A row belonging to both is ambiguous everywhere it's read; one belonging to neither is an orphan. The database refuses both rather than trusting every caller to remember.

**Fill-in only, deliberately.** Portal links are minted against a *customer*, so a lead has no address to send to. The card says so and points at converting first. Sending to leads would need a token model for them — worth doing separately if you want it.

MCP: `fill_onboarding_form` now takes `customer_id` **or** `lead_id`, and refuses both or neither.

## The thing I found on the way, which matters more

**Staff-filled credentials were being stored in plaintext.**

In #449 I wrote:

```ts
const stored = processAnswersForStorage(schema, clean);  // encrypts secure fields
...
answers: clean,   // ← wrote the UNencrypted one
```

The encrypted value was computed and thrown away. I described that PR as encrypting staff-filled credentials "through the same path the customer portal uses". **That was not true**, and it has been live on main since #449 merged.

**I audited the table: zero secure answers stored, plaintext or otherwise.** Nothing was ever written in the clear — the window existed but nothing went through it. Fixed here.

The MCP version of the same code did use `stored`; only the server action was wrong, which is exactly why it survived review — the two looked equivalent.

## Verification

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests ✅ · migration verified against the live DB (both columns, nullable `customer_id`, both CHECKs, recorded)

Not clicked through — local dev needs a login I can't perform. **Test the credential path specifically**: fill a form with a secure field against a client, then reveal it. If it reveals correctly it's encrypted; the old code would have failed to decrypt.