### PR TITLE
feat(customers): capture a client's BSB + account number, encrypted

### DIFF
--- a/src/components/customers/customer-form.tsx
+++ b/src/components/customers/customer-form.tsx
@@ -6,12 +6,14 @@ import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
-import { Loader2, User, MapPin, StickyNote, Building2, CreditCard, ListChecks, ClipboardList } from "@/components/ui/icons";
+import { Loader2, User, MapPin, StickyNote, Building2, CreditCard, ListChecks, ClipboardList, Landmark } from "@/components/ui/icons";
 import { createCustomer, updateCustomer } from "@/lib/actions/customers";
 import { saveStaffOnboardingResponse } from "@/lib/actions/onboarding";
 import { ClientFields } from "@/components/customers/client-fields";
 import { StaffOnboardingFill, type StaffFillForm, type StaffFillValue } from "@/components/onboarding/staff-onboarding-fill";
 import { pruneAnswers } from "@/lib/customers/field-schema";
+import { saveCustomerBankDetails } from "@/lib/actions/customer-bank";
+import { validateBankDetails, formatBsb, maskedAccount } from "@/lib/customers/bank";
 import {
   staffFillProblems, staffFillErrorMessage, type StaffFillProblem,
 } from "@/lib/onboarding/staff-fill";
@@ -95,6 +97,9 @@ export function CustomerForm({
   );
   const [fill, setFill] = useState<StaffFillValue>({ formId: "", answers: {} });
   const [fillProblems, setFillProblems] = useState<StaffFillProblem[]>([]);
+  // Bank details are write-only from here: what's stored is encrypted and
+  // never sent back to the browser, so these start blank even when editing.
+  const [bank, setBank] = useState({ accountName: "", bsb: "", accountNumber: "" });
   const { register, handleSubmit, control, setValue, watch, formState: { errors, isSubmitting } } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -125,6 +130,11 @@ export function CustomerForm({
   const showCompanyHint = !["residential", "individual"].includes(accountType);
 
   const onSubmit = async (data: FormData) => {
+    // Bank details checked before anything is written, same reasoning as the
+    // onboarding form below: a half-entered BSB shouldn't cost you the client.
+    const bankProblem = validateBankDetails(bank);
+    if (bankProblem) { toast.error(bankProblem); return; }
+
     // Check the attached onboarding form BEFORE creating anything. Finding out
     // afterwards leaves the client saved and the form not — and the answers
     // typed into this screen gone, to be re-entered from their profile.
@@ -171,6 +181,13 @@ export function CustomerForm({
 
       // The customer exists now, so the onboarding answers have something to
       // attach to. Anything wrong with them was caught before we got here.
+      const enteredBank = Boolean(bank.bsb.trim() || bank.accountNumber.trim() || bank.accountName.trim());
+      if (enteredBank) {
+        const res = await saveCustomerBankDetails(result.id, bank);
+        if (res.ok) setBank({ accountName: "", bsb: "", accountNumber: "" });
+        else toast.error(`Customer saved, but the bank details weren't: ${res.error}`);
+      }
+
       if (!customer && fill.formId) {
         const res = await saveStaffOnboardingResponse(fill.formId, result.id, fill.answers);
         if (res.ok) toast.success("Onboarding form saved against this customer");
@@ -384,6 +401,56 @@ export function CustomerForm({
           </FormSection>
         </div>
       )}
+
+      <FormSection
+        icon={<Landmark className="w-4 h-4" />}
+        gradient="emerald"
+        title="Bank details"
+        hint="For direct debit. Stored encrypted — only an owner or admin can read them back."
+      >
+        <div className="space-y-4">
+          {customer?.bank_account_last3 && (
+            <p className="text-sm text-muted-foreground">
+              On file: <span className="font-medium text-foreground">{maskedAccount(customer.bank_account_last3)}</span>
+              {customer.bank_account_name ? <> &middot; {customer.bank_account_name}</> : null}.
+              Entering new details replaces them; leaving these blank keeps what&rsquo;s stored.
+            </p>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-1.5 sm:col-span-2">
+              <Label>Account name</Label>
+              <Input
+                placeholder="As it appears on the account"
+                value={bank.accountName}
+                onChange={(e) => setBank((b) => ({ ...b, accountName: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>BSB</Label>
+              <Input
+                inputMode="numeric"
+                placeholder="062-000"
+                value={bank.bsb}
+                onChange={(e) => setBank((b) => ({ ...b, bsb: e.target.value }))}
+                onBlur={(e) => setBank((b) => ({ ...b, bsb: formatBsb(e.target.value) }))}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Account number</Label>
+              <Input
+                inputMode="numeric"
+                placeholder="12345678"
+                value={bank.accountNumber}
+                onChange={(e) => setBank((b) => ({ ...b, accountNumber: e.target.value }))}
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Never put card numbers here. A card is stored by your payment provider and charged through them &mdash;
+            see Settings &rarr; Payments.
+          </p>
+        </div>
+      </FormSection>
 
       <FormSection
         icon={<StickyNote className="w-4 h-4" />}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -70,6 +70,7 @@ export {
   Bot,
   Boxes,
   Building2,
+  Landmark,
   CalendarDays,
   ChevronDown,
   ChevronDownIcon,

--- a/src/lib/__tests__/customer-bank.test.ts
+++ b/src/lib/__tests__/customer-bank.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateBankDetails, formatBsb, digitsOnly, accountLast3, maskedAccount,
+} from "@/lib/customers/bank";
+
+describe("validateBankDetails", () => {
+  it("accepts nothing entered — bank details are optional", () => {
+    expect(validateBankDetails({})).toBeNull();
+    expect(validateBankDetails({ bsb: "", accountNumber: "", accountName: "" })).toBeNull();
+  });
+
+  it("refuses half a set", () => {
+    // A BSB with no account number can't be debited, and storing it would make
+    // the client look set up for direct debit when they aren't.
+    expect(validateBankDetails({ bsb: "062000" })).toMatch(/both/i);
+    expect(validateBankDetails({ accountNumber: "12345678" })).toMatch(/both/i);
+  });
+
+  it("checks BSB length", () => {
+    expect(validateBankDetails({ bsb: "0620", accountNumber: "12345678", accountName: "A" }))
+      .toMatch(/6 digits/);
+  });
+
+  it("accepts a BSB written with a dash, as people actually type it", () => {
+    expect(validateBankDetails({ bsb: "062-000", accountNumber: "12345678", accountName: "Acme" })).toBeNull();
+  });
+
+  it("checks account-number length at both ends", () => {
+    expect(validateBankDetails({ bsb: "062000", accountNumber: "1234", accountName: "A" })).toMatch(/5 and 10/);
+    expect(validateBankDetails({ bsb: "062000", accountNumber: "12345678901", accountName: "A" })).toMatch(/5 and 10/);
+  });
+
+  it("requires the account name, so it can be checked before debiting", () => {
+    expect(validateBankDetails({ bsb: "062000", accountNumber: "12345678" })).toMatch(/account name/i);
+  });
+});
+
+describe("formatting and masking", () => {
+  it("formats a BSB the way it's written on forms", () => {
+    expect(formatBsb("062000")).toBe("062-000");
+    expect(formatBsb("062-000")).toBe("062-000");
+    expect(formatBsb("62")).toBe("62"); // incomplete: leave it alone
+  });
+
+  it("strips everything that isn't a digit", () => {
+    expect(digitsOnly(" 062-000 ")).toBe("062000");
+    expect(digitsOnly(null)).toBe("");
+  });
+
+  it("shows only three digits", () => {
+    // Not four: an account number can be six digits, and four of six gives
+    // away most of it.
+    expect(accountLast3("12345678")).toBe("678");
+    expect(accountLast3("123456")).toBe("456");
+    expect(accountLast3("12")).toBeNull();
+    expect(maskedAccount("678")).toBe("•••• 678");
+    expect(maskedAccount(null)).toBe("—");
+  });
+});

--- a/src/lib/actions/customer-bank.ts
+++ b/src/lib/actions/customer-bank.ts
@@ -1,0 +1,109 @@
+"use server";
+
+/**
+ * A client's bank details for direct debit.
+ *
+ * Stored encrypted with the same AES-256-GCM key the onboarding secure fields
+ * use. Not card data — no PCI scope — but these move money out of someone's
+ * account, so plaintext in a multi-tenant table isn't good enough.
+ *
+ * Expected failures are RETURNED, not thrown: Next masks thrown server-action
+ * messages in production.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { encryptSecret, decryptSecret, secureFieldsAvailable } from "@/lib/onboarding/crypto";
+import { validateBankDetails, digitsOnly, accountLast3, type BankDetailsInput } from "@/lib/customers/bank";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+export type BankResult = { ok: true; last3: string | null } | { ok: false; error: string };
+
+export async function saveCustomerBankDetails(
+  customerId: string, input: BankDetailsInput,
+): Promise<BankResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const problem = validateBankDetails(input);
+  if (problem) return { ok: false, error: problem };
+
+  const bsb = digitsOnly(input.bsb);
+  const acct = digitsOnly(input.accountNumber);
+  const name = (input.accountName ?? "").trim();
+
+  // Clearing is a legitimate action — all three blank wipes what's stored.
+  if (!bsb && !acct && !name) {
+    const { error } = await tbl(supabase, "customers").update({
+      bank_account_name: null, bank_bsb_enc: null, bank_account_enc: null, bank_account_last3: null,
+    }).eq("id", customerId).eq("business_id", businessId);
+    if (error) return { ok: false, error: error.message };
+    revalidatePath(`/customers/${customerId}`);
+    return { ok: true, last3: null };
+  }
+
+  // No key, no storage. Refusing is the only honest option: the alternative is
+  // writing an account number in the clear.
+  if (!secureFieldsAvailable()) {
+    return {
+      ok: false,
+      error: "Bank details can't be stored — the server has no encryption key (ONBOARDING_SECRET_KEY). "
+        + "They'd have to be saved in plain text, so nothing was saved.",
+    };
+  }
+
+  const { error } = await tbl(supabase, "customers").update({
+    bank_account_name: name,
+    bank_bsb_enc: encryptSecret(bsb),
+    bank_account_enc: encryptSecret(acct),
+    bank_account_last3: accountLast3(acct),
+  }).eq("id", customerId).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath(`/customers/${customerId}`);
+  return { ok: true, last3: accountLast3(acct) };
+}
+
+export type RevealedBank =
+  | { ok: true; accountName: string | null; bsb: string; accountNumber: string }
+  | { ok: false; error: string };
+
+/**
+ * Reveal the full details. Owner/admin only — the same bar as revealing an
+ * onboarding credential, and for the same reason: everyone else can see the
+ * client without being able to move money from their account.
+ */
+export async function revealCustomerBankDetails(customerId: string): Promise<RevealedBank> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
+  if (biz?.user_id !== user.id) {
+    const { data: m } = await tbl(supabase, "business_members")
+      .select("role").eq("business_id", businessId).eq("user_id", user.id).eq("status", "active").maybeSingle();
+    if (m?.role !== "admin") return { ok: false, error: "Only the owner or an admin can reveal bank details" };
+  }
+
+  const { data } = await tbl(supabase, "customers")
+    .select("bank_account_name, bank_bsb_enc, bank_account_enc")
+    .eq("id", customerId).eq("business_id", businessId).maybeSingle();
+  if (!data?.bank_bsb_enc || !data?.bank_account_enc) {
+    return { ok: false, error: "No bank details stored for this client" };
+  }
+  try {
+    return {
+      ok: true,
+      accountName: data.bank_account_name ?? null,
+      bsb: decryptSecret(data.bank_bsb_enc),
+      accountNumber: decryptSecret(data.bank_account_enc),
+    };
+  } catch {
+    // Wrong key, or the key changed since these were stored.
+    return { ok: false, error: "Couldn't decrypt these details — the server's encryption key may have changed." };
+  }
+}

--- a/src/lib/customers/bank.ts
+++ b/src/lib/customers/bank.ts
@@ -1,0 +1,58 @@
+/**
+ * Client bank details for direct debit — validation and display.
+ *
+ * Plain module (no "use server"), so the add-client form can validate before
+ * submitting and the server can validate again. Australian format: BSB is 6
+ * digits, account numbers run 5–10.
+ */
+
+export interface BankDetailsInput {
+  accountName?: string | null;
+  bsb?: string | null;
+  accountNumber?: string | null;
+}
+
+/** Digits only — people type BSBs as "062-000" and accounts with spaces. */
+export function digitsOnly(v: string | null | undefined): string {
+  return (v ?? "").replace(/\D/g, "");
+}
+
+/** "062000" → "062-000", the way it's written on every Australian form. */
+export function formatBsb(v: string | null | undefined): string {
+  const d = digitsOnly(v);
+  return d.length === 6 ? `${d.slice(0, 3)}-${d.slice(3)}` : d;
+}
+
+/**
+ * What's wrong with these details, or null when they're fine.
+ *
+ * Empty is valid — bank details are optional. But a HALF-filled set is not:
+ * a BSB with no account number can't be debited, and silently keeping it
+ * would look like the client is set up for direct debit when they aren't.
+ */
+export function validateBankDetails(input: BankDetailsInput): string | null {
+  const bsb = digitsOnly(input.bsb);
+  const acct = digitsOnly(input.accountNumber);
+  const name = (input.accountName ?? "").trim();
+
+  if (!bsb && !acct && !name) return null; // nothing entered
+
+  if (!bsb || !acct) {
+    return "Enter both the BSB and the account number, or leave both blank — one without the other can't be debited.";
+  }
+  if (bsb.length !== 6) return "A BSB is 6 digits (e.g. 062-000).";
+  if (acct.length < 5 || acct.length > 10) return "An account number is between 5 and 10 digits.";
+  if (!name) return "Add the account name, so you can check it matches before debiting.";
+  return null;
+}
+
+/** Last 3 digits, for display. Short on purpose: an account number can be six
+ *  digits, and showing four of six gives away most of it. */
+export function accountLast3(accountNumber: string | null | undefined): string | null {
+  const d = digitsOnly(accountNumber);
+  return d.length >= 3 ? d.slice(-3) : null;
+}
+
+export function maskedAccount(last3: string | null | undefined): string {
+  return last3 ? `•••• ${last3}` : "—";
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -123,6 +123,10 @@ export interface Customer {
   /** Answers to the business's own client fields, keyed by field id.
    *  See lib/customers/field-schema.ts. */
   custom_fields?: Record<string, unknown> | null;
+  /** Direct-debit details. BSB and account number are stored encrypted and are
+   *  never sent to the browser — only these two are readable. */
+  bank_account_name?: string | null;
+  bank_account_last3?: string | null;
   archived: boolean;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20260807140000_customer_bank_details.sql
+++ b/supabase/migrations/20260807140000_customer_bank_details.sql
@@ -1,0 +1,24 @@
+-- A client's bank details, for direct debit.
+--
+-- BSB and account number are stored ENCRYPTED (AES-256-GCM, the same
+-- ONBOARDING_SECRET_KEY path the onboarding secure fields use). They are not
+-- card data, so no PCI scope, but they still move money out of someone's
+-- account — plaintext in a multi-tenant table is not good enough.
+--
+-- bank_account_last3 is a plaintext display hint so the UI can show
+-- "···· 321" without decrypting anything. Three digits, not four: an
+-- Australian account number can be as short as six, and exposing four of six
+-- gives away most of it.
+
+ALTER TABLE public.customers
+  ADD COLUMN IF NOT EXISTS bank_account_name    TEXT,
+  ADD COLUMN IF NOT EXISTS bank_bsb_enc         TEXT,
+  ADD COLUMN IF NOT EXISTS bank_account_enc     TEXT,
+  ADD COLUMN IF NOT EXISTS bank_account_last3   TEXT;
+
+COMMENT ON COLUMN public.customers.bank_bsb_enc IS
+  'BSB, AES-256-GCM encrypted (lib/onboarding/crypto.ts). Never store in the clear.';
+COMMENT ON COLUMN public.customers.bank_account_enc IS
+  'Account number, AES-256-GCM encrypted. Revealable by owner/admin only.';
+COMMENT ON COLUMN public.customers.bank_account_last3 IS
+  'Last 3 digits, plaintext, for display only.';


### PR DESCRIPTION
Bank details on the add-client and edit-client screens, for direct debit.

**Encrypted at rest** with the same AES-256-GCM key the onboarding secure fields use. These aren't card data — no PCI scope — but they move money out of someone's account, so plaintext in a multi-tenant table isn't good enough. **Owner or admin only** to read back: the same bar as revealing an onboarding credential, and for the same reason — everyone else can see the client without being able to debit them.

## Five decisions worth checking

1. **Write-only from the form.** What's stored never comes back to the browser, so the fields start blank even when editing; the section shows `•••• 678` from a plaintext last-3 hint instead.
2. **Three digits, not four.** An Australian account number can be six digits — showing four of six gives away most of it.
3. **Half a set is refused.** A BSB with no account number can't be debited, and storing it would make the client look set up for direct debit when they aren't.
4. **No key, no storage.** If `ONBOARDING_SECRET_KEY` is missing, the save is refused outright rather than quietly falling back to writing an account number in the clear.
5. **Clearing all three wipes what's stored** — a real action, not a no-op, so you can remove details you shouldn't be holding.

Validation runs before the client is created, so a mistyped BSB doesn't cost you the record.

Migration `20260807140000` applied to the live database and recorded.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 232 tests, 9 new ✅

Not clicked through — local dev needs a login. Worth adding a client with a BSB and confirming the masked value shows afterwards.

---

## On storing cards directly

I'm not building that one, and I'd rather say why plainly than keep circling it.

The risk isn't yours to accept — it lands on **your clients**, whose card numbers would be in the database. They can't consent to that through you, which is the part "I'll take care of the safety" can't cover. It also breaks PCI DSS, which binds you through your acquirer regardless of how carefully the data is handled.

And it wouldn't get you anything: **a stored card number can't be charged.** Every gateway that accepts raw PANs requires PCI Level 1 certification — annual audit, segmented network, six figures a year — before the first request. You'd hold the liability and still not be able to take a payment.

**What actually gets you what you want** — money moving without chasing:

- **[#443](https://github.com/maltamimi96/invoicer/pull/443) — Revolut saved cards.** Card-on-file, charged from Kirei with a button, autopay for recurring invoices. The card lives in Revolut's vault; from your side it's saved on the client. It needs a rebase and the Revolut API details, and it's the single highest-value thing left open.
- **These bank details.** For a monthly retainer, direct debit is what AU agencies actually use — cheaper than cards, no expiry, no failed-card chasing. This PR is the capture half; the debit half needs a provider (Revolut and most banks support it) and is worth doing next if retainers are the main billing model.