### PR TITLE
fix(cron): two schedules that silently dropped customer emails

### DIFF
--- a/src/app/api/cron/process-scheduled-sends/route.ts
+++ b/src/app/api/cron/process-scheduled-sends/route.ts
@@ -1,7 +1,11 @@
 /**
  * GET /api/cron/process-scheduled-sends
  *
- * Runs every minute via Vercel Cron. Pulls pending scheduled_sends rows whose
+ * Runs every 5 minutes via Vercel Cron — see the schedule in vercel.json.
+ * It was scheduled DAILY while this docstring claimed "every minute", so a
+ * send set for 3pm could go out the following morning.
+ *
+ * Pulls pending scheduled_sends rows whose
  * send_at has passed, locks each by flipping status to 'sending', then
  * dispatches the email/SMS using the admin Supabase client (cron has no user
  * session). Re-renders the PDF and rolls a portal token the same way the

--- a/src/app/api/cron/workorder-complete/route.ts
+++ b/src/app/api/cron/workorder-complete/route.ts
@@ -1,7 +1,7 @@
 /**
  * GET /api/cron/workorder-complete
  *
- * Runs every 4 hours via Vercel Cron.
+ * Runs every 4 hours via Vercel Cron — see the schedule in vercel.json.
  * For every business with the "workorder-complete-notifier" agent enabled:
  *  - Finds work orders recently set to "completed"
  *  - Skips work orders already notified
@@ -30,7 +30,13 @@ export async function GET(req: NextRequest) {
   if (denied) return denied;
 
   const sb = createAdminClient();
-  // Look back 5 hours (slightly more than the 4-hour cron interval)
+  // One hour more than the 4-hour cron interval, so a late or skipped run
+  // still catches its window. Double-sends are impossible regardless: every
+  // send is recorded and `alreadyNotified` skips them.
+  //
+  // This was 5 hours while the cron ran ONCE A DAY — around 19 of every 24
+  // hours of completions were never emailed at all. The schedule now matches
+  // what this code was written for.
   const lookback = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
     },
     {
       "path": "/api/cron/workorder-complete",
-      "schedule": "0 18 * * *"
+      "schedule": "0 */4 * * *"
     },
     {
       "path": "/api/cron/recurring-jobs",
@@ -33,7 +33,7 @@
     },
     {
       "path": "/api/cron/process-scheduled-sends",
-      "schedule": "0 8 * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/email-leads",


### PR DESCRIPTION
Both routes were written for one cadence and scheduled at another. Nothing errored — the work just never happened.

## 1. `workorder-complete` — ~19 of every 24 hours of completion emails, never sent

It looks back **5 hours**, sized for the "every 4 hours" its own docstring describes. It ran **once a day at 18:00 UTC**. So only jobs completed between 13:00 and 18:00 UTC were ever emailed; everything else fell outside the window and was silently skipped.

Now runs every 4 hours, as written.

**Safe to change:** every send is recorded and `alreadyNotified` skips it, so a wider or overlapping window can't double-send. No catch-up burst either — the window is forward-looking, so completions from weeks ago stay unsent rather than surprising customers with stale email.

## 2. `process-scheduled-sends` — up to 24 hours late

Docstring says "runs every minute". It was scheduled daily at 08:00. An invoice you scheduled for 3pm went out the following morning.

Now every 5 minutes — precise enough for a scheduled send, without the invocation cost of a per-minute job.

**Neither was a platform limit.** This project already runs `*/2`, `*/3`, `*/15` and `*/30` crons. It was drift between the code and `vercel.json`.

## One self-inflicted detour

I first put the cron expressions in the docstrings — `*/5` inside a `/* */` block comment **closes the comment**, which broke the build. Caught by `tsc`, fixed, worth knowing if you ever document a schedule in a comment.

## Deliberately not fixed here

**`/api/cron/reminders` is still single-tenant** — hardcoded business UUID and a hardcoded `Crown Roofers <noreply@…>` FROM. Connected Studio and every other business get **no job reminders at all**. That needs the handler restructured around a business loop with per-business FROM, which is a real change rather than a schedule fix. Worth its own PR, and I'd rather do it with a clear head than tack it on here.

Also still open from the same investigation: **five webhook events are subscribable but never fire** (`invoice.overdue`, `quote.accepted`, `quote.rejected`, `booking.confirmed`, `booking.no_show`). Relevant to automations — those are triggers people would expect to exist.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests ✅ · `vercel.json` parses, 17 crons