### PR TITLE
refactor(sms): a session-free SMS layer (automations Phase 0)

### DIFF
--- a/src/lib/actions/sms.ts
+++ b/src/lib/actions/sms.ts
@@ -5,53 +5,13 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 
 import { getUser } from "@/lib/auth";
+import { sendSmsFor } from "@/lib/sms";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const tbl = (sb: any, name: string) => (sb as any).from(name);
 
 /** Sanitise a business name down to an 11-char alphanumeric Sender ID for AU SMS.
  *  Strips non-alphanum, prefers PascalCase abbreviation.
  *  e.g. "Crown Roofers" → "CrownRoof", "Bob's Plumbing & Gas" → "BobsPlumbng" */
-function deriveSenderId(name: string): string {
-  const cleaned = name.replace(/[^A-Za-z0-9]+/g, "");
-  return cleaned.slice(0, 11) || "Kirei";
-}
-
-interface ClickSendResponse {
-  http_code: number;
-  data?: { messages?: Array<{ message_id?: string; status?: string }> };
-  response_msg?: string;
-}
-
-/** POST a single SMS through ClickSend. Returns the provider message id +
- *  status. Throws with the API's error message on failure. */
-async function clicksendSend(args: { from: string; to: string; body: string }): Promise<{ id: string; status: string }> {
-  const username = process.env.CLICKSEND_USERNAME;
-  const apiKey   = process.env.CLICKSEND_API_KEY;
-  if (!username || !apiKey) throw new Error("ClickSend credentials not configured");
-
-  const auth = Buffer.from(`${username}:${apiKey}`).toString("base64");
-  const res = await fetch("https://rest.clicksend.com/v3/sms/send", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Basic ${auth}`,
-    },
-    body: JSON.stringify({
-      messages: [{ from: args.from, to: args.to, body: args.body, source: "kirei" }],
-    }),
-  });
-
-  const json = (await res.json().catch(() => ({}))) as ClickSendResponse;
-  if (!res.ok || json.http_code !== 200) {
-    throw new Error(`SMS send failed: ${json.response_msg ?? res.statusText}`);
-  }
-  const msg = json.data?.messages?.[0];
-  return {
-    id:     msg?.message_id ?? "",
-    status: msg?.status     ?? "sent",
-  };
-}
-
 export interface SmsConversation {
   id: string;
   business_id: string;
@@ -103,6 +63,13 @@ export async function getMessages(conversationId: string): Promise<SmsMessage[]>
   return (data ?? []) as SmsMessage[];
 }
 
+/**
+ * Send a text as the signed-in user's business.
+ *
+ * The work lives in lib/sms.ts, which takes the business id explicitly so
+ * crons, webhooks and automations can send too. This wrapper only resolves
+ * WHO is sending.
+ */
 export async function sendSms(payload: {
   to: string;           // E.164 phone, e.g. +61412345678
   body: string;
@@ -113,68 +80,10 @@ export async function sendSms(payload: {
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
-  // Resolve the Sender ID — use the business's saved sms_sender_id if set,
-  // otherwise derive an 11-char alpha tag from their name. Customers see this
-  // as the "from" on their phone instead of an unfamiliar number.
-  const { data: business } = await tbl(supabase, "businesses")
-    .select("name, sms_sender_id")
-    .eq("id", businessId)
-    .single();
-  const fromName = business?.sms_sender_id?.trim() || deriveSenderId(business?.name ?? "Kirei");
-
-  // Get or create conversation
-  let { data: conv } = await tbl(supabase, "sms_conversations")
-    .select("id")
-    .eq("business_id", businessId)
-    .eq("customer_phone", payload.to)
-    .maybeSingle();
-
-  if (!conv) {
-    const { data: newConv, error: convErr } = await tbl(supabase, "sms_conversations")
-      .insert({
-        business_id: businessId,
-        customer_id: payload.customerId ?? null,
-        customer_name: payload.customerName,
-        customer_phone: payload.to,
-        last_message_at: new Date().toISOString(),
-      })
-      .select("id")
-      .single();
-    if (convErr) throw convErr;
-    conv = newConv;
-  }
-
-  // Send via ClickSend
-  const sent = await clicksendSend({
-    from: fromName,
-    to:   payload.to,
-    body: payload.body,
-  });
-
-  // Save message to DB. We reuse the existing twilio_sid column to store the
-  // ClickSend message id — schema-compat for now, can rename later.
-  const { data: msg, error: msgErr } = await tbl(supabase, "sms_messages")
-    .insert({
-      conversation_id: conv.id,
-      business_id: businessId,
-      direction: "outbound",
-      body: payload.body,
-      from_number: fromName,
-      to_number: payload.to,
-      twilio_sid: sent.id,
-      status: sent.status,
-    })
-    .select("id")
-    .single();
-  if (msgErr) throw msgErr;
-
-  // Update conversation last_message_at
-  await tbl(supabase, "sms_conversations")
-    .update({ last_message_at: new Date().toISOString() })
-    .eq("id", conv.id);
+  const res = await sendSmsFor(supabase, businessId, payload);
 
   revalidatePath("/messages");
-  return { conversationId: conv.id, messageId: msg.id };
+  return { conversationId: res.conversationId, messageId: res.messageId };
 }
 
 export async function markConversationRead(conversationId: string): Promise<void> {

--- a/src/lib/booking/notify.ts
+++ b/src/lib/booking/notify.ts
@@ -4,6 +4,7 @@
  * relies on session-scoped helpers. Fire-and-forget: never throws to callers.
  */
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { clickSendSend, deriveSenderId } from "@/lib/sms";
 import { dispatchWebhook } from "@/lib/webhooks";
 import { bookingEmailHtml, type BookingEmailKind } from "@/lib/emails/booking";
 import type { BookingSettings, Appointment, WebhookEvent } from "@/types/database";
@@ -39,20 +40,10 @@ function fmtLocal(iso: string, tz: string): string {
   }).format(new Date(iso));
 }
 
-function deriveSenderId(name: string): string {
-  return (name.replace(/[^A-Za-z0-9]+/g, "").slice(0, 11)) || "Kirei";
-}
-
 async function sendSmsRaw(from: string, to: string, body: string): Promise<void> {
-  const username = process.env.CLICKSEND_USERNAME;
-  const apiKey = process.env.CLICKSEND_API_KEY;
-  if (!username || !apiKey) return;
-  const auth = Buffer.from(`${username}:${apiKey}`).toString("base64");
-  await fetch("https://rest.clicksend.com/v3/sms/send", {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Basic ${auth}` },
-    body: JSON.stringify({ messages: [{ from, to, body, source: "kirei" }] }),
-  }).catch(() => undefined);
+  // Shared with actions/sms.ts — this used to be a second, subtly different
+  // copy of the same HTTP call.
+  await clickSendSend({ from, to, body });
 }
 
 /** Fire booking.* to both the business_webhooks system and the booking-specific

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -1,0 +1,125 @@
+/**
+ * SMS — the session-free layer.
+ *
+ * `actions/sms.ts` resolves the business from `getUser()`, which means a cron,
+ * a webhook or an automation can't send a text: there is no session. This
+ * module takes the business id explicitly, so anything with a Supabase client
+ * can use it.
+ *
+ * It also ends a duplicate: the ClickSend HTTP call existed twice, in
+ * `actions/sms.ts` and `booking/notify.ts`, with different error handling.
+ * One copy now.
+ *
+ * Plain module — no "use server". Import it from actions, routes and crons.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sb = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Sb, name: string) => sb.from(name);
+
+interface ClickSendResponse {
+  http_code: number;
+  data?: { messages?: Array<{ message_id?: string; status?: string }> };
+  response_msg?: string;
+}
+
+/** True when the server can send at all. Check before offering SMS as an
+ *  action, so an automation fails at save time rather than at 3am. */
+export function smsConfigured(): boolean {
+  return Boolean(process.env.CLICKSEND_USERNAME && process.env.CLICKSEND_API_KEY);
+}
+
+/**
+ * An 11-character alphanumeric Sender ID — what shows as the "from" on the
+ * recipient's phone. ClickSend rejects anything longer.
+ */
+export function deriveSenderId(name: string): string {
+  return (name.replace(/[^A-Za-z0-9]+/g, "").slice(0, 11)) || "Kirei";
+}
+
+/** POST a single SMS through ClickSend. Returns the provider message id +
+ *  status. Throws with the API's error message on failure. */
+export async function clickSendSend(
+  args: { from: string; to: string; body: string },
+): Promise<{ id: string; status: string }> {
+  const username = process.env.CLICKSEND_USERNAME;
+  const apiKey = process.env.CLICKSEND_API_KEY;
+  if (!username || !apiKey) throw new Error("ClickSend credentials not configured");
+
+  const auth = Buffer.from(`${username}:${apiKey}`).toString("base64");
+  const res = await fetch("https://rest.clicksend.com/v3/sms/send", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Basic ${auth}` },
+    body: JSON.stringify({
+      messages: [{ from: args.from, to: args.to, body: args.body, source: "kirei" }],
+    }),
+  });
+
+  const json = (await res.json().catch(() => ({}))) as ClickSendResponse;
+  if (!res.ok || json.http_code !== 200) {
+    throw new Error(`SMS send failed: ${json.response_msg ?? res.statusText}`);
+  }
+  const msg = json.data?.messages?.[0];
+  return { id: msg?.message_id ?? "", status: msg?.status ?? "sent" };
+}
+
+export interface SendSmsForResult {
+  conversationId: string;
+  messageId: string;
+  providerId: string;
+}
+
+/**
+ * Send a text on behalf of a business and record it in the conversation.
+ *
+ * The business id is a parameter, not something read from a session — that's
+ * the whole point of this function existing.
+ */
+export async function sendSmsFor(
+  sb: Sb,
+  businessId: string,
+  payload: { to: string; body: string; customerName: string; customerId?: string | null },
+): Promise<SendSmsForResult> {
+  // The Sender ID the recipient sees: the business's own if set, otherwise
+  // derived from its name — never a bare number they won't recognise.
+  const { data: business } = await tbl(sb, "businesses")
+    .select("name, sms_sender_id").eq("id", businessId).single();
+  const fromName = business?.sms_sender_id?.trim() || deriveSenderId(business?.name ?? "Kirei");
+
+  let { data: conv } = await tbl(sb, "sms_conversations")
+    .select("id").eq("business_id", businessId).eq("customer_phone", payload.to).maybeSingle();
+
+  if (!conv) {
+    const { data: created, error } = await tbl(sb, "sms_conversations").insert({
+      business_id: businessId,
+      customer_id: payload.customerId ?? null,
+      customer_name: payload.customerName,
+      customer_phone: payload.to,
+      last_message_at: new Date().toISOString(),
+    }).select("id").single();
+    if (error) throw error;
+    conv = created;
+  }
+
+  const sent = await clickSendSend({ from: fromName, to: payload.to, body: payload.body });
+
+  // twilio_sid holds the ClickSend message id — schema compatibility from the
+  // provider switch, renameable later.
+  const { data: msg, error: msgErr } = await tbl(sb, "sms_messages").insert({
+    conversation_id: conv.id,
+    business_id: businessId,
+    direction: "outbound",
+    body: payload.body,
+    from_number: fromName,
+    to_number: payload.to,
+    twilio_sid: sent.id,
+    status: sent.status,
+  }).select("id").single();
+  if (msgErr) throw msgErr;
+
+  await tbl(sb, "sms_conversations")
+    .update({ last_message_at: new Date().toISOString() }).eq("id", conv.id);
+
+  return { conversationId: conv.id, messageId: msg.id, providerId: sent.id };
+}


### PR DESCRIPTION
Groundwork for automations, and worth doing on its own merits.

## The blocker

`sendSms` resolved the business from `getUser()`. Nothing without a session could send a text — not a cron, not a webhook, and **not an automation**. "When a job completes, text the customer" was impossible to build without this.

`src/lib/sms.ts` now takes the business id as a parameter. `sendSms` becomes a thin wrapper that resolves *who* is sending and delegates the *how*, so the existing Messages UI path is unchanged.

## A bug found while extracting

The ClickSend call existed **twice** — `actions/sms.ts` and `booking/notify.ts` — with different error handling. **The booking copy ignored the response entirely**, so a message ClickSend rejected (bad number, no credit, invalid sender ID) looked successful and nothing was logged. Booking reminders could silently fail to send.

Both now go through one implementation that throws on the API's error.

`deriveSenderId` had two copies as well. The shared one is **the exact implementation already in production**, not a rewrite — sender IDs won't shift for anyone.

## Also

`smsConfigured()` so the automations builder can refuse an SMS action at save time, rather than letting you save something that fails at 3am.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests ✅ · one `rest.clicksend.com` call site left in the codebase, down from two

## Next

Phase 1 — the engine and the plugin: `automations` + `automation_runs` tables (modelled on `scheduled_sends`' claim-lock and `seo_jobs`' status machine), an awaited emit point called from `lib/actions` rather than the lossy `dispatchWebhook`, and a `*/2` runner. Registered as a plugin, default off, route-gated, in the agency preset.

Your example — client created → onboarding form emailed — is the first trigger/action pair it'll run.