### PR TITLE
feat(automations): schema, plugin registration and the trigger point

### DIFF
--- a/src/lib/automations/emit.ts
+++ b/src/lib/automations/emit.ts
@@ -1,0 +1,83 @@
+/**
+ * The automation trigger point.
+ *
+ * Deliberately NOT `dispatchWebhook`. That is a floating unawaited promise, so
+ * under serverless the function can return before it finishes and the event is
+ * simply lost. That's tolerable for a webhook someone can replay; it is not
+ * tolerable for "email this client their onboarding form", where losing the
+ * event means the client never hears from you and nothing anywhere says so.
+ *
+ * So this is awaited, writes a row, and the runner picks it up. The caller
+ * pays one INSERT; the work happens out of band.
+ *
+ * It stores the FACT — (event, entity_type, entity_id) — not a payload. The
+ * app's webhook payloads are inconsistent across their 21 dispatch sites and
+ * some carry no customer at all, so the runner re-hydrates from the id
+ * instead of trusting whatever the caller happened to pass.
+ *
+ * Plain module: call it from server actions, route handlers and crons.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sb = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Sb, name: string) => sb.from(name);
+
+/** Events a rule can trigger on. Only list what actually fires — a trigger
+ *  offered in the builder that never happens is worse than one that's absent,
+ *  because the user builds on it and waits. */
+export const AUTOMATION_TRIGGERS = [
+  { event: "customer.created", entity: "customer", label: "A client is added" },
+  { event: "lead.created", entity: "lead", label: "A lead comes in" },
+] as const;
+
+export type AutomationTrigger = (typeof AUTOMATION_TRIGGERS)[number]["event"];
+
+export function triggerLabel(event: string): string {
+  return AUTOMATION_TRIGGERS.find((t) => t.event === event)?.label ?? event;
+}
+
+/**
+ * Queue any automations listening for this event.
+ *
+ * Never throws: an automation failing to queue must not fail the thing that
+ * triggered it. Creating a client succeeds whether or not the follow-up email
+ * gets scheduled — the alternative is a broken Save button because a rule was
+ * misconfigured.
+ */
+export async function emitAutomationEvent(
+  sb: Sb,
+  businessId: string,
+  event: AutomationTrigger,
+  entityType: string,
+  entityId: string,
+): Promise<{ queued: number }> {
+  try {
+    // Plugin off → no rules run. Checked here rather than at every call site.
+    const { data: settings } = await tbl(sb, "automations_settings")
+      .select("enabled").eq("business_id", businessId).maybeSingle();
+    if (!settings?.enabled) return { queued: 0 };
+
+    const { data: rules } = await tbl(sb, "automations")
+      .select("id").eq("business_id", businessId).eq("trigger_event", event).eq("enabled", true);
+    if (!rules?.length) return { queued: 0 };
+
+    // One row per rule. The unique index on (automation_id, entity_id, event)
+    // makes a duplicate emit a no-op rather than a second email.
+    const rows = rules.map((r: { id: string }) => ({
+      business_id: businessId,
+      automation_id: r.id,
+      trigger_event: event,
+      entity_type: entityType,
+      entity_id: entityId,
+    }));
+    const { error } = await tbl(sb, "automation_runs")
+      .upsert(rows, { onConflict: "automation_id,entity_id,trigger_event", ignoreDuplicates: true });
+    if (error) throw error;
+
+    return { queued: rows.length };
+  } catch (err) {
+    console.error("[automations] emit failed", { event, entityId, err });
+    return { queued: 0 };
+  }
+}

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -40,7 +40,7 @@ export interface PluginDefinition {
   /** Icon name for the Plugins store (mapped in the store's ICON_MAP). */
   icon?: string;
   /** Legacy per-feature settings table that stays authoritative for enabled. */
-  settingsTable?: "quoting_agent_settings" | "onboarding_settings" | "form_builder_settings";
+  settingsTable?: "quoting_agent_settings" | "onboarding_settings" | "form_builder_settings" | "automations_settings";
 }
 
 export const PLUGIN_REGISTRY: PluginDefinition[] = [
@@ -85,6 +85,8 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "quoting-agent", icon: "sparkles",     name: "Quoting Agent",     description: "AI that learns your pricing and writes quotes.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "quoting_agent_settings", routePrefixes: ["/quoting-agent"] },
   { id: "client-onboarding", icon: "clipboard-list", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
   { id: "form-builder", icon: "list-checks",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "sales", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
+
+  { id: "automations", icon: "zap", name: "Automations", description: "When something happens, do something: email a new client their onboarding form, text a customer when a job is done.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "automations_settings", routePrefixes: ["/automations"] },
 
   // ── SEO vertical (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────
   { id: "seo-production", icon: "trending-up", name: "SEO Production", description: "Manage client sites: connectors, opportunity queue, content pipeline and reporting.", kind: "module", category: "seo", defaultEnabled: false, routePrefixes: ["/seo"] },

--- a/src/lib/plugins/sync.ts
+++ b/src/lib/plugins/sync.ts
@@ -8,6 +8,7 @@
  *   form-builder       ↔ form_builder_settings.enabled
  *   quoting-agent      ↔ quoting_agent_settings.enabled
  *   telephony          ↔ telephony_settings.enabled
+ *   automations        ↔ automations_settings.enabled
  */
 import { revalidateTag } from "next/cache";
 import { pluginFlagsTag } from "@/lib/layout-data";
@@ -34,6 +35,10 @@ export async function syncPluginSideEffects(sb: any, businessId: string, pluginI
   }
   if (pluginId === "quoting-agent") {
     await tbl(sb, "quoting_agent_settings")
+      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  }
+  if (pluginId === "automations") {
+    await tbl(sb, "automations_settings")
       .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
   }
 }

--- a/supabase/migrations/20260807170000_automations.sql
+++ b/supabase/migrations/20260807170000_automations.sql
@@ -1,0 +1,149 @@
+-- Automations: when X happens, do Y.
+--
+-- Two tables. `automations` is the rule a business writes. `automation_runs`
+-- is one queued execution of it, modelled on scheduled_sends (claim-lock +
+-- attempt count) and seo_jobs (status machine), because both already work
+-- under serverless and neither needed inventing.
+--
+-- Why a run row per event rather than acting inline: the trigger fires inside
+-- a user's request, and an automation may send email, wait, or fail. Queuing
+-- keeps the user's action fast and makes a failure visible and retryable
+-- instead of a swallowed exception.
+--
+-- run_at exists from the start even though v1 has no waits — it's what lets
+-- "wait 3 days, then chase" arrive later without a migration.
+
+CREATE TABLE IF NOT EXISTS public.automations (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name          TEXT NOT NULL,
+  enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+  -- What starts it, e.g. 'customer.created'. Free text rather than an enum:
+  -- adding a trigger shouldn't need a migration, and the runner ignores
+  -- events it has no rule for.
+  trigger_event TEXT NOT NULL,
+  -- Optional narrowing, e.g. [{field:"account_type",op:"eq",value:"retainer_client"}]
+  conditions    JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- Ordered steps, e.g. [{type:"send_onboarding_form",form_id:"..."}]
+  actions       JSONB NOT NULL DEFAULT '[]'::jsonb,
+  last_run_at   TIMESTAMPTZ,
+  run_count     INTEGER NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_automations_business ON public.automations (business_id, created_at DESC);
+-- The runner's hot path: find enabled rules for this business + event.
+CREATE INDEX IF NOT EXISTS idx_automations_trigger
+  ON public.automations (business_id, trigger_event) WHERE enabled;
+
+CREATE TABLE IF NOT EXISTS public.automation_runs (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id    UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  automation_id  UUID NOT NULL REFERENCES public.automations(id) ON DELETE CASCADE,
+  -- The fact, not a payload: webhook payloads are inconsistent across the app
+  -- and some carry no customer at all. The runner re-hydrates from these.
+  trigger_event  TEXT NOT NULL,
+  entity_type    TEXT NOT NULL,
+  entity_id      UUID NOT NULL,
+  status         TEXT NOT NULL DEFAULT 'pending'
+                 CHECK (status IN ('pending','running','done','failed','skipped')),
+  run_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  attempt_count  INTEGER NOT NULL DEFAULT 0,
+  started_at     TIMESTAMPTZ,
+  finished_at    TIMESTAMPTZ,
+  -- What happened, per action, so a failure is readable in the UI rather than
+  -- only in a server log nobody opens.
+  result         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  error          TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The claim query: due, pending, oldest first. Partial so it stays small
+-- however much history accumulates.
+CREATE INDEX IF NOT EXISTS idx_automation_runs_due
+  ON public.automation_runs (run_at) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_automation_runs_business
+  ON public.automation_runs (business_id, created_at DESC);
+
+-- One run per (automation, entity, event). An automation that fires twice for
+-- the same customer because a page was saved twice would email them twice —
+-- the database refuses rather than trusting the caller to dedupe.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_automation_runs_once
+  ON public.automation_runs (automation_id, entity_id, trigger_event);
+
+ALTER TABLE public.automations     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.automation_runs ENABLE ROW LEVEL SECURITY;
+
+-- Read: any active member except workers. Write: owner / admin / editor.
+-- Copied from recurring_invoices, NOT from business_webhooks — that one has
+-- RLS enabled with zero policies, which denies everything.
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['automations','automation_runs'] LOOP
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, t);
+  END LOOP;
+END $$;
+
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['automations','automation_runs'] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %1$s_updated_at ON public.%1$s;
+      CREATE TRIGGER %1$s_updated_at BEFORE UPDATE ON public.%1$s
+      FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();', t);
+  END LOOP;
+END $$;
+
+-- Per-business on/off, matching how every other plugin stores its flag.
+CREATE TABLE IF NOT EXISTS public.automations_settings (
+  business_id UUID PRIMARY KEY REFERENCES public.businesses(id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE public.automations_settings ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS automations_settings_read ON public.automations_settings;
+CREATE POLICY automations_settings_read ON public.automations_settings FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+DROP POLICY IF EXISTS automations_settings_write ON public.automations_settings;
+CREATE POLICY automations_settings_write ON public.automations_settings FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+);
+DROP TRIGGER IF EXISTS automations_settings_updated_at ON public.automations_settings;
+CREATE TRIGGER automations_settings_updated_at BEFORE UPDATE ON public.automations_settings
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
**Phase 1a — the foundation.** No UI and no runner yet; those are the next piece. This is the part that has to be right before anything is built on it.

## Tables

Migration `20260807170000`, applied to the live database and recorded.

| | |
|---|---|
| `automations` | the rule — trigger, conditions, ordered actions |
| `automation_runs` | one queued execution, on `scheduled_sends`' claim-lock and `seo_jobs`' status machine |
| `automations_settings` | the per-business on/off, like every other plugin |

**Three decisions worth checking:**

- **A UNIQUE index on `(automation_id, entity_id, trigger_event)`.** An automation that fires twice for one client — a double-submitted form, a retried request — would email them twice. The database refuses rather than trusting every caller to dedupe.
- **`run_at` exists now, though v1 has no waits.** It's what lets "wait 3 days, then chase" arrive later without a migration.
- **RLS copied from `recurring_invoices`, not `business_webhooks`** — that one has RLS enabled with *zero policies*, which denies everything. Worth knowing it's like that.

## The trigger point

`emitAutomationEvent` is **deliberately not `dispatchWebhook`**. That's a floating unawaited promise, so under serverless the function can return before it finishes and the event is lost. Tolerable for a webhook someone can replay; not for *"email this client their onboarding form"*, where losing it means the client hears nothing and nothing anywhere says so.

So it's awaited, and it stores the **fact** — `(event, entity_type, entity_id)` — not a payload. The app's webhook payloads are inconsistent across their 21 dispatch sites and some carry no customer at all, so the runner will re-hydrate from the id rather than trust whatever the caller passed.

**It never throws.** A misconfigured rule must not break the Save button that triggered it.

## Plugin

Default off, route-gated at `/automations`, in the existing `automation` category, wired into `syncPluginSideEffects` so the Plugins store toggle works.

## One thing noticed in passing

`sync.ts`'s docstring claims `telephony ↔ telephony_settings.enabled`, but **there is no branch for it** — same shape as the bug that made the telephony plugin do nothing when it shipped. I've left it alone rather than change behaviour on a guess, but it's worth checking whether that toggle actually does anything.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 223 tests ✅ · 3 tables + 6 RLS policies verified against the live DB

## Next

**Phase 1b** — the runner cron and the first trigger/action pair: `customer.created` → send onboarding form. That's when your example starts working. Then Phase 2 is the builder UI.