### PR TITLE
feat(automations): the runner, and the first rule that works end to end

### DIFF
--- a/src/app/api/cron/automation-runs/route.ts
+++ b/src/app/api/cron/automation-runs/route.ts
@@ -1,0 +1,147 @@
+/**
+ * GET /api/cron/automation-runs
+ *
+ * Runs every 2 minutes — see the schedule in vercel.json.
+ *
+ * Claims due automation_runs rows, executes each rule's actions in order, and
+ * records what happened per action so a failure is readable in the UI rather
+ * than only in a log nobody opens.
+ *
+ * The claim is a compare-and-set on status: pending → running, filtered by the
+ * status we expected. Two overlapping invocations can't both take the same
+ * row, which matters because these actions send email.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCron } from "@/lib/cron-auth";
+import { sendOnboardingFormFor } from "@/lib/onboarding/send";
+
+export const maxDuration = 300;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Give up after this many tries so a permanently broken rule stops retrying
+ *  forever and starts showing as failed. */
+const MAX_ATTEMPTS = 3;
+/** Bounded per invocation: these send email, and a 300s budget is finite. */
+const BATCH = 25;
+
+interface ActionResult { type: string; ok: boolean; detail?: string }
+
+/**
+ * Does this entity match the rule's conditions?
+ *
+ * Conditions are plain field comparisons against the re-hydrated entity. An
+ * unknown operator returns FALSE rather than true — a condition nobody
+ * understands should stop the automation, not wave it through.
+ */
+function matches(entity: Record<string, unknown>, conditions: unknown): boolean {
+  if (!Array.isArray(conditions) || conditions.length === 0) return true;
+  return conditions.every((c) => {
+    const cond = c as { field?: string; op?: string; value?: unknown };
+    if (!cond?.field) return false;
+    const actual = entity[cond.field];
+    switch (cond.op) {
+      case "eq":       return String(actual ?? "") === String(cond.value ?? "");
+      case "neq":      return String(actual ?? "") !== String(cond.value ?? "");
+      case "contains": return String(actual ?? "").toLowerCase().includes(String(cond.value ?? "").toLowerCase());
+      case "set":      return actual !== null && actual !== undefined && actual !== "";
+      case "not_set":  return actual === null || actual === undefined || actual === "";
+      default:         return false;
+    }
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function runAction(sb: any, businessId: string, entityId: string, action: any): Promise<ActionResult> {
+  const type = String(action?.type ?? "unknown");
+  try {
+    if (type === "send_onboarding_form") {
+      if (!action.form_id) return { type, ok: false, detail: "No form chosen on this action" };
+      const res = await sendOnboardingFormFor(sb, businessId, action.form_id, entityId, { email: true });
+      return res.ok
+        ? { type, ok: true, detail: `Sent, request ${res.request_id}` }
+        : { type, ok: false, detail: res.error };
+    }
+    return { type, ok: false, detail: `Unknown action "${type}"` };
+  } catch (err) {
+    return { type, ok: false, detail: err instanceof Error ? err.message : "Action failed" };
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const denied = requireCron(req);
+  if (denied) return denied;
+
+  const sb = createAdminClient();
+  const now = new Date().toISOString();
+
+  const { data: due } = await tbl(sb, "automation_runs")
+    .select("id, business_id, automation_id, entity_type, entity_id, attempt_count")
+    .eq("status", "pending").lte("run_at", now)
+    .order("run_at", { ascending: true }).limit(BATCH);
+
+  let done = 0, failed = 0, skipped = 0;
+
+  for (const run of due ?? []) {
+    // Compare-and-set: only proceed if this invocation flipped it. Filtering
+    // on the expected status is what stops two overlapping runs double-sending.
+    const { data: claimed } = await tbl(sb, "automation_runs")
+      .update({ status: "running", started_at: new Date().toISOString(), attempt_count: run.attempt_count + 1 })
+      .eq("id", run.id).eq("status", "pending").select("id").maybeSingle();
+    if (!claimed) continue;
+
+    const finish = async (status: string, result: ActionResult[], error?: string) => {
+      await tbl(sb, "automation_runs").update({
+        status, result, error: error ?? null, finished_at: new Date().toISOString(),
+      }).eq("id", run.id);
+    };
+
+    try {
+      const { data: rule } = await tbl(sb, "automations")
+        .select("id, enabled, conditions, actions").eq("id", run.automation_id).maybeSingle();
+
+      // Disabled or deleted between queueing and running — not a failure.
+      if (!rule?.enabled) { await finish("skipped", [], "Automation is switched off"); skipped++; continue; }
+
+      const table = run.entity_type === "lead" ? "leads" : "customers";
+      const { data: entity } = await tbl(sb, table)
+        .select("*").eq("id", run.entity_id).eq("business_id", run.business_id).maybeSingle();
+      // Deleted since. Skipping beats erroring on something that's simply gone.
+      if (!entity) { await finish("skipped", [], "The record no longer exists"); skipped++; continue; }
+
+      if (!matches(entity, rule.conditions)) {
+        await finish("skipped", [], "Conditions didn't match"); skipped++; continue;
+      }
+
+      const results: ActionResult[] = [];
+      for (const action of (rule.actions ?? [])) {
+        results.push(await runAction(sb, run.business_id, run.entity_id, action));
+      }
+
+      const anyFailed = results.some((r) => !r.ok);
+      if (anyFailed && run.attempt_count + 1 < MAX_ATTEMPTS) {
+        // Back to pending for another go — a bounced provider call is often
+        // transient, and the unique index means requeueing can't duplicate.
+        await tbl(sb, "automation_runs").update({
+          status: "pending", result: results, run_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+        }).eq("id", run.id);
+        continue;
+      }
+
+      await finish(anyFailed ? "failed" : "done", results,
+        anyFailed ? results.filter((r) => !r.ok).map((r) => r.detail).join("; ") : undefined);
+      anyFailed ? failed++ : done++;
+
+      await tbl(sb, "automations").update({
+        last_run_at: new Date().toISOString(), run_count: (rule.run_count ?? 0) + 1,
+      }).eq("id", rule.id);
+    } catch (err) {
+      await finish("failed", [], err instanceof Error ? err.message : "Run failed");
+      failed++;
+    }
+  }
+
+  return NextResponse.json({ ok: true, claimed: (due ?? []).length, done, failed, skipped });
+}

--- a/src/lib/__tests__/use-server-exports.test.ts
+++ b/src/lib/__tests__/use-server-exports.test.ts
@@ -57,4 +57,28 @@ describe("\"use server\" files", () => {
     expect(offenders, `Move these to a plain module — a non-async export breaks every export in the file at runtime:\n${offenders.join("\n")}`)
       .toEqual([]);
   });
+
+  it("never RE-exports a type with `export type { X }`", () => {
+    // Inline `export type X = …` and `export interface X` are fine: TypeScript
+    // erases them. A re-export STATEMENT is not — Next's server-actions
+    // transform enumerates every export and emits a runtime binding for it,
+    // then fails the build with "Export X doesn't exist in target module".
+    //
+    // This broke the build once already. Importers should take the type from
+    // the module that defines it.
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = readFileSync(file, "utf8").split(/\r?\n/);
+      lines.forEach((line, i) => {
+        const t = line.trim();
+        if (/^export\s+type\s*\{/.test(t) || /^export\s*\{\s*type\s/.test(t)) {
+          offenders.push(`${file}:${i + 1}  ${t.slice(0, 90)}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      `Import the type from where it's defined — a type re-export in a "use server" file fails the build:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
 });

--- a/src/lib/actions/customers.ts
+++ b/src/lib/actions/customers.ts
@@ -4,6 +4,7 @@ import { revalidatePath, revalidateTag, unstable_cache } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { dispatchWebhook } from "@/lib/webhooks";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import type { Customer } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
@@ -66,6 +67,10 @@ export async function createCustomer(payload: CreateCustomerInput): Promise<Cust
   revalidateTag(`customers-${businessId}`, {});
   revalidatePath("/customers");
   dispatchWebhook(businessId, "customer.created", data);
+  // Awaited, unlike dispatchWebhook above: an automation that never queues is
+  // an email the client never gets, with nothing to show it went missing.
+  // emitAutomationEvent swallows its own errors, so this can't fail the create.
+  await emitAutomationEvent(supabase, businessId, "customer.created", "customer", data.id);
   return data as Customer;
 }
 

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -13,6 +13,7 @@ import {
   staffOnlyCustomerFields, stripUnfillableAnswers, staffFillProblems, staffFillErrorMessage,
 } from "@/lib/onboarding/staff-fill";
 import { decryptSecret, isEncryptedAnswer, secureFieldsAvailable } from "@/lib/onboarding/crypto";
+import { sendOnboardingFormFor, type SendOnboardingResult } from "@/lib/onboarding/send";
 import type {
   OnboardingForm, OnboardingField, OnboardingRequest, OnboardingResponse,
 } from "@/types/database";
@@ -170,10 +171,6 @@ async function mintPortalToken(
 
 /** Send an onboarding form to a customer: creates the request, mints/reuses a
  *  portal token, and emails the fill link. Returns the link either way. */
-export type SendOnboardingResult =
-  | { ok: true; request_id: string; url: string }
-  | { ok: false; error: string };
-
 export async function sendOnboardingRequest(
   formId: string, customerId: string, opts: { email?: boolean } = {},
 ): Promise<SendOnboardingResult> {
@@ -181,83 +178,17 @@ export async function sendOnboardingRequest(
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
 
-  const [{ data: form }, { data: customer }, { data: biz }] = await Promise.all([
-    tbl(supabase, "onboarding_forms").select("id, name, status, schema").eq("id", formId).eq("business_id", businessId).maybeSingle(),
-    tbl(supabase, "customers").select("id, name, email").eq("id", customerId).eq("business_id", businessId).maybeSingle(),
-    tbl(supabase, "businesses").select("name, email").eq("id", businessId).single(),
-  ]);
-  // Expected failures are RETURNED, not thrown.
-  //
-  // Next.js masks thrown server-action messages in production — the client only
-  // ever sees "An error occurred in the Server Components render". So a helpful
-  // explanation that gets thrown is a helpful explanation the user never reads;
-  // it reached the server log and nowhere else. Anything the user can act on
-  // has to come back as data.
-  if (!form) return { ok: false as const, error: "Form not found" };
-  if (!customer) return { ok: false as const, error: "Customer not found" };
-  if ((form.schema ?? []).length === 0) {
-    return { ok: false as const, error: "Add at least one field before sending" };
+  // The work lives in lib/onboarding/send.ts, which takes the business id
+  // explicitly so a cron or an automation can send too. This resolves WHO.
+  const res = await sendOnboardingFormFor(supabase, businessId, formId, customerId, {
+    email: opts.email, createdBy: user.id,
+  });
+
+  if (res.ok) {
+    revalidatePath("/onboarding-forms");
+    revalidatePath(`/customers/${customerId}`);
   }
-
-  // A form with a secure field can't be submitted while the encryption key is
-  // missing — the customer would fill it in, hit save, and get an error they
-  // can do nothing about. Fail here, for the business, rather than in front of
-  // their client. The builder blocks adding these fields, but the MCP tools
-  // can create them, so this is the last line before a customer sees it.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const hasSecure = ((form.schema ?? []) as any[]).some((f) => f?.type === "secure");
-  if (hasSecure && !secureFieldsAvailable()) {
-    return {
-      ok: false as const,
-      error: "This form has a secure credential field, but the encryption key isn't set on the server — "
-        + "your customer wouldn't be able to submit it. Remove the secure field, or set ONBOARDING_SECRET_KEY.",
-    };
-  }
-
-  // Reuse an open request for the same form+customer instead of duplicating.
-  const { data: openReq } = await tbl(supabase, "onboarding_requests")
-    .select("id").eq("business_id", businessId).eq("form_id", formId)
-    .eq("customer_id", customerId).neq("status", "completed")
-    .order("created_at", { ascending: false }).limit(1).maybeSingle();
-
-  let requestId: string = openReq?.id ?? "";
-  if (!requestId) {
-    const { data: created, error } = await tbl(supabase, "onboarding_requests").insert({
-      business_id: businessId, form_id: formId, customer_id: customerId,
-    }).select("id").single();
-    if (error) throw error;
-    requestId = created.id;
-  }
-
-  const token = await mintPortalToken(supabase, businessId, customerId, user.id);
-  const url = `${appUrl()}/portal/${token}/onboarding/${requestId}`;
-
-  const shouldEmail = opts.email !== false;
-  if (shouldEmail) {
-    if (!customer.email) {
-      return { ok: false as const, error: "This customer has no email address — use Copy link instead" };
-    }
-    const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px;color:#111">
-      <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:28px">
-        <p style="font-size:13px;color:#666;margin:0 0 4px">${biz?.name ?? "Your provider"}</p>
-        <h1 style="font-size:20px;margin:0 0 12px">${form.name}</h1>
-        <p style="font-size:14px;line-height:1.6;color:#333">Hi ${customer.name ?? "there"}, please fill in a few details so we can get you set up. Your progress saves automatically.</p>
-        <p style="margin:24px 0"><a href="${url}" style="background:#2f6f73;color:#fff;text-decoration:none;padding:12px 22px;border-radius:8px;font-size:14px;font-weight:600">Open the form</a></p>
-        <p style="font-size:12px;color:#888">Or paste this link into your browser:<br>${url}</p>
-      </div></body></html>`;
-    await sendEmail({
-      to: customer.email,
-      subject: `${biz?.name ?? "Onboarding"}: ${form.name}`,
-      html,
-      from: buildBusinessFrom({ name: biz?.name ?? "Kirei", slug: biz?.slug, localPart: "onboarding" }),
-      replyTo: biz?.email ?? undefined,
-      tags: { business_id: businessId, doc_type: "custom", doc_id: requestId },
-    });
-  }
-
-  revalidatePath("/onboarding-forms");
-  revalidatePath(`/customers/${customerId}`);
-  return { ok: true as const, request_id: requestId, url };
+  return res;
 }
 
 export type StaffFillResult =

--- a/src/lib/onboarding/send.ts
+++ b/src/lib/onboarding/send.ts
@@ -1,0 +1,127 @@
+/**
+ * Sending an onboarding form — the session-free layer.
+ *
+ * `sendOnboardingRequest` resolves the business from `getUser()`, so a cron or
+ * an automation can't send a form: there's no session. Same shape as
+ * `lib/sms.ts`, and the same reason.
+ *
+ * Plain module — no "use server". Import from actions, routes and crons.
+ */
+import { randomBytes } from "node:crypto";
+import { appUrl } from "@/lib/app-url";
+import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { secureFieldsAvailable } from "./crypto";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sb = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: Sb, name: string) => sb.from(name);
+
+export type SendOnboardingResult =
+  | { ok: true; request_id: string; url: string }
+  | { ok: false; error: string };
+
+/** Reuse a live portal token for this customer, or mint one. */
+export async function mintPortalTokenFor(
+  sb: Sb, businessId: string, customerId: string, createdBy: string | null,
+): Promise<string> {
+  const { data: existing } = await tbl(sb, "customer_portal_tokens")
+    .select("token").eq("business_id", businessId).eq("customer_id", customerId)
+    .is("revoked_at", null)
+    .or("expires_at.is.null,expires_at.gt." + new Date().toISOString())
+    .order("created_at", { ascending: false }).limit(1).maybeSingle();
+  if (existing?.token) return existing.token as string;
+
+  const token = "cust_" + randomBytes(24).toString("hex");
+  const { error } = await tbl(sb, "customer_portal_tokens").insert({
+    token, business_id: businessId, customer_id: customerId, created_by: createdBy,
+    expires_at: new Date(Date.now() + 90 * 86_400_000).toISOString(),
+  });
+  if (error) throw error;
+  return token;
+}
+
+/**
+ * Create (or reuse) an onboarding request and optionally email the link.
+ *
+ * Expected failures are RETURNED, not thrown — Next masks thrown server-action
+ * messages in production, and an automation needs a reason it can record.
+ */
+export async function sendOnboardingFormFor(
+  sb: Sb,
+  businessId: string,
+  formId: string,
+  customerId: string,
+  opts: { email?: boolean; createdBy?: string | null } = {},
+): Promise<SendOnboardingResult> {
+  const [{ data: form }, { data: customer }, { data: biz }] = await Promise.all([
+    tbl(sb, "onboarding_forms").select("id, name, status, schema").eq("id", formId).eq("business_id", businessId).maybeSingle(),
+    tbl(sb, "customers").select("id, name, email").eq("id", customerId).eq("business_id", businessId).maybeSingle(),
+    // slug included: buildBusinessFrom uses it for the sending subdomain, and
+    // it was referenced here while never being selected — so every one of
+    // these emails fell back to the default sender.
+    tbl(sb, "businesses").select("name, email, slug").eq("id", businessId).single(),
+  ]);
+
+  if (!form) return { ok: false, error: "Form not found" };
+  if (!customer) return { ok: false, error: "Customer not found" };
+  if ((form.schema ?? []).length === 0) {
+    return { ok: false, error: "Add at least one field before sending" };
+  }
+
+  // A form with a secure field can't be submitted while the encryption key is
+  // missing — the customer would fill it in, hit save, and get an error they
+  // can do nothing about. Fail here, for the business, not in front of their
+  // client.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const hasSecure = ((form.schema ?? []) as any[]).some((f) => f?.type === "secure");
+  if (hasSecure && !secureFieldsAvailable()) {
+    return {
+      ok: false,
+      error: "This form has a secure credential field, but the encryption key isn't set on the server — "
+        + "your customer wouldn't be able to submit it. Remove the secure field, or set ONBOARDING_SECRET_KEY.",
+    };
+  }
+
+  // Reuse an open request for the same form+customer instead of duplicating.
+  const { data: openReq } = await tbl(sb, "onboarding_requests")
+    .select("id").eq("business_id", businessId).eq("form_id", formId)
+    .eq("customer_id", customerId).neq("status", "completed")
+    .order("created_at", { ascending: false }).limit(1).maybeSingle();
+
+  let requestId: string = openReq?.id ?? "";
+  if (!requestId) {
+    const { data: created, error } = await tbl(sb, "onboarding_requests").insert({
+      business_id: businessId, form_id: formId, customer_id: customerId,
+    }).select("id").single();
+    if (error) throw error;
+    requestId = created.id;
+  }
+
+  const token = await mintPortalTokenFor(sb, businessId, customerId, opts.createdBy ?? null);
+  const url = `${appUrl()}/portal/${token}/onboarding/${requestId}`;
+
+  if (opts.email !== false) {
+    if (!customer.email) {
+      return { ok: false, error: "This customer has no email address — use Copy link instead" };
+    }
+    const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px;color:#111">
+      <div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:28px">
+        <p style="font-size:13px;color:#666;margin:0 0 4px">${biz?.name ?? "Your provider"}</p>
+        <h1 style="font-size:20px;margin:0 0 12px">${form.name}</h1>
+        <p style="font-size:14px;line-height:1.6;color:#333">Hi ${customer.name ?? "there"}, please fill in a few details so we can get you set up. Your progress saves automatically.</p>
+        <p style="margin:24px 0"><a href="${url}" style="background:#2f6f73;color:#fff;text-decoration:none;padding:12px 22px;border-radius:8px;font-size:14px;font-weight:600">Open the form</a></p>
+        <p style="font-size:12px;color:#888">Or paste this link into your browser:<br>${url}</p>
+      </div></body></html>`;
+    await sendEmail({
+      to: customer.email,
+      subject: `${biz?.name ?? "Onboarding"}: ${form.name}`,
+      html,
+      from: buildBusinessFrom({ name: biz?.name ?? "Kirei", slug: biz?.slug, localPart: "onboarding" }),
+      replyTo: biz?.email ?? undefined,
+      tags: { business_id: businessId, doc_type: "custom", doc_id: requestId },
+    });
+  }
+
+  return { ok: true, request_id: requestId, url };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -44,6 +44,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/automation-runs",
+      "schedule": "*/2 * * * *"
+    },
+    {
       "path": "/api/cron/seo-jobs",
       "schedule": "*/2 * * * *"
     },


### PR DESCRIPTION
**Phase 1b.** Add a client → they get the onboarding form. The example this whole thread started from.

## The blocker, again

`sendOnboardingRequest` resolved the business from `getUser()`, so a cron could never send a form — exactly the problem `sendSms` had. Extracted `lib/onboarding/send.ts` the same way: the action is a thin wrapper that resolves *who*, the shared function takes the business id.

**Found while extracting:** `biz?.slug` was read but **never selected**, so every onboarding email fell back to the default sender instead of the business's own subdomain. Now selected.

## The runner — `/api/cron/automation-runs`, every 2 minutes

Six decisions worth checking, all about not doing the wrong thing with email:

- **Claims with a compare-and-set on status**, filtered by the status it expected. Two overlapping invocations can't take the same row.
- **Re-hydrates the entity** from `(entity_type, entity_id)` rather than trusting a payload — the app's webhook payloads are inconsistent and some carry no customer at all.
- **Unknown condition operators return FALSE.** A condition nobody understands should stop an automation, not wave it through.
- **Deleted record, or rule switched off between queueing and running → skipped, not failed.** Neither is an error worth alarming about.
- **Retries twice at 5-minute gaps, then fails visibly.** The unique index on `(automation, entity, event)` means requeueing can't duplicate a send.
- **Records a per-action result**, so a failure is readable rather than living in a log.

## The emit

`createCustomer` now **awaits** `emitAutomationEvent` — deliberately, on the line right after a `dispatchWebhook` that isn't awaited. A lost webhook is replayable; a lost automation is an email the client never gets, with nothing to show it went missing. It swallows its own errors, so it can't fail the create.

## A trap worth recording

**A type RE-EXPORT breaks a `"use server"` file.** `export type { X }` made Next's actions transform emit a runtime binding and fail the build with *"Export X doesn't exist in target module"*. Inline `export type X = …` and `export interface X` are fine — TypeScript erases those. The statement form is not.

The scanning test now catches it. It cost a build today, and it's the third variant of this same trap the project has hit.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 224 tests, 1 new guard ✅ · 18 crons, `vercel.json` parses

## To try it

1. Plugins → enable **Automations**
2. There's no builder yet (Phase 2), so insert a rule directly:

```sql
insert into automations (business_id, name, trigger_event, actions)
values ('<your business id>', 'Welcome pack', 'customer.created',
        '[{"type":"send_onboarding_form","form_id":"<a form id>"}]'::jsonb);
```

3. Add a client with an email address. Within ~2 minutes they get the form, and `automation_runs` shows the result.

**Phase 2** is the builder UI — When → If → Then, plus run history so this is usable without SQL.