### PR TITLE
feat(automations): the builder — When / If / Then, with run history

### DIFF
--- a/src/app/(dashboard)/automations/page.tsx
+++ b/src/app/(dashboard)/automations/page.tsx
@@ -1,0 +1,31 @@
+import {
+  getAutomationsEnabled, getAutomations, getAutomationRuns,
+} from "@/lib/actions/automations";
+import { getOnboardingForms } from "@/lib/actions/onboarding";
+import { AutomationsClient, AutomationsDisabled } from "@/components/automations/automations-client";
+
+/** Forms an automation can send. Only ones with fields — sending an empty form
+ *  fails at run time, and the builder shouldn't offer it. */
+async function loadSendableForms(): Promise<Array<{ id: string; name: string }>> {
+  try {
+    const forms = await getOnboardingForms();
+    return forms
+      .filter((f) => f.status !== "archived" && (f.schema?.length ?? 0) > 0)
+      .map((f) => ({ id: f.id, name: f.name }));
+  } catch {
+    return [];
+  }
+}
+
+export default async function AutomationsPage() {
+  const enabled = await getAutomationsEnabled();
+  if (!enabled) return <AutomationsDisabled />;
+
+  const [automations, runs, forms] = await Promise.all([
+    getAutomations(),
+    getAutomationRuns(),
+    loadSendableForms(),
+  ]);
+
+  return <AutomationsClient automations={automations} runs={runs} forms={forms} />;
+}

--- a/src/components/automations/automations-client.tsx
+++ b/src/components/automations/automations-client.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+/**
+ * The automations builder: When → If → Then, plus what actually happened.
+ *
+ * The run history is not decoration. An automation that silently stopped
+ * working is the failure mode that matters — you don't notice an email that
+ * didn't arrive — so every rule shows its last runs and why they ended.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  Plus, Trash2, Loader2, Zap, Check, X, ChevronDown,
+} from "@/components/ui/icons";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  TRIGGERS, CONDITION_OPS, CONDITION_FIELDS, actionsForTrigger, triggerFor,
+  validateAutomation, type AutomationCondition, type AutomationAction,
+} from "@/lib/automations/schema";
+import {
+  saveAutomation, setAutomationEnabled, deleteAutomation,
+  type AutomationRow, type AutomationRunRow,
+} from "@/lib/actions/automations";
+import { formatDate } from "@/lib/utils";
+
+interface Props {
+  automations: AutomationRow[];
+  runs: AutomationRunRow[];
+  forms: Array<{ id: string; name: string }>;
+}
+
+const BLANK = {
+  id: undefined as string | undefined,
+  name: "",
+  trigger_event: TRIGGERS[0].event,
+  conditions: [] as AutomationCondition[],
+  actions: [] as AutomationAction[],
+};
+
+export function AutomationsClient({ automations, runs, forms }: Props) {
+  const router = useRouter();
+  const [draft, setDraft] = useState<typeof BLANK | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const save = async () => {
+    if (!draft) return;
+    const problem = validateAutomation(draft);
+    if (problem) { toast.error(problem); return; }
+    setBusy(true);
+    try {
+      const res = await saveAutomation(draft);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success(draft.id ? "Automation updated" : "Automation created");
+      setDraft(null);
+      router.refresh();
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="Automations"
+        subtitle="When something happens, do something about it."
+        accent="linear-gradient(180deg, #3a847e 0%, #1f4f4a 100%)"
+        actions={
+          <Button onClick={() => setDraft({ ...BLANK })}>
+            <Plus className="w-4 h-4 mr-1.5" /> New automation
+          </Button>
+        }
+      />
+
+      {automations.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border p-10 text-center">
+          <Zap className="w-7 h-7 mx-auto mb-3 opacity-40" />
+          <p className="text-sm font-medium">Nothing automated yet</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            The common one: when a client is added, email them your onboarding form.
+          </p>
+          <Button className="mt-4" onClick={() => setDraft({ ...BLANK })}>
+            <Plus className="w-4 h-4 mr-1.5" /> New automation
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {automations.map((a) => (
+            <AutomationCard
+              key={a.id}
+              automation={a}
+              runs={runs.filter((r) => r.automation_id === a.id)}
+              forms={forms}
+              onEdit={() => setDraft({
+                id: a.id, name: a.name, trigger_event: a.trigger_event,
+                conditions: a.conditions ?? [], actions: a.actions ?? [],
+              })}
+            />
+          ))}
+        </div>
+      )}
+
+      <Dialog open={!!draft} onOpenChange={(o) => !o && setDraft(null)}>
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{draft?.id ? "Edit automation" : "New automation"}</DialogTitle>
+          </DialogHeader>
+          {draft && (
+            <Builder draft={draft} setDraft={setDraft} forms={forms} busy={busy} onSave={save} />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function Builder({ draft, setDraft, forms, busy, onSave }: {
+  draft: typeof BLANK;
+  setDraft: (d: typeof BLANK) => void;
+  forms: Array<{ id: string; name: string }>;
+  busy: boolean;
+  onSave: () => void;
+}) {
+  const trigger = triggerFor(draft.trigger_event);
+  const available = actionsForTrigger(draft.trigger_event);
+  const fields = CONDITION_FIELDS[trigger?.entity ?? "customer"] ?? [];
+
+  const set = (patch: Partial<typeof BLANK>) => setDraft({ ...draft, ...patch });
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1.5">
+        <Label>Name</Label>
+        <Input
+          value={draft.name}
+          placeholder="Welcome pack for new clients"
+          onChange={(e) => set({ name: e.target.value })}
+        />
+      </div>
+
+      <section className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">When</p>
+        <Select
+          value={draft.trigger_event}
+          onValueChange={(v) => {
+            // Actions are filtered by the trigger's entity, so ones that no
+            // longer apply are dropped rather than left to fail at run time.
+            const stillValid = draft.actions.filter((a) =>
+              actionsForTrigger(v).some((d) => d.type === a.type));
+            set({ trigger_event: v, conditions: [], actions: stillValid });
+          }}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {TRIGGERS.map((t) => <SelectItem key={t.event} value={t.event}>{t.label}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        {trigger && <p className="text-xs text-muted-foreground">{trigger.hint}</p>}
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          If <span className="font-normal normal-case">(optional — leave empty to run every time)</span>
+        </p>
+        {draft.conditions.map((c, i) => {
+          const opDef = CONDITION_OPS.find((o) => o.op === c.op);
+          return (
+            <div key={i} className="flex items-center gap-2 flex-wrap">
+              <Select value={c.field} onValueChange={(v) => {
+                const next = [...draft.conditions]; next[i] = { ...c, field: v }; set({ conditions: next });
+              }}>
+                <SelectTrigger className="w-[170px]"><SelectValue placeholder="Field" /></SelectTrigger>
+                <SelectContent>
+                  {fields.map((f) => <SelectItem key={f.field} value={f.field}>{f.label}</SelectItem>)}
+                </SelectContent>
+              </Select>
+              <Select value={c.op} onValueChange={(v) => {
+                const next = [...draft.conditions]; next[i] = { ...c, op: v }; set({ conditions: next });
+              }}>
+                <SelectTrigger className="w-[150px]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {CONDITION_OPS.map((o) => <SelectItem key={o.op} value={o.op}>{o.label}</SelectItem>)}
+                </SelectContent>
+              </Select>
+              {opDef?.needsValue && (
+                <Input
+                  className="flex-1 min-w-[140px]"
+                  value={c.value ?? ""}
+                  placeholder="Value"
+                  onChange={(e) => {
+                    const next = [...draft.conditions]; next[i] = { ...c, value: e.target.value }; set({ conditions: next });
+                  }}
+                />
+              )}
+              <button
+                aria-label="Remove condition"
+                className="text-muted-foreground hover:text-destructive"
+                onClick={() => set({ conditions: draft.conditions.filter((_, idx) => idx !== i) })}
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          );
+        })}
+        <Button size="sm" variant="outline" onClick={() => set({
+          conditions: [...draft.conditions, { field: fields[0]?.field ?? "", op: "eq", value: "" }],
+        })}>
+          <Plus className="w-3.5 h-3.5 mr-1.5" /> Add condition
+        </Button>
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Then</p>
+        {available.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            Nothing can run on this trigger yet.
+          </p>
+        )}
+        {draft.actions.map((a, i) => {
+          const def = available.find((d) => d.type === a.type);
+          return (
+            <div key={i} className="rounded-md border border-border p-3 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-medium">{def?.label ?? a.type}</p>
+                <button
+                  aria-label="Remove action"
+                  className="text-muted-foreground hover:text-destructive"
+                  onClick={() => set({ actions: draft.actions.filter((_, idx) => idx !== i) })}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+              {def?.needs === "onboarding_form" && (
+                <div className="space-y-1.5">
+                  <Label>Which form</Label>
+                  {forms.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      No onboarding forms yet — build one first, under Onboarding.
+                    </p>
+                  ) : (
+                    <Select value={a.form_id ?? ""} onValueChange={(v) => {
+                      const next = [...draft.actions]; next[i] = { ...a, form_id: v }; set({ actions: next });
+                    }}>
+                      <SelectTrigger><SelectValue placeholder="Choose a form…" /></SelectTrigger>
+                      <SelectContent>
+                        {forms.map((f) => <SelectItem key={f.id} value={f.id}>{f.name}</SelectItem>)}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+              )}
+              {def && <p className="text-xs text-muted-foreground">{def.hint}</p>}
+            </div>
+          );
+        })}
+        {available.map((d) => (
+          <Button key={d.type} size="sm" variant="outline"
+            onClick={() => set({ actions: [...draft.actions, { type: d.type }] })}>
+            <Plus className="w-3.5 h-3.5 mr-1.5" /> {d.label}
+          </Button>
+        ))}
+      </section>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button variant="outline" onClick={() => setDraft({ ...draft, id: undefined, name: "" })} disabled={busy}>
+          Clear
+        </Button>
+        <Button onClick={onSave} disabled={busy}>
+          {busy && <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />} Save automation
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const STATUS_TONE: Record<string, string> = {
+  done: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  failed: "bg-destructive/15 text-destructive",
+  skipped: "bg-muted text-muted-foreground",
+  pending: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+  running: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+};
+
+function AutomationCard({ automation, runs, forms, onEdit }: {
+  automation: AutomationRow;
+  runs: AutomationRunRow[];
+  forms: Array<{ id: string; name: string }>;
+  onEdit: () => void;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const trigger = triggerFor(automation.trigger_event);
+  const failures = runs.filter((r) => r.status === "failed").length;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="font-medium break-words">{automation.name}</p>
+            {!automation.enabled && <Badge variant="secondary">Off</Badge>}
+            {failures > 0 && (
+              <Badge variant="secondary" className="bg-destructive/15 text-destructive">
+                {failures} failed
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            When {(trigger?.label ?? automation.trigger_event).toLowerCase()}
+            {automation.conditions?.length ? `, if ${automation.conditions.length} condition${automation.conditions.length > 1 ? "s" : ""} match` : ""}
+            {" → "}
+            {(automation.actions ?? []).map((a) => {
+              const label = a.type === "send_onboarding_form"
+                ? `email ${forms.find((f) => f.id === a.form_id)?.name ?? "a form"}`
+                : a.type;
+              return label;
+            }).join(", ") || "nothing yet"}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {automation.run_count > 0
+              ? `Ran ${automation.run_count} time${automation.run_count > 1 ? "s" : ""}${automation.last_run_at ? ` · last ${formatDate(automation.last_run_at)}` : ""}`
+              : "Hasn't run yet"}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={automation.enabled}
+            disabled={busy}
+            onCheckedChange={async (v) => {
+              setBusy(true);
+              try { await setAutomationEnabled(automation.id, v); router.refresh(); }
+              finally { setBusy(false); }
+            }}
+          />
+          <Button size="sm" variant="outline" onClick={onEdit}>Edit</Button>
+          <Button size="sm" variant="outline" className="text-destructive hover:text-destructive"
+            disabled={busy}
+            onClick={async () => {
+              if (!confirm(`Delete "${automation.name}"? Its run history goes with it.`)) return;
+              setBusy(true);
+              try { await deleteAutomation(automation.id); toast.success("Deleted"); router.refresh(); }
+              finally { setBusy(false); }
+            }}>
+            <Trash2 className="w-3.5 h-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {runs.length > 0 && (
+        <div className="mt-3 border-t border-border/60 pt-3">
+          <button onClick={() => setOpen((v) => !v)}
+            className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <ChevronDown className={`w-3.5 h-3.5 transition-transform ${open ? "" : "-rotate-90"}`} />
+            Recent runs ({runs.length})
+          </button>
+          {open && (
+            <div className="mt-2 space-y-1.5">
+              {runs.slice(0, 10).map((r) => (
+                <div key={r.id} className="flex items-start gap-2 text-xs">
+                  <Badge variant="secondary" className={STATUS_TONE[r.status] ?? ""}>{r.status}</Badge>
+                  <span className="text-muted-foreground">{formatDate(r.created_at)}</span>
+                  {r.error && <span className="text-destructive break-words">{r.error}</span>}
+                  {!r.error && r.status === "done" && (
+                    <span className="inline-flex items-center gap-1 text-emerald-600">
+                      <Check className="w-3 h-3" /> sent
+                    </span>
+                  )}
+                  {r.attempt_count > 1 && (
+                    <span className="text-muted-foreground">· attempt {r.attempt_count}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Shown when the plugin is off — the same shape as the other plugin pages. */
+export function AutomationsDisabled() {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  return (
+    <div className="max-w-xl mx-auto py-12 text-center">
+      <Zap className="w-8 h-8 mx-auto mb-3 opacity-50" />
+      <h1 className="text-lg font-semibold">Automations</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        When a client is added, email them your onboarding form. When a lead comes in, create a task.
+        Rules that run themselves, so you stop remembering to.
+      </p>
+      <Button className="mt-5" disabled={busy} onClick={async () => {
+        setBusy(true);
+        try {
+          const { setAutomationsEnabled } = await import("@/lib/actions/automations");
+          await setAutomationsEnabled(true);
+          router.refresh();
+        } finally { setBusy(false); }
+      }}>
+        {busy ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" /> : <Check className="w-4 h-4 mr-1.5" />}
+        Turn on Automations
+      </Button>
+    </div>
+  );
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -1,4 +1,5 @@
 import {
+  Zap,
   LayoutDashboard, FileText, FileCheck, Users,
   Package, FileStack, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target, Megaphone, DollarSign, Send, Phone,
 } from "@/components/ui/icons";
@@ -20,6 +21,7 @@ export const navSections: NavSection[] = [
     { label: "Messages",   href: "/messages",   icon: MessageSquare,   plugin: "messages" },
     { label: "Calls",      href: "/calls",      icon: Phone,           plugin: "telephony" },
     { label: "Tasks",      href: "/tasks",      icon: Columns3                      },
+    { label: "Automations",href: "/automations",icon: Zap,             plugin: "automations" },
   ]},
   { section: "Sales", items: [
     { label: "Leads",         href: "/leads",         icon: UserPlus,     plugin: "leads"             },

--- a/src/lib/actions/automations.ts
+++ b/src/lib/actions/automations.ts
@@ -1,0 +1,168 @@
+"use server";
+
+/**
+ * Automations CRUD + the plugin flag.
+ *
+ * Expected failures are RETURNED, not thrown — Next masks thrown server-action
+ * messages in production, and "why won't my automation save" is exactly the
+ * question that needs a real answer.
+ */
+import { revalidatePath, revalidateTag } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { pluginFlagsTag } from "@/lib/layout-data";
+import {
+  validateAutomation, type AutomationCondition, type AutomationAction,
+} from "@/lib/automations/schema";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+export interface AutomationRow {
+  id: string;
+  business_id: string;
+  name: string;
+  enabled: boolean;
+  trigger_event: string;
+  conditions: AutomationCondition[];
+  actions: AutomationAction[];
+  last_run_at: string | null;
+  run_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AutomationRunRow {
+  id: string;
+  automation_id: string;
+  trigger_event: string;
+  entity_type: string;
+  entity_id: string;
+  status: string;
+  attempt_count: number;
+  finished_at: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  result: any[];
+  error: string | null;
+  created_at: string;
+}
+
+export type SaveResult = { ok: true; id: string } | { ok: false; error: string };
+
+export async function getAutomationsEnabled(): Promise<boolean> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "automations_settings")
+    .select("enabled").eq("business_id", businessId).maybeSingle();
+  return Boolean(data?.enabled);
+}
+
+export async function setAutomationsEnabled(enabled: boolean): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "automations_settings")
+    .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  if (error) throw error;
+
+  // Mirror into the Plugins store so the card reflects state whichever side
+  // was toggled — the same pattern the other plugins use.
+  try {
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (createAdminClient() as any).from("business_agent_installs").upsert(
+      { business_id: businessId, agent_id: "automations", enabled, updated_at: new Date().toISOString() },
+      { onConflict: "business_id,agent_id" },
+    );
+  } catch { /* non-fatal */ }
+
+  revalidateTag(pluginFlagsTag(businessId), "max");
+  revalidatePath("/automations");
+  revalidatePath("/agents");
+  revalidatePath("/", "layout");
+}
+
+export async function getAutomations(): Promise<AutomationRow[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data, error } = await tbl(supabase, "automations")
+    .select("*").eq("business_id", businessId).order("created_at", { ascending: false });
+  if (error) throw new Error(`Couldn't load your automations: ${error.message}`);
+  return (data ?? []) as AutomationRow[];
+}
+
+/** Recent runs, newest first — the answer to "did it actually fire?". */
+export async function getAutomationRuns(automationId?: string): Promise<AutomationRunRow[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  let q = tbl(supabase, "automation_runs")
+    .select("id, automation_id, trigger_event, entity_type, entity_id, status, attempt_count, finished_at, result, error, created_at")
+    .eq("business_id", businessId).order("created_at", { ascending: false }).limit(50);
+  if (automationId) q = q.eq("automation_id", automationId);
+  const { data } = await q;
+  return (data ?? []) as AutomationRunRow[];
+}
+
+export async function saveAutomation(input: {
+  id?: string;
+  name: string;
+  trigger_event: string;
+  conditions: AutomationCondition[];
+  actions: AutomationAction[];
+  enabled?: boolean;
+}): Promise<SaveResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // The same check the browser ran. A check only the client performs isn't one.
+  const problem = validateAutomation(input);
+  if (problem) return { ok: false, error: problem };
+
+  const row = {
+    business_id: businessId,
+    name: input.name.trim(),
+    trigger_event: input.trigger_event,
+    conditions: input.conditions ?? [],
+    actions: input.actions ?? [],
+    enabled: input.enabled ?? true,
+  };
+
+  if (input.id) {
+    const { error } = await tbl(supabase, "automations")
+      .update(row).eq("id", input.id).eq("business_id", businessId);
+    if (error) return { ok: false, error: error.message };
+    revalidatePath("/automations");
+    return { ok: true, id: input.id };
+  }
+
+  const { data, error } = await tbl(supabase, "automations").insert(row).select("id").single();
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/automations");
+  return { ok: true, id: data.id };
+}
+
+export async function setAutomationEnabled(id: string, enabled: boolean): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { error } = await tbl(supabase, "automations")
+    .update({ enabled }).eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/automations");
+}
+
+export async function deleteAutomation(id: string): Promise<void> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  // Runs cascade with the rule; the history goes with the thing it describes.
+  const { error } = await tbl(supabase, "automations")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/automations");
+}

--- a/src/lib/automations/schema.ts
+++ b/src/lib/automations/schema.ts
@@ -1,0 +1,143 @@
+/**
+ * What an automation can be made of.
+ *
+ * Plain module — the builder UI, the server actions and the runner all read
+ * these lists, so a trigger or action can't exist in one and not another.
+ *
+ * The rule for adding a trigger: only list events that ACTUALLY fire. A
+ * trigger offered in the builder that never happens is worse than one that's
+ * missing, because someone builds on it and waits for an email that was never
+ * coming.
+ */
+
+export interface TriggerDef {
+  event: string;
+  entity: "customer" | "lead";
+  label: string;
+  /** What the sentence reads like in the builder: "When a client is added…" */
+  hint: string;
+}
+
+export const TRIGGERS: TriggerDef[] = [
+  {
+    event: "customer.created",
+    entity: "customer",
+    label: "A client is added",
+    hint: "Runs once, when the client record is first created.",
+  },
+  {
+    event: "lead.created",
+    entity: "lead",
+    label: "A lead comes in",
+    hint: "Runs when a lead is created — including from a public form.",
+  },
+];
+
+export interface ActionDef {
+  type: string;
+  label: string;
+  /** Which entities this action can act on. Sending a form needs a customer:
+   *  portal links are minted against one, so a lead has no address to send to. */
+  entities: Array<"customer" | "lead">;
+  /** Config the action needs before it can be saved. */
+  needs?: "onboarding_form";
+  hint: string;
+}
+
+export const ACTIONS: ActionDef[] = [
+  {
+    type: "send_onboarding_form",
+    label: "Email them an onboarding form",
+    entities: ["customer"],
+    needs: "onboarding_form",
+    hint: "Sends the form's portal link. Leads can't receive one — convert them first.",
+  },
+];
+
+export interface ConditionOpDef { op: string; label: string; needsValue: boolean }
+
+export const CONDITION_OPS: ConditionOpDef[] = [
+  { op: "eq", label: "is", needsValue: true },
+  { op: "neq", label: "is not", needsValue: true },
+  { op: "contains", label: "contains", needsValue: true },
+  { op: "set", label: "has any value", needsValue: false },
+  { op: "not_set", label: "is empty", needsValue: false },
+];
+
+/** Fields worth filtering on, per entity. Deliberately a short list: the
+ *  runner compares against the raw row, so offering every column would invite
+ *  conditions on things like `updated_at` that read as nonsense. */
+export const CONDITION_FIELDS: Record<string, Array<{ field: string; label: string }>> = {
+  customer: [
+    { field: "account_type", label: "Client type" },
+    { field: "email", label: "Email" },
+    { field: "phone", label: "Phone" },
+    { field: "company", label: "Company" },
+    { field: "city", label: "City" },
+  ],
+  lead: [
+    { field: "status", label: "Status" },
+    { field: "source", label: "Source" },
+    { field: "service", label: "Service" },
+    { field: "email", label: "Email" },
+    { field: "suburb", label: "Suburb" },
+  ],
+};
+
+export interface AutomationCondition { field: string; op: string; value?: string }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface AutomationAction { type: string; [key: string]: any }
+
+export function triggerFor(event: string): TriggerDef | undefined {
+  return TRIGGERS.find((t) => t.event === event);
+}
+
+export function actionsForTrigger(event: string): ActionDef[] {
+  const entity = triggerFor(event)?.entity;
+  return entity ? ACTIONS.filter((a) => a.entities.includes(entity)) : [];
+}
+
+/**
+ * Why this automation can't be saved, or null when it's fine.
+ *
+ * Runs in the browser before saving and again on the server. Catching it early
+ * matters more here than elsewhere: a rule that saves but can never fire looks
+ * identical to one that works until the day you notice nobody was emailed.
+ */
+export function validateAutomation(input: {
+  name?: string;
+  trigger_event?: string;
+  conditions?: AutomationCondition[];
+  actions?: AutomationAction[];
+}): string | null {
+  if (!input.name?.trim()) return "Give it a name so you can recognise it later.";
+  const trigger = triggerFor(input.trigger_event ?? "");
+  if (!trigger) return "Choose what starts this automation.";
+
+  const actions = input.actions ?? [];
+  if (actions.length === 0) return "Add at least one thing for it to do.";
+
+  const allowed = actionsForTrigger(trigger.event);
+  for (const a of actions) {
+    const def = allowed.find((d) => d.type === a.type);
+    if (!def) {
+      const known = ACTIONS.find((d) => d.type === a.type);
+      return known
+        ? `"${known.label}" can't run on ${trigger.label.toLowerCase()} — ${known.hint}`
+        : `Unknown action "${a.type}".`;
+    }
+    if (def.needs === "onboarding_form" && !a.form_id) {
+      return `Choose which form "${def.label}" should send.`;
+    }
+  }
+
+  for (const c of input.conditions ?? []) {
+    if (!c.field) return "Every condition needs a field.";
+    const opDef = CONDITION_OPS.find((o) => o.op === c.op);
+    if (!opDef) return `Unknown condition "${c.op}".`;
+    if (opDef.needsValue && !String(c.value ?? "").trim()) {
+      return `The "${opDef.label}" condition needs a value.`;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
**Phase 2.** Automations are now usable without touching SQL.

`/automations` shows an enable card when the plugin is off, otherwise the list and a **When → If → Then** builder. Sidebar entry gated on the plugin, same as the others.

## Five decisions worth checking

**The run history is on the card, not buried.** An automation that quietly stopped working is the failure mode that matters — nobody notices an email that *didn't* arrive. Each rule shows recent runs, their status, and why they ended, with a "N failed" badge when relevant.

**Changing the trigger drops actions that can't run on the new entity**, rather than leaving them to fail at run time. Sending an onboarding form needs a customer — portal links are minted against one, so a lead has no address to send to.

**Only forms with fields are offered.** An empty form fails when the runner tries to send it, so listing it would be a trap.

**Conditions use a short curated field list**, not every column. The runner compares against the raw row, so offering `updated_at` would let you build a condition that reads as nonsense.

**Validation runs in the browser and again in the action.** A rule that saves but can never fire looks identical to one that works, until the day you notice nobody was emailed.

## Structure

`lib/automations/schema.ts` is the single source for triggers, actions, operators and validation. The builder, the server actions and the runner all read it — so a trigger can't exist in one place and not another, which is how these things drift.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 224 tests ✅

**Not clicked through** — local dev needs a login I can't perform. Worth building the welcome-pack rule on the preview and adding a test client to watch it fire.

## Where this leaves the plan

- ✅ Phase 0 — session-free SMS
- ✅ Phase 1 — schema, plugin, emit, runner
- ✅ Phase 2 — the builder
- ⬜ **Phase 3** — waits (`run_at` is already in the table, so no migration), plus more triggers and actions: send SMS (now possible via `lib/sms.ts`), create task, update a field.

The trigger list is deliberately two entries. Adding more means making sure each event *actually fires* — `form.submitted` doesn't exist today, and `/api/f/[slug]/submit` bypasses `createLead()` so public form submissions don't even fire `lead.created`. That's the next thing to fix if you want form-driven automations.