### PR TITLE
feat(automations): lead triggers actually fire, and a text-them action

### DIFF
--- a/src/app/api/cron/automation-runs/route.ts
+++ b/src/app/api/cron/automation-runs/route.ts
@@ -15,6 +15,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireCron } from "@/lib/cron-auth";
 import { sendOnboardingFormFor } from "@/lib/onboarding/send";
+import { sendSmsFor, smsConfigured } from "@/lib/sms";
 
 export const maxDuration = 300;
 
@@ -54,9 +55,24 @@ function matches(entity: Record<string, unknown>, conditions: unknown): boolean 
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function runAction(sb: any, businessId: string, entityId: string, action: any): Promise<ActionResult> {
+async function runAction(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sb: any, businessId: string, entityId: string, action: any, entity: Record<string, any>,
+): Promise<ActionResult> {
   const type = String(action?.type ?? "unknown");
   try {
+    if (type === "send_sms") {
+      if (!smsConfigured()) return { type, ok: false, detail: "SMS isn't configured on the server" };
+      const to = String(entity.phone ?? "").trim();
+      // Not a failure worth retrying: they simply have no number.
+      if (!to) return { type, ok: true, detail: "Skipped — no phone number on record" };
+      const body = String(action.message ?? "").replace(/\{\{name\}\}/g, String(entity.name ?? "there"));
+      const res = await sendSmsFor(sb, businessId, {
+        to, body, customerName: String(entity.name ?? "Customer"),
+        customerId: entity.id && action.__entity === "customer" ? entity.id : null,
+      });
+      return { type, ok: true, detail: `Texted ${to} (${res.providerId})` };
+    }
     if (type === "send_onboarding_form") {
       if (!action.form_id) return { type, ok: false, detail: "No form chosen on this action" };
       const res = await sendOnboardingFormFor(sb, businessId, action.form_id, entityId, { email: true });
@@ -117,7 +133,8 @@ export async function GET(req: NextRequest) {
 
       const results: ActionResult[] = [];
       for (const action of (rule.actions ?? [])) {
-        results.push(await runAction(sb, run.business_id, run.entity_id, action));
+        results.push(await runAction(sb, run.business_id, run.entity_id,
+          { ...action, __entity: run.entity_type }, entity));
       }
 
       const anyFailed = results.some((r) => !r.ok);

--- a/src/app/api/f/[slug]/submit/route.ts
+++ b/src/app/api/f/[slug]/submit/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { processAnswersForStorage, missingRequiredFields, invalidAnswerFields } from "@/lib/onboarding/answers";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
@@ -97,6 +98,12 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
         } else {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           leadId = (created as any)?.id ?? null;
+        }
+        // This route calls upsert_lead directly rather than createLead(), so
+        // until now a public form submission fired NOTHING — the one use case
+        // automations were wanted for had no trigger signal at all.
+        if (leadId) {
+          await emitAutomationEvent(sb, form.business_id, "lead.created", "lead", leadId);
         }
       } catch (e) {
         console.error("[form-submit] lead creation threw:", e instanceof Error ? e.message : e);

--- a/src/components/automations/automations-client.tsx
+++ b/src/components/automations/automations-client.tsx
@@ -17,6 +17,7 @@ import {
 import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
@@ -257,6 +258,22 @@ function Builder({ draft, setDraft, forms, busy, onSave }: {
                   )}
                 </div>
               )}
+              {def?.needs === "message" && (
+                <div className="space-y-1.5">
+                  <Label>Message</Label>
+                  <Textarea
+                    rows={3}
+                    value={a.message ?? ""}
+                    placeholder="Hi {{name}}, thanks for getting in touch — we'll be in contact shortly."
+                    onChange={(e) => {
+                      const next = [...draft.actions]; next[i] = { ...a, message: e.target.value }; set({ actions: next });
+                    }}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {String(a.message ?? "").length} characters · one segment is 160
+                  </p>
+                </div>
+              )}
               {def && <p className="text-xs text-muted-foreground">{def.hint}</p>}
             </div>
           );
@@ -321,6 +338,7 @@ function AutomationCard({ automation, runs, forms, onEdit }: {
             {(automation.actions ?? []).map((a) => {
               const label = a.type === "send_onboarding_form"
                 ? `email ${forms.find((f) => f.id === a.form_id)?.name ?? "a form"}`
+                : a.type === "send_sms" ? "send a text"
                 : a.type;
               return label;
             }).join(", ") || "nothing yet"}

--- a/src/lib/actions/leads.ts
+++ b/src/lib/actions/leads.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { dispatchWebhook } from "@/lib/webhooks";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import { createCustomer } from "@/lib/actions/customers";
 import { createQuote } from "@/lib/actions/quotes";
 import { createWorkOrder } from "@/lib/actions/work-orders";
@@ -101,6 +102,9 @@ export async function createLead(payload: {
 
   revalidatePath("/leads");
   dispatchWebhook(businessId, "lead.created", data);
+  // Awaited, unlike the webhook above: a lost automation is a follow-up that
+  // never happens, with nothing to show it went missing.
+  await emitAutomationEvent(supabase, businessId, "lead.created", "lead", data.id);
   return data as Lead;
 }
 

--- a/src/lib/automations/schema.ts
+++ b/src/lib/automations/schema.ts
@@ -40,7 +40,7 @@ export interface ActionDef {
    *  portal links are minted against one, so a lead has no address to send to. */
   entities: Array<"customer" | "lead">;
   /** Config the action needs before it can be saved. */
-  needs?: "onboarding_form";
+  needs?: "onboarding_form" | "message";
   hint: string;
 }
 
@@ -51,6 +51,13 @@ export const ACTIONS: ActionDef[] = [
     entities: ["customer"],
     needs: "onboarding_form",
     hint: "Sends the form's portal link. Leads can't receive one — convert them first.",
+  },
+  {
+    type: "send_sms",
+    label: "Text them",
+    entities: ["customer", "lead"],
+    needs: "message",
+    hint: "Sent from your business name. {{name}} is replaced with theirs.",
   },
 ];
 
@@ -128,6 +135,13 @@ export function validateAutomation(input: {
     }
     if (def.needs === "onboarding_form" && !a.form_id) {
       return `Choose which form "${def.label}" should send.`;
+    }
+    if (def.needs === "message") {
+      const body = String(a.message ?? "").trim();
+      if (!body) return `Write the message for "${def.label}".`;
+      // One segment is 160 chars; longer is billed per segment. Warn at the
+      // point of writing rather than on the invoice.
+      if (body.length > 480) return "That text is over 3 message segments — shorten it or it gets expensive.";
     }
   }
 


### PR DESCRIPTION
**Phase 3a.**

## 1. `lead.created` now fires — from both paths

`createLead` dispatched a webhook but nothing for automations. Worse: **`/api/f/[slug]/submit` bypasses `createLead()` entirely** and calls `upsert_lead` directly, so a public form submission fired *nothing at all*.

That's the one flagged in the original design as "the headline use case has zero trigger signal". Both paths now emit, awaited.

So this works now:

> **When** a lead comes in → **text them** "Thanks for getting in touch, we'll call you shortly."

including from a form embedded on your site.

## 2. "Text them" as an action

Possible because of Phase 0 — `sendSmsFor` takes the business id, so a cron can send.

**Four decisions:**

- **No phone number → reported as skipped, not failed.** Retrying three times won't produce a number, and a red run for "this lead didn't leave a mobile" is noise that trains you to ignore the log.
- **`{{name}}` is substituted** from the record.
- **Live character count in the builder, and the validator refuses over three segments.** SMS is billed per 160 characters — the place to notice length is while writing, not on the invoice.
- **`customer_id` is only attached when the subject is actually a customer.** Otherwise the conversation row would claim a lead's phone belongs to a customer that doesn't exist.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 224 tests ✅

Not clicked through — local dev needs a login. Worth submitting your own public form on the preview and watching the run appear.

## Plan

- ✅ Phase 0 — session-free SMS
- ✅ Phase 1 — schema, plugin, emit, runner
- ✅ Phase 2 — builder + run history
- ✅ Phase 3a — lead triggers + SMS action
- ⬜ **Phase 3b** — waits (`run_at` is already there, no migration), create-task and update-field actions. Create-task needs the same session-free extraction SMS and onboarding-send both needed; that's the pattern now.