### PR TITLE
feat(automations): wait before running

### DIFF
--- a/src/components/automations/automations-client.tsx
+++ b/src/components/automations/automations-client.tsx
@@ -26,8 +26,8 @@ import {
 } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
-  TRIGGERS, CONDITION_OPS, CONDITION_FIELDS, actionsForTrigger, triggerFor,
-  validateAutomation, type AutomationCondition, type AutomationAction,
+  TRIGGERS, CONDITION_OPS, CONDITION_FIELDS, DELAY_CHOICES, actionsForTrigger, triggerFor,
+  delayLabel, validateAutomation, type AutomationCondition, type AutomationAction,
 } from "@/lib/automations/schema";
 import {
   saveAutomation, setAutomationEnabled, deleteAutomation,
@@ -47,6 +47,7 @@ const BLANK = {
   trigger_event: TRIGGERS[0].event,
   conditions: [] as AutomationCondition[],
   actions: [] as AutomationAction[],
+  delay_minutes: 0,
 };
 
 export function AutomationsClient({ automations, runs, forms }: Props) {
@@ -102,7 +103,7 @@ export function AutomationsClient({ automations, runs, forms }: Props) {
               forms={forms}
               onEdit={() => setDraft({
                 id: a.id, name: a.name, trigger_event: a.trigger_event,
-                conditions: a.conditions ?? [], actions: a.actions ?? [],
+                conditions: a.conditions ?? [], actions: a.actions ?? [], delay_minutes: a.delay_minutes ?? 0,
               })}
             />
           ))}
@@ -165,6 +166,22 @@ function Builder({ draft, setDraft, forms, busy, onSave }: {
           </SelectContent>
         </Select>
         {trigger && <p className="text-xs text-muted-foreground">{trigger.hint}</p>}
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Wait</p>
+        <Select value={String(draft.delay_minutes)} onValueChange={(v) => set({ delay_minutes: Number(v) })}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {DELAY_CHOICES.map((d) => (
+              <SelectItem key={d.minutes} value={String(d.minutes)}>{d.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Conditions are checked when it RUNS, not when it was triggered — so a lead that
+          converts during the wait can be filtered out by then.
+        </p>
       </section>
 
       <section className="space-y-2">
@@ -333,6 +350,7 @@ function AutomationCard({ automation, runs, forms, onEdit }: {
           </div>
           <p className="text-sm text-muted-foreground mt-0.5">
             When {(trigger?.label ?? automation.trigger_event).toLowerCase()}
+            {automation.delay_minutes > 0 ? `, ${delayLabel(automation.delay_minutes).toLowerCase()}` : ""}
             {automation.conditions?.length ? `, if ${automation.conditions.length} condition${automation.conditions.length > 1 ? "s" : ""} match` : ""}
             {" → "}
             {(automation.actions ?? []).map((a) => {

--- a/src/lib/actions/automations.ts
+++ b/src/lib/actions/automations.ts
@@ -27,6 +27,7 @@ export interface AutomationRow {
   trigger_event: string;
   conditions: AutomationCondition[];
   actions: AutomationAction[];
+  delay_minutes: number;
   last_run_at: string | null;
   run_count: number;
   created_at: string;
@@ -113,6 +114,7 @@ export async function saveAutomation(input: {
   trigger_event: string;
   conditions: AutomationCondition[];
   actions: AutomationAction[];
+  delay_minutes?: number;
   enabled?: boolean;
 }): Promise<SaveResult> {
   const supabase = await createClient();
@@ -129,6 +131,7 @@ export async function saveAutomation(input: {
     trigger_event: input.trigger_event,
     conditions: input.conditions ?? [],
     actions: input.actions ?? [],
+    delay_minutes: input.delay_minutes ?? 0,
     enabled: input.enabled ?? true,
   };
 

--- a/src/lib/automations/emit.ts
+++ b/src/lib/automations/emit.ts
@@ -59,17 +59,20 @@ export async function emitAutomationEvent(
     if (!settings?.enabled) return { queued: 0 };
 
     const { data: rules } = await tbl(sb, "automations")
-      .select("id").eq("business_id", businessId).eq("trigger_event", event).eq("enabled", true);
+      .select("id, delay_minutes").eq("business_id", businessId).eq("trigger_event", event).eq("enabled", true);
     if (!rules?.length) return { queued: 0 };
 
     // One row per rule. The unique index on (automation_id, entity_id, event)
     // makes a duplicate emit a no-op rather than a second email.
-    const rows = rules.map((r: { id: string }) => ({
+    // run_at carries the wait. The runner already filters on `run_at <= now()`,
+    // so a delayed rule needs nothing else.
+    const rows = rules.map((r: { id: string; delay_minutes?: number }) => ({
       business_id: businessId,
       automation_id: r.id,
       trigger_event: event,
       entity_type: entityType,
       entity_id: entityId,
+      run_at: new Date(Date.now() + (r.delay_minutes ?? 0) * 60_000).toISOString(),
     }));
     const { error } = await tbl(sb, "automation_runs")
       .upsert(rows, { onConflict: "automation_id,entity_id,trigger_event", ignoreDuplicates: true });

--- a/src/lib/automations/schema.ts
+++ b/src/lib/automations/schema.ts
@@ -111,12 +111,30 @@ export function actionsForTrigger(event: string): ActionDef[] {
  * matters more here than elsewhere: a rule that saves but can never fire looks
  * identical to one that works until the day you notice nobody was emailed.
  */
+/** Wait options, in minutes. Anything longer than 90 days isn't a follow-up. */
+export const DELAY_CHOICES: Array<{ minutes: number; label: string }> = [
+  { minutes: 0, label: "Straight away" },
+  { minutes: 60, label: "After 1 hour" },
+  { minutes: 60 * 24, label: "After 1 day" },
+  { minutes: 60 * 24 * 3, label: "After 3 days" },
+  { minutes: 60 * 24 * 7, label: "After 1 week" },
+  { minutes: 60 * 24 * 30, label: "After 30 days" },
+];
+
+export function delayLabel(minutes: number): string {
+  return DELAY_CHOICES.find((d) => d.minutes === minutes)?.label ?? `After ${minutes} minutes`;
+}
+
 export function validateAutomation(input: {
   name?: string;
   trigger_event?: string;
   conditions?: AutomationCondition[];
   actions?: AutomationAction[];
+  delay_minutes?: number;
 }): string | null {
+  const delay = input.delay_minutes ?? 0;
+  if (!Number.isInteger(delay) || delay < 0) return "The wait has to be zero or more minutes.";
+  if (delay > 129_600) return "That's more than 90 days — too long to be a follow-up.";
   if (!input.name?.trim()) return "Give it a name so you can recognise it later.";
   const trigger = triggerFor(input.trigger_event ?? "");
   if (!trigger) return "Choose what starts this automation.";

--- a/supabase/migrations/20260807190000_automation_delay.sql
+++ b/supabase/migrations/20260807190000_automation_delay.sql
@@ -1,0 +1,23 @@
+-- "Wait, then do it."
+--
+-- The run table already carried run_at, so the delay is the only thing
+-- missing: emit sets run_at = now() + delay, and the runner's existing
+-- `run_at <= now()` filter does the rest. No new machinery.
+--
+-- Rule-level rather than per-action: "wait 3 days then text them" is the shape
+-- people actually want. Per-action waits mean a run that sits half-finished,
+-- which needs a step pointer and a resume path — worth it only if someone
+-- genuinely needs a sequence.
+
+ALTER TABLE public.automations
+  ADD COLUMN IF NOT EXISTS delay_minutes INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE public.automations
+  DROP CONSTRAINT IF EXISTS automations_delay_check;
+-- Up to 90 days. Longer isn't a follow-up, it's a forgotten row.
+ALTER TABLE public.automations
+  ADD CONSTRAINT automations_delay_check
+  CHECK (delay_minutes >= 0 AND delay_minutes <= 129600);
+
+COMMENT ON COLUMN public.automations.delay_minutes IS
+  'Minutes to wait after the trigger before running. 0 = immediately.';


### PR DESCRIPTION
**Phase 3b.** *"When a lead comes in, wait 3 days, then text them."*

## Almost free, by design

The run table already carried `run_at`, so this is **one column and one line**: emit sets `run_at = now() + delay`, and the runner's existing `run_at <= now()` filter does the rest.

That's why `run_at` went in during Phase 1 despite having no use then — the alternative was a migration on a table with live rows.

## Three decisions

**Rule-level, not per-action.** "Wait 3 days then text them" is the shape people actually want. Per-action waits mean a run sitting half-finished, which needs a step pointer and a resume path — worth building only for genuine multi-step sequences.

**Conditions are evaluated when the run EXECUTES**, not when it was queued. So a lead that converts during the wait gets filtered out by then — which is the useful behaviour, and the builder says so rather than leaving you to discover it.

**Capped at 90 days**, in the CHECK constraint and the validator. Longer than that isn't a follow-up, it's a forgotten row.

Migration `20260807190000` applied and recorded.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 224 tests ✅

## The plan is now complete as scoped

- ✅ Phase 0 — session-free SMS
- ✅ Phase 1 — schema, plugin, emit, runner
- ✅ Phase 2 — builder + run history
- ✅ Phase 3a — lead triggers + SMS action
- ✅ Phase 3b — waits

What you can build today: two triggers (client added, lead in — including from a public form), an optional wait up to 90 days, conditions, and two actions (email an onboarding form, send a text).

**What's deliberately not there:** create-task and update-field actions, and more triggers. Create-task needs the same session-free extraction SMS and onboarding-send both needed — three for three, so it's a known pattern now. More triggers need their events to actually fire; the five subscribable-but-never-fired webhook events (`invoice.overdue`, `quote.accepted`, `quote.rejected`, `booking.confirmed`, `booking.no_show`) are the obvious candidates, and each needs wiring at its source first.