### PR TITLE
fix(automations): every lead source fires lead.created, not just some

### DIFF
--- a/src/app/api/audit/[slug]/submit/route.ts
+++ b/src/app/api/audit/[slug]/submit/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import { randomBytes } from "node:crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { rateLimit, clientIp } from "@/lib/booking/public";
@@ -59,6 +60,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
     p_source_ref: slug,
   }).single();
   if (lead?.id) await tbl(sb, "seo_audits").update({ lead_id: lead.id }).eq("id", audit.id);
+  // Another upsert_lead caller that bypasses createLead(): without this an
+  // audit request never triggers a lead automation.
+  if (lead?.id) await emitAutomationEvent(sb, business.id, "lead.created", "lead", lead.id);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/cron/email-leads/route.ts
+++ b/src/app/api/cron/email-leads/route.ts
@@ -10,6 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import Anthropic from "@anthropic-ai/sdk";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { fetchEmailsSince, type RawEmail, type ImapConfig } from "@/lib/email-reader";
@@ -327,6 +328,11 @@ async function processBusinessEmails(
       // Distinguish "new lead row" vs "merged into existing" so the digest is honest.
       // upsert_lead returns the row in both cases; we infer "merged" when sources
       // already contained 'email' from a prior run with the same Message-ID.
+      const upsertedId = (upserted as { id?: string } | null)?.id;
+      // The inbox scanner is a real lead source; it fired nothing before.
+      if (upsertedId) {
+        await emitAutomationEvent(sb, config.business_id, "lead.created", "lead", upsertedId);
+      }
       const refs = (upserted as { source_refs?: Array<{ ref?: string | null }> } | null)?.source_refs ?? [];
       const isMergeOfSameEmail = email.messageId
         ? refs.filter((r) => r.ref === email.messageId).length > 1

--- a/src/app/api/public/v1/biz/[slug]/bookings/route.ts
+++ b/src/app/api/public/v1/biz/[slug]/bookings/route.ts
@@ -10,6 +10,7 @@
  * manage_token for self-serve reschedule/cancel.
  */
 import { NextRequest } from "next/server";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import {
   resolveTenant, json, publicError, preflight, rateLimit, clientIp,
   honeypotTripped, verifyCaptcha,
@@ -149,6 +150,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
         p_source: "website", p_source_ref: "online-booking",
       }).single();
       leadId = (lead as { id?: string } | null)?.id ?? null;
+      // Same bypass — a booking that creates a lead should trigger the same
+      // automations as a lead from any other source.
+      if (leadId) await emitAutomationEvent(sb, businessId, "lead.created", "lead", leadId);
     }
     if (settings.create_work_order && ownerId) {
       const next = biz?.work_order_next_number ?? 1;

--- a/src/app/api/v1/leads/route.ts
+++ b/src/app/api/v1/leads/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { authenticateApiKey, requireScope } from "@/lib/api-auth";
 import { dispatchWebhook } from "@/lib/webhooks";
@@ -72,6 +73,11 @@ export async function POST(req: NextRequest) {
   }
 
   dispatchWebhook(ctx.businessId, "lead.created", data);
+  // Awaited, unlike the webhook above: leads posted by an external integration
+  // deserve the same automations as ones typed in by hand.
+  if (data) {
+    await emitAutomationEvent(sb, ctx.businessId, "lead.created", "lead", (data as { id: string }).id);
+  }
   return NextResponse.json({ ok: true, lead: data }, { status: 201 });
 }
 

--- a/src/lib/actions/prospects.ts
+++ b/src/lib/actions/prospects.ts
@@ -6,6 +6,7 @@
  * land in later PRs. Scopes: prospects:read / prospects:write.
  */
 import { revalidatePath } from "next/cache";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
@@ -197,6 +198,14 @@ export async function convertProspectToLead(id: string): Promise<{ lead_id: stri
   }).single();
   if (error) throw error;
   await tbl(supabase, "prospects").update({ status: "converted", lead_id: lead?.id ?? null }).eq("id", id).eq("business_id", businessId);
+
+  // This path calls upsert_lead directly rather than createLead(), so without
+  // this it fired nothing — the same gap the public form submit route had.
+  // A converted prospect IS a new lead as far as an automation is concerned.
+  if (lead?.id) {
+    await emitAutomationEvent(supabase, businessId, "lead.created", "lead", lead.id);
+  }
+
   revalidatePath("/prospects");
   revalidatePath(`/prospects/${id}`);
   return { lead_id: lead?.id ?? null };

--- a/src/lib/telephony/ingest.ts
+++ b/src/lib/telephony/ingest.ts
@@ -12,6 +12,7 @@
  * every write is explicitly scoped by business_id.
  */
 import { matchKey } from "./phone";
+import { emitAutomationEvent } from "@/lib/automations/emit";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SB = any;
@@ -251,6 +252,9 @@ export async function ingestCallEvent(
       }).single();
       const leadId = typeof lead === "string" ? lead : lead?.id;
       if (leadId) { patch.created_lead_id = leadId; out.created_lead = true; }
+      // A missed call that became a lead should trigger the same automations
+      // as any other lead — that's often the one you most want to chase.
+      if (leadId) await emitAutomationEvent(sb, businessId, "lead.created", "lead", leadId);
     } catch {
       // A lead we couldn't create must not cost us the call log itself.
     }


### PR DESCRIPTION
Started as one line for prospect conversion. Auditing the callers found five more.

## The problem

`upsert_lead` is the single ingest entry point, and **seven paths call it directly** rather than going through `createLead()`. So a *"when a lead comes in"* automation worked for leads typed in by hand and **silently did nothing** for every other source:

| Source | |
|---|---|
| Prospect conversion | fixed here |
| Public form submissions | fixed in #462 |
| SEO audit requests | fixed here |
| Public bookings | fixed here |
| `/api/v1/leads` — landing pages, integrations | fixed here |
| Inbox scanner cron | fixed here |
| Missed calls | fixed here |

That's the worst kind of half-working: the rule looks fine, fires *sometimes*, and the times it doesn't leave no trace at all. You'd conclude automations were unreliable rather than that a source was unwired.

The missed-call one is worth calling out — a missed call that becomes a lead is often the one you *most* want an automatic text on.

## Deliberately not covered

**The two MCP paths.** MCP is a parallel implementation against raw Supabase that doesn't fire `dispatchWebhook` either, and routing automations through it is explicitly ruled out in CLAUDE.md. So a lead created by the assistant doesn't trigger automations — that's the existing design, not an oversight. Worth revisiting if it bites.

`npx tsc --noEmit` ✅ · `npm run build` ✅ · 233 tests ✅ · every `upsert_lead` caller outside MCP now emits