### PR TITLE
feat(vault): store the passwords you hold for clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,15 @@ A remote **Model Context Protocol** server at **`/api/mcp`** (`mcp-handler` pack
 
 **Scopes** (`ApiScope` in `src/types/database.ts`): `leads/customers/quotes/invoices/work_orders/tasks/products/settings` × `read|write`, plus `email:send`, `agent:access`, and the `admin` wildcard. `expandApiScopes()` turns `admin` into the full set. The Settings → API UI and `createApiKey` validator both derive from `ALL_API_SCOPES`, so new scopes appear + validate automatically.
 
+**🔴 The one standing exception: `revealVaultSecret`.** The password vault
+(`src/lib/actions/vault.ts`) has MCP tools for listing and writing entries but
+deliberately **none for reading a password back**, and none should be added.
+Revealing a credential over MCP would put a client's password into a model
+context, a conversation transcript and an `assistant_messages` row — outside
+the encryption and the audit log that justify storing it. Reveal is a
+cookie-authed server action, owner/admin only, logged. See the header comment
+in `src/lib/mcp/tools/vault-tools.ts`.
+
 **🔴 STANDING RULE — every new feature MUST get an MCP tool.** When you add a server action / capability (new entity, new mutation, new workflow), you also add the matching tool(s) to `src/lib/mcp/register-tools.ts` in the same PR: pick/extend a scope, write the zod schema, scope-check, run via the admin client scoped by `business_id`. The MCP surface is expected to stay at parity with the app's capabilities — treat "added a feature but not its MCP tool" as an incomplete change.
 
 Middleware whitelists `/api/mcp`, `/api/oauth/`, and `/.well-known/` (they own their auth).

--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -15,6 +15,53 @@ import {
 } from "@/lib/actions/onboarding";
 import { getClientFieldConfig } from "@/lib/actions/client-fields";
 import { CustomerDetailClient, type CustomerOnboardingData } from "@/components/customers/customer-detail-client";
+import { listVaultItems, vaultReady } from "@/lib/actions/vault";
+import type { VaultItemView } from "@/lib/vault/items";
+
+/**
+ * Vault tab data — this client's stored logins.
+ *
+ * Returns null (no tab at all) when the plugin is off OR the viewer isn't an
+ * owner/admin: listVaultItems returns [] for anyone else, but an empty tab
+ * would advertise that credentials exist and just aren't theirs to see.
+ * Deliberately gated on the same flag the sidebar uses, so turning the plugin
+ * off removes it from the client profile too.
+ */
+async function loadVault(customerId: string): Promise<{ items: VaultItemView[]; ready: boolean } | null> {
+  try {
+    const { createClient } = await import("@/lib/supabase/server");
+    const { getActiveBizId } = await import("@/lib/active-business");
+    const { getUser } = await import("@/lib/auth");
+    const supabase = await createClient();
+    const user = await getUser();
+    const businessId = await getActiveBizId(supabase, user.id);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sb = supabase as any;
+    const [{ data: settings }, { data: install }] = await Promise.all([
+      sb.from("vault_settings").select("enabled").eq("business_id", businessId).maybeSingle(),
+      sb.from("business_agent_installs").select("enabled")
+        .eq("business_id", businessId).eq("agent_id", "vault").maybeSingle(),
+    ]);
+    // settingsTable ?? installRow ?? default(false) — the resolver's own order.
+    const enabled = settings?.enabled ?? install?.enabled ?? false;
+    if (!enabled) return null;
+
+    // RLS already blocks non-admins; this makes the TAB disappear for them
+    // rather than showing an empty one.
+    const { data: biz } = await sb.from("businesses").select("user_id").eq("id", businessId).single();
+    if (biz?.user_id !== user.id) {
+      const { data: m } = await sb.from("business_members").select("role")
+        .eq("business_id", businessId).eq("user_id", user.id).eq("status", "active").maybeSingle();
+      if (m?.role !== "admin") return null;
+    }
+
+    const [items, ready] = await Promise.all([listVaultItems(customerId), vaultReady()]);
+    return { items, ready };
+  } catch {
+    return null;
+  }
+}
 
 /** Onboarding tab data — only when the plugin is enabled; never break the page. */
 async function loadOnboarding(customerId: string): Promise<CustomerOnboardingData | null> {
@@ -63,7 +110,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
 
 async function CustomerDetailContent({ id }: { id: string }) {
   try {
-    const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles, onboarding, fieldConfig] = await Promise.all([
+    const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles, onboarding, fieldConfig, vault] = await Promise.all([
       getCustomer(id),
       getInvoices({ customer_id: id }),
       getQuotes({ customer_id: id }),
@@ -76,6 +123,7 @@ async function CustomerDetailContent({ id }: { id: string }) {
       getBillingProfilesForAccount(id).catch(() => []),
       loadOnboarding(id),
       getClientFieldConfig().catch(() => null),
+      loadVault(id),
     ]);
     return (
       <CustomerDetailClient
@@ -91,6 +139,7 @@ async function CustomerDetailContent({ id }: { id: string }) {
         currency={business.currency}
         businessCountry={business.country ?? null}
         onboarding={onboarding}
+        vault={vault}
         clientFields={fieldConfig?.fields ?? []}
         accountTypes={fieldConfig?.accountTypes ?? []}
         cardProviders={{

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -6,6 +6,7 @@ import { DashboardShell } from "@/components/layout/dashboard-shell";
 import { isWorker, isPathAllowedForWorker, type Role } from "@/lib/permissions";
 import { resolveEnabledPlugins, ROUTE_GATES } from "@/lib/plugins/registry";
 import { PRESETS_BY_ID } from "@/lib/plugins/presets";
+import type { NavConfig } from "@/lib/nav/config";
 import { getLayoutBusinesses, fetchLayoutBusinessesDirect, getPluginFlags } from "@/lib/layout-data";
 import type { Business } from "@/types/database";
 
@@ -86,11 +87,17 @@ export default async function DashboardLayout({ children }: { children: React.Re
     if (gate && !plugins[gate.pluginId]) redirect("/dashboard");
   }
 
-  // Vocabulary v1 — sidebar label overrides from the business's industry preset.
-  const vocab = business.industry_preset ? PRESETS_BY_ID[business.industry_preset]?.vocab ?? null : null;
+  // The business's words, resolved ONCE here so the sidebar and the pages
+  // can't disagree: their own overrides win, then the industry preset, then
+  // the built-in labels (supplied by whatever renders them).
+  const presetVocab = business.industry_preset ? PRESETS_BY_ID[business.industry_preset]?.vocab ?? null : null;
+  const navConfig = (business.nav_config ?? null) as NavConfig | null;
+  const vocab = presetVocab || navConfig?.labels
+    ? { ...(presetVocab ?? {}), ...(navConfig?.labels ?? {}) }
+    : null;
 
   return (
-    <DashboardShell business={business} businesses={allBusinesses} user={user} userRole={userRole} features={plugins} vocab={vocab}>
+    <DashboardShell business={business} businesses={allBusinesses} user={user} userRole={userRole} features={plugins} vocab={vocab} navConfig={navConfig}>
       {children}
     </DashboardShell>
   );

--- a/src/app/(dashboard)/settings/navigation/page.tsx
+++ b/src/app/(dashboard)/settings/navigation/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { getNavConfig } from "@/lib/actions/navigation";
+import { resolveEnabledPlugins } from "@/lib/plugins/registry";
+import { getPluginFlags } from "@/lib/layout-data";
+import { PRESETS_BY_ID } from "@/lib/plugins/presets";
+import { navSections, filterNav } from "@/components/layout/nav-config";
+import { NavigationSettings, type NavRow } from "@/components/settings/navigation-settings";
+
+export default async function NavigationSettingsPage() {
+  const supabase = await createClient();
+  const user = await getUser().catch(() => null);
+  if (!user) redirect("/auth/login");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: biz } = await (supabase as any)
+    .from("businesses").select("industry_preset").eq("id", businessId).maybeSingle();
+
+  const flags = await getPluginFlags(businessId);
+  const plugins = resolveEnabledPlugins(flags.installRows, {
+    quoting_agent_settings: flags.quoting,
+    onboarding_settings: flags.onboarding,
+    form_builder_settings: flags.formBuilder,
+  });
+
+  // Only offer what this business actually has: listing a disabled plugin's
+  // page here would invite renaming something that isn't in their sidebar.
+  // `nav` is omitted on purpose so hidden items still appear — otherwise
+  // hiding one would remove the only control that could bring it back.
+  const rows: NavRow[] = filterNav(navSections, { workerView: false, features: plugins })
+    .flatMap((s) => s.items.map((i) => ({ href: i.href, fallback: i.label, section: s.section })));
+
+  const preset = biz?.industry_preset ? PRESETS_BY_ID[biz.industry_preset] : null;
+
+  return (
+    <NavigationSettings
+      rows={rows}
+      config={await getNavConfig()}
+      presetVocab={preset?.vocab ?? null}
+      presetName={preset?.label ?? null}
+    />
+  );
+}

--- a/src/app/(dashboard)/vault/page.tsx
+++ b/src/app/(dashboard)/vault/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { listVaultItems, getVaultLog, vaultReady } from "@/lib/actions/vault";
+import { VaultClient } from "@/components/vault/vault-client";
+
+export default async function VaultPage() {
+  const supabase = await createClient();
+  const user = await getUser().catch(() => null);
+  if (!user) redirect("/auth/login");
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any;
+  const [items, log, ready, { data: customers }] = await Promise.all([
+    listVaultItems(),
+    getVaultLog(),
+    vaultReady(),
+    sb.from("customers").select("id, name").eq("business_id", businessId).order("name").limit(1000),
+  ]);
+
+  return (
+    <VaultClient
+      items={items}
+      customers={(customers ?? []) as { id: string; name: string }[]}
+      log={log}
+      ready={ready}
+    />
+  );
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -60,6 +60,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   "clipboard-list": ClipboardList,
   "list-checks": ListChecks,
   "layout-dashboard": LayoutDashboard,
+  lock: Lock,
   users: Users,
   columns: Columns3,
   "users-2": Users2,

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -8,6 +8,7 @@ import {
   FileCheck, Wrench, ClipboardList, StickyNote, User, Users, Home,
   Trash2, Star, Save, X, ChevronDown, ChevronUp, ImageIcon, MessageSquare,
   CreditCard, DollarSign, Paperclip, ListChecks,
+  Lock,
 } from "@/components/ui/icons";
 import { AttachmentsPanel } from "@/components/attachments/attachments-panel";
 import { ClientFieldsSummary } from "@/components/customers/client-fields";
@@ -46,6 +47,8 @@ import {
   type BillingProfilePayload,
 } from "@/lib/actions/billing-profiles";
 import { CustomerOnboardingCard } from "@/components/onboarding/customer-onboarding-card";
+import { VaultClient } from "@/components/vault/vault-client";
+import type { VaultItemView } from "@/lib/vault/items";
 import type { OnboardingRequestRow } from "@/lib/actions/onboarding";
 import type {
   Customer, InvoiceWithCustomer, QuoteWithCustomer,
@@ -86,6 +89,9 @@ interface Props {
   accountTypes?: AccountTypeOption[];
   /** Connected card providers, so the payment toggle names the real one. */
   cardProviders?: { stripeEnabled: boolean; revolutEnabled: boolean };
+  /** Vault entries for THIS client; null when the plugin is off or the
+   *  viewer isn't an owner/admin — the tab then doesn't exist at all. */
+  vault?: { items: VaultItemView[]; ready: boolean } | null;
 }
 
 // ── Property Modal ─────────────────────────────────────────────────────────────
@@ -516,6 +522,7 @@ export function CustomerDetailClient({
   clientFields = [],
   accountTypes = [],
   cardProviders,
+  vault,
 }: Props) {
   const [customer, setCustomer] = useState(initial);
   const [editing, setEditing] = useState(false);
@@ -754,7 +761,26 @@ export function CustomerDetailClient({
                     <ClipboardList className="w-3.5 h-3.5" />Onboarding ({onboarding.requests.length})
                   </TabsTrigger>
                 )}
+                {vault && (
+                  <TabsTrigger value="passwords" className="gap-1.5">
+                    <Lock className="w-3.5 h-3.5" />Passwords ({vault.items.length})
+                  </TabsTrigger>
+                )}
               </TabsList>
+
+              {/* ── Passwords ── */}
+              {vault && (
+                <TabsContent value="passwords" className="mt-3">
+                  <VaultClient
+                    items={vault.items}
+                    customers={[]}
+                    log={[]}
+                    ready={vault.ready}
+                    lockedCustomerId={customer.id}
+                    embedded
+                  />
+                </TabsContent>
+              )}
 
               {/* ── Onboarding ── */}
               {onboarding && (

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -11,6 +11,7 @@ import { canManageSettings, isWorker, ROLE_LABELS } from "@/lib/permissions";
 import { KireiMark } from "@/components/brand/kirei-logo";
 import { BusinessSwitcher } from "@/components/business/business-switcher";
 import { navSections, filterNav } from "./nav-config";
+import type { NavConfig } from "@/lib/nav/config";
 
 interface AppSidebarProps {
   business: Business;
@@ -20,14 +21,16 @@ interface AppSidebarProps {
   features?: Record<string, boolean>;
   /** Label overrides keyed by href (industry-preset vocabulary, e.g. Work Orders → Projects). */
   vocab?: Record<string, string> | null;
+  /** The business's hide/reorder choices from Settings → Navigation. */
+  navConfig?: NavConfig | null;
   open: boolean;
   onClose: () => void;
 }
 
-export function AppSidebar({ business, businesses, userRole, features, vocab, open, onClose }: AppSidebarProps) {
+export function AppSidebar({ business, businesses, userRole, features, vocab, navConfig, open, onClose }: AppSidebarProps) {
   const pathname = usePathname();
   const workerView = isWorker(userRole);
-  const visibleSections = filterNav(navSections, { workerView, features });
+  const visibleSections = filterNav(navSections, { workerView, features, nav: navConfig });
 
   const isActive = (href: string) =>
     href === "/dashboard" ? pathname === "/dashboard" : pathname.startsWith(href);

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -11,6 +11,8 @@ import { RouteProgress } from "./route-progress";
 import { TabBusinessGuard } from "./tab-business-guard";
 import { FocusModeProvider, useFocusMode } from "./focus-mode";
 import { AssistantProvider } from "./assistant-context";
+import { VocabProvider } from "./vocab-provider";
+import type { NavConfig } from "@/lib/nav/config";
 // The floating AI assistant starts closed and drags in framer-motion + voice
 // capture. Lazy-load it (client-only) so its chunk stays out of every dashboard
 // page's first load — the trigger button appears a beat after hydration.
@@ -31,8 +33,10 @@ interface DashboardShellProps {
   /** Feature flags fetched on the server. Drives conditional sidebar items
    *  (e.g. the Quoting Agent tab only shows when enabled). */
   features?: Record<string, boolean>;
-  /** Sidebar label overrides keyed by href (industry-preset vocabulary). */
+  /** Resolved label overrides keyed by href (business override over preset). */
   vocab?: Record<string, string> | null;
+  /** The business's hide/reorder choices, for the sidebar. */
+  navConfig?: NavConfig | null;
   children: React.ReactNode;
 }
 
@@ -52,13 +56,13 @@ export function DashboardShell(props: DashboardShellProps) {
   );
 }
 
-function ShellBody({ business, businesses, user, userRole, features, vocab, children }: DashboardShellProps) {
+function ShellBody({ business, businesses, user, userRole, features, vocab, navConfig, children }: DashboardShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { focus } = useFocusMode();
   const workerView = isWorker(userRole);
 
   return (
-    <>
+    <VocabProvider labels={vocab ?? null}>
       <Suspense fallback={null}><RouteProgress /></Suspense>
       {/* MYOB chrome: a full-width accent top bar spans over the sidebar
           column, then a row of sidebar + content beneath it. */}
@@ -83,6 +87,7 @@ function ShellBody({ business, businesses, user, userRole, features, vocab, chil
               userRole={userRole}
               features={features}
               vocab={vocab}
+              navConfig={navConfig}
               open={sidebarOpen}
               onClose={() => setSidebarOpen(false)}
             />
@@ -113,6 +118,6 @@ function ShellBody({ business, businesses, user, userRole, features, vocab, chil
       </div>
 
       <AgentPanel />
-    </>
+    </VocabProvider>
   );
 }

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -1,5 +1,5 @@
 import {
-  Zap,
+  Zap, Lock,
   LayoutDashboard, FileText, FileCheck, Users,
   Package, FileStack, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target, Megaphone, DollarSign, Send, Phone,
 } from "@/components/ui/icons";
@@ -48,6 +48,7 @@ export const navSections: NavSection[] = [
     { label: "Outreach",   href: "/outreach",   icon: Send,          plugin: "outreach" },
     { label: "Customers",  href: "/customers",  icon: Users                         },
     { label: "Contacts",   href: "/contacts",   icon: Users2                        },
+    { label: "Passwords",  href: "/vault",      icon: Lock,          plugin: "vault" },
     { label: "Onboarding", href: "/onboarding-forms", icon: ClipboardList, plugin: "client-onboarding" },
   ]},
   { section: "Catalog", items: [

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -3,6 +3,7 @@ import {
   LayoutDashboard, FileText, FileCheck, Users,
   Package, FileStack, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target, Megaphone, DollarSign, Send, Phone,
 } from "@/components/ui/icons";
+import { applyOrder, isHidden, type NavConfig } from "@/lib/nav/config";
 
 export type NavItem = {
   label: string;
@@ -77,16 +78,30 @@ export const navSections: NavSection[] = [
 /** Filter nav sections by worker role + enabled plugins, dropping empty sections. */
 export function filterNav(
   sections: NavSection[],
-  opts: { workerView: boolean; features?: Record<string, boolean> },
+  opts: {
+    workerView: boolean;
+    features?: Record<string, boolean>;
+    /** The business's own hide/reorder choices. Ordering is within a section:
+     *  sections keep their built-in order so an item can't be reordered out of
+     *  the group that explains what it is. */
+    nav?: NavConfig | null;
+  },
 ): NavSection[] {
   return sections
     .map((s) => ({
       ...s,
-      items: s.items.filter((i) => {
-        if (opts.workerView && !i.worker) return false;
-        if (i.plugin && !opts.features?.[i.plugin]) return false;
-        return true;
-      }),
+      items: applyOrder(
+        s.items.filter((i) => {
+          if (opts.workerView && !i.worker) return false;
+          if (i.plugin && !opts.features?.[i.plugin]) return false;
+          // A worker's nav is not the owner's to prune — hiding is a
+          // preference, and a worker hidden out of their own jobs list has no
+          // way to get it back.
+          if (!opts.workerView && isHidden(i.href, opts.nav)) return false;
+          return true;
+        }),
+        opts.nav,
+      ),
     }))
     .filter((s) => s.items.length > 0);
 }

--- a/src/components/layout/vocab-provider.tsx
+++ b/src/components/layout/vocab-provider.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * The business's words, available to any page — not just the sidebar.
+ *
+ * This is the fix for a real mismatch: the agency preset renamed Work Orders
+ * to "Projects" in the nav, and the page it opened still said "Work Orders"
+ * everywhere. The nav and the page now read the same resolved map.
+ *
+ * Resolution (business override → preset → built-in) happens on the server,
+ * in the layout. The client is handed the answer, so a page can't resolve it
+ * differently from the sidebar.
+ */
+
+import { createContext, useContext } from "react";
+import { singularise, type Vocab } from "@/lib/nav/config";
+
+const VocabContext = createContext<Record<string, string> | null>(null);
+
+export function VocabProvider({
+  labels, children,
+}: { labels: Record<string, string> | null; children: React.ReactNode }) {
+  return <VocabContext.Provider value={labels}>{children}</VocabContext.Provider>;
+}
+
+/**
+ * What this business calls the thing at `href`.
+ *
+ * `fallbackPlural` is the built-in name, so a page that hasn't been given a
+ * label still reads correctly — nothing renders blank or "undefined".
+ */
+export function useVocab(href: string, fallbackPlural: string): Vocab {
+  const labels = useContext(VocabContext);
+  const plural = labels?.[href] ?? fallbackPlural;
+  return { plural, singular: singularise(plural) };
+}
+
+/** Lowercased, for mid-sentence use ("no projects yet"). */
+export function lower(word: string): string {
+  // Only lowercase a word that looks like ordinary title-case. An acronym or
+  // a deliberately-capitalised brand name ("SEO Tasks") should stay as typed.
+  return /^[A-Z][a-z]+(\s[A-Za-z][a-z]+)*$/.test(word) ? word.toLowerCase() : word;
+}

--- a/src/components/settings/navigation-settings.tsx
+++ b/src/components/settings/navigation-settings.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * Settings → Navigation. Rename, reorder and hide sidebar items.
+ *
+ * Reordering is within a section, deliberately: the sections are what explain
+ * what an item is, and letting "Invoices" slide up into Workspace would make
+ * the grouping meaningless. Renaming is unrestricted.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Reorder } from "framer-motion";
+import { toast } from "sonner";
+import { Eye, EyeOff, GripVertical, Loader2, RotateCcw } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/layout/page-header";
+import { saveNavConfig } from "@/lib/actions/navigation";
+import { labelFor, type NavConfig } from "@/lib/nav/config";
+
+export interface NavRow {
+  href: string;
+  /** The built-in name — what it's called with no preset and no override. */
+  fallback: string;
+  section: string;
+}
+
+export function NavigationSettings({
+  rows, config, presetVocab, presetName,
+}: {
+  rows: NavRow[];
+  config: NavConfig | null;
+  presetVocab: Record<string, string> | null;
+  presetName: string | null;
+}) {
+  const router = useRouter();
+  const [labels, setLabels] = useState<Record<string, string>>(config?.labels ?? {});
+  const [hidden, setHidden] = useState<string[]>(config?.hidden ?? []);
+  const [order, setOrder] = useState<string[]>(
+    // Seed from the rows as displayed, so dragging one item doesn't reshuffle
+    // everything else relative to it.
+    config?.order?.length ? config.order : rows.map((r) => r.href),
+  );
+  const [busy, setBusy] = useState(false);
+
+  const sections = Array.from(new Set(rows.map((r) => r.section)));
+  const rank = new Map(order.map((h, i) => [h, i]));
+  const inSection = (s: string) =>
+    rows.filter((r) => r.section === s)
+      .sort((a, b) => (rank.get(a.href) ?? 1e9) - (rank.get(b.href) ?? 1e9));
+
+  /** What it's called right now — override, else preset, else built-in. */
+  const current = (r: NavRow) => labelFor(r.href, r.fallback, { labels }, presetVocab);
+
+  const save = async (next?: Partial<NavConfig>) => {
+    setBusy(true);
+    try {
+      const res = await saveNavConfig({ labels, hidden, order, ...next });
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success("Navigation updated");
+      router.refresh();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Failed"); }
+    finally { setBusy(false); }
+  };
+
+  const resetAll = async () => {
+    setLabels({}); setHidden([]); setOrder(rows.map((r) => r.href));
+    await save({ labels: {}, hidden: [], order: [] });
+  };
+
+  /** Reorder within one section, then splice it back into the global order. */
+  const reorderSection = (section: string, hrefs: string[]) => {
+    const others = order.filter((h) => !hrefs.includes(h));
+    const anchor = order.findIndex((h) => hrefs.includes(h));
+    const at = anchor === -1 ? others.length : anchor;
+    setOrder([...others.slice(0, at), ...hrefs, ...others.slice(at)]);
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Navigation"
+        subtitle="Rename, reorder and hide the items in your sidebar."
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={resetAll} disabled={busy}>
+              <RotateCcw className="mr-1.5 h-3.5 w-3.5" /> Reset
+            </Button>
+            <Button size="sm" onClick={() => save()} disabled={busy}>
+              {busy && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />} Save
+            </Button>
+          </div>
+        }
+      />
+
+      {presetName && (
+        <p className="text-sm text-muted-foreground">
+          Names you don&rsquo;t set follow the <strong>{presetName}</strong> preset —
+          so if the preset improves, yours does too. Anything you type here wins over it.
+        </p>
+      )}
+
+      {sections.map((section) => {
+        const items = inSection(section);
+        return (
+          <Card key={section}>
+            <CardContent className="space-y-1 p-4">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {section}
+              </p>
+              <Reorder.Group
+                axis="y"
+                values={items.map((i) => i.href)}
+                onReorder={(hrefs) => reorderSection(section, hrefs as string[])}
+                className="space-y-1"
+              >
+                {items.map((row) => {
+                  const isHidden = hidden.includes(row.href);
+                  return (
+                    <Reorder.Item
+                      key={row.href}
+                      value={row.href}
+                      className="flex items-center gap-2 rounded-md border border-transparent bg-card px-1 py-1 hover:border-border"
+                    >
+                      <GripVertical className="h-4 w-4 shrink-0 cursor-grab text-muted-foreground" />
+                      <Input
+                        value={current(row)}
+                        disabled={busy}
+                        aria-label={`Name for ${row.fallback}`}
+                        onChange={(e) => setLabels({ ...labels, [row.href]: e.target.value })}
+                        className={isHidden ? "opacity-50" : ""}
+                      />
+                      <span className="hidden w-40 shrink-0 truncate text-xs text-muted-foreground sm:block">
+                        {row.href}
+                      </span>
+                      <Button
+                        type="button" variant="ghost" size="sm" disabled={busy}
+                        aria-label={isHidden ? `Show ${row.fallback}` : `Hide ${row.fallback}`}
+                        onClick={() => setHidden(
+                          isHidden ? hidden.filter((h) => h !== row.href) : [...hidden, row.href],
+                        )}
+                      >
+                        {isHidden ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </Button>
+                    </Reorder.Item>
+                  );
+                })}
+              </Reorder.Group>
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      {/* Hiding is not disabling. Say so, or someone will hide Invoices
+          expecting it to stop invoicing. */}
+      <p className="text-xs text-muted-foreground">
+        Hiding an item only removes it from the sidebar — the pages still work and
+        anyone with the link can reach them. To turn a feature off entirely, use
+        the Plugins store. Workers always keep their own navigation.
+      </p>
+    </div>
+  );
+}

--- a/src/components/settings/settings-client.tsx
+++ b/src/components/settings/settings-client.tsx
@@ -270,6 +270,22 @@ export function SettingsClient({ business: initial, apiKeys, emailConfig, webhoo
         <TabsContent value="business" className="space-y-4 mt-6">
           <Card>
             <CardHeader>
+              <CardTitle className="text-base">Navigation</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between gap-4">
+              <p className="text-sm text-muted-foreground">
+                Rename, reorder and hide the items in your sidebar. Names you don&rsquo;t set follow
+                your industry&rsquo;s preset — an agency sees Projects and Proposals where a trades
+                business sees Work Orders and Quotes.
+              </p>
+              <Button asChild variant="outline" className="shrink-0">
+                <a href="/settings/navigation">Edit navigation</a>
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
               <CardTitle className="text-base">Client fields</CardTitle>
             </CardHeader>
             <CardContent className="flex items-center justify-between gap-4">

--- a/src/components/vault/vault-client.tsx
+++ b/src/components/vault/vault-client.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+/**
+ * The password vault.
+ *
+ * The reveal interaction is the whole design. A password is shown only when
+ * asked for, is fetched fresh from the server each time (nothing secret sits
+ * in component state waiting to be found), and auto-hides after 30 seconds so
+ * a walked-away-from screen doesn't leave a client's login on display.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  Lock, Plus, Search, Eye, EyeOff, Copy, Trash2, Loader2, ExternalLink,
+  Pencil, ClipboardList, RefreshCw,
+} from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { PageHeader } from "@/components/layout/page-header";
+import { useConfirm } from "@/components/ui/confirm";
+import {
+  saveVaultItem, revealVaultSecret, deleteVaultItem, type VaultLogEntry,
+} from "@/lib/actions/vault";
+import {
+  VAULT_CATEGORIES, categoryLabel, generatePassword, passwordStrength,
+  normaliseUrl, type VaultItemView,
+} from "@/lib/vault/items";
+
+/** How long a revealed password stays on screen. */
+const HIDE_AFTER_MS = 30_000;
+
+interface Props {
+  items: VaultItemView[];
+  customers: { id: string; name: string }[];
+  log: VaultLogEntry[];
+  /** False when APP_ENCRYPTION_KEY isn't set — nothing can be stored. */
+  ready: boolean;
+  /** Fixed client on a customer profile; hides the client picker. */
+  lockedCustomerId?: string;
+  /** Compact mode for the customer profile tab. */
+  embedded?: boolean;
+}
+
+export function VaultClient({ items, customers, log, ready, lockedCustomerId, embedded }: Props) {
+  const router = useRouter();
+  const confirm = useConfirm();
+  const [query, setQuery] = useState("");
+  const [editing, setEditing] = useState<VaultItemView | "new" | null>(null);
+  const [showLog, setShowLog] = useState(false);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((i) =>
+      i.title.toLowerCase().includes(q)
+      || (i.username ?? "").toLowerCase().includes(q)
+      || (i.customer_name ?? "").toLowerCase().includes(q));
+  }, [items, query]);
+
+  const remove = async (item: VaultItemView) => {
+    if (!(await confirm({
+      title: `Delete “${item.title}”?`,
+      body: "The password is gone for good — there's no undo and no copy anywhere else.",
+    }))) return;
+    const res = await deleteVaultItem(item.id);
+    if (!res.ok) { toast.error(res.error); return; }
+    toast.success("Deleted");
+    router.refresh();
+  };
+
+  return (
+    <div className="space-y-4">
+      {!embedded && (
+        <PageHeader
+          title="Passwords"
+          subtitle="Account logins you hold for clients. Encrypted, owner and admin only, every reveal logged."
+          actions={
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={() => setShowLog(true)}>
+                <ClipboardList className="mr-1.5 h-3.5 w-3.5" /> Access log
+              </Button>
+              <Button size="sm" onClick={() => setEditing("new")} disabled={!ready}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" /> Add password
+              </Button>
+            </div>
+          }
+        />
+      )}
+
+      {/* Nothing can be stored without a key. Say it once, plainly, instead of
+          letting every save fail with a server error. */}
+      {!ready && (
+        <Card className="border-destructive/40 bg-destructive/5">
+          <CardContent className="p-4 text-sm">
+            <p className="font-medium text-destructive">The vault can&rsquo;t store anything yet</p>
+            <p className="mt-1 text-muted-foreground">
+              It needs <code className="font-mono text-xs">APP_ENCRYPTION_KEY</code> (64 hex characters)
+              set on the server. Until then nothing is saved — deliberately, rather than
+              falling back to storing passwords in plain text.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {embedded && (
+        <div className="flex justify-end">
+          <Button size="sm" variant="outline" onClick={() => setEditing("new")} disabled={!ready}>
+            <Plus className="mr-1.5 h-3.5 w-3.5" /> Add password
+          </Button>
+        </div>
+      )}
+
+      {items.length > 4 && (
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query} onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name, username or client…" className="pl-9"
+          />
+        </div>
+      )}
+
+      {filtered.length === 0 ? (
+        <Card><CardContent className="py-10 text-center text-sm text-muted-foreground">
+          <Lock className="mx-auto mb-2 h-7 w-7 opacity-40" />
+          {items.length === 0
+            ? "No passwords stored yet."
+            : "Nothing matches that search."}
+        </CardContent></Card>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((item) => (
+            <VaultRow
+              key={item.id} item={item} showClient={!lockedCustomerId}
+              onEdit={() => setEditing(item)} onDelete={() => remove(item)}
+            />
+          ))}
+        </div>
+      )}
+
+      {editing && (
+        <VaultItemDialog
+          item={editing === "new" ? null : editing}
+          customers={customers}
+          lockedCustomerId={lockedCustomerId}
+          onClose={() => setEditing(null)}
+          onSaved={() => { setEditing(null); router.refresh(); }}
+        />
+      )}
+
+      {showLog && <AccessLogDialog log={log} onClose={() => setShowLog(false)} />}
+    </div>
+  );
+}
+
+function VaultRow({
+  item, showClient, onEdit, onDelete,
+}: { item: VaultItemView; showClient: boolean; onEdit: () => void; onDelete: () => void }) {
+  const [secret, setSecret] = useState<{ password: string | null; notes: string | null } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Auto-hide. Without this a revealed password stays up until navigation —
+  // on a shared or unattended screen that's the whole exposure.
+  useEffect(() => {
+    if (!secret) return;
+    const t = setTimeout(() => setSecret(null), HIDE_AFTER_MS);
+    return () => clearTimeout(t);
+  }, [secret]);
+
+  const reveal = async () => {
+    if (secret) { setSecret(null); return; }
+    setBusy(true);
+    try {
+      // Always fetched fresh — the plaintext is never cached in this component
+      // between reveals, so hiding it actually discards it.
+      const res = await revealVaultSecret(item.id);
+      if (!res.ok) { toast.error(res.error); return; }
+      setSecret(res.data);
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Failed"); }
+    finally { setBusy(false); }
+  };
+
+  const copy = async () => {
+    setBusy(true);
+    try {
+      const res = await revealVaultSecret(item.id);
+      if (!res.ok) { toast.error(res.error); return; }
+      if (!res.data.password) { toast.error("No password stored on this entry"); return; }
+      await navigator.clipboard.writeText(res.data.password);
+      toast.success("Password copied — it stays on your clipboard until you copy something else");
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Failed"); }
+    finally { setBusy(false); }
+  };
+
+  const href = normaliseUrl(item.url);
+
+  return (
+    <Card>
+      <CardContent className="p-3 sm:p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="font-medium break-words">{item.title}</p>
+              <Badge variant="secondary" className="text-xs">{categoryLabel(item.category)}</Badge>
+              {showClient && item.customer_name && (
+                <Badge variant="outline" className="text-xs">{item.customer_name}</Badge>
+              )}
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              {item.username && <span className="font-mono break-all">{item.username}</span>}
+              {href && (
+                <a href={href} target="_blank" rel="noreferrer noopener"
+                   className="inline-flex items-center gap-1 hover:text-foreground">
+                  <ExternalLink className="h-3 w-3" /> Open
+                </a>
+              )}
+              {!item.has_password && <span className="italic">notes only</span>}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1">
+            <Button size="sm" variant="ghost" onClick={copy} disabled={busy || !item.has_password}
+                    aria-label={`Copy the password for ${item.title}`}>
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+            <Button size="sm" variant="ghost" onClick={reveal} disabled={busy}
+                    aria-label={secret ? `Hide the password for ${item.title}` : `Show the password for ${item.title}`}>
+              {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                : secret ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onEdit} aria-label={`Edit ${item.title}`}>
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onDelete} aria-label={`Delete ${item.title}`}
+                    className="text-destructive hover:text-destructive">
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+
+        {secret && (
+          <div className="mt-3 space-y-2 rounded-md border border-border bg-muted/40 p-3">
+            {secret.password && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Password</p>
+                <p className="font-mono text-sm break-all select-all">{secret.password}</p>
+              </div>
+            )}
+            {secret.notes && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Secure notes</p>
+                <p className="whitespace-pre-wrap text-sm break-words select-all">{secret.notes}</p>
+              </div>
+            )}
+            <p className="text-[11px] text-muted-foreground">
+              Hides itself in 30 seconds. This view was recorded in the access log.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function VaultItemDialog({
+  item, customers, lockedCustomerId, onClose, onSaved,
+}: {
+  item: VaultItemView | null;
+  customers: { id: string; name: string }[];
+  lockedCustomerId?: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState(item?.title ?? "");
+  const [category, setCategory] = useState(item?.category ?? "login");
+  const [username, setUsername] = useState(item?.username ?? "");
+  const [url, setUrl] = useState(item?.url ?? "");
+  const [password, setPassword] = useState("");
+  const [notes, setNotes] = useState("");
+  const [showPw, setShowPw] = useState(false);
+  const [customerId, setCustomerId] = useState(lockedCustomerId ?? item?.customer_id ?? "none");
+  const [busy, setBusy] = useState(false);
+
+  const strength = passwordStrength(password);
+  const isEdit = Boolean(item);
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      const res = await saveVaultItem(item?.id ?? null, {
+        title, category, username, url, password, notes,
+        customerId: customerId === "none" ? null : customerId,
+      });
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success(isEdit ? "Saved" : "Stored");
+      onSaved();
+    } catch (e) { toast.error(e instanceof Error ? e.message : "Failed"); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit entry" : "Add a password"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="v-title">Name</Label>
+            <Input id="v-title" value={title} onChange={(e) => setTitle(e.target.value)}
+                   placeholder="Acme — Meta Business Manager" autoFocus />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="v-cat">Type</Label>
+              <Select value={category} onValueChange={setCategory}>
+                <SelectTrigger id="v-cat"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {VAULT_CATEGORIES.map((c) => (
+                    <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {!lockedCustomerId && (
+              <div>
+                <Label htmlFor="v-client">Client</Label>
+                <Select value={customerId} onValueChange={setCustomerId}>
+                  <SelectTrigger id="v-client"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Not a client&rsquo;s — ours</SelectItem>
+                    {customers.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="v-user">Username or email</Label>
+            <Input id="v-user" value={username} onChange={(e) => setUsername(e.target.value)}
+                   autoComplete="off" spellCheck={false} />
+          </div>
+
+          <div>
+            <Label htmlFor="v-url">Web address</Label>
+            <Input id="v-url" value={url} onChange={(e) => setUrl(e.target.value)}
+                   placeholder="business.facebook.com" autoComplete="off" spellCheck={false} />
+          </div>
+
+          <div>
+            <Label htmlFor="v-pw">Password</Label>
+            <div className="flex gap-2">
+              <Input
+                id="v-pw"
+                // type=text when shown, so the browser doesn't offer to save
+                // someone else's password into the operator's own password
+                // manager — autoComplete="new-password" is the strongest hint.
+                type={showPw ? "text" : "password"}
+                value={password} onChange={(e) => setPassword(e.target.value)}
+                placeholder={isEdit ? "Leave blank to keep the stored one" : ""}
+                autoComplete="new-password" spellCheck={false}
+                className="font-mono"
+              />
+              <Button type="button" variant="outline" size="icon" onClick={() => setShowPw((v) => !v)}
+                      aria-label={showPw ? "Hide password" : "Show password"}>
+                {showPw ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+              <Button type="button" variant="outline" size="icon"
+                      onClick={() => { setPassword(generatePassword()); setShowPw(true); }}
+                      aria-label="Generate a password">
+                <RefreshCw className="h-4 w-4" />
+              </Button>
+            </div>
+            {password && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {strength.label}{strength.hint ? ` — ${strength.hint}` : ""}
+              </p>
+            )}
+            {isEdit && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Blank keeps the password that&rsquo;s already stored — it can&rsquo;t be pre-filled here.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="v-notes">Secure notes</Label>
+            <Textarea id="v-notes" value={notes} onChange={(e) => setNotes(e.target.value)}
+                      rows={3} placeholder="Recovery codes, security questions, PIN…" />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Encrypted the same way as the password.
+              {isEdit && " Blank keeps what's stored."}
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={busy}>Cancel</Button>
+          <Button onClick={save} disabled={busy || !title.trim()}>
+            {busy && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            {isEdit ? "Save" : "Store"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const ACTION_WORDS: Record<string, string> = {
+  reveal: "viewed", create: "added", update: "edited", delete: "deleted",
+};
+
+function AccessLogDialog({ log, onClose }: { log: VaultLogEntry[]; onClose: () => void }) {
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader><DialogTitle>Access log</DialogTitle></DialogHeader>
+        {log.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">Nothing yet.</p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {log.map((e) => (
+              <li key={e.id} className="flex items-baseline justify-between gap-3 py-2 text-sm">
+                <span className="min-w-0 break-words">
+                  <span className="text-muted-foreground">{e.user_email ?? "Someone"}</span>{" "}
+                  {ACTION_WORDS[e.action] ?? e.action}{" "}
+                  <span className="font-medium">{e.item_title ?? "an entry"}</span>
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {new Date(e.created_at).toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/work-orders/work-order-new-client.tsx
+++ b/src/components/work-orders/work-order-new-client.tsx
@@ -22,6 +22,7 @@ import { getSitesForAccount, getSite } from "@/lib/actions/sites";
 import { getContactsForAccount } from "@/lib/actions/account-contacts";
 import { getBillingProfilesForAccount, getSiteBilling } from "@/lib/actions/billing-profiles";
 import type { Customer, MemberProfile, Site, AccountContact, BillingProfile } from "@/types/database";
+import { useVocab, lower } from "@/components/layout/vocab-provider";
 
 const AVATAR_COLORS = [
   "bg-blue-500","bg-violet-500","bg-pink-500","bg-orange-500",
@@ -48,6 +49,7 @@ interface WorkOrderNewClientProps {
 export function WorkOrderNewClient({
   customers: initialCustomers, profiles, templates = [], defaultCustomerId, defaultSiteId, defaultSiteAddress,
 }: WorkOrderNewClientProps) {
+  const v = useVocab("/work-orders", "Work Orders");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [customers, setCustomers] = useState(initialCustomers);
@@ -218,7 +220,7 @@ export function WorkOrderNewClient({
   return (
     <div className="space-y-6 max-w-3xl mx-auto">
       <PageHeader
-        title="New work order"
+        title={`New ${lower(v.singular)}`}
         subtitle="Assign a job to your team — they'll submit photos from site"
         accent="linear-gradient(180deg, #fbbf24 0%, #b45309 100%)"
       />
@@ -437,7 +439,7 @@ export function WorkOrderNewClient({
       <div className="flex justify-end gap-3">
         <Link href="/work-orders"><Button variant="outline">Cancel</Button></Link>
         <Button onClick={handleSubmit} disabled={isPending || !title.trim()}>
-          {isPending ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Creating...</> : "Create Work Order"}
+          {isPending ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Creating...</> : `Create ${v.singular}`}
         </Button>
       </div>
     </div>

--- a/src/components/work-orders/work-order-templates-client.tsx
+++ b/src/components/work-orders/work-order-templates-client.tsx
@@ -13,8 +13,10 @@ import {
   createWorkOrderTemplate, updateWorkOrderTemplate, deleteWorkOrderTemplate,
 } from "@/lib/actions/work-order-templates";
 import type { WorkOrderTemplate } from "@/types/database";
+import { useVocab, lower } from "@/components/layout/vocab-provider";
 
 export function WorkOrderTemplatesClient({ initial }: { initial: WorkOrderTemplate[] }) {
+  const v = useVocab("/work-orders", "Work Orders");
   const [templates, setTemplates] = useState(initial);
   const [selectedId, setSelectedId] = useState<string | null>(initial[0]?.id ?? null);
   const [newName, setNewName] = useState("");
@@ -23,7 +25,7 @@ export function WorkOrderTemplatesClient({ initial }: { initial: WorkOrderTempla
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Work-order templates" subtitle="Predefined starting points for new work orders. Pick one from the New Work Order form to prefill the common fields." />
+      <PageHeader title={`${v.singular} templates`} subtitle={`Predefined starting points for new ${lower(v.plural)}. Pick one from the New ${v.singular} form to prefill the common fields.`} />
 
       <Card className="p-5 space-y-4">
         <div className="font-semibold flex items-center gap-1.5"><FileStack className="size-4" /> Templates</div>

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -19,6 +19,7 @@ import type { GradientName as KireiGradient } from "@/components/ui/kirei";
 import type { WorkOrderWithCustomer, WorkOrderStatus, BusinessMember } from "@/types/database";
 import type { Role } from "@/lib/permissions";
 import { canManageTeam } from "@/lib/permissions";
+import { useVocab, lower } from "@/components/layout/vocab-provider";
 
 const TABS: { value: WorkOrderStatus | "all"; label: string }[] = [
   { value: "all",         label: "All"         },
@@ -57,6 +58,7 @@ interface WorkOrdersClientProps {
 }
 
 export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps) {
+  const v = useVocab("/work-orders", "Work Orders");
   const canDelete = canManageTeam(userRole);
   const router = useRouter();
   const [tab, setTab] = useState<typeof TABS[number]["value"]>("all");
@@ -90,7 +92,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
     setBusy(true);
     try {
       await deleteWorkOrder(deleteId);
-      toast.success("Work order deleted");
+      toast.success(`${v.singular} deleted`);
       router.refresh();
     } catch { toast.error("Failed to delete"); }
     setBusy(false);
@@ -104,12 +106,12 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
   const handleBulkDelete = async () => {
     const ids = [...selected];
     if (!ids.length) return;
-    if (!(await confirm({ title: `Delete ${ids.length} work order${ids.length === 1 ? "" : "s"}?`, body: "This permanently deletes the orders and their photos." }))) return;
+    if (!(await confirm({ title: `Delete ${ids.length} ${lower(ids.length === 1 ? v.singular : v.plural)}?`, body: "This permanently deletes them and their photos." }))) return;
     setBulkBusy(true);
     try {
       await bulkDeleteWorkOrders(ids);
       setSelected(new Set());
-      toast.success(`${ids.length} work order${ids.length === 1 ? "" : "s"} deleted`);
+      toast.success(`${ids.length} ${lower(ids.length === 1 ? v.singular : v.plural)} deleted`);
       router.refresh();
     } catch (e) { toast.error(e instanceof Error ? e.message : "Failed to delete"); }
     setBulkBusy(false);
@@ -122,7 +124,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
     try {
       await bulkUpdateWorkOrderStatus(ids, status);
       setSelected(new Set());
-      toast.success(`${ids.length} work order${ids.length === 1 ? "" : "s"} updated`);
+      toast.success(`${ids.length} ${lower(ids.length === 1 ? v.singular : v.plural)} updated`);
       router.refresh();
     } catch (e) { toast.error(e instanceof Error ? e.message : "Couldn't update status"); }
     setBulkBusy(false);
@@ -139,15 +141,15 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Work Orders"
+        title={v.plural}
         subtitle={`${workOrders.length} total · ${stats.onSite} on site now`}
         accent="linear-gradient(180deg, #fbbf24 0%, #b45309 100%)"
         actions={
           <>
-            <CleanupButton entity="work_orders" entityLabel="work orders" />
+            <CleanupButton entity="work_orders" entityLabel={lower(v.plural)} />
             <Link href="/work-orders/new">
               <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
-                <Plus className="w-4 h-4" /> New work order
+                <Plus className="w-4 h-4" /> New {lower(v.singular)}
               </AnimatedPress>
             </Link>
           </>
@@ -170,7 +172,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
       {canDelete && (
         <BulkBar
           count={selected.size}
-          noun="work order"
+          noun={lower(v.singular)}
           busy={bulkBusy}
           onDelete={handleBulkDelete}
           onClear={() => setSelected(new Set())}
@@ -180,7 +182,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
               disabled={bulkBusy}
               onChange={(e) => { const v = e.target.value; if (v) handleBulkStatus(v as WorkOrderStatus); }}
               className="h-8 rounded-md border border-border bg-card px-2 text-sm cursor-pointer"
-              aria-label="Set status for selected work orders"
+              aria-label={`Set status for selected ${lower(v.plural)}`}
             >
               <option value="" disabled>Set status…</option>
               {STATUS_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
@@ -193,9 +195,9 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
         <EmptyState
           icon={<Wrench className="w-7 h-7" />}
           gradient="amber"
-          title="No work orders"
+          title={`No ${lower(v.plural)}`}
           hint="Send workers on-site to capture photos. AI generates a scope of work from what they find."
-          cta={{ label: "New work order", href: "/work-orders/new", icon: <Plus className="w-4 h-4" /> }}
+          cta={{ label: `New ${lower(v.singular)}`, href: "/work-orders/new", icon: <Plus className="w-4 h-4" /> }}
         />
       ) : (
         <div className="rounded-xl border border-border bg-card overflow-hidden">
@@ -217,7 +219,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
                 onMouseEnter={() => router.prefetch(`/work-orders/${wo.id}`)}
                 className="group flex flex-wrap items-center gap-3 px-4 py-3 cursor-pointer transition-colors hover:bg-muted/40"
               >
-                {canDelete && <input type="checkbox" checked={selected.has(wo.id)} onChange={() => toggle(wo.id)} onClick={(e) => e.stopPropagation()} className="w-4 h-4 cursor-pointer shrink-0" aria-label="Select work order" />}
+                {canDelete && <input type="checkbox" checked={selected.has(wo.id)} onChange={() => toggle(wo.id)} onClick={(e) => e.stopPropagation()} className="w-4 h-4 cursor-pointer shrink-0" aria-label={`Select ${lower(v.singular)}`} />}
                 <GradientTile gradient={STATUS_GRADIENT[wo.status] ?? "primary"} size={40} radius={10}>
                   <Briefcase className="w-4 h-4" />
                 </GradientTile>
@@ -285,7 +287,7 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
       <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete work order?</AlertDialogTitle>
+            <AlertDialogTitle>Delete {lower(v.singular)}?</AlertDialogTitle>
             <AlertDialogDescription>This will permanently delete the order and all associated photos.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/lib/actions/navigation.ts
+++ b/src/lib/actions/navigation.ts
@@ -1,0 +1,78 @@
+"use server";
+
+/**
+ * Settings → Navigation: rename, reorder and hide sidebar items.
+ *
+ * Only owners and admins can change it — it's a business-wide change, and an
+ * editor renaming "Invoices" would change it for everyone.
+ *
+ * Expected failures are RETURNED, not thrown: Next masks thrown server-action
+ * messages in production, and "something went wrong" is not a validation error.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { validateNavConfig, type NavConfig } from "@/lib/nav/config";
+import type { Role } from "@/lib/permissions";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+/** Owner is derived from businesses.user_id and never stored in members. */
+async function callerRole(
+  supabase: Awaited<ReturnType<typeof createClient>>, userId: string, businessId: string,
+): Promise<Role> {
+  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
+  if (biz?.user_id === userId) return "owner";
+  const { data: member } = await tbl(supabase, "business_members")
+    .select("role").eq("business_id", businessId).eq("user_id", userId)
+    .eq("status", "active").maybeSingle();
+  return (member?.role ?? "viewer") as Role;
+}
+
+export type NavConfigResult = { ok: true } | { ok: false; error: string };
+
+export async function saveNavConfig(config: NavConfig): Promise<NavConfigResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const role = await callerRole(supabase, user.id, businessId);
+  if (role !== "owner" && role !== "admin") {
+    return { ok: false, error: "Only an owner or admin can change the navigation" };
+  }
+
+  const problem = validateNavConfig(config);
+  if (problem) return { ok: false, error: problem };
+
+  // Drop labels that match nothing / empty arrays, so an untouched config
+  // stores NULL and keeps following the industry preset rather than freezing
+  // today's preset values into the row.
+  const labels = Object.fromEntries(
+    Object.entries(config.labels ?? {}).filter(([, v]) => v.trim().length > 0),
+  );
+  const clean: NavConfig = {};
+  if (Object.keys(labels).length) clean.labels = labels;
+  if (config.hidden?.length) clean.hidden = config.hidden;
+  if (config.order?.length) clean.order = config.order;
+  const value = Object.keys(clean).length ? clean : null;
+
+  const { error } = await tbl(supabase, "businesses")
+    .update({ nav_config: value }).eq("id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  // The sidebar is rendered by the dashboard layout, so the whole tree needs
+  // revalidating — revalidating one page would leave the old names up.
+  revalidatePath("/", "layout");
+  return { ok: true };
+}
+
+export async function getNavConfig(): Promise<NavConfig | null> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  const { data } = await tbl(supabase, "businesses")
+    .select("nav_config").eq("id", businessId).maybeSingle();
+  return (data?.nav_config ?? null) as NavConfig | null;
+}

--- a/src/lib/actions/vault.ts
+++ b/src/lib/actions/vault.ts
@@ -1,0 +1,294 @@
+"use server";
+
+/**
+ * Password vault — the only path in or out of vault_items.
+ *
+ * Three rules hold everywhere in this file:
+ *
+ *  1. **Ciphertext never leaves the server.** The list returns
+ *     `has_password: boolean`, not the encrypted blob. There is no reason for
+ *     a browser to hold ciphertext, and holding it means a cached RSC payload
+ *     or a devtools inspection carries a secret it didn't need to.
+ *  2. **Plaintext only on an explicit reveal**, by an owner or admin, and the
+ *     reveal is logged. RLS already restricts these tables to owner/admin, but
+ *     reveal re-checks in application code — this is the one place worth
+ *     paying for defence in depth.
+ *  3. **No key, no save.** If APP_ENCRYPTION_KEY is missing the feature
+ *     refuses rather than falling back to plaintext. A vault that silently
+ *     stores passwords in the clear is worse than no vault.
+ *
+ * Expected failures are RETURNED, not thrown — Next masks thrown server-action
+ * messages in production.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { encryptSecret, decryptSecret, encryptionAvailable } from "@/lib/crypto";
+import {
+  validateVaultItem, normaliseUrl,
+  type VaultItemInput, type VaultItemView,
+} from "@/lib/vault/items";
+import type { Role } from "@/lib/permissions";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uid = (v: string | null | undefined) => (v && UUID_RE.test(v.trim()) ? v.trim() : null);
+const str = (v: string | null | undefined) => {
+  const t = (v ?? "").trim();
+  return t.length ? t : null;
+};
+
+export type VaultResult<T = undefined> =
+  | ({ ok: true } & (T extends undefined ? object : { data: T }))
+  | { ok: false; error: string };
+
+async function callerRole(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any, userId: string, businessId: string,
+): Promise<Role> {
+  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
+  if (biz?.user_id === userId) return "owner";
+  const { data: member } = await tbl(supabase, "business_members")
+    .select("role").eq("business_id", businessId).eq("user_id", userId)
+    .eq("status", "active").maybeSingle();
+  return (member?.role ?? "viewer") as Role;
+}
+
+const canUseVault = (role: Role) => role === "owner" || role === "admin";
+
+/** Record who did what. Never records the secret itself. */
+async function log(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any, businessId: string,
+  entry: { item_id: string | null; item_title: string | null; user_id: string; user_email: string | null; action: string },
+) {
+  // Best-effort: a failed audit write must not block the user's action, but it
+  // must be awaited — a floating promise in a serverless function is a log
+  // entry that may simply never be written.
+  const { error } = await tbl(supabase, "vault_access_log").insert({ business_id: businessId, ...entry });
+  if (error) console.error("[vault] audit write failed", error.message);
+}
+
+/** Entries, newest first. Never includes ciphertext or plaintext. */
+export async function listVaultItems(customerId?: string): Promise<VaultItemView[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!canUseVault(await callerRole(supabase, user.id, businessId))) return [];
+
+  let q = tbl(supabase, "vault_items")
+    .select("id, title, category, username, url, customer_id, password_enc, notes_enc, created_at, updated_at, customers(name)")
+    .eq("business_id", businessId)
+    .order("updated_at", { ascending: false })
+    .limit(500);
+  const cid = uid(customerId);
+  if (cid) q = q.eq("customer_id", cid);
+
+  const { data, error } = await q;
+  if (error) { console.error("[vault] list failed", error.message); return []; }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((data ?? []) as any[]).map((r) => ({
+    id: r.id,
+    title: r.title,
+    category: r.category,
+    username: r.username,
+    url: r.url,
+    customer_id: r.customer_id,
+    customer_name: r.customers?.name ?? null,
+    // Booleans, not the blobs. This mapping is the rule — don't spread `r`.
+    has_password: Boolean(r.password_enc),
+    has_notes: Boolean(r.notes_enc),
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }));
+}
+
+export async function saveVaultItem(
+  itemId: string | null,
+  input: VaultItemInput,
+): Promise<VaultResult<{ id: string }>> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!canUseVault(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can use the vault" };
+  }
+  if (!encryptionAvailable()) {
+    return {
+      ok: false,
+      error: "The vault needs APP_ENCRYPTION_KEY (64 hex characters) set on the server before it can store anything.",
+    };
+  }
+
+  const id = uid(itemId);
+  const problem = validateVaultItem(input, { isNew: !id });
+  if (problem) return { ok: false, error: problem };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row: Record<string, any> = {
+    business_id: businessId,
+    title: (input.title ?? "").trim(),
+    category: str(input.category) ?? "other",
+    username: str(input.username),
+    url: normaliseUrl(input.url),
+    customer_id: uid(input.customerId),
+  };
+
+  // A blank secret field on an EDIT means "leave it alone", not "erase it" —
+  // the form can't prefill a password it was never given. Clearing is done by
+  // deleting the entry.
+  const password = input.password ?? "";
+  const notes = input.notes ?? "";
+  if (password.trim() || !id) row.password_enc = password.trim() ? encryptSecret(password) : null;
+  if (notes.trim() || !id) row.notes_enc = notes.trim() ? encryptSecret(notes) : null;
+
+  if (id) {
+    const { error } = await tbl(supabase, "vault_items")
+      .update(row).eq("id", id).eq("business_id", businessId);
+    if (error) return { ok: false, error: error.message };
+    await log(supabase, businessId, {
+      item_id: id, item_title: row.title, user_id: user.id, user_email: user.email ?? null, action: "update",
+    });
+    revalidatePath("/vault");
+    if (row.customer_id) revalidatePath(`/customers/${row.customer_id}`);
+    return { ok: true, data: { id } };
+  }
+
+  row.created_by = user.id;
+  const { data, error } = await tbl(supabase, "vault_items").insert(row).select("id").single();
+  if (error) return { ok: false, error: error.message };
+  await log(supabase, businessId, {
+    item_id: data.id, item_title: row.title, user_id: user.id, user_email: user.email ?? null, action: "create",
+  });
+  revalidatePath("/vault");
+  if (row.customer_id) revalidatePath(`/customers/${row.customer_id}`);
+  return { ok: true, data: { id: data.id } };
+}
+
+/**
+ * Decrypt one entry, for one look.
+ *
+ * The role check here is redundant with RLS by design. RLS is the gate that
+ * matters, but this is the single function in the app that turns stored
+ * ciphertext into a password, and a future refactor that moved it onto the
+ * admin client would silently lose the gate. Cheap insurance.
+ */
+export async function revealVaultSecret(
+  itemId: string,
+): Promise<VaultResult<{ password: string | null; notes: string | null }>> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!canUseVault(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can reveal a password" };
+  }
+  const id = uid(itemId);
+  if (!id) return { ok: false, error: "Not found" };
+
+  const { data, error } = await tbl(supabase, "vault_items")
+    .select("id, title, password_enc, notes_enc")
+    .eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: "Not found" };
+
+  let password: string | null = null;
+  let notes: string | null = null;
+  try {
+    if (data.password_enc) password = decryptSecret(data.password_enc);
+    if (data.notes_enc) notes = decryptSecret(data.notes_enc);
+  } catch {
+    // Almost always a changed/rotated key. Say that, rather than "malformed
+    // payload" — the person reading it needs to know the data isn't corrupt.
+    return {
+      ok: false,
+      error: "This couldn't be decrypted. It was saved with a different APP_ENCRYPTION_KEY than the server is using now.",
+    };
+  }
+
+  await log(supabase, businessId, {
+    item_id: id, item_title: data.title, user_id: user.id, user_email: user.email ?? null, action: "reveal",
+  });
+  return { ok: true, data: { password, notes } };
+}
+
+export async function deleteVaultItem(itemId: string): Promise<VaultResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!canUseVault(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can use the vault" };
+  }
+  const id = uid(itemId);
+  if (!id) return { ok: false, error: "Not found" };
+
+  // Read the title first: once the row is gone the audit entry can't name it.
+  const { data: existing } = await tbl(supabase, "vault_items")
+    .select("title, customer_id").eq("id", id).eq("business_id", businessId).maybeSingle();
+
+  const { error } = await tbl(supabase, "vault_items")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  await log(supabase, businessId, {
+    item_id: null, item_title: existing?.title ?? null,
+    user_id: user.id, user_email: user.email ?? null, action: "delete",
+  });
+  revalidatePath("/vault");
+  if (existing?.customer_id) revalidatePath(`/customers/${existing.customer_id}`);
+  return { ok: true };
+}
+
+export interface VaultLogEntry {
+  id: string;
+  item_title: string | null;
+  user_email: string | null;
+  action: string;
+  created_at: string;
+}
+
+/** Who opened what, newest first. */
+export async function getVaultLog(limit = 100): Promise<VaultLogEntry[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!canUseVault(await callerRole(supabase, user.id, businessId))) return [];
+
+  const { data } = await tbl(supabase, "vault_access_log")
+    .select("id, item_title, user_email, action, created_at")
+    .eq("business_id", businessId)
+    .order("created_at", { ascending: false })
+    .limit(Math.min(limit, 500));
+  return (data ?? []) as VaultLogEntry[];
+}
+
+/** Whether the server can actually encrypt — the UI says so up front. */
+export async function vaultReady(): Promise<boolean> {
+  return encryptionAvailable();
+}
+
+export async function setVaultEnabled(enabled: boolean): Promise<VaultResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!canUseVault(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can turn the vault on" };
+  }
+  const { error } = await tbl(supabase, "vault_settings")
+    .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  if (error) return { ok: false, error: error.message };
+
+  // Mirror into the plugin install row so the Plugins store and the sidebar
+  // agree — the same two-way sync every other flagged plugin does.
+  await tbl(supabase, "business_agent_installs")
+    .upsert({ business_id: businessId, agent_id: "vault", enabled }, { onConflict: "business_id,agent_id" });
+
+  revalidatePath("/", "layout");
+  return { ok: true };
+}

--- a/src/lib/assistant/scopes.ts
+++ b/src/lib/assistant/scopes.ts
@@ -20,7 +20,25 @@
 import { ALL_API_SCOPES, type ApiScope } from "@/types/database";
 import type { Role } from "@/lib/permissions";
 
-const EVERY_SCOPE = ALL_API_SCOPES.map((s) => s.value).filter((s) => s !== "admin");
+/**
+ * Scopes that must never be handed out by the blanket read/write expansions
+ * below.
+ *
+ * READ_SCOPES/WRITE_SCOPES are derived from ALL_API_SCOPES, so adding a scope
+ * to that list silently grants it to editors and viewers. For an ordinary
+ * entity that's the intent. For the password vault it is not: those tables are
+ * owner/admin-only in the database precisely because the entries are other
+ * people's account credentials, and the assistant runs on the admin client
+ * that bypasses exactly that check.
+ *
+ * (No tool ever returns a decrypted password — reveal is a cookie-authed
+ * server action only. This keeps even the entry list away from roles that
+ * can't see it in the UI.)
+ */
+const NEVER_AUTO_GRANTED: readonly string[] = ["vault:read", "vault:write"];
+
+const EVERY_SCOPE = ALL_API_SCOPES.map((s) => s.value)
+  .filter((s) => s !== "admin" && !NEVER_AUTO_GRANTED.includes(s));
 
 const READ_SCOPES = EVERY_SCOPE.filter((s) => s.endsWith(":read"));
 const WRITE_SCOPES = EVERY_SCOPE.filter((s) => s.endsWith(":write"));

--- a/src/lib/crypto.test.ts
+++ b/src/lib/crypto.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+/**
+ * The vault's whole security claim rests on this file. Uses a throwaway key
+ * set per-test — never the real APP_ENCRYPTION_KEY.
+ *
+ * crypto.ts reads process.env at call time (not at import), which is what
+ * makes swapping the key mid-test possible — and is also why the "wrong key"
+ * case below is a genuine test of the failure, not a simulation of it.
+ */
+const KEY_A = "a".repeat(64);
+const KEY_B = "b".repeat(64);
+
+let saved: { app?: string; onboarding?: string };
+
+beforeEach(() => {
+  saved = { app: process.env.APP_ENCRYPTION_KEY, onboarding: process.env.ONBOARDING_SECRET_KEY };
+  process.env.APP_ENCRYPTION_KEY = KEY_A;
+  delete process.env.ONBOARDING_SECRET_KEY;
+});
+
+afterEach(() => {
+  if (saved.app === undefined) delete process.env.APP_ENCRYPTION_KEY;
+  else process.env.APP_ENCRYPTION_KEY = saved.app;
+  if (saved.onboarding === undefined) delete process.env.ONBOARDING_SECRET_KEY;
+  else process.env.ONBOARDING_SECRET_KEY = saved.onboarding;
+});
+
+describe("secret encryption", () => {
+  it("round-trips, including unicode and long values", async () => {
+    const { encryptSecret, decryptSecret } = await import("./crypto");
+    for (const plain of ["hunter2", "p@ss wörd — ✓", "x".repeat(4000), "{\"json\":true}"]) {
+      expect(decryptSecret(encryptSecret(plain))).toBe(plain);
+    }
+  });
+
+  it("produces different ciphertext each time for the same input", async () => {
+    // A fresh IV per call. Without it, two clients sharing a password would be
+    // visibly identical in a database dump.
+    const { encryptSecret } = await import("./crypto");
+    const a = encryptSecret("same");
+    const b = encryptSecret("same");
+    expect(a).not.toBe(b);
+  });
+
+  it("never contains the plaintext", async () => {
+    const { encryptSecret } = await import("./crypto");
+    expect(encryptSecret("SuperSecret123")).not.toContain("SuperSecret123");
+  });
+
+  it("refuses to decrypt with a different key", async () => {
+    const { encryptSecret, decryptSecret } = await import("./crypto");
+    const payload = encryptSecret("hunter2");
+    process.env.APP_ENCRYPTION_KEY = KEY_B;
+    expect(() => decryptSecret(payload)).toThrow();
+  });
+
+  it("refuses tampered ciphertext (GCM auth tag)", async () => {
+    // Authenticated encryption: a flipped byte must fail loudly, not decrypt
+    // to garbage that then gets shown to someone as a password.
+    const { encryptSecret, decryptSecret } = await import("./crypto");
+    const [v, iv, tag, ct] = encryptSecret("hunter2").split(".");
+    const buf = Buffer.from(ct, "base64");
+    buf[0] ^= 0xff;
+    expect(() => decryptSecret([v, iv, tag, buf.toString("base64")].join("."))).toThrow();
+  });
+
+  it("reports unavailable rather than throwing when no key is set", async () => {
+    // This is what makes the vault refuse to save instead of storing
+    // plaintext — the check must be a boolean, not an exception.
+    const { encryptionAvailable } = await import("./crypto");
+    expect(encryptionAvailable()).toBe(true);
+    delete process.env.APP_ENCRYPTION_KEY;
+    expect(encryptionAvailable()).toBe(false);
+    process.env.APP_ENCRYPTION_KEY = "too-short";
+    expect(encryptionAvailable()).toBe(false);
+  });
+});

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -571,6 +571,43 @@ export function registerTools(register: ToolFn): void {
       return text(data);
     });
 
+  // Navigation — what the sidebar is called, in what order, what's hidden.
+  // Renaming is the point of it: an agency asks for "Projects", not "Work
+  // Orders", and the assistant can now do that in one instruction.
+  tool("get_navigation", "Get the business's sidebar navigation overrides: {labels: {href: name}, hidden: [href], order: [href]}. NULL/empty means it follows the industry preset.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:read");
+      const { data } = await t(ctx, "businesses").select("nav_config, industry_preset").eq("id", ctx.businessId).single();
+      return text(data);
+    });
+
+  tool("update_navigation", "Rename, reorder or hide sidebar items. Keys are page paths ('/work-orders', '/quotes', '/customers'). Only the provided parts change — pass an empty object/array for a part to clear it back to the industry preset. Hiding removes an item from the sidebar; it does NOT disable the feature (use set_plugin_enabled for that).",
+    {
+      labels: z.record(z.string(), z.string()).optional().describe('Page path → name, e.g. {"/work-orders": "Projects"}'),
+      hidden: z.array(z.string()).optional().describe("Page paths to hide from the sidebar"),
+      order: z.array(z.string()).optional().describe("Page paths in display order; anything omitted keeps its default position"),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "settings:write");
+      const { data: row } = await t(ctx, "businesses").select("nav_config").eq("id", ctx.businessId).single();
+      const prev = (row?.nav_config ?? {}) as Record<string, unknown>;
+      // Merge, so renaming one item doesn't silently drop the hide/order the
+      // user set in Settings.
+      const next: Record<string, unknown> = { ...prev };
+      if (args.labels !== undefined) next.labels = { ...(prev.labels as object ?? {}), ...args.labels };
+      if (args.hidden !== undefined) next.hidden = args.hidden;
+      if (args.order !== undefined) next.order = args.order;
+      for (const k of ["labels", "hidden", "order"]) {
+        const v = next[k];
+        if (!v || (Array.isArray(v) ? v.length === 0 : Object.keys(v).length === 0)) delete next[k];
+      }
+      const value = Object.keys(next).length ? next : null;
+      const { error } = await t(ctx, "businesses").update({ nav_config: value }).eq("id", ctx.businessId);
+      if (error) throw new Error(error.message);
+      return text({ ok: true, nav_config: value });
+    });
+
   tool("update_settings", "Update business settings / preferences. Only provided fields change. Common fields: name, email, phone, address, currency, accent_color, sidebar_theme, bg_pattern, invoice_prefix, quote_prefix, bank_name, bank_account_number, bank_account_name, bank_sort_code, license_number. Document defaults: default_notes, payment_terms, and the per-type default terms & conditions default_invoice_terms / default_quote_terms (pre-fill new invoices / quotes — same as the PDF template editor's 'Default terms & conditions').",
     {
       name: z.string().optional(), email: z.string().optional(), phone: z.string().optional(), address: z.string().optional(),

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -41,6 +41,7 @@ import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
 import { registerProspectTools } from "./tools/prospects-tools";
+import { registerVaultTools } from "./tools/vault-tools";
 import { registerOutreachTools } from "./tools/outreach-tools";
 import { registerTelephonyTools } from "./tools/telephony-tools";
 import { registerAssistantTools } from "./tools/assistant-tools";
@@ -1758,6 +1759,7 @@ export function registerTools(register: ToolFn): void {
 
   // ===== PROSPECTS =====
   registerProspectTools(tool);
+  registerVaultTools(tool);
   registerOutreachTools(tool);
   registerTelephonyTools(tool);
 

--- a/src/lib/mcp/tools/vault-tools.ts
+++ b/src/lib/mcp/tools/vault-tools.ts
@@ -1,0 +1,190 @@
+/**
+ * MCP tools for the password vault.
+ *
+ * ⚠️ **There is deliberately no `reveal` tool, and there never should be.**
+ *
+ * Every other feature in Kirei gets full MCP parity — that's a standing rule.
+ * This is the one exception, and it's a considered one rather than an
+ * oversight: revealing a stored credential puts a client's password into a
+ * model context, a conversation transcript and an `assistant_messages` row,
+ * where it is no longer covered by the encryption or the audit log that
+ * justify storing it at all. Reading a password is a deliberate human act at a
+ * screen; `revealVaultSecret` (a cookie-authed server action) is the only path.
+ *
+ * What these tools do give you: finding and organising entries by voice or
+ * chat, which is the actual daily need ("what logins do we hold for Acme?").
+ *
+ * Writing IS allowed — saving a credential someone hands you is useful and
+ * one-directional. The value goes in encrypted and cannot come back out here.
+ *
+ * The `vault:*` scopes are excluded from the assistant's automatic role
+ * expansion (src/lib/assistant/scopes.ts), so only an owner/admin — or an API
+ * key granted them on purpose — reaches these at all.
+ */
+import { z } from "zod";
+import { assertScope, t, text } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
+import { validateVaultItem, normaliseUrl, VAULT_CATEGORIES } from "@/lib/vault/items";
+
+const CATEGORIES = VAULT_CATEGORIES.map((c) => c.value);
+
+export function registerVaultTools(tool: ToolFn): void {
+  tool("list_vault_items",
+    "List password-vault entries: what accounts you hold credentials for, optionally filtered to one client. Returns titles, usernames and URLs — NEVER the passwords, which can only be revealed in the app.",
+    {
+      customer_id: UUID.optional().describe("Only entries for this client"),
+      search: z.string().optional().describe("Match against the title or username"),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "vault:read");
+      let q = t(ctx, "vault_items")
+        .select("id, title, category, username, url, customer_id, password_enc, notes_enc, updated_at, customers(name)")
+        .eq("business_id", ctx.businessId)
+        .order("updated_at", { ascending: false })
+        .limit(200);
+      if (args.customer_id) q = q.eq("customer_id", args.customer_id);
+
+      const { data, error } = await q;
+      if (error) throw new Error(error.message);
+
+      const term = (args.search ?? "").trim().toLowerCase();
+      // Filtered here rather than with .or(): PostgREST's or-grammar shatters
+      // on a comma or a dot in the term, and this list is capped at 200 rows.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = ((data ?? []) as any[]).filter((r) =>
+        !term
+        || (r.title ?? "").toLowerCase().includes(term)
+        || (r.username ?? "").toLowerCase().includes(term));
+
+      return text(rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        category: r.category,
+        username: r.username,
+        url: r.url,
+        client: r.customers?.name ?? null,
+        customer_id: r.customer_id,
+        // Booleans, never the stored value. Do not be tempted to widen this.
+        has_password: Boolean(r.password_enc),
+        has_notes: Boolean(r.notes_enc),
+        updated_at: r.updated_at,
+      })));
+    });
+
+  tool("create_vault_item",
+    "Save a credential to the password vault. The password is encrypted immediately and can never be read back through this API — only in the app, by an owner or admin, with the access logged.",
+    {
+      title: z.string().describe('What the account is, e.g. "Acme — Meta Business Manager"'),
+      password: z.string().optional().describe("Stored encrypted. Cannot be retrieved through MCP."),
+      username: z.string().optional(),
+      url: z.string().optional(),
+      notes: z.string().optional().describe("Recovery codes / security answers. Also encrypted."),
+      category: z.enum(CATEGORIES as [string, ...string[]]).optional(),
+      customer_id: UUID.optional().describe("The client this login belongs to"),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "vault:write");
+      if (!encryptionAvailable()) {
+        throw new Error("The vault needs APP_ENCRYPTION_KEY (64 hex chars) set on the server before it can store anything.");
+      }
+      const problem = validateVaultItem(
+        { title: args.title, url: args.url, password: args.password, notes: args.notes },
+        { isNew: true },
+      );
+      if (problem) throw new Error(problem);
+
+      const { data, error } = await t(ctx, "vault_items").insert({
+        business_id: ctx.businessId,
+        title: args.title.trim(),
+        category: args.category ?? "other",
+        username: args.username?.trim() || null,
+        url: normaliseUrl(args.url),
+        customer_id: args.customer_id ?? null,
+        password_enc: args.password?.trim() ? encryptSecret(args.password) : null,
+        notes_enc: args.notes?.trim() ? encryptSecret(args.notes) : null,
+      }).select("id").single();
+      if (error) throw new Error(error.message);
+
+      await t(ctx, "vault_access_log").insert({
+        business_id: ctx.businessId, item_id: data.id, item_title: args.title.trim(),
+        // No cookie session here, so no user id — the log says it came from the
+        // API rather than pretending a person did it.
+        user_email: "(API / assistant)", action: "create",
+      });
+      return text({ ok: true, id: data.id });
+    });
+
+  tool("update_vault_item",
+    "Change a vault entry. Omit `password` to leave the stored one untouched — passing an empty string does NOT clear it.",
+    {
+      id: UUID,
+      title: z.string().optional(),
+      username: z.string().optional(),
+      url: z.string().optional(),
+      password: z.string().optional().describe("Replaces the stored password. Omit to keep it."),
+      notes: z.string().optional(),
+      category: z.enum(CATEGORIES as [string, ...string[]]).optional(),
+      customer_id: UUID.optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "vault:write");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const patch: Record<string, any> = {};
+      if (args.title !== undefined) patch.title = args.title.trim();
+      if (args.username !== undefined) patch.username = args.username.trim() || null;
+      if (args.url !== undefined) patch.url = normaliseUrl(args.url);
+      if (args.category !== undefined) patch.category = args.category;
+      if (args.customer_id !== undefined) patch.customer_id = args.customer_id;
+      if (args.password?.trim()) {
+        if (!encryptionAvailable()) throw new Error("The vault needs APP_ENCRYPTION_KEY set on the server.");
+        patch.password_enc = encryptSecret(args.password);
+      }
+      if (args.notes?.trim()) {
+        if (!encryptionAvailable()) throw new Error("The vault needs APP_ENCRYPTION_KEY set on the server.");
+        patch.notes_enc = encryptSecret(args.notes);
+      }
+      if (Object.keys(patch).length === 0) throw new Error("Nothing to change");
+
+      const { error } = await t(ctx, "vault_items")
+        .update(patch).eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw new Error(error.message);
+
+      await t(ctx, "vault_access_log").insert({
+        business_id: ctx.businessId, item_id: args.id, item_title: patch.title ?? null,
+        user_email: "(API / assistant)", action: "update",
+      });
+      return text({ ok: true });
+    });
+
+  tool("delete_vault_item", "Permanently delete a vault entry. The audit log entry survives.",
+    { id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "vault:write");
+      const { data: existing } = await t(ctx, "vault_items")
+        .select("title").eq("id", args.id).eq("business_id", ctx.businessId).maybeSingle();
+      const { error } = await t(ctx, "vault_items")
+        .delete().eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw new Error(error.message);
+
+      await t(ctx, "vault_access_log").insert({
+        business_id: ctx.businessId, item_id: null, item_title: existing?.title ?? null,
+        user_email: "(API / assistant)", action: "delete",
+      });
+      return text({ ok: true });
+    });
+
+  tool("list_vault_access_log",
+    "Who opened, added or removed vault entries, newest first. Use to answer 'who had that password'.",
+    { limit: z.number().int().min(1).max(500).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "vault:read");
+      const { data, error } = await t(ctx, "vault_access_log")
+        .select("id, item_title, user_email, action, created_at")
+        .eq("business_id", ctx.businessId)
+        .order("created_at", { ascending: false })
+        .limit(args.limit ?? 100);
+      if (error) throw new Error(error.message);
+      return text(data ?? []);
+    });
+}

--- a/src/lib/nav/config.test.ts
+++ b/src/lib/nav/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  labelFor, singularise, applyOrder, isHidden, validateNavConfig,
+} from "./config";
+
+describe("labelFor", () => {
+  const preset = { "/work-orders": "Projects" };
+
+  it("prefers the business's own override over the preset", () => {
+    expect(labelFor("/work-orders", "Work Orders", { labels: { "/work-orders": "Engagements" } }, preset))
+      .toBe("Engagements");
+  });
+
+  it("falls back to the preset, then to the built-in label", () => {
+    expect(labelFor("/work-orders", "Work Orders", null, preset)).toBe("Projects");
+    expect(labelFor("/quotes", "Quotes", null, preset)).toBe("Quotes");
+    expect(labelFor("/quotes", "Quotes", null, null)).toBe("Quotes");
+  });
+});
+
+describe("singularise", () => {
+  it("handles the endings that appear in this app's nav", () => {
+    expect(singularise("Projects")).toBe("Project");
+    expect(singularise("Deliveries")).toBe("Delivery");
+    expect(singularise("Proposals")).toBe("Proposal");
+    expect(singularise("Boxes")).toBe("Box");
+  });
+
+  it("leaves a word that isn't a plural alone", () => {
+    expect(singularise("Schedule")).toBe("Schedule");
+    expect(singularise("Progress")).toBe("Progress");
+  });
+});
+
+describe("applyOrder", () => {
+  const items = [{ href: "/a" }, { href: "/b" }, { href: "/c" }];
+
+  it("sorts by the configured order", () => {
+    expect(applyOrder(items, { order: ["/c", "/a", "/b"] }).map((i) => i.href))
+      .toEqual(["/c", "/a", "/b"]);
+  });
+
+  it("keeps unlisted items rather than dropping them", () => {
+    // A nav item shipped after the business reordered must still appear —
+    // this is the regression that would silently hide new features.
+    const out = applyOrder(items, { order: ["/c"] }).map((i) => i.href);
+    expect(out).toContain("/a");
+    expect(out).toContain("/b");
+    expect(out[0]).toBe("/c");
+  });
+
+  it("is a no-op with no order set", () => {
+    expect(applyOrder(items, null).map((i) => i.href)).toEqual(["/a", "/b", "/c"]);
+    expect(applyOrder(items, { order: [] }).map((i) => i.href)).toEqual(["/a", "/b", "/c"]);
+  });
+});
+
+describe("isHidden", () => {
+  it("only hides what was named", () => {
+    expect(isHidden("/tasks", { hidden: ["/tasks"] })).toBe(true);
+    expect(isHidden("/leads", { hidden: ["/tasks"] })).toBe(false);
+    expect(isHidden("/tasks", null)).toBe(false);
+  });
+});
+
+describe("validateNavConfig", () => {
+  it("accepts a normal config", () => {
+    expect(validateNavConfig({ labels: { "/work-orders": "Projects" }, hidden: ["/tasks"] })).toBeNull();
+  });
+
+  it("rejects a blank name, an over-long name, and a non-path key", () => {
+    expect(validateNavConfig({ labels: { "/a": "  " } })).toMatch(/blank/);
+    expect(validateNavConfig({ labels: { "/a": "x".repeat(25) } })).toMatch(/too long/);
+    expect(validateNavConfig({ labels: { "work-orders": "Projects" } })).toMatch(/isn't a page/);
+  });
+});

--- a/src/lib/nav/config.ts
+++ b/src/lib/nav/config.ts
@@ -1,0 +1,113 @@
+/**
+ * What the navigation is called, in what order, and what's hidden.
+ *
+ * The industry preset supplies defaults (an agency calls Work Orders
+ * "Projects"); a business can override any of it. Plain module — the sidebar,
+ * the settings editor and the pages themselves all read it, so a label can't
+ * mean one thing in the nav and another on the page it opens.
+ *
+ * The naming is deliberate: `labels` is keyed by href, not by some separate
+ * id, because the href is the one identifier the nav, the router and the
+ * settings editor already agree on.
+ */
+
+export interface NavConfig {
+  /** href → what to call it. */
+  labels?: Record<string, string>;
+  /** hrefs to hide. Hiding is not disabling — the route still works if you
+   *  have the link, and the plugin system is what actually turns things off. */
+  hidden?: string[];
+  /** hrefs in the order they should appear. Anything missing keeps its
+   *  default position, so a partial order isn't a way to lose items. */
+  order?: string[];
+}
+
+/** A page's own noun, for headings and buttons — "Project" from "Projects". */
+export interface Vocab {
+  /** Plural, as shown in the nav: "Projects". */
+  plural: string;
+  /** Singular, for a heading or button: "Project". */
+  singular: string;
+}
+
+/**
+ * Resolve the label for an href.
+ *
+ * Order: the business's own override, then the preset's vocab, then the
+ * built-in label. Anything else would make a preset able to override a
+ * deliberate choice.
+ */
+export function labelFor(
+  href: string,
+  fallback: string,
+  config: NavConfig | null | undefined,
+  presetVocab: Record<string, string> | null | undefined,
+): string {
+  return config?.labels?.[href] ?? presetVocab?.[href] ?? fallback;
+}
+
+/**
+ * Singularise a plural label well enough for a heading.
+ *
+ * Deliberately simple: it handles the endings that actually appear in this
+ * app's nav ("Projects", "Proposals", "Deliveries", "Clients"). It's used for
+ * button text, so being wrong is cosmetic — and a business that dislikes the
+ * result can set the label themselves.
+ */
+export function singularise(plural: string): string {
+  const p = plural.trim();
+  if (/ies$/i.test(p)) return p.slice(0, -3) + "y";      // Deliveries → Delivery
+  if (/(ses|xes|zes|ches|shes)$/i.test(p)) return p.slice(0, -2); // Boxes → Box
+  if (/ss$/i.test(p)) return p;                          // Progress stays
+  if (/s$/i.test(p)) return p.slice(0, -1);              // Projects → Project
+  return p;
+}
+
+export function vocabFor(
+  href: string,
+  fallbackPlural: string,
+  config: NavConfig | null | undefined,
+  presetVocab: Record<string, string> | null | undefined,
+): Vocab {
+  const plural = labelFor(href, fallbackPlural, config, presetVocab);
+  return { plural, singular: singularise(plural) };
+}
+
+export function isHidden(href: string, config: NavConfig | null | undefined): boolean {
+  return Boolean(config?.hidden?.includes(href));
+}
+
+/**
+ * Sort by the configured order, keeping unlisted items where they were.
+ *
+ * An item absent from `order` must NOT vanish or jump to the end: new nav
+ * items ship all the time, and a business that reordered once shouldn't stop
+ * seeing them or find them piled up at the bottom.
+ */
+export function applyOrder<T extends { href: string }>(
+  items: T[],
+  config: NavConfig | null | undefined,
+): T[] {
+  const order = config?.order;
+  if (!order?.length) return items;
+  const rank = new Map(order.map((h, i) => [h, i]));
+  return items
+    .map((item, i) => ({ item, i, rank: rank.get(item.href) }))
+    .sort((a, b) => {
+      if (a.rank === undefined && b.rank === undefined) return a.i - b.i;
+      if (a.rank === undefined) return 1;
+      if (b.rank === undefined) return -1;
+      return a.rank - b.rank;
+    })
+    .map((x) => x.item);
+}
+
+/** Reject junk before it reaches the database. */
+export function validateNavConfig(config: NavConfig): string | null {
+  for (const [href, label] of Object.entries(config.labels ?? {})) {
+    if (!href.startsWith("/")) return `"${href}" isn't a page.`;
+    if (!label.trim()) return "A name can't be blank — remove the override instead.";
+    if (label.length > 24) return `"${label}" is too long for the sidebar — keep it under 24 characters.`;
+  }
+  return null;
+}

--- a/src/lib/plugins/presets.ts
+++ b/src/lib/plugins/presets.ts
@@ -14,7 +14,11 @@ export interface IndustryPreset {
   description: string;
   /** Optional-module ids enabled by this preset (everything else optional is disabled). */
   plugins: string[];
-  /** Sidebar label overrides keyed by nav href (minimal vocab layer v1). */
+  /** What this industry calls each page, keyed by nav href.
+   *  Read by the sidebar AND by the pages themselves (via the vocab context in
+   *  src/components/layout/vocab-provider.tsx), so an agency's "Projects" tab
+   *  opens a screen that also says Projects. A business can override any of it
+   *  in Settings → Navigation. */
   vocab?: Record<string, string>;
 }
 

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -40,7 +40,7 @@ export interface PluginDefinition {
   /** Icon name for the Plugins store (mapped in the store's ICON_MAP). */
   icon?: string;
   /** Legacy per-feature settings table that stays authoritative for enabled. */
-  settingsTable?: "quoting_agent_settings" | "onboarding_settings" | "form_builder_settings" | "automations_settings";
+  settingsTable?: "quoting_agent_settings" | "onboarding_settings" | "form_builder_settings" | "automations_settings" | "vault_settings";
 }
 
 export const PLUGIN_REGISTRY: PluginDefinition[] = [
@@ -86,6 +86,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "client-onboarding", icon: "clipboard-list", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
   { id: "form-builder", icon: "list-checks",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "sales", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
 
+  { id: "vault", icon: "lock", name: "Password vault", description: "Store the account logins you hold for clients — encrypted, owner/admin only, every reveal logged.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "vault_settings", routePrefixes: ["/vault"] },
   { id: "automations", icon: "zap", name: "Automations", description: "When something happens, do something: email a new client their onboarding form, text a customer when a job is done.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "automations_settings", routePrefixes: ["/automations"] },
 
   // ── SEO vertical (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────

--- a/src/lib/plugins/sync.ts
+++ b/src/lib/plugins/sync.ts
@@ -33,6 +33,10 @@ export async function syncPluginSideEffects(sb: any, businessId: string, pluginI
     await tbl(sb, "form_builder_settings")
       .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
   }
+  if (pluginId === "vault") {
+    await tbl(sb, "vault_settings")
+      .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });
+  }
   if (pluginId === "quoting-agent") {
     await tbl(sb, "quoting_agent_settings")
       .upsert({ business_id: businessId, enabled }, { onConflict: "business_id" });

--- a/src/lib/vault/items.test.ts
+++ b/src/lib/vault/items.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateVaultItem, normaliseUrl, passwordStrength, generatePassword, categoryLabel,
+} from "./items";
+import { assistantScopesForRole } from "@/lib/assistant/scopes";
+
+describe("validateVaultItem", () => {
+  it("requires a name", () => {
+    expect(validateVaultItem({ title: "  ", password: "x" }, { isNew: true })).toMatch(/name/i);
+  });
+
+  it("rejects a new entry with nothing secret in it", () => {
+    expect(validateVaultItem({ title: "Acme" }, { isNew: true })).toMatch(/password or some secure notes/i);
+  });
+
+  it("accepts notes with no password", () => {
+    expect(validateVaultItem({ title: "Acme", notes: "recovery: 1234" }, { isNew: true })).toBeNull();
+  });
+
+  it("allows a blank password on EDIT — that means 'keep the stored one'", () => {
+    // The form can't prefill a password it was never given, so requiring one
+    // on every edit would make renaming an entry impossible without retyping
+    // the secret.
+    expect(validateVaultItem({ title: "Acme" }, { isNew: false })).toBeNull();
+  });
+});
+
+describe("normaliseUrl", () => {
+  it("adds a scheme so the Open link actually opens", () => {
+    expect(normaliseUrl("business.facebook.com")).toBe("https://business.facebook.com");
+    expect(normaliseUrl("https://x.com")).toBe("https://x.com");
+    expect(normaliseUrl("  ")).toBeNull();
+    expect(normaliseUrl(null)).toBeNull();
+  });
+});
+
+describe("passwordStrength", () => {
+  it("rates length above everything else", () => {
+    expect(passwordStrength("aB3!").score).toBeLessThan(passwordStrength("aB3!aB3!aB3!aB3!").score);
+  });
+
+  it("caps obvious patterns however long they are", () => {
+    expect(passwordStrength("aaaaaaaaaaaaaaaaaaaa").score).toBeLessThanOrEqual(1);
+    expect(passwordStrength("password123456789").score).toBeLessThanOrEqual(1);
+  });
+
+  it("never returns a hint once it's strong", () => {
+    expect(passwordStrength("Tr0ub4dor&3xample!!").hint).toBeNull();
+  });
+});
+
+describe("generatePassword", () => {
+  it("respects the requested length within bounds", () => {
+    expect(generatePassword(20)).toHaveLength(20);
+    expect(generatePassword(4)).toHaveLength(8);    // floor
+    expect(generatePassword(999)).toHaveLength(64); // ceiling
+  });
+
+  it("omits characters that can't be read down a phone", () => {
+    // These get transcribed by a human into someone else's login screen.
+    for (let i = 0; i < 40; i++) {
+      expect(generatePassword(40)).not.toMatch(/[lIO01]/);
+    }
+  });
+
+  it("always contains every character class", () => {
+    for (let i = 0; i < 40; i++) {
+      const pw = generatePassword(12);
+      expect(pw).toMatch(/[a-z]/);
+      expect(pw).toMatch(/[A-Z]/);
+      expect(pw).toMatch(/[2-9]/);
+      expect(pw).toMatch(/[!@#$%^&*\-_=+?]/);
+    }
+  });
+
+  it("doesn't repeat itself", () => {
+    const seen = new Set(Array.from({ length: 50 }, () => generatePassword(16)));
+    expect(seen.size).toBe(50);
+  });
+});
+
+describe("categoryLabel", () => {
+  it("falls back rather than rendering a raw value", () => {
+    expect(categoryLabel("social")).toBe("Social / ads account");
+    expect(categoryLabel("something-new")).toBe("Other");
+  });
+});
+
+/**
+ * The security boundary that a future scope addition would silently breach.
+ * READ_SCOPES/WRITE_SCOPES are derived from ALL_API_SCOPES, so without the
+ * explicit exclusion an editor or viewer would inherit vault access the
+ * database denies them.
+ */
+describe("vault scopes are never auto-granted to the assistant", () => {
+  it("keeps editors and viewers out of the vault", () => {
+    for (const role of ["editor", "viewer"] as const) {
+      const scopes = assistantScopesForRole(role) ?? [];
+      expect(scopes).not.toContain("vault:read");
+      expect(scopes).not.toContain("vault:write");
+    }
+  });
+
+  it("still denies workers everything", () => {
+    expect(assistantScopesForRole("worker")).toBeNull();
+  });
+});

--- a/src/lib/vault/items.ts
+++ b/src/lib/vault/items.ts
@@ -1,0 +1,163 @@
+/**
+ * Password vault — shapes, categories and validation.
+ *
+ * Plain module (no "use server"), so the browser can validate and generate
+ * before submitting and the server can validate again without importing
+ * anything that touches node:crypto.
+ */
+
+export const VAULT_CATEGORIES = [
+  { value: "login", label: "Website login" },
+  { value: "social", label: "Social / ads account" },
+  { value: "hosting", label: "Hosting / server" },
+  { value: "domain", label: "Domain registrar" },
+  { value: "software", label: "Software / SaaS" },
+  { value: "email", label: "Email account" },
+  { value: "wifi", label: "Wi-Fi / network" },
+  { value: "banking", label: "Banking / finance" },
+  { value: "other", label: "Other" },
+] as const;
+
+export type VaultCategory = (typeof VAULT_CATEGORIES)[number]["value"];
+
+export function categoryLabel(value: string): string {
+  return VAULT_CATEGORIES.find((c) => c.value === value)?.label ?? "Other";
+}
+
+/**
+ * A vault entry as the browser sees it.
+ *
+ * There is no `password` field and no ciphertext. The list never carries the
+ * secret — not even encrypted — so a stray console.log, a React DevTools
+ * inspection or a cached RSC payload can't spill one. The plaintext exists in
+ * the browser only for the moment after an explicit reveal.
+ */
+export interface VaultItemView {
+  id: string;
+  title: string;
+  category: string;
+  username: string | null;
+  url: string | null;
+  customer_id: string | null;
+  customer_name?: string | null;
+  has_password: boolean;
+  has_notes: boolean;
+  updated_at: string;
+  created_at: string;
+}
+
+export interface VaultItemInput {
+  title?: string | null;
+  category?: string | null;
+  username?: string | null;
+  url?: string | null;
+  password?: string | null;
+  notes?: string | null;
+  customerId?: string | null;
+}
+
+/** What's wrong with this entry, or null when it's fine. */
+export function validateVaultItem(input: VaultItemInput, opts: { isNew: boolean }): string | null {
+  const title = (input.title ?? "").trim();
+  if (!title) return "Give it a name, so you can find it later.";
+  if (title.length > 120) return "That name is too long — keep it under 120 characters.";
+
+  const url = (input.url ?? "").trim();
+  if (url && !/^https?:\/\/\S+$/i.test(url) && !/^[\w-]+(\.[\w-]+)+/.test(url)) {
+    return "That doesn't look like a web address.";
+  }
+
+  // An entry with nothing secret in it is a contact note, not a vault entry —
+  // but only reject it on create. On edit, a blank password field means
+  // "leave the stored one alone", not "delete it".
+  if (opts.isNew && !(input.password ?? "").trim() && !(input.notes ?? "").trim()) {
+    return "Add a password or some secure notes — otherwise there's nothing to protect.";
+  }
+  return null;
+}
+
+/** Normalise a typed address so the "open" link actually opens. */
+export function normaliseUrl(url: string | null | undefined): string | null {
+  const v = (url ?? "").trim();
+  if (!v) return null;
+  return /^https?:\/\//i.test(v) ? v : `https://${v}`;
+}
+
+export interface PasswordStrength {
+  /** 0–4. */
+  score: number;
+  label: string;
+  /** The single most useful thing to change, or null when it's already strong. */
+  hint: string | null;
+}
+
+/**
+ * A rough strength read for the generator and the entry form.
+ *
+ * Deliberately not a security control — it never blocks saving. Client
+ * passwords are often set by the client, and refusing to store a weak one
+ * would just push it back into a spreadsheet, which is worse.
+ */
+export function passwordStrength(pw: string): PasswordStrength {
+  if (!pw) return { score: 0, label: "—", hint: null };
+
+  const classes = [/[a-z]/, /[A-Z]/, /[0-9]/, /[^A-Za-z0-9]/].filter((re) => re.test(pw)).length;
+  let score = 0;
+  if (pw.length >= 8) score++;
+  if (pw.length >= 12) score++;
+  if (classes >= 3) score++;
+  if (pw.length >= 16 && classes >= 3) score++;
+
+  // Obvious patterns cap it however long the password is.
+  if (/^(.)\1+$/.test(pw) || /^(1234|qwer|abcd|pass|admin)/i.test(pw)) score = Math.min(score, 1);
+
+  const label = ["Very weak", "Weak", "Fair", "Strong", "Very strong"][score];
+  const hint =
+    score >= 3 ? null
+    : pw.length < 12 ? "Longer helps more than anything else — aim for 16+."
+    : classes < 3 ? "Mix in capitals, numbers or symbols."
+    : "Try a longer passphrase.";
+  return { score, label, hint };
+}
+
+const ALPHABET = {
+  lower: "abcdefghijkmnopqrstuvwxyz",   // no l
+  upper: "ABCDEFGHJKLMNPQRSTUVWXYZ",    // no I, O
+  digit: "23456789",                     // no 0, 1
+  symbol: "!@#$%^&*-_=+?",
+};
+
+/**
+ * Generate a password using the browser's CSPRNG.
+ *
+ * Ambiguous characters (l/I/1, O/0) are left out: these get read aloud down
+ * the phone and typed into someone else's login screen, and a password nobody
+ * can transcribe gets replaced with a weak one.
+ */
+export function generatePassword(length = 20, useSymbols = true): string {
+  const pool = ALPHABET.lower + ALPHABET.upper + ALPHABET.digit + (useSymbols ? ALPHABET.symbol : "");
+  const required = [ALPHABET.lower, ALPHABET.upper, ALPHABET.digit, ...(useSymbols ? [ALPHABET.symbol] : [])];
+  const len = Math.max(8, Math.min(64, length));
+
+  const bytes = new Uint32Array(len);
+  crypto.getRandomValues(bytes);
+  const chars = Array.from(bytes, (b) => pool[b % pool.length]);
+
+  // Guarantee one of each class. Placed at fixed positions and then shuffled,
+  // NOT written to random positions: random positions collide, and a collision
+  // silently drops a class — which is how this shipped a password with no
+  // digit in it.
+  const picks = new Uint32Array(required.length);
+  crypto.getRandomValues(picks);
+  required.forEach((set, i) => { chars[i] = set[picks[i] % set.length]; });
+
+  // Fisher-Yates, CSPRNG-driven, so the guaranteed characters don't sit in a
+  // predictable prefix.
+  const swaps = new Uint32Array(len);
+  crypto.getRandomValues(swaps);
+  for (let i = len - 1; i > 0; i--) {
+    const j = swaps[i] % (i + 1);
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return chars.join("");
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -59,6 +59,8 @@ export interface Business {
   sidebar_theme: string;
   /** Industry preset id (src/lib/plugins/presets.ts); null = no preset applied. */
   industry_preset?: string | null;
+  /** Navigation overrides (Settings → Navigation). NULL = the industry preset. */
+  nav_config?: import("@/lib/nav/config").NavConfig | null;
   /** Card-provider state. In the DB since the Stripe/Revolut work; the type
    *  never caught up, so pages reading them failed to compile. */
   stripe_charges_enabled?: boolean | null;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1631,6 +1631,8 @@ export interface WebhookDelivery {
 // ----------------------------------------------------------------
 
 export type ApiScope =
+  | 'vault:read'
+  | 'vault:write'
   | 'leads:read'
   | 'leads:write'
   | 'customers:read'
@@ -1701,6 +1703,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'products:write',   label: 'Create / edit products', group: 'Products' },
   { value: 'materials:read',   label: 'Read materials',    group: 'Materials' },
   { value: 'materials:write',  label: 'Create / edit materials', group: 'Materials' },
+  { value: 'vault:read',       label: 'List vault entries (never the passwords)', group: 'Vault' },
+  { value: 'vault:write',      label: 'Create / edit vault entries', group: 'Vault' },
   { value: 'settings:read',    label: 'Read settings',     group: 'Settings' },
   { value: 'settings:write',   label: 'Edit settings & preferences', group: 'Settings' },
   { value: 'bookings:read',    label: 'Read bookings & config', group: 'Bookings' },

--- a/supabase/migrations/20260808140000_nav_config.sql
+++ b/supabase/migrations/20260808140000_nav_config.sql
@@ -1,0 +1,15 @@
+-- Per-business navigation: rename, reorder, hide.
+--
+-- The industry preset already supplied a `vocab` map (Work Orders → Projects
+-- for an agency), but it was fixed at the preset and consumed only by the
+-- sidebar. This makes it the business's own, and extends it past the nav.
+--
+-- NULL = use the preset, exactly like customer_field_schema. That keeps every
+-- existing business on today's behaviour until they change something, and
+-- means improvements to a preset keep flowing until they don't want them to.
+
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS nav_config JSONB;
+
+COMMENT ON COLUMN public.businesses.nav_config IS
+  'Navigation overrides: {"labels":{"/work-orders":"Projects"},"hidden":["/tasks"],"order":["/dashboard",...]}. NULL = the industry preset''s vocab.';

--- a/supabase/migrations/20260808160000_vault.sql
+++ b/supabase/migrations/20260808160000_vault.sql
@@ -1,0 +1,152 @@
+-- Password vault: the account logins an agency holds on its clients' behalf.
+--
+-- Every secret column is AES-256-GCM ciphertext (src/lib/crypto.ts,
+-- APP_ENCRYPTION_KEY). Nothing here is ever written in the clear — the app
+-- refuses to save when no encryption key is configured rather than falling
+-- back to plaintext, which is the failure mode that actually leaks.
+--
+-- What the ciphertext protects against: a database dump, a leaked backup, a
+-- read-only SQL compromise. What it does NOT protect against: someone holding
+-- both the server env var and the database. That is a deliberate trade for
+-- recoverability — a zero-knowledge passphrase would make a forgotten
+-- passphrase mean permanent loss of every client credential.
+
+CREATE TABLE IF NOT EXISTS public.vault_items (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  -- Optional: an entry can belong to a client, or be the business's own
+  -- (its Meta Business account, a shared tool login).
+  -- CASCADE, not SET NULL: deleting a client should not leave their
+  -- credentials sitting in the table with nothing to say whose they were.
+  customer_id   UUID REFERENCES public.customers(id) ON DELETE CASCADE,
+  title         TEXT NOT NULL,
+  -- Free text, not an enum: a new kind of account shouldn't need a migration.
+  category      TEXT NOT NULL DEFAULT 'other',
+  -- Plaintext on purpose. You search by username and it is not the secret —
+  -- encrypting it would mean decrypting every row to run a search.
+  username      TEXT,
+  url           TEXT,
+  password_enc  TEXT,
+  -- Recovery codes, security answers, PINs — as sensitive as the password,
+  -- so encrypted the same way rather than dropped in a notes column.
+  notes_enc     TEXT,
+  created_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON COLUMN public.vault_items.password_enc IS
+  'AES-256-GCM ciphertext (lib/crypto.ts). NEVER store or return plaintext.';
+COMMENT ON COLUMN public.vault_items.notes_enc IS
+  'AES-256-GCM ciphertext. Recovery codes / security answers.';
+
+CREATE INDEX IF NOT EXISTS idx_vault_items_business
+  ON public.vault_items (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_vault_items_customer
+  ON public.vault_items (business_id, customer_id);
+
+-- Who looked at what, and when.
+--
+-- A vault without this is unauditable: the whole point of putting shared
+-- credentials in one place is being able to answer "who had the Meta password
+-- before it was misused". Reveals are logged; the plaintext never is.
+CREATE TABLE IF NOT EXISTS public.vault_access_log (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  -- SET NULL + a title snapshot, so the trail survives the item being
+  -- deleted. An audit log that disappears when someone removes the evidence
+  -- is not an audit log.
+  item_id     UUID REFERENCES public.vault_items(id) ON DELETE SET NULL,
+  item_title  TEXT,
+  user_id     UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  user_email  TEXT,
+  action      TEXT NOT NULL CHECK (action IN ('reveal','create','update','delete')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vault_log_business
+  ON public.vault_access_log (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_vault_log_item
+  ON public.vault_access_log (item_id, created_at DESC);
+
+ALTER TABLE public.vault_items      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.vault_access_log ENABLE ROW LEVEL SECURITY;
+
+-- Read: owner + admin ONLY. Deliberately tighter than every other table in
+-- this app, which lets any non-worker member read. Editors and viewers have
+-- no business reading the ciphertext or knowing which accounts exist, and
+-- workers are excluded by not being in the list at all.
+--
+-- Write is the same set: there is no useful "can add but not read" role for a
+-- credential store.
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['vault_items','vault_access_log'] LOOP
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_admin_read ON public.%1$s;
+      CREATE POLICY %1$s_admin_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members
+            WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+        )
+      );
+      DROP POLICY IF EXISTS %1$s_admin_write ON public.%1$s;
+      CREATE POLICY %1$s_admin_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members
+            WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members
+            WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+        )
+      );
+    $f$, t);
+  END LOOP;
+END $$;
+
+DROP TRIGGER IF EXISTS vault_items_updated_at ON public.vault_items;
+CREATE TRIGGER vault_items_updated_at BEFORE UPDATE ON public.vault_items
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- Per-business on/off, matching how every other plugin stores its flag.
+CREATE TABLE IF NOT EXISTS public.vault_settings (
+  business_id UUID PRIMARY KEY REFERENCES public.businesses(id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE public.vault_settings ENABLE ROW LEVEL SECURITY;
+
+-- The FLAG is readable by any non-worker member (the nav needs to know
+-- whether to show the tab); the CONTENTS are not. Only owner/admin can flip it.
+DROP POLICY IF EXISTS vault_settings_read ON public.vault_settings;
+CREATE POLICY vault_settings_read ON public.vault_settings FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  )
+);
+DROP POLICY IF EXISTS vault_settings_write ON public.vault_settings;
+CREATE POLICY vault_settings_write ON public.vault_settings FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+  )
+);
+
+DROP TRIGGER IF EXISTS vault_settings_updated_at ON public.vault_settings;
+CREATE TRIGGER vault_settings_updated_at BEFORE UPDATE ON public.vault_settings
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
A place for the account logins an agency holds on its clients' behalf — Meta Business Manager, hosting, registrars — instead of a spreadsheet. Per client or standalone, encrypted, owner/admin only, every look recorded.

## Encryption

AES-256-GCM through the existing `lib/crypto.ts` / `APP_ENCRYPTION_KEY` (already set on Vercel for the SEO connectors).

Chosen over a zero-knowledge passphrase **deliberately**, with the trade stated: a server key means a compromised server *plus* a compromised database can decrypt — but a forgotten passphrase would mean every client credential lost permanently, with no reset and no support path. Recoverability won. This is recorded so nobody "upgrades" it later without asking.

## The security shape

Each of these is load-bearing, not decoration:

| | |
|---|---|
| **RLS** | `vault_items` / `vault_access_log` are **owner + admin** for read *and* write — tighter than every other table in the app, which allows any non-worker member. Only the on/off flag is member-readable, so the nav still works. Verified against the live database. |
| **Assistant scopes** | `vault:read` / `vault:write` are excluded from the automatic role expansion. `READ_SCOPES`/`WRITE_SCOPES` derive from `ALL_API_SCOPES`, so adding a scope silently grants it to editors and viewers — and the assistant runs on the admin client that bypasses the RLS above. **A test guards this**, because the next scope someone adds would otherwise reopen it. |
| **No reveal over MCP** | Deliberate, and the one documented exception to the every-feature-gets-an-MCP-tool standing rule. Revealing a credential to a model puts it in a transcript and an `assistant_messages` row — outside the encryption and the audit log that justify storing it at all. Writing is allowed (one-directional and useful); reading back is a cookie-authed server action only. Noted in CLAUDE.md so it isn't "fixed" later. |
| **Fails closed** | No `APP_ENCRYPTION_KEY` means refusing to save, with a clear message — never a plaintext fallback. |
| **Nothing leaks to the browser** | The list returns `has_password: boolean`, not ciphertext. Reveals are fetched fresh each time and auto-hide after 30 seconds. |
| **Audit survives deletion** | `vault_access_log` keeps a title snapshot and `ON DELETE SET NULL`. A log that disappears when someone removes the evidence isn't a log. |

## A real bug the tests caught

The password generator wrote its required characters (one lower, one upper, one digit, one symbol) to **random positions** — which collide. A generated password could legitimately contain no digit at all, and it did. Now placed then Fisher-Yates shuffled with the CSPRNG. **Verified over 50,000 generations**: zero missing classes, zero ambiguous characters, 5000/5000 unique.

## Verification

`tsc` clean · **264 tests** (21 new), suite run **3×** for stability since the crypto tests mutate `process.env` · production build clean, `/vault` in the route list · crypto round-trip proven including *wrong key* and *tampered ciphertext* both failing closed · RLS policies queried on the live database and confirmed admin-only.

**Not clicked through.** Local dev can't authenticate against the stale `.env.local` Supabase keys, so the UI is verified on the Vercel preview, not here.

## Migration

`20260808160000_vault.sql` — applied to the live database and recorded.

## Enabling it

Off by default. Turn it on in the Plugins store (**Password vault**, under Contacts) — that writes `vault_settings` and the install row through the usual `syncPluginSideEffects` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)