### PR TITLE
feat(ui): Kirei Dashboard v2 — four themes, icon rail, new overview

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,6 +200,254 @@
   letter-spacing: -0.03em;
 }
 
+
+/* ==========================================================================
+   Kirei Dashboard v2 themes - Midnight / Daylight / Azure / Orchid
+   --------------------------------------------------------------------------
+   Ported from the Claude Design project "Kirei Dashboard v2". The design
+   ships its own token names (--panel, --ac, --mu, ...). Rather than restyle
+   every component to those names, each theme is expressed in the SHADCN
+   contract the whole app already reads (--background, --card, --border,
+   --primary, ...) - so every existing page picks the theme up for free.
+
+   Two conversions were needed and are worth knowing about:
+
+   1. The design's borders are rgba over a surface (rgba(255,255,255,.07)).
+      hsl(var(--border)) needs a solid colour, so each border is composited
+      over the panel it actually sits on rather than approximated by eye.
+   2. The design's `bg` is the plate BEHIND its floating rounded shell. In the
+      app the content area fills the viewport, so `panel` becomes the canvas
+      and `bg` survives as --canvas-deep for the glow layer.
+
+   Light/dark is a property of the theme, not a separate toggle: Daylight is
+   light, the other three are dark. `color-scheme` tells the browser so native
+   controls and scrollbars follow.
+   ========================================================================== */
+
+[data-theme="Midnight"] {
+  /* Canvas is the design's `panel` (its floating shell interior): the app's
+     content area fills the viewport, so there is no outer `bg` plate. `bg`
+     survives as --canvas-deep for the glow layer behind the shell. */
+  --background: 217.5 41.4% 11.4%;
+  --foreground: 217.5 61.5% 94.9%;
+  --card: 218.6 36.8% 14.9%;
+  --card-foreground: 217.5 61.5% 94.9%;
+  --popover: 218.6 36.8% 14.9%;
+  --popover-foreground: 217.5 61.5% 94.9%;
+  --primary: 217.2 91.2% 59.8%;
+  --primary-foreground: 0.0 0.0% 100.0%;
+  --nav: 217.5 41.4% 11.4%;
+  --nav-foreground: 217.5 61.5% 94.9%;
+  --secondary: 218.2 34.7% 18.6%;
+  --secondary-foreground: 217.5 61.5% 94.9%;
+  --muted: 218.2 34.7% 18.6%;
+  --muted-foreground: 218.5 20.2% 62.2%;
+  --accent: 217.2 91.2% 59.8%;
+  --accent-foreground: 0.0 0.0% 100.0%;
+  --destructive: 0.0 90.6% 70.8%;
+  --destructive-foreground: 0.0 0.0% 100.0%;
+  --border: 218.2 24.4% 17.6%;
+  --input: 218.2 24.4% 17.6%;
+  --ring: 217.2 91.2% 59.8%;
+  --radius: 0.875rem;                 /* 14px - the mock's card radius */
+
+  /* Design tokens the new shell and dashboard use directly. Kept under their
+     own names so they can't collide with the shadcn contract above. */
+  --canvas-deep: 220.0 47.4% 7.5%;
+  --surface-3: 218.2 34.7% 18.6%;
+  --border-strong: 220.0 18.6% 22.2%;
+  --accent-2: 187.9 85.7% 53.3%;
+  --accent-soft: rgba(59,130,246,.16);
+  --ok: 158.1 64.4% 51.6%;
+  --warn: 43.3 96.4% 56.3%;
+  --bad: 0.0 90.6% 70.8%;
+  --lime: 82.0 84.5% 67.1%;
+  --glow: rgba(59,130,246,.18);
+  --shadow-panel: 0 24px 60px rgba(0,0,0,.45);
+  /* The sidebar follows the theme rather than the older data-sidebar-theme
+     presets: in the mock the rail is the same panel as the shell, lit by an
+     accent wash at the top. Mapping the sidebar tokens here means the existing
+     bg-sidebar / text-sidebar-foreground classes need no changes. */
+  --sidebar: var(--background);
+  --sidebar-foreground: var(--muted-foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  color-scheme: dark;
+}
+
+[data-theme="Daylight"] {
+  /* Canvas is the design's `panel` (its floating shell interior): the app's
+     content area fills the viewport, so there is no outer `bg` plate. `bg`
+     survives as --canvas-deep for the glow layer behind the shell. */
+  --background: 0.0 0.0% 100.0%;
+  --foreground: 220.0 42.9% 11.0%;
+  --card: 220.0 50.0% 97.6%;
+  --card-foreground: 220.0 42.9% 11.0%;
+  --popover: 220.0 50.0% 97.6%;
+  --popover-foreground: 220.0 42.9% 11.0%;
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 0.0 0.0% 100.0%;
+  --nav: 0.0 0.0% 100.0%;
+  --nav-foreground: 220.0 42.9% 11.0%;
+  --secondary: 218.2 44.0% 95.1%;
+  --secondary-foreground: 220.0 42.9% 11.0%;
+  --muted: 218.2 44.0% 95.1%;
+  --muted-foreground: 217.9 15.7% 47.5%;
+  --accent: 221.2 83.2% 53.3%;
+  --accent-foreground: 0.0 0.0% 100.0%;
+  --destructive: 0.0 72.2% 50.6%;
+  --destructive-foreground: 0.0 0.0% 100.0%;
+  --border: 210.0 5.6% 92.9%;
+  --input: 210.0 5.6% 92.9%;
+  --ring: 221.2 83.2% 53.3%;
+  --radius: 0.875rem;                 /* 14px - the mock's card radius */
+
+  /* Design tokens the new shell and dashboard use directly. Kept under their
+     own names so they can't collide with the shadcn contract above. */
+  --canvas-deep: 216.0 41.7% 95.3%;
+  --surface-3: 218.2 44.0% 95.1%;
+  --border-strong: 220.0 4.8% 87.6%;
+  --accent-2: 198.6 88.7% 48.4%;
+  --accent-soft: rgba(37,99,235,.10);
+  --ok: 161.4 93.5% 30.4%;
+  --warn: 32.1 94.6% 43.7%;
+  --bad: 0.0 72.2% 50.6%;
+  --lime: 84.8 85.2% 34.5%;
+  --glow: rgba(37,99,235,.12);
+  --shadow-panel: 0 24px 60px rgba(16,24,40,.12);
+  /* The sidebar follows the theme rather than the older data-sidebar-theme
+     presets: in the mock the rail is the same panel as the shell, lit by an
+     accent wash at the top. Mapping the sidebar tokens here means the existing
+     bg-sidebar / text-sidebar-foreground classes need no changes. */
+  --sidebar: var(--background);
+  --sidebar-foreground: var(--muted-foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  color-scheme: light;
+}
+
+[data-theme="Azure"] {
+  /* Canvas is the design's `panel` (its floating shell interior): the app's
+     content area fills the viewport, so there is no outer `bg` plate. `bg`
+     survives as --canvas-deep for the glow layer behind the shell. */
+  --background: 215.7 75.5% 19.2%;
+  --foreground: 214.3 100.0% 95.9%;
+  --card: 215.0 70.0% 23.5%;
+  --card-foreground: 214.3 100.0% 95.9%;
+  --popover: 215.0 70.0% 23.5%;
+  --popover-foreground: 214.3 100.0% 95.9%;
+  --primary: 215.4 100.0% 62.2%;
+  --primary-foreground: 211.5 88.1% 13.1%;
+  --nav: 215.7 75.5% 19.2%;
+  --nav-foreground: 214.3 100.0% 95.9%;
+  --secondary: 215.0 65.8% 28.6%;
+  --secondary-foreground: 214.3 100.0% 95.9%;
+  --muted: 215.0 65.8% 28.6%;
+  --muted-foreground: 215.3 52.3% 74.5%;
+  --accent: 215.4 100.0% 62.2%;
+  --accent-foreground: 211.5 88.1% 13.1%;
+  --destructive: 0.0 93.5% 81.8%;
+  --destructive-foreground: 211.5 88.1% 13.1%;
+  --border: 215.8 48.2% 27.3%;
+  --input: 215.8 48.2% 27.3%;
+  --ring: 215.4 100.0% 62.2%;
+  --radius: 0.875rem;                 /* 14px - the mock's card radius */
+
+  /* Design tokens the new shell and dashboard use directly. Kept under their
+     own names so they can't collide with the shadcn contract above. */
+  --canvas-deep: 216.0 82.1% 13.1%;
+  --surface-3: 215.0 65.8% 28.6%;
+  --border-strong: 216.0 34.9% 33.7%;
+  --accent-2: 199.4 95.5% 73.9%;
+  --accent-soft: rgba(125,211,252,.16);
+  --ok: 170.6 76.9% 64.3%;
+  --warn: 45.9 96.7% 64.5%;
+  --bad: 0.0 93.5% 81.8%;
+  --lime: 82.7 78.0% 55.5%;
+  --glow: rgba(125,211,252,.22);
+  --shadow-panel: 0 24px 60px rgba(2,14,32,.5);
+  /* The sidebar follows the theme rather than the older data-sidebar-theme
+     presets: in the mock the rail is the same panel as the shell, lit by an
+     accent wash at the top. Mapping the sidebar tokens here means the existing
+     bg-sidebar / text-sidebar-foreground classes need no changes. */
+  --sidebar: var(--background);
+  --sidebar-foreground: var(--muted-foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  color-scheme: dark;
+}
+
+[data-theme="Orchid"] {
+  /* Canvas is the design's `panel` (its floating shell interior): the app's
+     content area fills the viewport, so there is no outer `bg` plate. `bg`
+     survives as --canvas-deep for the glow layer behind the shell. */
+  --background: 260.6 50.0% 12.5%;
+  --foreground: 262.9 100.0% 95.9%;
+  --card: 260.0 48.8% 16.9%;
+  --card-foreground: 262.9 100.0% 95.9%;
+  --popover: 260.0 48.8% 16.9%;
+  --popover-foreground: 262.9 100.0% 95.9%;
+  --primary: 258.3 89.5% 66.3%;
+  --primary-foreground: 0.0 0.0% 100.0%;
+  --nav: 260.6 50.0% 12.5%;
+  --nav-foreground: 262.9 100.0% 95.9%;
+  --secondary: 259.2 47.7% 21.8%;
+  --secondary-foreground: 262.9 100.0% 95.9%;
+  --muted: 259.2 47.7% 21.8%;
+  --muted-foreground: 261.3 29.6% 68.2%;
+  --accent: 258.3 89.5% 66.3%;
+  --accent-foreground: 0.0 0.0% 100.0%;
+  --destructive: 351.3 94.5% 71.4%;
+  --destructive-foreground: 0.0 0.0% 100.0%;
+  --border: 260.7 27.6% 20.6%;
+  --input: 260.7 27.6% 20.6%;
+  --ring: 258.3 89.5% 66.3%;
+  --radius: 0.875rem;                 /* 14px - the mock's card radius */
+
+  /* Design tokens the new shell and dashboard use directly. Kept under their
+     own names so they can't collide with the shadcn contract above. */
+  --canvas-deep: 261.8 52.4% 8.2%;
+  --surface-3: 259.2 47.7% 21.8%;
+  --border-strong: 260.0 20.0% 26.5%;
+  --accent-2: 292.0 91.4% 72.5%;
+  --accent-soft: rgba(139,92,246,.18);
+  --ok: 141.9 69.2% 58.0%;
+  --warn: 43.3 96.4% 56.3%;
+  --bad: 351.3 94.5% 71.4%;
+  --lime: 252.5 94.7% 85.1%;
+  --glow: rgba(139,92,246,.22);
+  --shadow-panel: 0 24px 60px rgba(10,4,20,.55);
+  /* The sidebar follows the theme rather than the older data-sidebar-theme
+     presets: in the mock the rail is the same panel as the shell, lit by an
+     accent wash at the top. Mapping the sidebar tokens here means the existing
+     bg-sidebar / text-sidebar-foreground classes need no changes. */
+  --sidebar: var(--background);
+  --sidebar-foreground: var(--muted-foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  color-scheme: dark;
+}
+
 /* ─── Sidebar theme presets ───────────────────────────────── */
 
 /* Dark Navy (default — already set in :root) */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,7 +56,21 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" data-theme="console" suppressHydrationWarning>
+    <html lang="en" data-theme="Midnight" suppressHydrationWarning>
+      <head>
+        {/* Paint the business's theme before first render.
+            Three of the four palettes are dark, so without this every cold
+            load flashes the Midnight default (or white) before the provider
+            catches up - the one thing a dark theme must not do. The provider
+            mirrors the choice into localStorage; this only reads it. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('kirei.ui-theme');`
+              + `if(t&&['Midnight','Daylight','Azure','Orchid'].indexOf(t)>-1)`
+              + `document.documentElement.dataset.theme=t;}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body className={`${jakarta.variable} font-sans antialiased`} suppressHydrationWarning>
         <ThemeProvider
           attribute="class"

--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -1,330 +1,62 @@
 "use client";
 
+/**
+ * The owner/admin dashboard.
+ *
+ * The overview itself is the Kirei Dashboard v2 design (see
+ * ./v2/dashboard-v2.tsx). This file is the composition: the redesigned
+ * overview, then the widgets that were already here.
+ *
+ * The widgets are kept deliberately. The mock never included briefing, tasks,
+ * outlook or new leads — but removing working features to match a mock that
+ * simply didn't draw them would be a loss of function dressed up as a
+ * redesign. They sit below the overview instead.
+ */
+
 import Link from "next/link";
-import {
-  TrendingUp, Clock, AlertTriangle, CheckCircle, Plus, FileText,
-  Wrench, MapPin, User, ArrowRight, FileCheck, UserPlus, ChevronRight,
-  DollarSign, Calendar, Briefcase,
-} from "@/components/ui/icons";
-import { formatCurrency } from "@/lib/utils";
+import { UserPlus, Plus } from "@/components/ui/icons";
 import { BriefingWidget } from "@/components/briefing/briefing-widget";
 import { TasksWidget } from "@/components/tasks/tasks-widget";
 import { OutlookWidget } from "@/components/dashboard/outlook-widget";
 import { NewLeadsWidget } from "@/components/dashboard/new-leads-widget";
-import {
-  FadeIn, HubTile, StatTile, CardListRow, AnimatedPress, GradientTile,
-} from "@/components/ui/kirei";
-import type { WorkOrderWithCustomer, WorkOrderStatus } from "@/types/database";
-import type { GradientName } from "@/components/ui/kirei";
-
-const STATUS_PILL_TEXT: Record<WorkOrderStatus, string> = {
-  draft: "Draft", assigned: "Assigned", in_progress: "In progress",
-  submitted: "Submitted", reviewed: "Reviewed", completed: "Completed", cancelled: "Cancelled",
-};
-
-const STATUS_PILL_TONE: Record<WorkOrderStatus, string> = {
-  draft:       "bg-muted text-muted-foreground",
-  assigned:    "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200",
-  in_progress: "bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200",
-  submitted:   "bg-violet-100 text-violet-900 dark:bg-violet-900/40 dark:text-violet-200",
-  reviewed:    "bg-yellow-100 text-yellow-900 dark:bg-yellow-900/40 dark:text-yellow-200",
-  completed:   "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200",
-  cancelled:   "bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200",
-};
+import { DashboardV2, type DashboardV2Stats } from "@/components/dashboard/v2/dashboard-v2";
+import type { WorkOrderWithCustomer } from "@/types/database";
 
 interface DashboardClientProps {
   todayJobs: WorkOrderWithCustomer[];
-  stats: {
-    totalRevenue: number;
-    outstanding: number;
-    overdue: number;
-    paidThisMonth: number;
-    recentInvoices: Array<{
-      id?: string;
-      number?: string;
-      status?: string;
-      total?: number;
-      due_date?: string;
-      issue_date?: string;
-      customers?: { name?: string } | null;
-    }>;
-    monthlyData: Array<{ month: string; revenue: number; invoiced: number }>;
-  };
+  stats: DashboardV2Stats;
   currency?: string;
 }
 
-function fmtShort(n: number, currency: string) {
-  if (Math.abs(n) >= 1000) {
-    return (n / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 }).replace(/\.0$/, "") + "k " + currency;
-  }
-  return formatCurrency(n, currency);
-}
-
 export function DashboardClient({ stats, currency = "GBP", todayJobs }: DashboardClientProps) {
-  const todayStr = new Date().toISOString().split("T")[0];
-  const now = new Date();
-  const hour = now.getHours();
-  const greeting = hour < 5 ? "Late night" : hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
-
-  const monthly = stats.monthlyData.slice(-6);
-  const maxBar  = Math.max(...monthly.map((m) => m.revenue), 1);
-  const totalBilled = monthly.reduce((s, m) => s + m.revenue, 0);
-
-  const scheduledToday = todayJobs.filter((j) => j.scheduled_date === todayStr);
-  const tomorrowStr = (() => {
-    const t = new Date(); t.setDate(t.getDate() + 1);
-    return t.toISOString().split("T")[0];
-  })();
-  const tomorrow = todayJobs.filter((j) => j.scheduled_date === tomorrowStr);
-
-  const lastMonth = monthly[monthly.length - 2]?.revenue ?? 0;
-  const thisMonth = monthly[monthly.length - 1]?.revenue ?? 0;
-  const monthDelta = lastMonth > 0 ? ((thisMonth - lastMonth) / lastMonth) * 100 : 0;
+  const hour = new Date().getHours();
+  const greeting =
+    hour < 5 ? "Late night" : hour < 12 ? "Morning" : hour < 18 ? "Afternoon" : "Evening";
 
   return (
     <div className="space-y-6">
-      {/* ── Greeting + primary CTA ─────────────────────────────────────────── */}
-      <FadeIn>
-        <div className="flex items-end justify-between gap-3 flex-wrap">
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{greeting}.</h1>
-            <p className="text-sm text-muted-foreground mt-1">Here&apos;s what&apos;s happening today.</p>
-          </div>
-          <Link href="/invoices/new">
-            <AnimatedPress className="inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold shadow-sm">
-              <Plus className="w-4 h-4" /> New invoice
-            </AnimatedPress>
-          </Link>
-        </div>
-      </FadeIn>
+      <DashboardV2 stats={stats} currency={currency} todayJobs={todayJobs} greeting={greeting} />
 
-      {/* ── Overdue alert strip ────────────────────────────────────────────── */}
-      {stats.overdue > 0 && (
-        <FadeIn delay={60}>
-          <Link href="/invoices?status=overdue" className="block">
-            <AnimatedPress className="flex items-center gap-3 px-4 py-3 rounded-md bg-rose-50 dark:bg-rose-950/30 border border-rose-200/60 dark:border-rose-900/40">
-              <GradientTile gradient="rose" size={40} radius={10}>
-                <AlertTriangle className="w-4 h-4" />
-              </GradientTile>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-semibold text-rose-900 dark:text-rose-200 leading-tight">
-                  {formatCurrency(stats.overdue, currency)} overdue
-                </p>
-                <p className="text-xs text-rose-700/80 dark:text-rose-300/70">Send reminders to bring these in</p>
-              </div>
-              <ArrowRight className="w-4 h-4 text-rose-700 dark:text-rose-300 shrink-0" />
-            </AnimatedPress>
-          </Link>
-        </FadeIn>
-      )}
-
-      {/* ── KPI tiles (gradient-tinted) ────────────────────────────────────── */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        {[
-          { gradient: "softTeal"   as GradientName, tone: "#1f4f4a", icon: <DollarSign className="w-3.5 h-3.5" />,
-            label: `Revenue (${monthly[monthly.length - 1]?.month ?? "this month"})`,
-            value: fmtShort(thisMonth, currency),
-            sub:   monthDelta !== 0 ? `${monthDelta >= 0 ? "+" : ""}${Math.round(monthDelta * 10) / 10}% vs last month` : "vs last month" },
-          { gradient: "softBlue"   as GradientName, tone: "#1e3a8a", icon: <Clock className="w-3.5 h-3.5" />,
-            label: "Outstanding", value: fmtShort(stats.outstanding, currency),
-            sub: `${stats.recentInvoices.length} recent invoices`, href: "/invoices?status=pending" },
-          { gradient: "softRose"   as GradientName, tone: "#9f1239", icon: <AlertTriangle className="w-3.5 h-3.5" />,
-            label: "Overdue", value: fmtShort(stats.overdue, currency),
-            sub: stats.overdue > 0 ? "needs follow-up" : "all clear",
-            href: stats.overdue > 0 ? "/invoices?status=overdue" : undefined },
-          { gradient: "softAmber"  as GradientName, tone: "#78350f", icon: <CheckCircle className="w-3.5 h-3.5" />,
-            label: "Paid this month", value: fmtShort(stats.paidThisMonth, currency),
-            sub: "settled invoices" },
-        ].map((t, i) => (
-          <FadeIn key={t.label} delay={120 + i * 50}>
-            <StatTile {...t} toneColor={t.tone} />
-          </FadeIn>
-        ))}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <BriefingWidget />
+        <TasksWidget />
+        <OutlookWidget />
+        <NewLeadsWidget />
       </div>
 
-      {/* ── Quick actions (mobile-style hub tiles) ─────────────────────────── */}
-      <FadeIn delay={320}>
-        <div>
-          <h2 className="text-[11px] uppercase tracking-wide font-bold text-muted-foreground mb-2">Quick actions</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-            <HubTile href="/invoices/new"    gradient="emerald" icon={<FileText  className="w-5 h-5" />} label="New invoice"  hint="Bill a customer" />
-            <HubTile href="/quotes/new"      gradient="violet"  icon={<FileCheck className="w-5 h-5" />} label="New quote"    hint="Send an estimate" />
-            <HubTile href="/work-orders/new" gradient="blue"    icon={<Wrench    className="w-5 h-5" />} label="Work order"   hint="Schedule a job" />
-            <HubTile href="/customers/new"   gradient="primary" icon={<UserPlus  className="w-5 h-5" />} label="Add customer" hint="New contact" />
-          </div>
-        </div>
-      </FadeIn>
-
-      {/* ── 2-col content area ─────────────────────────────────────────────── */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-5">
-        {/* LEFT: revenue + briefing + recent invoices */}
-        <div className="flex flex-col gap-5">
-          <FadeIn delay={380}><BriefingWidget compact /></FadeIn>
-
-          {/* Revenue chart card */}
-          <FadeIn delay={440}>
-            <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
-              <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-                <div>
-                  <h3 className="text-sm font-semibold">Revenue, last 6 months</h3>
-                  <p className="text-xs text-muted-foreground mt-0.5">Paid invoices, trailing</p>
-                </div>
-                <GradientTile gradient="primary" size={32} radius={8}>
-                  <TrendingUp className="w-4 h-4" />
-                </GradientTile>
-              </div>
-              <div className="p-5">
-                <div className="flex items-end justify-between gap-2 h-32">
-                  {monthly.map((m) => {
-                    const pct = (m.revenue / maxBar) * 100;
-                    return (
-                      <div key={m.month} className="flex flex-col items-center gap-1.5 flex-1 min-w-0">
-                        <div className="w-full flex items-end justify-center h-full">
-                          <div
-                            className="w-full max-w-[28px] rounded-md"
-                            style={{
-                              height: `${Math.max(pct, 4)}%`,
-                              backgroundImage: "linear-gradient(180deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.7) 100%)",
-                            }}
-                            title={formatCurrency(m.revenue, currency)}
-                          />
-                        </div>
-                        <span className="text-[10px] text-muted-foreground">{m.month}</span>
-                      </div>
-                    );
-                  })}
-                </div>
-                <div className="flex items-center justify-between pt-4 mt-2 border-t border-border">
-                  <span className="text-xs text-muted-foreground">Total billed</span>
-                  <span className="text-sm font-semibold tabular-nums">{formatCurrency(totalBilled, currency)}</span>
-                </div>
-              </div>
-            </div>
-          </FadeIn>
-
-          {/* Recent invoices — card list, no table */}
-          <FadeIn delay={500}>
-            <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
-              <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-                <h3 className="text-sm font-semibold">Recent invoices</h3>
-                <Link href="/invoices" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-                  View all <ChevronRight className="w-3 h-3" />
-                </Link>
-              </div>
-              {stats.recentInvoices.length === 0 ? (
-                <div className="p-8 text-center">
-                  <p className="text-sm font-medium">No invoices yet</p>
-                  <p className="text-xs text-muted-foreground mt-1 mb-4">Create your first invoice to get started.</p>
-                  <Link href="/invoices/new">
-                    <AnimatedPress className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium">
-                      <Plus className="w-3 h-3" /> New invoice
-                    </AnimatedPress>
-                  </Link>
-                </div>
-              ) : (
-                <div className="p-2 space-y-1.5">
-                  {stats.recentInvoices.slice(0, 5).map((inv, i) => (
-                    <CardListRow
-                      key={inv.id ?? i}
-                      href={inv.id ? `/invoices/${inv.id}` : undefined}
-                      gradient={inv.status === "paid" ? "emerald" : inv.status === "overdue" ? "rose" : "primary"}
-                      icon={<FileText className="w-4 h-4" />}
-                      title={<><span className="font-mono text-xs text-muted-foreground mr-2">{inv.number}</span>{inv.customers?.name ?? "—"}</>}
-                      meta={inv.issue_date ?? inv.due_date ?? ""}
-                      trailing={formatCurrency(inv.total ?? 0, currency)}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          </FadeIn>
-        </div>
-
-        {/* RIGHT: schedule + leads + tasks + outlook */}
-        <div className="flex flex-col gap-5">
-          {/* Today's schedule */}
-          <FadeIn delay={420}>
-            <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
-              <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-                <div className="flex items-center gap-2.5">
-                  <GradientTile gradient="amber" size={32} radius={8}>
-                    <Calendar className="w-4 h-4" />
-                  </GradientTile>
-                  <div>
-                    <h3 className="text-sm font-semibold">Today&apos;s schedule</h3>
-                    <p className="text-xs text-muted-foreground">{now.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" })}</p>
-                  </div>
-                </div>
-                <Link href="/work-orders" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-                  All jobs <ChevronRight className="w-3 h-3" />
-                </Link>
-              </div>
-              <div className="p-2 space-y-1.5">
-                {scheduledToday.length === 0 ? (
-                  <div className="p-6 text-center">
-                    <p className="text-sm font-medium">Nothing scheduled today</p>
-                    <p className="text-xs text-muted-foreground mt-1">Add a work order to fill your day.</p>
-                  </div>
-                ) : (
-                  scheduledToday.slice(0, 6).map((wo) => <ScheduleCard key={wo.id} wo={wo} />)
-                )}
-                {tomorrow.length > 0 && (
-                  <>
-                    <div className="border-t border-border my-2" />
-                    <div className="text-[10px] uppercase tracking-wide font-bold text-muted-foreground px-2 pb-1">Tomorrow</div>
-                    {tomorrow.slice(0, 3).map((wo) => <ScheduleCard key={wo.id} wo={wo} />)}
-                  </>
-                )}
-              </div>
-            </div>
-          </FadeIn>
-
-          <FadeIn delay={480}><NewLeadsWidget /></FadeIn>
-          <FadeIn delay={540}><TasksWidget /></FadeIn>
-          <FadeIn delay={600}><OutlookWidget /></FadeIn>
-        </div>
+      {/* Two destinations the old overview offered that the v2 layout has no
+          slot for. Kept as a footer row rather than dropped - "add a client"
+          was one click from the dashboard and should stay that way. */}
+      <div className="flex flex-wrap gap-3">
+        <Link href="/customers/new"
+          className="flex items-center gap-2 rounded-2xl border border-border bg-card px-4 py-3 text-sm font-medium transition-colors hover:border-[hsl(var(--border-strong))]">
+          <UserPlus className="h-4 w-4 text-[hsl(var(--accent-2))]" /> New client
+        </Link>
+        <Link href="/leads/new"
+          className="flex items-center gap-2 rounded-2xl border border-border bg-card px-4 py-3 text-sm font-medium transition-colors hover:border-[hsl(var(--border-strong))]">
+          <Plus className="h-4 w-4 text-[hsl(var(--lime))]" /> New lead
+        </Link>
       </div>
     </div>
-  );
-}
-
-// ── Sub-components ─────────────────────────────────────────────────────────
-
-function ScheduleCard({ wo }: { wo: WorkOrderWithCustomer }) {
-  const time = wo.start_time ? wo.start_time.slice(0, 5) : "—";
-  const status = (wo.status ?? "draft") as WorkOrderStatus;
-  const gradient: GradientName =
-    status === "in_progress" ? "amber" :
-    status === "submitted"   ? "violet" :
-    status === "completed"   ? "emerald" :
-    "primary";
-
-  return (
-    <Link href={`/work-orders/${wo.id}`} className="block">
-      <AnimatedPress className="flex items-center gap-3 p-3 rounded-md bg-card border border-border/70 hover:border-primary/30 transition-colors">
-        <GradientTile gradient={gradient} size={40} radius={10}>
-          <Briefcase className="w-4 h-4" />
-        </GradientTile>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-mono font-semibold text-foreground tabular-nums">{time}</span>
-            <span className="text-sm font-medium text-foreground break-words">{wo.customers?.name ?? wo.title}</span>
-          </div>
-          <div className="text-xs text-muted-foreground flex items-center gap-3 mt-0.5 min-w-0">
-            <span className="inline-flex items-center gap-1 min-w-0 break-words">
-              <MapPin className="w-3 h-3 shrink-0" /><span className="break-words">{wo.property_address ?? "—"}</span>
-            </span>
-            {wo.assigned_to_email && (
-              <span className="hidden sm:inline-flex items-center gap-1 min-w-0 break-words">
-                <User className="w-3 h-3 shrink-0" /><span className="break-words">{wo.assigned_to_email}</span>
-              </span>
-            )}
-          </div>
-        </div>
-        <span className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full ${STATUS_PILL_TONE[status]} shrink-0`}>
-          {STATUS_PILL_TEXT[status]}
-        </span>
-      </AnimatedPress>
-    </Link>
   );
 }

--- a/src/components/dashboard/v2/dashboard-v2.tsx
+++ b/src/components/dashboard/v2/dashboard-v2.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+/**
+ * The Kirei Dashboard v2 overview.
+ *
+ * Ported from the Claude Design project of the same name. Two things about the
+ * port are worth knowing:
+ *
+ *  1. **The mock's colours are theme tokens now**, not literals. The design's
+ *     --ac / --mu / --panel2 became --primary / --muted-foreground / --card in
+ *     globals.css, so this file uses ordinary Tailwind classes and picks up
+ *     whichever of the four palettes is active.
+ *  2. **Every number here is real.** The mock ships invented figures
+ *     (Ardent Studio, £12,600). Where the app has no source for a panel, the
+ *     panel is sourced differently rather than filled with plausible fiction —
+ *     see the revenue-split note below.
+ */
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Plus, FileCheck, Wrench, ChevronRight, DollarSign, Clock,
+  AlertTriangle, CheckCircle, MapPin, User,
+} from "@/components/ui/icons";
+import { formatCurrency } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { useVocab, lower } from "@/components/layout/vocab-provider";
+import type { WorkOrderWithCustomer } from "@/types/database";
+
+export interface DashboardV2Stats {
+  totalRevenue: number;
+  outstanding: number;
+  overdue: number;
+  paidThisMonth: number;
+  recentInvoices: Array<{
+    id?: string; number?: string; status?: string; total?: number;
+    due_date?: string; issue_date?: string; customers?: { name?: string } | null;
+  }>;
+  monthlyData: Array<{ month: string; revenue: number; invoiced: number }>;
+}
+
+const RANGES = [3, 6, 12] as const;
+const FILTERS = ["All", "Paid", "Sent", "Overdue"] as const;
+
+/** Status → which semantic colour the mock uses for it. */
+function toneFor(status?: string): "ok" | "warn" | "bad" | "mu" {
+  const s = (status ?? "").toLowerCase();
+  if (s === "paid") return "ok";
+  if (s === "overdue") return "bad";
+  if (s === "sent" || s === "partial") return "warn";
+  return "mu";
+}
+
+const TONE_TEXT: Record<string, string> = {
+  ok: "text-[hsl(var(--ok))]",
+  warn: "text-[hsl(var(--warn))]",
+  bad: "text-[hsl(var(--bad))]",
+  mu: "text-muted-foreground",
+};
+
+function initialsOf(name?: string | null): string {
+  const parts = (name ?? "").trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return "—";
+  return (parts[0][0] + (parts[1]?.[0] ?? "")).toUpperCase();
+}
+
+export function DashboardV2({
+  stats, currency = "GBP", todayJobs, greeting,
+}: {
+  stats: DashboardV2Stats;
+  currency?: string;
+  todayJobs: WorkOrderWithCustomer[];
+  /** "Morning" / "Afternoon" - the mock's header line, shown here because our
+   *  header is global and this greeting is specific to the dashboard. */
+  greeting: string;
+}) {
+  const jobs = useVocab("/work-orders", "Work Orders");
+  const [range, setRange] = useState<(typeof RANGES)[number]>(6);
+  const [filter, setFilter] = useState<(typeof FILTERS)[number]>("All");
+
+  const series = useMemo(() => stats.monthlyData.slice(-range), [stats.monthlyData, range]);
+
+  const overdueInvoices = stats.recentInvoices.filter((i) => (i.status ?? "").toLowerCase() === "overdue");
+
+  const rows = useMemo(() => {
+    if (filter === "All") return stats.recentInvoices;
+    return stats.recentInvoices.filter((i) => (i.status ?? "").toLowerCase() === filter.toLowerCase());
+  }, [stats.recentInvoices, filter]);
+
+  /**
+   * The mock's "Where the money comes from" splits revenue by service category
+   * (Kitchens / Wardrobes / ...). Kirei stores no category on an invoice, so
+   * inventing one would mean drawing a chart of nothing. Split by CUSTOMER
+   * instead — same question, answered from data that actually exists.
+   */
+  const split = useMemo(() => {
+    const byCustomer = new Map<string, number>();
+    for (const inv of stats.recentInvoices) {
+      const name = inv.customers?.name?.trim() || "Unattributed";
+      byCustomer.set(name, (byCustomer.get(name) ?? 0) + Number(inv.total ?? 0));
+    }
+    const all = [...byCustomer.entries()].sort((a, b) => b[1] - a[1]);
+    const top = all.slice(0, 3);
+    const restTotal = all.slice(3).reduce((n, [, v]) => n + v, 0);
+    const parts = restTotal > 0 ? [...top, ["Everyone else", restTotal] as [string, number]] : top;
+    const total = parts.reduce((n, [, v]) => n + v, 0);
+    return { total, parts: parts.map(([name, value]) => ({ name, value, pct: total > 0 ? value / total : 0 })) };
+  }, [stats.recentInvoices]);
+
+  return (
+    <div className="grid min-h-0 gap-5 xl:grid-cols-[minmax(0,1fr)_352px]">
+      <div className="flex min-w-0 flex-col gap-5">
+        <div>
+          <h1 className="text-[26px] font-semibold leading-tight tracking-[-0.02em]">{greeting}!</h1>
+          <p className="mt-1.5 text-sm text-muted-foreground">Here&rsquo;s what&rsquo;s on your books today.</p>
+        </div>
+
+        {/* ── Quick actions ─────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center gap-3.5">
+          <Link href="/invoices/new" className={cn(
+            "flex items-center gap-2.5 rounded-2xl bg-primary px-5 py-3.5 text-sm font-semibold text-primary-foreground",
+            "transition-transform duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:brightness-110",
+          )}>
+            <Plus className="h-[17px] w-[17px]" /> New invoice
+          </Link>
+          <Link href="/quotes/new" className={cn(
+            "flex items-center gap-2.5 rounded-2xl border border-border bg-card px-5 py-3.5 text-sm font-medium",
+            "transition-[transform,border-color] duration-200 hover:-translate-y-0.5 hover:border-[hsl(var(--border-strong))]",
+          )}>
+            <FileCheck className="h-[17px] w-[17px] text-[hsl(var(--accent-2))]" /> New quote
+          </Link>
+          <Link href="/work-orders/new" className={cn(
+            "flex items-center gap-2.5 rounded-2xl border border-border bg-card px-5 py-3.5 text-sm font-medium",
+            "transition-[transform,border-color] duration-200 hover:-translate-y-0.5 hover:border-[hsl(var(--border-strong))]",
+          )}>
+            <Wrench className="h-[17px] w-[17px] text-[hsl(var(--lime))]" /> New {lower(jobs.singular)}
+          </Link>
+
+          {/* The mock's overdue nudge. Shown only when there IS overdue money —
+              a cheerful "£0 overdue across 0 invoices" is noise. */}
+          {stats.overdue > 0 && (
+            <button
+              type="button"
+              onClick={() => setFilter("Overdue")}
+              className={cn(
+                "ml-auto flex items-center gap-3 rounded-2xl border border-border bg-card px-4 py-3",
+                "transition-colors duration-200 hover:border-[hsl(var(--bad))]",
+              )}
+            >
+              <span className="h-2 w-2 shrink-0 rounded-full bg-[hsl(var(--bad))]" />
+              <span className="text-sm font-medium">
+                {formatCurrency(stats.overdue, currency)} overdue
+                {overdueInvoices.length > 0 && ` across ${overdueInvoices.length} invoice${overdueInvoices.length === 1 ? "" : "s"}`}
+              </span>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            </button>
+          )}
+        </div>
+
+        {/* ── KPI tiles ─────────────────────────────────────────────── */}
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <Kpi icon={<DollarSign className="h-[18px] w-[18px] text-primary" />}
+               label="Revenue, all time" value={formatCurrency(stats.totalRevenue, currency)} />
+          <Kpi icon={<Clock className="h-[18px] w-[18px] text-[hsl(var(--accent-2))]" />}
+               label="Outstanding" value={formatCurrency(stats.outstanding, currency)}
+               note={`${stats.recentInvoices.filter((i) => ["sent", "partial", "overdue"].includes((i.status ?? "").toLowerCase())).length} open`} />
+          <Kpi icon={<AlertTriangle className="h-[18px] w-[18px] text-[hsl(var(--bad))]" />}
+               label="Overdue" value={formatCurrency(stats.overdue, currency)}
+               badge={overdueInvoices.length > 0 ? `${overdueInvoices.length} late` : undefined} badgeTone="bad" />
+          <Kpi icon={<CheckCircle className="h-[18px] w-[18px] text-primary-foreground" />}
+               iconOnAccent
+               label="Collected this month" value={formatCurrency(stats.paidThisMonth, currency)} emphasis />
+        </div>
+
+        {/* ── Revenue flow + split ──────────────────────────────────── */}
+        <div className="grid gap-4 lg:grid-cols-[1.45fr_1fr]">
+          <section className="overflow-hidden rounded-[22px] border border-border bg-card">
+            <div className="flex flex-wrap items-center justify-between gap-3 p-5">
+              <div>
+                <h3 className="text-base font-semibold">Revenue flow</h3>
+                <p className="mt-1 text-[13px] text-muted-foreground">
+                  Paid invoices, trailing {range} months
+                </p>
+              </div>
+              <div className="flex items-center gap-1 rounded-xl border border-border bg-background p-1">
+                {RANGES.map((r) => (
+                  <button key={r} type="button" onClick={() => setRange(r)}
+                    className={cn(
+                      "rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200",
+                      range === r ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground",
+                    )}>{r}M</button>
+                ))}
+              </div>
+            </div>
+            <RevenueFlow series={series} currency={currency} />
+          </section>
+
+          <section className="overflow-hidden rounded-[22px] border border-border bg-card p-5">
+            <h3 className="text-base font-semibold">Where the money comes from</h3>
+            {/* Said plainly: the mock split by service category, which Kirei
+                does not record. This is by client, from recent invoices. */}
+            <p className="mt-1 text-[13px] text-muted-foreground">By client, from recent invoices</p>
+            {split.total <= 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">No invoices yet.</p>
+            ) : (
+              <div className="mt-5 flex flex-col items-center gap-5">
+                <Donut parts={split.parts} />
+                <div className="w-full space-y-2.5">
+                  {split.parts.map((p, i) => (
+                    <div key={p.name} className="flex items-center gap-2.5">
+                      <span className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ background: SLICE[i % SLICE.length] }} />
+                      <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">{p.name}</span>
+                      <span className="text-[13px] font-semibold tabular-nums">{Math.round(p.pct * 100)}%</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* ── Invoice ledger ────────────────────────────────────────── */}
+        <section className="overflow-hidden rounded-[22px] border border-border bg-card">
+          <div className="flex flex-wrap items-center justify-between gap-3 p-5">
+            <h3 className="text-base font-semibold">Invoice ledger</h3>
+            <div className="flex items-center gap-1 rounded-xl border border-border bg-background p-1">
+              {FILTERS.map((f) => (
+                <button key={f} type="button" onClick={() => setFilter(f)}
+                  className={cn(
+                    "rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200",
+                    filter === f ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground",
+                  )}>{f}</button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-[92px_1fr_110px_100px] gap-4 border-b border-border px-5 pb-2.5 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground max-sm:hidden">
+            <span>Number</span><span>Customer</span><span>Status</span><span className="text-right">Amount</span>
+          </div>
+
+          {rows.length === 0 ? (
+            <p className="px-5 py-12 text-center text-sm text-muted-foreground">
+              {filter === "All" ? "No invoices yet." : `No ${filter.toLowerCase()} invoices.`}
+            </p>
+          ) : (
+            <div className="p-2">
+              {rows.map((inv) => {
+                const tone = toneFor(inv.status);
+                return (
+                  <Link
+                    key={inv.id ?? inv.number}
+                    href={inv.id ? `/invoices/${inv.id}` : "/invoices"}
+                    className="grid grid-cols-[1fr_auto] items-center gap-4 rounded-2xl px-3 py-3.5 transition-colors hover:bg-background sm:grid-cols-[92px_1fr_110px_100px]"
+                  >
+                    <span className="font-mono text-xs text-muted-foreground">{inv.number ?? "—"}</span>
+                    <span className="flex min-w-0 items-center gap-3">
+                      <span className="flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-xl bg-secondary text-[11.5px] font-semibold">
+                        {initialsOf(inv.customers?.name)}
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium">{inv.customers?.name ?? "—"}</span>
+                        {inv.issue_date && (
+                          <span className="block text-xs text-muted-foreground">
+                            Issued {new Date(inv.issue_date).toLocaleDateString()}
+                          </span>
+                        )}
+                      </span>
+                    </span>
+                    <span className={cn(
+                      "justify-self-start rounded-full bg-[var(--accent-soft)] px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] max-sm:hidden",
+                      TONE_TEXT[tone],
+                    )}>{inv.status ?? "—"}</span>
+                    <span className="text-right text-sm font-semibold tabular-nums">
+                      {formatCurrency(Number(inv.total ?? 0), currency)}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* ── Scheduled ─────────────────────────────────────────────── */}
+      <aside className="flex min-w-0 flex-col gap-4 xl:border-l xl:border-border xl:pl-6">
+        <div>
+          <h3 className="text-[17px] font-semibold">Scheduled</h3>
+          <p className="mt-1 text-[12.5px] text-muted-foreground">
+            {new Date().toLocaleDateString(undefined, { weekday: "long", day: "numeric", month: "long", year: "numeric" })}
+          </p>
+        </div>
+
+        {todayJobs.length === 0 ? (
+          <div className="rounded-2xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+            Nothing booked in today.
+          </div>
+        ) : (
+          todayJobs.map((job) => (
+            <Link key={job.id} href={`/work-orders/${job.id}`}
+              className="rounded-2xl border border-border bg-card p-4 transition-[transform,border-color] duration-200 hover:-translate-y-0.5 hover:border-[hsl(var(--border-strong))]">
+              <p className="text-[14.5px] font-semibold">{job.customers?.name ?? "Job"}</p>
+              {job.title && <p className="mt-1 text-[12.5px] text-muted-foreground">{job.title}</p>}
+              {job.property_address && (
+                <p className="mt-2.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <MapPin className="h-3.5 w-3.5 shrink-0" />
+                  <span className="truncate">{job.property_address}</span>
+                </p>
+              )}
+              {job.assigned_to_email && (
+                <p className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <User className="h-3.5 w-3.5 shrink-0" />
+                  <span className="truncate">{job.assigned_to_email}</span>
+                </p>
+              )}
+            </Link>
+          ))
+        )}
+      </aside>
+    </div>
+  );
+}
+
+/* ── pieces ───────────────────────────────────────────────────────────── */
+
+function Kpi({
+  icon, label, value, note, badge, badgeTone, emphasis, iconOnAccent,
+}: {
+  icon: React.ReactNode; label: string; value: string;
+  note?: string; badge?: string; badgeTone?: "ok" | "bad"; emphasis?: boolean; iconOnAccent?: boolean;
+}) {
+  return (
+    <div className={cn(
+      "rounded-[20px] border p-5 transition-transform duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-[3px]",
+      emphasis ? "border-[hsl(var(--border-strong))] bg-secondary" : "border-border bg-card",
+    )}>
+      <div className="flex items-center justify-between">
+        <span className={cn(
+          "flex h-9 w-9 items-center justify-center rounded-xl",
+          iconOnAccent ? "bg-primary" : "bg-[var(--accent-soft)]",
+        )}>{icon}</span>
+        {badge && (
+          <span className={cn(
+            "rounded-full bg-[var(--accent-soft)] px-2.5 py-1.5 text-xs font-semibold",
+            badgeTone === "bad" ? "text-[hsl(var(--bad))]" : "text-[hsl(var(--ok))]",
+          )}>{badge}</span>
+        )}
+        {!badge && note && <span className="text-xs font-medium text-muted-foreground">{note}</span>}
+      </div>
+      <p className="mt-5 text-[12.5px] font-medium text-muted-foreground">{label}</p>
+      <p className="mt-2 text-[32px] font-semibold leading-none tracking-[-0.03em] tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+/**
+ * The mock's line chart, drawn from real monthly totals.
+ *
+ * Plain SVG rather than recharts: it is one polyline and an area fill, and the
+ * bundle-size budget in CI exists precisely to stop a chart library being
+ * pulled into the dashboard for this.
+ */
+function RevenueFlow({ series, currency }: { series: Array<{ month: string; revenue: number }>; currency: string }) {
+  const W = 640, H = 200, PAD = 8;
+  if (series.length === 0) {
+    return <p className="px-5 pb-8 text-center text-sm text-muted-foreground">No revenue recorded yet.</p>;
+  }
+  const max = Math.max(...series.map((m) => m.revenue), 1);
+  const step = series.length > 1 ? (W - PAD * 2) / (series.length - 1) : 0;
+  const pt = (i: number, v: number) => [PAD + i * step, H - PAD - (v / max) * (H - PAD * 2)] as const;
+  const points = series.map((m, i) => pt(i, m.revenue));
+  const line = points.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+  const area = `${line} L${points[points.length - 1][0].toFixed(1)},${H - PAD} L${points[0][0].toFixed(1)},${H - PAD} Z`;
+
+  return (
+    <div className="px-5 pb-5">
+      <svg viewBox={`0 0 ${W} ${H}`} className="h-[200px] w-full" role="img"
+           aria-label={`Revenue over the last ${series.length} months, peaking at ${formatCurrency(max, currency)}`}>
+        <defs>
+          <linearGradient id="revfill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity="0.28" />
+            <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d={area} fill="url(#revfill)" />
+        <path d={line} fill="none" stroke="hsl(var(--primary))" strokeWidth="2.5"
+              strokeLinecap="round" strokeLinejoin="round" />
+        {points.map(([x, y], i) => (
+          <circle key={i} cx={x} cy={y} r="3.5" fill="hsl(var(--card))" stroke="hsl(var(--primary))" strokeWidth="2" />
+        ))}
+      </svg>
+      <div className="mt-2 flex justify-between text-[11px] text-muted-foreground">
+        {series.map((m) => <span key={m.month}>{m.month}</span>)}
+      </div>
+    </div>
+  );
+}
+
+const SLICE = [
+  "hsl(var(--primary))",
+  "hsl(var(--accent-2))",
+  "hsl(var(--lime))",
+  "hsl(var(--surface-3))",
+];
+
+function Donut({ parts }: { parts: Array<{ name: string; pct: number }> }) {
+  const R = 54, C = 2 * Math.PI * R;
+  let offset = 0;
+  return (
+    <svg viewBox="0 0 140 140" className="h-[140px] w-[140px] -rotate-90" role="img" aria-label="Revenue split by client">
+      {parts.map((p, i) => {
+        const len = p.pct * C;
+        const el = (
+          <circle key={p.name} cx="70" cy="70" r={R} fill="none" strokeWidth="16"
+                  stroke={SLICE[i % SLICE.length]}
+                  strokeDasharray={`${len} ${C - len}`} strokeDashoffset={-offset} />
+        );
+        offset += len;
+        return el;
+      })}
+    </svg>
+  );
+}

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -3,8 +3,7 @@
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { KireiWordmark, KireiMark } from "@/components/brand/kirei-logo";
-import { Moon, Sun, LogOut, Settings, User, Menu, Bot } from "@/components/ui/icons";
-import { useTheme } from "next-themes";
+import { LogOut, Settings, User, Menu, Bot } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -14,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { BriefingBell } from "@/components/briefing/briefing-bell";
 import { GlobalSearch } from "./global-search";
+import { ThemeSwatches } from "./theme-swatches";
 import { useAssistant } from "./assistant-context";
 import type { Business } from "@/types/database";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
@@ -35,7 +35,6 @@ interface AppHeaderProps {
  */
 export function AppHeader({ user, onMenuClick, workerView, features, vocab }: AppHeaderProps) {
   const router = useRouter();
-  const { theme, setTheme } = useTheme();
   const { toggle: toggleAssistant } = useAssistant();
   const supabase = createClient();
 
@@ -56,11 +55,14 @@ export function AppHeader({ user, onMenuClick, workerView, features, vocab }: Ap
   const iconBtn = "inline-flex h-9 w-9 items-center justify-center rounded-md text-nav-foreground/90 transition-colors hover:bg-white/15";
 
   return (
-    <header className="flex h-16 shrink-0 items-center bg-nav text-nav-foreground">
+    <header
+      className="flex h-[72px] shrink-0 items-center border-b border-border bg-background text-foreground"
+      style={{ backgroundImage: "linear-gradient(180deg, var(--accent-soft) 0%, transparent 100%)" }}
+    >
       {/* Brand segment — over the sidebar column (desktop). The lockup carries
           the name, so there's no wordmark text beside it. */}
-      <div className="hidden md:flex h-full w-64 shrink-0 items-center border-r border-white/15 px-4">
-        <KireiWordmark className="h-6 w-auto" accentClassName="fill-[#F05A42]" />
+      <div className="hidden md:flex h-11 shrink-0 items-center border-r border-border pl-6 pr-4">
+        <KireiWordmark className="h-[26px] w-auto" />
       </div>
 
       {/* Mobile: menu + mark (the full lockup won't fit beside the search) */}
@@ -72,28 +74,21 @@ export function AppHeader({ user, onMenuClick, workerView, features, vocab }: Ap
       </div>
 
       {/* Search */}
-      <div className="flex flex-1 items-center px-3 md:px-5">
+      <div className="flex flex-1 items-center px-3 md:px-6">
         <div className="w-full max-w-lg">
           <GlobalSearch workerView={workerView} features={features} vocab={vocab} />
         </div>
       </div>
 
       {/* Actions */}
-      <div className="flex items-center gap-0.5 pr-2 md:pr-4">
+      <div className="flex items-center gap-1 pr-2 md:pr-6">
         <button className={iconBtn} onClick={toggleAssistant} aria-label="AI assistant" title="Ask Kirei">
           <Bot className="h-[18px] w-[18px]" />
         </button>
         <div className="[&_button]:text-nav-foreground [&_button:hover]:bg-white/15">
           <BriefingBell />
         </div>
-        <button
-          className={iconBtn}
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          aria-label="Toggle theme"
-        >
-          <Sun className="h-[18px] w-[18px] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[18px] w-[18px] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-        </button>
+        <ThemeSwatches className="mx-1.5" />
         <Link href="/settings" className={iconBtn} aria-label="Settings">
           <Settings className="h-[18px] w-[18px]" />
         </Link>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { Settings, X } from "@/components/ui/icons";
+import { useEffect, useState } from "react";
+import { Settings, X, Menu } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
 import type { Role } from "@/lib/permissions";
@@ -27,8 +28,38 @@ interface AppSidebarProps {
   onClose: () => void;
 }
 
+/** Where the rail remembers whether it was expanded. Per browser, not per
+ *  business: it is a preference about this screen, not about the company. */
+const RAIL_KEY = "kirei.rail-open";
+
 export function AppSidebar({ business, businesses, userRole, features, vocab, navConfig, open, onClose }: AppSidebarProps) {
   const pathname = usePathname();
+  // Starts collapsed to match the mock's default, then restores the saved
+  // choice on mount. Reading localStorage during render would desync SSR.
+  const [railOpen, setRailOpen] = useState(false);
+  useEffect(() => {
+    try { setRailOpen(localStorage.getItem(RAIL_KEY) === "1"); } catch { /* private mode */ }
+  }, []);
+  const toggleRail = () => setRailOpen((v) => {
+    try { localStorage.setItem(RAIL_KEY, v ? "0" : "1"); } catch { /* private mode */ }
+    return !v;
+  });
+
+  // The drawer on mobile is always full width — a 84px icon rail you had to
+  // open a drawer to see would be useless.
+  const expanded = railOpen || open;
+
+  /** Label that slides away rather than disappearing, as in the mock. */
+  const labelCls = cn(
+    "relative z-10 whitespace-nowrap overflow-hidden transition-[opacity,max-width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+    expanded ? "opacity-100 max-w-[160px]" : "opacity-0 max-w-0",
+  );
+  /** 48px row, 16px radius, centred when collapsed — the mock's railRow(). */
+  const rowCls = (active: boolean) => cn(
+    "relative flex items-center gap-3.5 h-12 rounded-2xl text-sm transition-[background,color,padding] duration-[260ms] ease-[cubic-bezier(0.4,0,0.2,1)]",
+    expanded ? "px-3.5 justify-start" : "px-0 justify-center",
+    active ? "text-primary-foreground font-semibold" : "text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium",
+  );
   const workerView = isWorker(userRole);
   const visibleSections = filterNav(navSections, { workerView, features, nav: navConfig });
 
@@ -36,7 +67,17 @@ export function AppSidebar({ business, businesses, userRole, features, vocab, na
     href === "/dashboard" ? pathname === "/dashboard" : pathname.startsWith(href);
 
   const content = (
-    <div className="flex flex-col h-full w-64 bg-sidebar text-sidebar-foreground border-r border-sidebar-border">
+    <div
+      className={cn(
+        "flex flex-col h-full bg-sidebar text-sidebar-foreground border-r border-sidebar-border",
+        "transition-[width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+        expanded ? "w-[244px]" : "w-[84px]",
+      )}
+      // The mock lights the top of the rail with an accent wash that fades out
+      // by 42%. Inline because the stop position is part of the design, not a
+      // Tailwind scale value.
+      style={{ backgroundImage: "linear-gradient(180deg, var(--accent-soft) 0%, transparent 42%)" }}
+    >
       {/* Mobile-only close (desktop brand lives in the top bar) */}
       <div className="md:hidden flex justify-end px-3 pt-3">
         <button
@@ -48,13 +89,35 @@ export function AppSidebar({ business, businesses, userRole, features, vocab, na
         </button>
       </div>
 
+      {/* Collapse toggle — the mock's "Menu" row. Hidden on mobile, where the
+          drawer is opened and closed from the header instead. */}
+      <div className={cn("hidden md:block", expanded ? "px-3.5 pt-3.5" : "px-4 pt-3.5")}>
+        <button
+          type="button"
+          onClick={toggleRail}
+          aria-expanded={railOpen}
+          aria-label={railOpen ? "Collapse menu" : "Expand menu"}
+          className={cn(rowCls(false), "w-full text-sidebar-foreground")}
+        >
+          <Menu className="relative z-10 w-[18px] h-[18px] flex-shrink-0" />
+          <span className={labelCls}>Menu</span>
+        </button>
+      </div>
+
       {/* Nav */}
-      <nav className="flex-1 px-3 py-3 overflow-y-auto">
+      <nav className={cn("flex-1 py-3 overflow-y-auto overflow-x-hidden", expanded ? "px-3.5" : "px-4")}>
         {visibleSections.map((group, gi) => (
           <div key={group.section} className={cn("flex flex-col gap-1", gi > 0 && "mt-4")}>
-            <p className="px-2.5 pt-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-sidebar-foreground/55">
+            <p className={cn(
+              "px-2.5 pt-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-sidebar-foreground/55",
+              "overflow-hidden whitespace-nowrap transition-[opacity,height] duration-200",
+              // Collapsed, a section heading sitting over centred icons reads
+              // as noise; a hairline separates the groups instead.
+              expanded ? "opacity-100 h-auto" : "opacity-0 h-0 pt-0 pb-0",
+            )}>
               {group.section}
             </p>
+            {!expanded && gi > 0 && <div className="mx-3 my-1.5 h-px bg-sidebar-border" aria-hidden />}
             {group.items.map((item, i) => {
               const active = isActive(item.href);
               return (
@@ -67,25 +130,25 @@ export function AppSidebar({ business, businesses, userRole, features, vocab, na
                   <Link
                     href={item.href}
                     onClick={onClose}
-                    className={cn(
-                      "relative flex items-center gap-3 px-3.5 py-2.5 rounded-md text-sm transition-colors duration-150",
-                      active
-                        ? "text-primary-foreground font-semibold"
-                        : "text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium"
-                    )}
+                    // Collapsed, the label is visually gone but still in the
+                    // DOM for screen readers — so title= carries it for mouse
+                    // users without duplicating it for assistive tech.
+                    title={!expanded ? (vocab?.[item.href] ?? item.label) : undefined}
+                    className={rowCls(active)}
                   >
                     {active && (
                       <motion.span
                         layoutId="sidebar-active-pill"
-                        className="absolute inset-0 rounded-lg bg-primary shadow-sm"
+                        className="absolute inset-0 rounded-2xl bg-primary"
+                        style={{ boxShadow: "0 8px 22px var(--accent-soft)" }}
                         transition={{ type: "spring", stiffness: 380, damping: 30 }}
                       />
                     )}
                     <item.icon className={cn(
-                      "relative z-10 w-[18px] h-[18px] flex-shrink-0 transition-colors",
+                      "relative z-10 w-5 h-5 flex-shrink-0 transition-colors",
                       active ? "text-primary-foreground" : "text-sidebar-foreground/70"
                     )} />
-                    <span className="relative z-10">{vocab?.[item.href] ?? item.label}</span>
+                    <span className={labelCls}>{vocab?.[item.href] ?? item.label}</span>
                   </Link>
                 </motion.div>
               );
@@ -95,49 +158,57 @@ export function AppSidebar({ business, businesses, userRole, features, vocab, na
       </nav>
 
       {/* Footer */}
-      <div className="px-3 pb-3 pt-2 border-t border-sidebar-border space-y-1">
+      <div className={cn("pb-3 pt-2 border-t border-sidebar-border space-y-1", expanded ? "px-3.5" : "px-4")}>
         {canManageSettings(userRole) && (
           <Link
             href="/settings"
             onClick={onClose}
-            className={cn(
-              "relative flex items-center gap-3 px-3.5 py-2.5 rounded-md text-sm transition-colors duration-150",
-              pathname.startsWith("/settings")
-                ? "text-primary-foreground font-semibold"
-                : "text-sidebar-foreground hover:bg-sidebar-accent/60 font-medium"
-            )}
+            title={!expanded ? "Settings" : undefined}
+            className={rowCls(pathname.startsWith("/settings"))}
           >
             {pathname.startsWith("/settings") && (
               <motion.span
                 layoutId="sidebar-active-pill"
-                className="absolute inset-0 rounded-lg bg-primary shadow-sm"
+                className="absolute inset-0 rounded-2xl bg-primary"
+                style={{ boxShadow: "0 8px 22px var(--accent-soft)" }}
                 transition={{ type: "spring", stiffness: 380, damping: 30 }}
               />
             )}
             <Settings className={cn(
-              "w-[18px] h-[18px] relative z-10",
+              "w-5 h-5 relative z-10",
               pathname.startsWith("/settings") ? "text-primary-foreground" : "text-sidebar-foreground/70"
             )} />
-            <span className="relative z-10">Settings</span>
+            <span className={labelCls}>Settings</span>
           </Link>
         )}
 
-        {/* Business switcher — anchored at the bottom */}
-        <div className="pt-1">
-          <BusinessSwitcher
-            business={business}
-            businesses={businesses}
-            onClose={onClose}
-          />
-        </div>
+        {/* Business switcher — anchored at the bottom. Collapsed, the rail is
+            84px wide and the switcher's name + chevron cannot fit, so it is
+            replaced by the mark: still a way to see which business you are in,
+            and expanding the rail is one click away. */}
+        {expanded ? (
+          <>
+            <div className="pt-1">
+              <BusinessSwitcher
+                business={business}
+                businesses={businesses}
+                onClose={onClose}
+              />
+            </div>
 
-        <div className="flex items-center justify-between px-1 pt-1.5">
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-sidebar-foreground/50">
-            {ROLE_LABELS[userRole]}
-          </span>
-          {/* Kirei platform attribution — mark only, no text, no border */}
-          <KireiMark className="h-5 w-auto text-sidebar-foreground/60" />
-        </div>
+            <div className="flex items-center justify-between px-1 pt-1.5">
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-sidebar-foreground/50">
+                {ROLE_LABELS[userRole]}
+              </span>
+              {/* Kirei platform attribution — mark only, no text, no border */}
+              <KireiMark className="h-5 w-auto text-sidebar-foreground/60" />
+            </div>
+          </>
+        ) : (
+          <div className="flex justify-center pt-2" title={business.name}>
+            <KireiMark className="h-5 w-auto text-sidebar-foreground/60" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/layout/appearance-provider.tsx
+++ b/src/components/layout/appearance-provider.tsx
@@ -2,6 +2,31 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 
+/**
+ * The Kirei Dashboard v2 palettes.
+ *
+ * Light vs dark is a property of the theme, not a separate switch — Daylight
+ * is the light one. `swatch`/`ring` mirror the design's own theme picker so
+ * the dot in the header reads as the theme it selects.
+ */
+export const UI_THEMES = [
+  { key: "Midnight", label: "Midnight", swatch: "#3B82F6", ring: "#111A29", dark: true  },
+  { key: "Daylight", label: "Daylight", swatch: "#2563EB", ring: "#FFFFFF", dark: false },
+  { key: "Azure",    label: "Azure",    swatch: "#7DD3FC", ring: "#0C2A56", dark: true  },
+  { key: "Orchid",   label: "Orchid",   swatch: "#8B5CF6", ring: "#1B1030", dark: true  },
+] as const;
+
+export type UiThemeKey = (typeof UI_THEMES)[number]["key"];
+
+export const DEFAULT_UI_THEME: UiThemeKey = "Midnight";
+
+/** Where the no-flash boot script in the root layout stashes the choice. */
+export const UI_THEME_STORAGE_KEY = "kirei.ui-theme";
+
+export function isUiTheme(v: unknown): v is UiThemeKey {
+  return typeof v === "string" && UI_THEMES.some((t) => t.key === v);
+}
+
 export const ACCENT_PRESETS = [
   { key: "teal",    label: "Teal",    hex: "#3a847e" },
   { key: "blue",    label: "Blue",    hex: "#2563eb" },
@@ -111,18 +136,22 @@ interface AppearanceContextValue {
   accentColor: string;
   bgPattern: string;
   sidebarTheme: string;
+  uiTheme: UiThemeKey;
   setAccentColor: (c: string) => void;
   setBgPattern: (p: string) => void;
   setSidebarTheme: (t: string) => void;
+  setUiTheme: (t: UiThemeKey) => void;
 }
 
 const AppearanceContext = createContext<AppearanceContextValue>({
   accentColor: "teal",
   bgPattern: "none",
   sidebarTheme: "light",
+  uiTheme: DEFAULT_UI_THEME,
   setAccentColor: () => {},
   setBgPattern: () => {},
   setSidebarTheme: () => {},
+  setUiTheme: () => {},
 });
 
 export function useAppearance() {
@@ -134,15 +163,20 @@ export function AppearanceProvider({
   accentColor: initialAccent = "blue",
   bgPattern: initialPattern = "none",
   sidebarTheme: initialTheme = "light",
+  uiTheme: initialUiTheme = DEFAULT_UI_THEME,
 }: {
   children: React.ReactNode;
   accentColor?: string;
   bgPattern?: string;
   sidebarTheme?: string;
+  uiTheme?: string;
 }) {
   const [accentColor, setAccentColor]     = useState(initialAccent);
   const [bgPattern,   setBgPattern]       = useState(initialPattern);
   const [sidebarTheme, setSidebarTheme]   = useState(initialTheme);
+  const [uiTheme, setUiTheme] = useState<UiThemeKey>(
+    isUiTheme(initialUiTheme) ? initialUiTheme : DEFAULT_UI_THEME,
+  );
 
   // Sync state when the active business changes (router.refresh re-renders
   // this provider with the new business's saved appearance, but useState
@@ -151,13 +185,23 @@ export function AppearanceProvider({
   useEffect(() => { setAccentColor(initialAccent);  }, [initialAccent]);
   useEffect(() => { setBgPattern(initialPattern);   }, [initialPattern]);
   useEffect(() => { setSidebarTheme(initialTheme);  }, [initialTheme]);
+  useEffect(() => {
+    if (isUiTheme(initialUiTheme)) setUiTheme(initialUiTheme);
+  }, [initialUiTheme]);
 
   useEffect(() => { document.documentElement.dataset.accent = accentColor; }, [accentColor]);
   useEffect(() => { document.documentElement.dataset.pattern = bgPattern; }, [bgPattern]);
   useEffect(() => { document.documentElement.dataset.sidebarTheme = sidebarTheme; }, [sidebarTheme]);
+  useEffect(() => {
+    document.documentElement.dataset.theme = uiTheme;
+    // Mirrored so the boot script can paint the right theme before first
+    // render. Without it, a dark-theme business gets a white flash on every
+    // cold load, which is exactly what the theme is meant to avoid.
+    try { localStorage.setItem(UI_THEME_STORAGE_KEY, uiTheme); } catch { /* private mode */ }
+  }, [uiTheme]);
 
   return (
-    <AppearanceContext.Provider value={{ accentColor, bgPattern, sidebarTheme, setAccentColor, setBgPattern, setSidebarTheme }}>
+    <AppearanceContext.Provider value={{ accentColor, bgPattern, sidebarTheme, uiTheme, setAccentColor, setBgPattern, setSidebarTheme, setUiTheme }}>
       {children}
     </AppearanceContext.Provider>
   );

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -42,7 +42,7 @@ interface DashboardShellProps {
 
 export function DashboardShell(props: DashboardShellProps) {
   return (
-    <AppearanceProvider accentColor={props.business.accent_color} bgPattern={props.business.bg_pattern} sidebarTheme={props.business.sidebar_theme}>
+    <AppearanceProvider accentColor={props.business.accent_color} bgPattern={props.business.bg_pattern} sidebarTheme={props.business.sidebar_theme} uiTheme={props.business.ui_theme}>
       <AppLoadingProvider>
       <ConfirmProvider>
       <FocusModeProvider>

--- a/src/components/layout/theme-swatches.tsx
+++ b/src/components/layout/theme-swatches.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * The four-dot theme picker from the header of the Kirei Dashboard v2 design.
+ *
+ * It replaces the old light/dark toggle rather than sitting beside it: light
+ * and dark are now properties of the theme (Daylight is the light one), so two
+ * controls would contradict each other — pick Midnight, then "light mode", and
+ * neither the app nor the user knows what was meant.
+ *
+ * Buttons, not divs: this is a real control and has to be reachable by keyboard.
+ */
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { useAppearance, UI_THEMES, type UiThemeKey } from "./appearance-provider";
+import { setUiTheme as persistUiTheme } from "@/lib/actions/appearance";
+
+export function ThemeSwatches({ className }: { className?: string }) {
+  const { uiTheme, setUiTheme } = useAppearance();
+  const [, startTransition] = useTransition();
+
+  const pick = (key: UiThemeKey) => {
+    // Applied locally first so the whole app repaints on the click, then
+    // persisted. If saving fails the theme still changed for this session —
+    // say so rather than silently reverting under them.
+    setUiTheme(key);
+    startTransition(async () => {
+      const res = await persistUiTheme(key);
+      if (!res.ok) toast.error(`${res.error} — the theme will reset on your next visit.`);
+    });
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Colour theme"
+      className={cn(
+        "hidden items-center gap-2 rounded-full border border-border bg-card p-1.5 sm:flex",
+        className,
+      )}
+    >
+      {UI_THEMES.map((t) => {
+        const active = uiTheme === t.key;
+        return (
+          <button
+            key={t.key}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            title={t.label}
+            aria-label={t.label}
+            onClick={() => pick(t.key)}
+            className={cn(
+              "h-[26px] w-[26px] rounded-full transition-transform duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]",
+              "outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring",
+              active ? "scale-100 outline outline-2 outline-foreground" : "scale-[0.88] outline outline-2 outline-transparent",
+            )}
+            // The inner ring is the theme's own panel colour, so each dot reads
+            // as a miniature of the theme it selects — straight from the mock.
+            style={{ background: t.swatch, boxShadow: `inset 0 0 0 3px ${t.ring}` }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/actions/appearance.ts
+++ b/src/lib/actions/appearance.ts
@@ -1,0 +1,39 @@
+"use server";
+
+/**
+ * Persisting the chosen palette.
+ *
+ * Split out of the settings action file because the header's theme picker is
+ * on every page, and importing the whole settings module for one column write
+ * would drag its dependencies into every route.
+ *
+ * Expected failures are RETURNED — Next masks thrown server-action messages in
+ * production, and "the theme didn't save" is worth telling someone about.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+
+const THEMES = ["Midnight", "Daylight", "Azure", "Orchid"];
+
+export type ThemeResult = { ok: true } | { ok: false; error: string };
+
+export async function setUiTheme(theme: string): Promise<ThemeResult> {
+  if (!THEMES.includes(theme)) return { ok: false, error: "Unknown theme" };
+
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase as any)
+    .from("businesses").update({ ui_theme: theme }).eq("id", businessId);
+  // RLS decides who may write this; a viewer's update matches no rows and
+  // returns no error, which is the right outcome — their session still shows
+  // the theme they picked, the business's saved default is unchanged.
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath("/", "layout");
+  return { ok: true };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -57,6 +57,8 @@ export interface Business {
   accent_color: string;
   bg_pattern: string;
   sidebar_theme: string;
+  /** Kirei Dashboard v2 palette: Midnight | Daylight | Azure | Orchid. */
+  ui_theme?: string;
   /** Industry preset id (src/lib/plugins/presets.ts); null = no preset applied. */
   industry_preset?: string | null;
   /** Navigation overrides (Settings → Navigation). NULL = the industry preset. */

--- a/supabase/migrations/20260809100000_ui_theme.sql
+++ b/supabase/migrations/20260809100000_ui_theme.sql
@@ -1,0 +1,13 @@
+-- Which of the Kirei Dashboard v2 palettes a business uses.
+--
+-- Midnight / Daylight / Azure / Orchid, from the Claude Design project. Light
+-- vs dark is a property of the theme itself (Daylight is the light one), so
+-- this replaces the separate dark-mode question rather than sitting beside it.
+--
+-- Defaults to Midnight, matching the design's own default. Existing businesses
+-- get Midnight too: the previous 'console' theme is retired, not offered.
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS ui_theme TEXT NOT NULL DEFAULT 'Midnight';
+
+COMMENT ON COLUMN public.businesses.ui_theme IS
+  'Kirei Dashboard v2 palette: Midnight | Daylight | Azure | Orchid.';


### PR DESCRIPTION
Implements the **Kirei Dashboard v2** Claude Design project across the whole app, with the mock's blue palette as designed.

## How it reaches every page

The palette is expressed in the **shadcn token contract the app already reads** (`--background`, `--card`, `--border`, `--primary`), not in the design's own token names (`--panel`, `--ac`, `--mu`). That is the whole trick: every existing page picks up the theme for free, without touching 200 components.

Two conversions were needed, both commented where they live:

- **Borders.** The mock's are `rgba` over a surface; `hsl(var(--border))` needs a solid colour. Each is composited over the panel it actually sits on rather than eyeballed.
- **The canvas.** The mock's `bg` is the plate *behind* its floating shell. Our content fills the viewport, so `panel` becomes the canvas and `bg` survives as `--canvas-deep` for the glow layer.

All **48 tokens across the four themes round-trip exactly** back to the design's source hex. The first pass was off by 1/255 on twelve of them — it re-derived from the already-lossy value instead of the source. Fixed and re-verified.

## Themes replace the light/dark toggle

Light vs dark is now a property of the theme — **Daylight** is the light one. So the header's sun/moon toggle is **replaced by** the mock's four-dot picker rather than sitting next to it: two controls that can contradict each other ("Midnight" + "light mode") is worse than one. A boot script paints the saved theme before first render, because three of four are dark and a white flash on every cold load is exactly what a dark theme must not do.

Stored per business in `businesses.ui_theme`, default Midnight.

## The icon rail

The sidebar becomes the mock's collapsible rail (84px ↔ 244px, 48px rows, 16px radius, accent wash at the top, spring-animated active pill). It keeps **every existing nav item, section, plugin gate, worker rule and the vocab layer**.

Collapsed, two honest concessions: section headings become hairlines (a heading over centred icons is noise), and the business switcher becomes the Kirei mark — it cannot fit in 84px, and a clipped switcher is worse than an honest one.

## The overview

Quick actions, four KPI tiles, revenue flow with 3/6/12M range, revenue split, invoice ledger with status filters, and the Scheduled column — all wired to real data.

**Two deliberate departures from the mock:**

1. The mock splits revenue by service category (Kitchens / Wardrobes / Joinery). Kirei records no category on an invoice, so this **splits by client** from real invoices instead. Same question, answered from data that exists, rather than a chart of invented categories.
2. Briefing, tasks, outlook and new-leads widgets are **kept**, below the overview. The mock never drew them — but deleting working features to match a mock is not a redesign.

The chart is plain SVG, not recharts: it is one polyline and an area fill, and the bundle budget exists precisely to stop a chart library being pulled in for that.

## Verification

`tsc` clean · **264 tests** pass · production build clean · bundle budget passes.

Because this repo has previously shipped a Tailwind arbitrary value that **compiled to nothing**, I checked the built CSS directly: all four `[data-theme=…]` blocks and every arbitrary value (`hsl(var(--ok))`, `var(--accent-soft)`, `hsl(var(--border-strong))`, …) are confirmed present in the production chunk.

**Not clicked through.** Local dev cannot authenticate against the stale `.env.local` Supabase keys, so the actual rendering is verified on the Vercel preview, not here. Worth a look at: each of the four themes, the rail collapsed and expanded, and a couple of non-dashboard pages (customers, invoices) to confirm they inherited the palette cleanly.

## Migration

`20260809100000_ui_theme.sql` — applied to the live database and recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)