### PR TITLE
feat(presets): two hubs — a lean one for tradies, everything for agencies

### DIFF
--- a/src/lib/plugins/presets.test.ts
+++ b/src/lib/plugins/presets.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { INDUSTRY_PRESETS, PRESETS_BY_ID } from "./presets";
+import { OPTIONAL_PLUGINS, PLUGIN_REGISTRY } from "./registry";
+
+const byId = (id: string) => {
+  const p = PRESETS_BY_ID[id];
+  if (!p) throw new Error(`preset ${id} missing`);
+  return p;
+};
+
+describe("the two hubs", () => {
+  it("agency is a genuine superset of trades", () => {
+    // The product promise is "agencies get everything". Before this was
+    // enforced, trades had ~32 modules and agency had 11 — the opposite.
+    const trades = new Set(byId("trades").plugins);
+    const agency = new Set(byId("agency").plugins);
+    const missing = [...trades].filter((p) => !agency.has(p));
+    expect(missing).toEqual([]);
+  });
+
+  it("agency enables every optional module", () => {
+    const agency = new Set(byId("agency").plugins);
+    const missing = OPTIONAL_PLUGINS.map((p) => p.id).filter((id) => !agency.has(id));
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps the trades hub genuinely smaller than everything", () => {
+    // The guard against drifting back to "on by default": if trades ever
+    // creeps past two-thirds of the catalogue it has stopped being a
+    // streamlined hub, which is the whole reason it exists.
+    const trades = byId("trades").plugins.length;
+    expect(trades).toBeLessThan(OPTIONAL_PLUGINS.length * 0.67);
+  });
+
+  it("keeps agency-shaped work out of the trades hub", () => {
+    // Named explicitly rather than by count: these are the modules that make a
+    // tradie's first login confusing, and a future preset edit that quietly
+    // re-adds one should fail here.
+    const trades = new Set(byId("trades").plugins);
+    for (const id of ["seo-production", "content-studio", "outreach", "prospects", "form-builder"]) {
+      expect(trades.has(id)).toBe(false);
+    }
+  });
+
+  it("gives a tradie what they actually need to trade", () => {
+    const trades = new Set(byId("trades").plugins);
+    for (const id of ["leads", "quotes", "jobs", "scheduling", "invoicing"]) {
+      expect(trades.has(id)).toBe(true);
+    }
+  });
+
+  it("only names plugins that exist", () => {
+    // A typo'd id is silently ignored by the resolver, so the module would
+    // just never turn on and nobody would know why.
+    const known = new Set(PLUGIN_REGISTRY.map((p) => p.id));
+    for (const preset of INDUSTRY_PRESETS) {
+      const unknown = preset.plugins.filter((id) => !known.has(id));
+      expect({ preset: preset.id, unknown }).toEqual({ preset: preset.id, unknown: [] });
+    }
+  });
+
+  it("only maps vocab onto real nav paths", () => {
+    for (const preset of INDUSTRY_PRESETS) {
+      for (const href of Object.keys(preset.vocab ?? {})) {
+        expect(href.startsWith("/")).toBe(true);
+      }
+    }
+  });
+
+  it("keeps the agency's own workspace speaking agency", () => {
+    // A trade business the agency operates keeps the trades preset and so keeps
+    // saying Work Orders; this is the agency's own workspace.
+    expect(byId("agency").vocab?.["/work-orders"]).toBe("Projects");
+    expect(byId("agency").vocab?.["/quotes"]).toBe("Proposals");
+  });
+});

--- a/src/lib/plugins/presets.ts
+++ b/src/lib/plugins/presets.ts
@@ -29,18 +29,55 @@ export const INDUSTRY_PRESETS: IndustryPreset[] = [
     id: "trades",
     label: "Trades & field services",
     description: "Roofing, electrical, plumbing, cleaning — jobs, scheduling, quoting and invoicing.",
-    // Everything on except the opt-in verticals (mirrors today's default app).
-    plugins: ALL_OPTIONAL.filter((id) => !["quoting-agent", "client-onboarding", "form-builder"].includes(id)),
+    /**
+     * The trades hub: what one trade business needs to run its own work, and
+     * nothing else.
+     *
+     * This used to be ALL_OPTIONAL minus three, so a tradie signed up and was
+     * handed SEO production, a content studio, an outreach agent, prospecting,
+     * payroll, inventory and a phone system on day one. That is the "too
+     * complicated" problem, and it was the default.
+     *
+     * Deliberately OUT (all reachable from the Plugins store if wanted):
+     *   seo-production, content-studio, outreach, prospects  - agency work
+     *   client-onboarding, form-builder, contracts           - agency workflow
+     *   payroll, inventory, assets, telephony, vault         - bigger-operation
+     *                                                          tools, opt in
+     *                                                          when you need them
+     */
+    plugins: [
+      // Winning work
+      "leads", "quotes", "quoting-agent",
+      // Doing the work
+      "jobs", "scheduling", "recurring-jobs", "site-reports", "booking",
+      // Getting paid
+      "invoicing", "recurring-billing", "expenses",
+      // The catalogue behind a quote
+      "products", "materials",
+      // Keeping in touch, and knowing how it's going
+      "messages", "analytics",
+      // Hours on a job feed both job costing and a wage
+      "timesheets",
+    ],
   },
   {
     id: "agency",
-    label: "Agency & creative services",
-    description: "Web, marketing, design and studio work — proposals, retainers, contracts and client onboarding.",
-    plugins: [
-      "prospects", "leads", "quotes", "invoicing", "recurring-billing", "contracts",
-      "jobs", "messages", "analytics",
-      "client-onboarding", "form-builder",
-    ],
+    label: "Agency (running Kirei for trade clients)",
+    description: "Operate several trade businesses from one login — plus the SEO, content, outreach and retainer tools you sell them.",
+    /**
+     * The agency hub: everything the trades hub has, plus everything an agency
+     * needs on top. A genuine superset, computed rather than listed, so a new
+     * module cannot be added to trades and silently missed here.
+     *
+     * The agency's own clients are trade BUSINESSES, not rows in `customers`
+     * — see the console work. Vocabulary keeps those two senses apart.
+     */
+    plugins: ALL_OPTIONAL,
+    /**
+     * The agency's OWN workspace speaks agency. A trade business it operates
+     * keeps the trades preset and so keeps saying Work Orders and Quotes -
+     * which is right: that business really is a trade business.
+     */
     vocab: {
       "/work-orders": "Projects",
       "/quotes": "Proposals",


### PR DESCRIPTION
Step 1 of the two-solutions plan. The one you can veto module-by-module before anything else is built on it.

## The presets were backwards

`trades` was defined as **ALL_OPTIONAL minus three** — so a tradie signed up and got SEO production, a content studio, an outreach agent, prospecting, payroll, inventory, assets and a phone system on their first login. `agency` was an explicit list of **eleven**.

Trades got *more* than agency. That's the opposite of the product, and it is precisely the "too complicated" first run you want to fix.

## The trades hub — 16 of 29 optional modules

| | |
|---|---|
| **Winning work** | leads, quotes, quoting-agent |
| **Doing the work** | jobs, scheduling, recurring-jobs, site-reports, booking |
| **Getting paid** | invoicing, recurring-billing, expenses |
| **Behind a quote** | products, materials |
| **Everything else** | messages, analytics, timesheets |

**Off by default** (all one click away in the Plugins store): assets, automations, client-onboarding, content-studio, contracts, form-builder, inventory, outreach, payroll, prospects, seo-production, telephony, vault.

Veto anything in either list and I'll move it before this merges.

## The agency hub — all 29

`plugins: ALL_OPTIONAL`, **computed rather than listed**, so a module added later can't be given to trades and silently missed here. That's "agencies get everything" enforced, not maintained by hand.

## Existing businesses are untouched — verified, not assumed

The resolver reads `business_agent_installs` and **never consults a preset**; presets apply at signup or on an explicit re-apply. Every live business already has install rows — Connected Studio 29, Ezy Current 24, Crown Roofers 17 — so none of them change.

If you *want* an existing trades business slimmed to the new set, re-applying the preset is the deliberate way to do it.

## One thing I nearly broke

Rewriting the agency block dropped its `Projects` / `Proposals` vocabulary — quietly reverting work you'd specifically asked for. Restored. A trade business an agency operates keeps the trades preset and so keeps saying **Work Orders**, which is right: that business really is a trade business. Only the agency's own workspace speaks agency.

## Tests

Eight, pinning the rules rather than the current values: agency is a genuine superset; trades stays under two-thirds of the catalogue; named agency modules absent from trades; named trade modules present; and no preset naming a plugin that doesn't exist — a typo'd id is silently ignored by the resolver, so the module would simply never appear and nobody would know why.

272 tests · `tsc` · production build.

## Next

Marketing pages (`/trades`, `/agencies`, pricing, contact sales) with signup pre-selecting the preset, then the agency console, then `app.kireihq.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)