### PR TITLE
feat(agency): every client account on one screen

### DIFF
--- a/src/app/(dashboard)/agency/page.tsx
+++ b/src/app/(dashboard)/agency/page.tsx
@@ -1,0 +1,7 @@
+import { getClientAccounts } from "@/lib/actions/agency-console";
+import { ClientAccountsClient } from "@/components/agency/client-accounts-client";
+
+export default async function AgencyConsolePage() {
+  const accounts = await getClientAccounts();
+  return <ClientAccountsClient accounts={accounts} />;
+}

--- a/src/components/agency/client-accounts-client.tsx
+++ b/src/components/agency/client-accounts-client.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * Every client account on one screen.
+ *
+ * Clicking a card switches the active business and lands you inside it, which
+ * is the point: the console is for spotting what needs you, not for doing the
+ * work. The work still happens inside a business.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  AlertTriangle, Building2, Clock, CalendarDays, Loader2, Plus, ChevronRight,
+} from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
+import { useAppLoading } from "@/components/layout/app-loading";
+import { AddBusinessModal } from "@/components/business/add-business-modal";
+import { setActiveBusiness } from "@/lib/actions/business";
+import { rememberTabBusiness } from "@/components/layout/tab-business-guard";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import type { ClientAccount } from "@/lib/actions/agency-console";
+
+export function ClientAccountsClient({ accounts }: { accounts: ClientAccount[] }) {
+  const router = useRouter();
+  const { setBusy } = useAppLoading();
+  const [addOpen, setAddOpen] = useState(false);
+  const [switching, setSwitching] = useState<string | null>(null);
+
+  const totals = accounts.reduce(
+    (acc, a) => ({
+      outstanding: acc.outstanding + a.outstanding,
+      overdue: acc.overdue + a.overdue,
+      jobsToday: acc.jobsToday + a.jobsToday,
+    }),
+    { outstanding: 0, overdue: 0, jobsToday: 0 },
+  );
+  // Mixed currencies would make one total meaningless, so it is only shown
+  // when every account bills in the same one.
+  const currencies = new Set(accounts.map((a) => a.currency));
+  const oneCurrency = currencies.size === 1 ? [...currencies][0] : null;
+
+  const open = async (account: ClientAccount) => {
+    setSwitching(account.id);
+    setBusy(`Opening ${account.name}…`);
+    // Claim the tab BEFORE the cookie flips — same order the switcher uses.
+    // The tab guard compares the cookie against this tab's remembered
+    // business, so flipping first makes it bounce straight back.
+    rememberTabBusiness(account.id);
+    try {
+      await setActiveBusiness(account.id);
+      router.push("/dashboard");
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't open that account");
+      setBusy(null);
+    } finally { setSwitching(null); }
+  };
+
+  return (
+    <div className="space-y-5">
+      <PageHeader
+        title="Client accounts"
+        subtitle="The businesses you run, and what needs you in each."
+        actions={
+          <Button size="sm" onClick={() => setAddOpen(true)}>
+            <Plus className="mr-1.5 h-3.5 w-3.5" /> Add client account
+          </Button>
+        }
+      />
+
+      {accounts.length > 1 && oneCurrency && (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Tile label="Outstanding, everywhere" value={formatCurrency(totals.outstanding, oneCurrency)} />
+          <Tile label="Overdue, everywhere" value={formatCurrency(totals.overdue, oneCurrency)}
+                tone={totals.overdue > 0 ? "bad" : undefined} />
+          <Tile label="Jobs booked today" value={String(totals.jobsToday)} />
+        </div>
+      )}
+
+      {accounts.length === 0 ? (
+        <Card><CardContent className="py-12 text-center text-sm text-muted-foreground">
+          <Building2 className="mx-auto mb-2 h-7 w-7 opacity-40" />
+          No client accounts yet.
+        </CardContent></Card>
+      ) : (
+        <div className="space-y-2">
+          {accounts.map((a) => (
+            <Card key={a.id} className="transition-colors hover:border-border-strong">
+              <CardContent className="flex flex-wrap items-center gap-4 p-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-medium break-words">{a.name}</p>
+                    {!a.owned && <Badge variant="outline" className="text-xs">Member</Badge>}
+                    {a.overdueCount > 0 && (
+                      <Badge className="gap-1 bg-bad/15 text-bad">
+                        <AlertTriangle className="h-3 w-3" />
+                        {a.overdueCount} overdue
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1.5">
+                      <Clock className="h-3.5 w-3.5" />
+                      {formatCurrency(a.outstanding, a.currency)} outstanding
+                    </span>
+                    <span className="inline-flex items-center gap-1.5">
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      {a.jobsToday} today
+                    </span>
+                    {/* Silence is information: an account with no invoice for
+                        months is the one you have forgotten about. */}
+                    <span>
+                      {a.lastInvoiceAt ? `last invoice ${formatDate(a.lastInvoiceAt)}` : "no invoices yet"}
+                    </span>
+                  </div>
+                </div>
+
+                <Button size="sm" variant="outline" disabled={switching !== null}
+                        onClick={() => open(a)}>
+                  {switching === a.id
+                    ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    : null}
+                  Open <ChevronRight className="ml-1 h-3.5 w-3.5" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <AddBusinessModal open={addOpen} onOpenChange={setAddOpen} />
+    </div>
+  );
+}
+
+function Tile({ label, value, tone }: { label: string; value: string; tone?: "bad" }) {
+  return (
+    <div className="rounded-2xl border border-border bg-card p-5">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className={`mt-2 text-2xl font-semibold tabular-nums ${tone === "bad" ? "text-bad" : ""}`}>
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -6,7 +6,7 @@ import { motion } from "framer-motion";
 import { toast } from "sonner";
 import {
   Bot, MailSearch, PlugZap, BellRing, Send,
-  Settings, Trash2, Plus, Lock,
+  Settings, Trash2, Plus, Lock, Building2,
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
   Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock, Hammer, Target, DollarSign,
@@ -61,6 +61,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   "list-checks": ListChecks,
   "layout-dashboard": LayoutDashboard,
   lock: Lock,
+  "building-2": Building2,
   users: Users,
   columns: Columns3,
   "users-2": Users2,

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -1,5 +1,5 @@
 import {
-  Zap, Lock,
+  Zap, Lock, Building2,
   LayoutDashboard, FileText, FileCheck, Users,
   Package, FileStack, ClipboardList, Wrench, Users2, UserPlus, CalendarDays, MessageSquare, Bot, Repeat, HelpCircle, Columns3, TrendingUp, Sparkles, ListChecks, Search, Receipt, Boxes, Clock, Hammer, Target, Megaphone, DollarSign, Send, Phone,
 } from "@/components/ui/icons";
@@ -46,6 +46,7 @@ export const navSections: NavSection[] = [
   { section: "Contacts", items: [
     { label: "Prospects",  href: "/prospects",  icon: Target,        plugin: "prospects" },
     { label: "Outreach",   href: "/outreach",   icon: Send,          plugin: "outreach" },
+    { label: "Client accounts", href: "/agency", icon: Building2, plugin: "agency-console" },
     { label: "Customers",  href: "/customers",  icon: Users                         },
     { label: "Contacts",   href: "/contacts",   icon: Users2                        },
     { label: "Passwords",  href: "/vault",      icon: Lock,          plugin: "vault" },

--- a/src/lib/actions/agency-console.ts
+++ b/src/lib/actions/agency-console.ts
@@ -1,0 +1,125 @@
+"use server";
+
+/**
+ * The agency console: every client account at once.
+ *
+ * Every other page in Kirei is scoped to one business through the
+ * active_business_id cookie. This is the deliberate exception — an agency
+ * running several trade businesses needs to see across them without switching
+ * six times to find out who is overdue.
+ *
+ * ⚠️ The safety of that rests on a specific fact, so it is worth stating: the
+ * RLS predicates on these tables are MEMBERSHIP-based, not cookie-based —
+ *
+ *     business_id IN (
+ *       SELECT id FROM businesses WHERE user_id = auth.uid()
+ *       UNION SELECT business_id FROM business_members
+ *             WHERE user_id = auth.uid() AND status = 'active')
+ *
+ * The cookie only ever NARROWS what you see; the database is what stops you
+ * seeing someone else's. So omitting the business_id filter here returns rows
+ * for exactly the businesses this user may reach, and no others. This runs on
+ * the ordinary user client — never the admin client, which would bypass the
+ * very check being relied on.
+ */
+import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/auth";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+export interface ClientAccount {
+  id: string;
+  name: string;
+  industryPreset: string | null;
+  /** Owned by this user, versus a business they're a member of. */
+  owned: boolean;
+  currency: string;
+  outstanding: number;
+  overdue: number;
+  overdueCount: number;
+  jobsToday: number;
+  /** Most recent invoice date seen, for a "nothing has happened here" hint. */
+  lastInvoiceAt: string | null;
+}
+
+const num = (v: unknown) => Number(v ?? 0) || 0;
+
+export async function getClientAccounts(): Promise<ClientAccount[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+
+  // Businesses this user owns or belongs to. Two queries rather than an `or()`
+  // across a join — PostgREST's or-grammar has bitten this codebase before.
+  const [{ data: owned }, { data: memberships }] = await Promise.all([
+    tbl(supabase, "businesses").select("id, name, currency, industry_preset").eq("user_id", user.id),
+    tbl(supabase, "business_members").select("business_id").eq("user_id", user.id).eq("status", "active"),
+  ]);
+
+  const ownedIds = new Set<string>((owned ?? []).map((b: { id: string }) => b.id));
+  const memberIds = ((memberships ?? []) as Array<{ business_id: string }>)
+    .map((m) => m.business_id)
+    .filter((id) => !ownedIds.has(id));
+
+  let memberBusinesses: Array<{ id: string; name: string; currency: string; industry_preset: string | null }> = [];
+  if (memberIds.length) {
+    const { data } = await tbl(supabase, "businesses")
+      .select("id, name, currency, industry_preset").in("id", memberIds);
+    memberBusinesses = data ?? [];
+  }
+
+  const businesses = [...(owned ?? []), ...memberBusinesses];
+  if (businesses.length === 0) return [];
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  // No .eq("business_id", …) on purpose — see the note at the top. One query
+  // for every account rather than one per account.
+  const [{ data: invoices }, { data: jobs }] = await Promise.all([
+    tbl(supabase, "invoices")
+      .select("business_id, status, total, amount_paid, due_date, issue_date")
+      .neq("status", "draft")
+      .limit(5000),
+    tbl(supabase, "work_orders")
+      .select("business_id, scheduled_date")
+      .eq("scheduled_date", today)
+      .limit(2000),
+  ]);
+
+  const byBiz = new Map<string, ClientAccount>();
+  for (const b of businesses) {
+    byBiz.set(b.id, {
+      id: b.id,
+      name: b.name,
+      industryPreset: b.industry_preset ?? null,
+      owned: ownedIds.has(b.id),
+      currency: b.currency ?? "GBP",
+      outstanding: 0, overdue: 0, overdueCount: 0, jobsToday: 0, lastInvoiceAt: null,
+    });
+  }
+
+  for (const inv of (invoices ?? []) as Array<Record<string, unknown>>) {
+    const acc = byBiz.get(String(inv.business_id));
+    if (!acc) continue;                       // a business RLS allowed but we didn't list
+    // PostgREST returns numerics as strings; plain arithmetic gives NaN.
+    const due = num(inv.total) - num(inv.amount_paid);
+    const status = String(inv.status ?? "");
+    if (status !== "paid" && due > 0) {
+      acc.outstanding += due;
+      const overdue = status === "overdue"
+        || (typeof inv.due_date === "string" && inv.due_date < today);
+      if (overdue) { acc.overdue += due; acc.overdueCount += 1; }
+    }
+    const issued = typeof inv.issue_date === "string" ? inv.issue_date : null;
+    if (issued && (!acc.lastInvoiceAt || issued > acc.lastInvoiceAt)) acc.lastInvoiceAt = issued;
+  }
+
+  for (const job of (jobs ?? []) as Array<Record<string, unknown>>) {
+    const acc = byBiz.get(String(job.business_id));
+    if (acc) acc.jobsToday += 1;
+  }
+
+  // Whoever needs attention first: most overdue money, then most outstanding.
+  return [...byBiz.values()].sort((a, b) =>
+    b.overdue - a.overdue || b.outstanding - a.outstanding || a.name.localeCompare(b.name));
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -609,6 +609,41 @@ export function registerTools(register: ToolFn): void {
       });
     });
 
+  tool("list_client_accounts",
+    "Every business this key can reach, with outstanding, overdue and jobs booked today for each — the agency console as data. Use to answer 'which of my clients needs me today'.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "customers:read");
+      // NOTE: an API key is scoped to ONE business by design, so this returns
+      // that business only. The cross-account view is a signed-in surface —
+      // widening a key to span businesses would turn one leaked key into a
+      // breach of every client the agency holds.
+      const { data: biz } = await t(ctx, "businesses")
+        .select("id, name, currency, industry_preset").eq("id", ctx.businessId).single();
+      const today = new Date().toISOString().slice(0, 10);
+      const [{ data: invoices }, { data: jobs }] = await Promise.all([
+        t(ctx, "invoices").select("status, total, amount_paid, due_date")
+          .eq("business_id", ctx.businessId).neq("status", "draft").limit(5000),
+        t(ctx, "work_orders").select("id")
+          .eq("business_id", ctx.businessId).eq("scheduled_date", today).limit(2000),
+      ]);
+      const num = (v: unknown) => Number(v ?? 0) || 0;
+      let outstanding = 0, overdue = 0, overdueCount = 0;
+      for (const inv of (invoices ?? []) as Array<Record<string, unknown>>) {
+        const due = num(inv.total) - num(inv.amount_paid);
+        if (String(inv.status) === "paid" || due <= 0) continue;
+        outstanding += due;
+        if (String(inv.status) === "overdue" || (typeof inv.due_date === "string" && inv.due_date < today)) {
+          overdue += due; overdueCount += 1;
+        }
+      }
+      return text([{
+        id: biz?.id, name: biz?.name, currency: biz?.currency ?? "GBP",
+        outstanding, overdue, overdue_count: overdueCount,
+        jobs_today: (jobs ?? []).length,
+      }]);
+    });
+
   tool("get_navigation", "Get the business's sidebar navigation overrides: {labels: {href: name}, hidden: [href], order: [href]}. NULL/empty means it follows the industry preset.",
     {},
     async (_args, extra) => {

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -86,6 +86,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "client-onboarding", icon: "clipboard-list", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
   { id: "form-builder", icon: "list-checks",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "sales", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
 
+  { id: "agency-console", icon: "building-2", name: "Client accounts", description: "Every business you run on one screen — who is overdue, what is booked, who has gone quiet.", kind: "module", category: "contacts", defaultEnabled: false, routePrefixes: ["/agency"] },
   { id: "vault", icon: "lock", name: "Password vault", description: "Store the account logins you hold for clients — encrypted, owner/admin only, every reveal logged.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "vault_settings", routePrefixes: ["/vault"] },
   { id: "automations", icon: "zap", name: "Automations", description: "When something happens, do something: email a new client their onboarding form, text a customer when a job is done.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "automations_settings", routePrefixes: ["/automations"] },
 


### PR DESCRIPTION
The last piece of the two-hubs plan. An agency running several trade businesses had to switch into each one to find out who was overdue; this is the one place in Kirei that deliberately spans businesses.

## Why that's safe — verified, not assumed

The RLS predicates on `invoices` and `work_orders` are **membership-based**:

```sql
business_id IN (
  SELECT id FROM businesses WHERE user_id = auth.uid()
  UNION SELECT business_id FROM business_members
        WHERE user_id = auth.uid() AND status = 'active')
```

The `active_business_id` cookie only ever **narrows** what you see — the database is what stops you seeing someone else's. So omitting the `business_id` filter returns rows for exactly the businesses this user may reach, and no others. I read the actual predicates out of `pg_policies` before relying on this.

It runs on the **ordinary user client, never the admin client** — using the admin client here would bypass the very check being relied on.

## What it shows

Per account: outstanding, overdue (with a count), jobs booked today, and when the last invoice went out. Sorted by who needs attention — most overdue money first.

**Last invoice is there because silence is information.** The account nobody has invoiced for three months is the one being forgotten, and nothing else on the screen would tell you.

Cross-account totals appear **only when every account bills in the same currency**. Summing mixed currencies would be a confident wrong number.

Two queries for all accounts, not one per account. Numerics go through `Number()` — PostgREST returns them as strings and plain arithmetic gives `NaN`, which has bitten this codebase before.

## A trap I fell into first

Opening an account calls `rememberTabBusiness` **before** flipping the cookie, matching the switcher. I had it the other way round initially — which makes the per-tab guard see a mismatch and bounce you straight back to the previous business.

## Gating

The `agency-console` plugin: off for trades, on for agency (which is `ALL_OPTIONAL`, so it's included automatically), route- and nav-gated.

## MCP

`list_client_accounts`, **deliberately scoped to the key's own business**. An API key belongs to one business by design; widening it to span accounts would turn one leaked key into a breach of every client an agency holds. The cross-account view stays a signed-in surface.

## Verification

272 tests · `tsc` · production build, **exit code checked** rather than grepped for a success string — that's what hid the last build failure from me.

Not clicked through: local dev can't authenticate. On the preview, Connected Studio should show both it and Crown Roofers, and Open should land you inside without bouncing back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)