### PR TITLE
fix: job reminders for every business, and one writer for "won"

### DIFF
--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -2,20 +2,48 @@
  * GET /api/cron/reminders
  *
  * Runs daily at 8pm UTC (6am AEST) via Vercel Cron.
- * 1. Sends Telegram to owner: today's full schedule
- * 2. Sends email to each assigned worker: their jobs for today
- * 3. Sends customer reminder emails for today's jobs
+ * 1. Telegram to the operator: today's schedule (one business — see below)
+ * 2. Email to each assigned worker: their jobs for today
+ * 3. Customer reminder emails for tomorrow's jobs
+ *
+ * This used to run for ONE hardcoded business id, with Crown Roofers' name,
+ * phone, ABN and reply-to baked into the customer email. So every other
+ * business on Kirei got no reminders at all — and had it merely been looped,
+ * their customers would have received another company's branding.
+ *
+ * It now runs for every business with jobs on the day, and each one's emails
+ * carry its own name, sender address and reply-to.
+ *
+ * Telegram is the exception and stays single-business on purpose:
+ * TELEGRAM_CHAT_ID is one person's chat, and broadcasting every tenant's
+ * schedule into it would leak other businesses' work to whoever owns it.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Resend } from "resend";
 import { requireCron } from "@/lib/cron-auth";
+import { buildBusinessFrom } from "@/lib/email";
 
-const BUSINESS_ID = process.env.AGENT_BUSINESS_ID ?? "ff3a47f3-54b0-45e3-b7a9-69ddc9fa787e";
+/** Whose schedule goes to the Telegram chat. Not a tenant filter any more. */
+const TELEGRAM_BUSINESS_ID = process.env.AGENT_BUSINESS_ID ?? "ff3a47f3-54b0-45e3-b7a9-69ddc9fa787e";
 const BOT_TOKEN   = process.env.TELEGRAM_BOT_TOKEN!;
 const CHAT_ID     = process.env.TELEGRAM_CHAT_ID!;
-const FROM        = process.env.RESEND_FROM_EMAIL ?? "Crown Roofers <noreply@crownroofers.com.au>";
+
+/** One business's details, for addressing its own emails. */
+interface BizContact {
+  id: string; name: string;
+  email: string | null; phone: string | null; website: string | null;
+}
+
+/** "Name <someone@theirslug.kireihq.com>" — the same per-business sender every
+ *  other outbound path uses, instead of one hardcoded address. */
+function fromFor(biz: BizContact): string {
+  // No slug is passed: `businesses` has no slug column, and buildBusinessFrom
+  // slugifies the name when one isn't given. Selecting a column that doesn't
+  // exist would have failed the whole query and killed reminders for everyone.
+  return buildBusinessFrom({ name: biz.name, localPart: "reminders" });
+}
 
 function getResend() { return new Resend(process.env.RESEND_API_KEY!); }
 
@@ -55,7 +83,7 @@ async function sendTelegram(text: string) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getJobsForDate(sb: any, date: string) {
+async function getJobsForDate(sb: any, businessId: string, date: string) {
   const { data } = await sb
     .from("work_orders")
     .select(`
@@ -66,12 +94,13 @@ async function getJobsForDate(sb: any, date: string) {
         member_profiles(id, name, email, phone)
       )
     `)
-    .eq("business_id", BUSINESS_ID)
+    .eq("business_id", businessId)
     .eq("scheduled_date", date)
     .not("status", "eq", "cancelled")
     .order("start_time", { ascending: true, nullsFirst: false });
   return (data ?? []) as any[];
 }
+
 
 export async function GET(req: NextRequest) {
   // Auth: Vercel sets CRON_SECRET, or allow explicit bearer
@@ -79,49 +108,93 @@ export async function GET(req: NextRequest) {
   if (denied) return denied;
 
   const sb = createAdminClient();
-  const today    = todayAEST();
+  const today = todayAEST();
   const tomorrow = tomorrowAEST();
 
-  const [todayJobs, tomorrowJobs] = await Promise.all([
-    getJobsForDate(sb, today),
-    getJobsForDate(sb, tomorrow),
-  ]);
+  // Which businesses actually have work on either day. One cheap query rather
+  // than walking every business on the platform every morning.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: scheduled } = await (sb as any)
+    .from("work_orders")
+    .select("business_id")
+    .in("scheduled_date", [today, tomorrow])
+    .not("status", "eq", "cancelled")
+    .limit(5000);
 
-  // ── 1. Telegram — today's schedule summary ────────────────────────────────
-  if (todayJobs.length === 0) {
+  const businessIds = [
+    ...new Set(((scheduled ?? []) as Array<{ business_id: string }>).map((r) => r.business_id)),
+  ];
+
+  if (businessIds.length === 0) {
+    // Still tell the operator their own day is clear, as it always did.
     await sendTelegram(`📅 <b>Schedule for ${fmtDate(today)}</b>\n\nNo jobs scheduled today. 🏖️`);
-  } else {
-    const lines = todayJobs.map((j: any) => {
-      const time = j.start_time ? ` · ${fmt12(j.start_time)}${j.end_time ? `–${fmt12(j.end_time)}` : ""}` : "";
-      const addr = j.property_address ? `\n   📍 ${j.property_address}` : "";
-      const workers = (j.work_order_assignments ?? [])
-        .map((a: any) => a.member_profiles?.name).filter(Boolean).join(", ");
-      const crew = workers ? `\n   👷 ${workers}` : "";
-      return `• <b>${j.title}</b>${time}${addr}${crew}`;
+    return NextResponse.json({
+      ok: true, businesses: 0,
+      today: { date: today, workers_emailed: 0 },
+      tomorrow: { date: tomorrow, customer_reminders: 0 },
     });
-    await sendTelegram(
-      `📅 <b>Schedule for ${fmtDate(today)}</b> — ${todayJobs.length} job${todayJobs.length > 1 ? "s" : ""}\n\n${lines.join("\n\n")}`
-    );
   }
 
-  // ── 2. Worker emails — today's jobs ───────────────────────────────────────
-  // Group jobs by worker
-  const workerJobMap = new Map<string, { profile: any; jobs: any[] }>();
-  for (const job of todayJobs) {
-    for (const assignment of (job.work_order_assignments ?? [])) {
-      const profile = assignment.member_profiles;
-      if (!profile?.email) continue;
-      if (!workerJobMap.has(profile.id)) {
-        workerJobMap.set(profile.id, { profile, jobs: [] });
-      }
-      workerJobMap.get(profile.id)!.jobs.push(job);
-    }
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: bizRows } = await (sb as any)
+    .from("businesses")
+    .select("id, name, email, phone, website")
+    .in("id", businessIds);
+  const businesses = (bizRows ?? []) as BizContact[];
 
   const resend = getResend();
-  await Promise.all(
-    Array.from(workerJobMap.values()).map(async ({ profile, jobs }) => {
-      const jobRows = jobs.map((j: any) => `
+  let workersEmailed = 0;
+  let customerReminders = 0;
+
+  for (const biz of businesses) {
+    const [todayJobs, tomorrowJobs] = await Promise.all([
+      getJobsForDate(sb, biz.id, today),
+      getJobsForDate(sb, biz.id, tomorrow),
+    ]);
+
+    // ── 1. Telegram — only the configured business (see the file header) ────
+    if (biz.id === TELEGRAM_BUSINESS_ID) {
+      if (todayJobs.length === 0) {
+        await sendTelegram(`📅 <b>Schedule for ${fmtDate(today)}</b>\n\nNo jobs scheduled today. 🏖️`);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const lines = todayJobs.map((j: any) => {
+          const time = j.start_time ? ` · ${fmt12(j.start_time)}${j.end_time ? `–${fmt12(j.end_time)}` : ""}` : "";
+          const addr = j.property_address ? `\n   📍 ${j.property_address}` : "";
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const workers = (j.work_order_assignments ?? [])
+            .map((a: any) => a.member_profiles?.name).filter(Boolean).join(", ");
+          const crew = workers ? `\n   👷 ${workers}` : "";
+          return `• <b>${j.title}</b>${time}${addr}${crew}`;
+        });
+        await sendTelegram(
+          `📅 <b>Schedule for ${fmtDate(today)}</b> — ${todayJobs.length} job${todayJobs.length > 1 ? "s" : ""}\n\n${lines.join("\n\n")}`,
+        );
+      }
+    }
+
+    // This business's own sender and reply-to, not one hardcoded address.
+    const from = fromFor(biz);
+    const replyTo = biz.email ?? undefined;
+    const footer = `${biz.name}${biz.website ? ` · ${biz.website}` : ""}`;
+
+    // ── 2. Worker emails — today's jobs ─────────────────────────────────────
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const workerJobMap = new Map<string, { profile: any; jobs: any[] }>();
+    for (const job of todayJobs) {
+      for (const assignment of job.work_order_assignments ?? []) {
+        const profile = assignment.member_profiles;
+        if (!profile?.email) continue;
+        if (!workerJobMap.has(profile.id)) workerJobMap.set(profile.id, { profile, jobs: [] });
+        workerJobMap.get(profile.id)!.jobs.push(job);
+      }
+    }
+    workersEmailed += workerJobMap.size;
+
+    await Promise.all(
+      Array.from(workerJobMap.values()).map(async ({ profile, jobs }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const jobRows = jobs.map((j: any) => `
         <tr>
           <td style="padding:10px 0;border-bottom:1px solid #f3f4f6;">
             <div style="font-weight:600;color:#111827;font-size:14px;">${j.title}</div>
@@ -129,93 +202,86 @@ export async function GET(req: NextRequest) {
             ${j.property_address ? `<div style="color:#6b7280;font-size:13px;margin-top:2px;">📍 ${j.property_address}</div>` : ""}
             ${j.customers?.phone ? `<div style="color:#6b7280;font-size:13px;margin-top:2px;">📞 ${j.customers.phone}</div>` : ""}
           </td>
-        </tr>
-      `).join("");
-
-      try {
-        await resend.emails.send({
-          from: FROM,
-          to: profile.email,
-          subject: `Your jobs today — ${fmtDate(today)}`,
-          html: `
-            <div style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px;">
-              <div style="background:#2563eb;color:white;padding:16px 24px;border-radius:10px 10px 0 0;">
-                <h1 style="margin:0;font-size:18px;">📅 Your Jobs Today</h1>
-                <p style="margin:4px 0 0;opacity:0.85;font-size:14px;">${fmtDate(today)}</p>
-              </div>
-              <div style="border:1px solid #e5e7eb;border-top:none;padding:20px 24px;border-radius:0 0 10px 10px;">
-                <p style="margin:0 0 16px;font-size:15px;color:#374151;">Hi ${profile.name.split(" ")[0]}, here are your jobs for today:</p>
+        </tr>`).join("");
+        try {
+          await resend.emails.send({
+            from, replyTo, to: profile.email,
+            subject: `Your jobs today — ${fmtDate(today)}`,
+            html: `
+              <div style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+                <h1 style="font-size:18px;color:#111827;">Hi ${String(profile.name ?? "").split(" ")[0]}, here's your day</h1>
                 <table style="width:100%;border-collapse:collapse;">${jobRows}</table>
-                <div style="margin-top:20px;padding:14px;background:#eff6ff;border-radius:8px;border:1px solid #bfdbfe;">
-                  <p style="margin:0;font-size:13px;color:#1e40af;">Questions? Call the office: <a href="tel:+61490688332" style="color:#2563eb;font-weight:bold;">0490 688 332</a></p>
-                </div>
-              </div>
-              <p style="margin-top:12px;font-size:11px;color:#9ca3af;text-align:center;">Crown Roofers · crownroofers.com.au</p>
-            </div>
-          `,
-        });
-      } catch (e) {
-        console.error(`Worker email failed for ${profile.email}:`, e);
-      }
-    })
-  );
+                <p style="margin-top:12px;font-size:11px;color:#9ca3af;text-align:center;">${footer}</p>
+              </div>`,
+          });
+        } catch (e) {
+          console.error(`[reminders] worker email failed for ${profile.email}:`, e);
+        }
+      }),
+    );
 
-  // ── 3. Customer reminder emails — tomorrow's jobs ─────────────────────────
-  await Promise.all(
-    tomorrowJobs
-      .filter((j: any) => j.customers?.email)
-      .map(async (j: any) => {
+    // ── 3. Customer reminders — tomorrow's jobs ─────────────────────────────
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const withEmail = tomorrowJobs.filter((j: any) => j.customers?.email);
+    customerReminders += withEmail.length;
+
+    await Promise.all(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      withEmail.map(async (j: any) => {
         const cust = j.customers;
         const timeStr = j.start_time
           ? `at <strong style="color:#2563eb;">${fmt12(j.start_time)}${j.end_time ? ` – ${fmt12(j.end_time)}` : ""}</strong>`
           : "tomorrow";
         try {
           await resend.emails.send({
-            from: FROM,
-            replyTo: "info@crownroofers.com.au",
-            to: cust.email,
-            subject: `Reminder: Crown Roofers visit tomorrow`,
+            from, replyTo, to: cust.email,
+            subject: `Reminder: ${biz.name} visit tomorrow`,
             html: `
               <div style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px;">
                 <div style="background:#f97316;color:white;padding:16px 24px;border-radius:10px 10px 0 0;">
                   <h1 style="margin:0;font-size:18px;">📅 Your appointment is tomorrow</h1>
                 </div>
                 <div style="border:1px solid #e5e7eb;border-top:none;padding:20px 24px;border-radius:0 0 10px 10px;">
-                  <p style="font-size:15px;color:#374151;">Hi ${cust.name.split(" ")[0]},</p>
+                  <p style="font-size:15px;color:#374151;">Hi ${String(cust.name ?? "").split(" ")[0]},</p>
                   <p style="font-size:15px;color:#374151;">This is a reminder that our team will be at <strong>${j.property_address || "your property"}</strong> ${timeStr} for <strong>${j.title}</strong>.</p>
                   <div style="background:#f9fafb;border-radius:8px;padding:16px;margin:16px 0;border:1px solid #e5e7eb;">
                     <p style="margin:0 0 4px;font-size:14px;color:#6b7280;">📅 ${fmtDate(tomorrow)}</p>
                     ${j.start_time ? `<p style="margin:0 0 4px;font-size:14px;color:#6b7280;">🕐 ${fmt12(j.start_time)}${j.end_time ? ` – ${fmt12(j.end_time)}` : ""}</p>` : ""}
                     ${j.property_address ? `<p style="margin:0;font-size:14px;color:#6b7280;">📍 ${j.property_address}</p>` : ""}
                   </div>
-                  <p style="font-size:14px;color:#6b7280;">Need to reschedule? Call us: <a href="tel:+61490688332" style="color:#f97316;font-weight:bold;">0490 688 332</a></p>
+                  ${biz.phone ? `<p style="font-size:14px;color:#6b7280;">Need to reschedule? Call us: <a href="tel:${biz.phone.replace(/\s/g, "")}" style="color:#f97316;font-weight:bold;">${biz.phone}</a></p>` : ""}
                 </div>
-                <p style="margin-top:12px;font-size:11px;color:#9ca3af;text-align:center;">Crown Roofers · ABN 69 683 690 5 · crownroofers.com.au</p>
-              </div>
-            `,
+                <p style="margin-top:12px;font-size:11px;color:#9ca3af;text-align:center;">${footer}</p>
+              </div>`,
           });
         } catch (e) {
-          console.error(`Customer reminder failed for ${cust.email}:`, e);
+          console.error(`[reminders] customer reminder failed for ${cust.email}:`, e);
         }
-      })
-  );
+      }),
+    );
 
-  // ── 4. Mark assignments as reminded ───────────────────────────────────────
-  const assignmentIds = todayJobs
-    .flatMap((j: any) => j.work_order_assignments ?? [])
-    .filter((a: any) => !a.reminder_sent_at)
-    .map((a: any) => a.id);
+    // ── 4. Mark assignments as reminded ─────────────────────────────────────
+    const assignmentIds = todayJobs
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .flatMap((j: any) => j.work_order_assignments ?? [])
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .filter((a: any) => !a.reminder_sent_at)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((a: any) => a.id);
 
-  if (assignmentIds.length > 0) {
-    await (sb as any)
-      .from("work_order_assignments")
-      .update({ reminder_sent_at: new Date().toISOString() })
-      .in("id", assignmentIds);
+    if (assignmentIds.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (sb as any)
+        .from("work_order_assignments")
+        .update({ reminder_sent_at: new Date().toISOString() })
+        .in("id", assignmentIds);
+    }
   }
 
   return NextResponse.json({
     ok: true,
-    today: { date: today, jobs: todayJobs.length, workers_emailed: workerJobMap.size },
-    tomorrow: { date: tomorrow, customer_reminders: tomorrowJobs.filter((j: any) => j.customers?.email).length },
+    businesses: businesses.length,
+    today: { date: today, workers_emailed: workersEmailed },
+    tomorrow: { date: tomorrow, customer_reminders: customerReminders },
   });
 }

--- a/src/lib/leads/promote.test.ts
+++ b/src/lib/leads/promote.test.ts
@@ -43,22 +43,26 @@ function makeSb(state: {
       update(patch: Record<string, unknown>) {
         calls.push(`update:${table}`);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const inSets: Record<string, unknown[]> = {};
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const upd: any = {
           eq(col: string, val: unknown) { filters[col] = val; return upd; },
+          in(col: string, vals: unknown[]) { inSets[col] = vals; return upd; },
           select() {
-            const store = state[table as "leads" | "customers"];
-            const hits = Object.values(store).filter((r) =>
-              Object.entries(filters).every(([k, v]) => r[k] === v));
+            const hits = match();
             hits.forEach((r) => Object.assign(r, patch));
             return Promise.resolve({ data: hits, error: null });
           },
           then(res: (v: unknown) => void) {
-            const store = state[table as "leads" | "customers"];
-            Object.values(store)
-              .filter((r) => Object.entries(filters).every(([k, v]) => r[k] === v))
-              .forEach((r) => Object.assign(r, patch));
+            match().forEach((r) => Object.assign(r, patch));
             return Promise.resolve({ data: null, error: null }).then(res);
           },
+        };
+        const match = () => {
+          const store = state[table as "leads" | "customers"];
+          return Object.values(store).filter((r) =>
+            Object.entries(filters).every(([k, v]) => r[k] === v)
+            && Object.entries(inSets).every(([k, vals]) => vals.includes(r[k])));
         };
         return upd;
       },
@@ -144,5 +148,54 @@ describe("markContactAsClient", () => {
     const { sb } = makeSb({ leads: {}, customers: {} });
     expect(await markContactAsClient(sb, BIZ, null)).toBe(false);
     expect(await markContactAsClient(sb, BIZ, undefined)).toBe(false);
+  });
+});
+
+describe("the pipeline follows the money", () => {
+  it("marks the linked lead won when the contact becomes a client", async () => {
+    // The drift this fixes: 11 leads were marked won, 10 of them with no
+    // contact at all, because three different places wrote "became a customer".
+    const state = {
+      leads: { L1: { id: "L1", business_id: BIZ, customer_id: "C1", status: "quoted" } },
+      customers: { C1: { id: "C1", business_id: BIZ, lifecycle_stage: "lead" } },
+    };
+    const { sb } = makeSb(state);
+    await markContactAsClient(sb, BIZ, "C1");
+    expect(state.customers.C1.lifecycle_stage).toBe("client");
+    expect(state.leads.L1.status).toBe("won");
+  });
+
+  it("does not reopen a lead someone marked lost", async () => {
+    const state = {
+      leads: { L1: { id: "L1", business_id: BIZ, customer_id: "C1", status: "lost" } },
+      customers: { C1: { id: "C1", business_id: BIZ, lifecycle_stage: "lead" } },
+    };
+    const { sb } = makeSb(state);
+    await markContactAsClient(sb, BIZ, "C1");
+    expect(state.leads.L1.status).toBe("lost");
+  });
+
+  it("moves a new lead to quoted when it is first billed", async () => {
+    const state = {
+      leads: { L1: { id: "L1", business_id: BIZ, name: "Acme", email: "a@b.c", customer_id: null, status: "new" } },
+      customers: {} as Record<string, Record<string, unknown>>,
+    };
+    const { sb } = makeSb(state);
+    await ensureContactForLead(sb, BIZ, "L1");
+    expect(state.leads.L1.status).toBe("quoted");
+    expect(state.leads.L1.customer_id).toBeTruthy();
+  });
+
+  it("still links the contact on a lead already marked won", async () => {
+    // The status guard must not stop the LINK being written, or a won lead
+    // would never get the contact row its invoice needs.
+    const state = {
+      leads: { L1: { id: "L1", business_id: BIZ, name: "Acme", email: "a@b.c", customer_id: null, status: "won" } },
+      customers: {} as Record<string, Record<string, unknown>>,
+    };
+    const { sb } = makeSb(state);
+    const res = await ensureContactForLead(sb, BIZ, "L1");
+    expect(state.leads.L1.status).toBe("won");
+    expect(state.leads.L1.customer_id).toBe(res.customerId);
   });
 });

--- a/src/lib/leads/promote.ts
+++ b/src/lib/leads/promote.ts
@@ -75,6 +75,14 @@ export async function ensureContactForLead(
   }).select("id").single();
   if (insErr) throw new Error(insErr.message);
 
+  // Billing them is a pipeline event: a lead you have just quoted is not still
+  // "new". Only nudged forward from the earliest states, so a manual "lost"
+  // or "won" is never overwritten by the act of raising a document.
+  await tbl(sb, "leads")
+    .update({ customer_id: created.id, status: "quoted" })
+    .eq("id", leadId).in("status", ["new", "contacted"]);
+  // The link itself must be written even when the status guard above matched
+  // nothing, or a lead already marked won/lost would never get its contact.
   await tbl(sb, "leads").update({ customer_id: created.id }).eq("id", leadId);
   return { customerId: created.id, created: true };
 }
@@ -98,6 +106,17 @@ export async function markContactAsClient(
       .eq("id", customerId).eq("business_id", businessId)
       .eq("lifecycle_stage", "lead")   // only ever lead → client, never back
       .select("id");
+
+    // The pipeline follows the money too. Two fields already meant "became a
+    // customer" — leads.status='won' and the contact's stage — and nothing kept
+    // them together: of 11 leads marked won, 10 had no contact at all. Payment
+    // is now the single authority and the board is derived from it, rather
+    // than being a third independent opinion.
+    await tbl(sb, "leads")
+      .update({ status: "won" })
+      .eq("business_id", businessId).eq("customer_id", customerId)
+      .in("status", ["new", "contacted", "quoted"]);   // never reopen a lost lead
+
     return Array.isArray(data) && data.length > 0;
   } catch (e) {
     console.error("[leads] promote to client failed", e instanceof Error ? e.message : e);


### PR DESCRIPTION
Two live defects, both found by checking rather than recalling.

## Reminders only ran for one business

`/api/cron/reminders` filtered on a hardcoded business id. **Every business except Crown Roofers got no reminders at all** — including Ezy Current Electrical, and including anyone who signs up through the front door we just built.

**Looping alone would have been worse than the bug.** The customer email had Crown Roofers' name, phone, ABN, reply-to and website baked into it, so another firm's customers would have been reminded of a *Crown Roofers* visit. Both had to be fixed together.

Each business's emails now carry its own name, sender (`buildBusinessFrom`, as every other outbound path does), reply-to, phone and footer.

**Telegram deliberately stays single-business.** `TELEGRAM_CHAT_ID` is one person's chat; broadcasting every tenant's schedule into it would leak other businesses' work to whoever owns that chat.

### Caught while wiring it

The query selected `businesses.slug` — **which doesn't exist**. That would have failed the whole query and killed reminders for *everyone*, replacing a bug affecting all-but-one with one affecting all. `buildBusinessFrom` slugifies the name when no slug is given, so the column isn't selected. I ran the exact remaining query against production before committing.

## Three writers disagreed about "became a customer"

`leads.status='won'`, `customers.lifecycle_stage='client'` and `leads.customer_id` all meant it, and nothing kept them together:

| | |
|---|---|
| leads marked `won` | **11** |
| leads with a contact | **9** |
| `won` **with no contact at all** | **10** |

#471 added the third writer without fixing that — a loose end I raised and then left.

**Payment is now the single authority.** `markContactAsClient` promotes the contact *and* marks the linked lead won; raising the first document nudges a new/contacted lead to `quoted`.

Both guard their transitions:
- a **lost** lead is never reopened
- a **won** lead is never demoted
- the contact link is written **even when the status guard matches nothing** — otherwise a won lead would never get the contact row its invoice needs

**Historical data is left alone.** The 10 won-but-unlinked leads predate this and may have been won without a Kirei contact; silently rewriting them would be inventing history. Say the word if you'd rather I backfilled them.

## Verification

283 tests (4 new on the transitions) · `tsc` · production build, **exit code checked**.

The cron itself is unverified end-to-end — it needs `CRON_SECRET` and sends real email, so I haven't fired it. Worth watching tomorrow's 6am run, or triggering it manually once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)