### PR TITLE
feat(routing): split the site from the product by hostname

### DIFF
--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { hostRedirectTarget, marketingHostFor, isMarketingPath } from "./host-routing";
+
+const APP = "app.kireihq.com";
+const SITE = "kireihq.com";
+
+function withAppHost<T>(value: string | undefined, fn: () => T): T {
+  const prev = process.env.NEXT_PUBLIC_APP_HOST;
+  if (value === undefined) delete process.env.NEXT_PUBLIC_APP_HOST;
+  else process.env.NEXT_PUBLIC_APP_HOST = value;
+  try { return fn(); } finally {
+    if (prev === undefined) delete process.env.NEXT_PUBLIC_APP_HOST;
+    else process.env.NEXT_PUBLIC_APP_HOST = prev;
+  }
+}
+
+afterEach(() => { delete process.env.NEXT_PUBLIC_APP_HOST; });
+
+describe("inert until configured", () => {
+  it("does nothing at all with no NEXT_PUBLIC_APP_HOST", () => {
+    // This is the rollback: unset the variable and the split disappears.
+    withAppHost(undefined, () => {
+      for (const p of ["/", "/dashboard", "/trades", "/api/stripe/webhook"]) {
+        expect(hostRedirectTarget(SITE, p)).toBeNull();
+        expect(hostRedirectTarget(APP, p)).toBeNull();
+      }
+    });
+  });
+});
+
+describe("splitting the two hosts", () => {
+  it("sends app paths on the marketing host to the app", () => {
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(SITE, "/dashboard")).toBe(`https://${APP}/dashboard`);
+      expect(hostRedirectTarget(SITE, "/invoices/123")).toBe(`https://${APP}/invoices/123`);
+      expect(hostRedirectTarget(SITE, "/auth/login")).toBe(`https://${APP}/auth/login`);
+      expect(hostRedirectTarget(SITE, "/onboarding")).toBe(`https://${APP}/onboarding`);
+    });
+  });
+
+  it("sends marketing paths on the app host back to the site", () => {
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(APP, "/trades")).toBe(`https://${SITE}/trades`);
+      expect(hostRedirectTarget(APP, "/pricing")).toBe(`https://${SITE}/pricing`);
+    });
+  });
+
+  it("keeps the app's own root on the app host", () => {
+    // app.kireihq.com/ must reach the dashboard, not bounce to the sales page.
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(APP, "/")).toBeNull();
+    });
+  });
+
+  it("leaves marketing pages alone on the marketing host", () => {
+    withAppHost(APP, () => {
+      for (const p of ["/", "/trades", "/agencies", "/pricing", "/contact-sales"]) {
+        expect(hostRedirectTarget(SITE, p)).toBeNull();
+      }
+    });
+  });
+});
+
+describe("what must never be redirected", () => {
+  it("never redirects /api — webhooks do not reliably follow them", () => {
+    // Stripe and Revolut webhooks are registered against the current host. A
+    // redirect on a POST is a payment that silently never gets recorded.
+    withAppHost(APP, () => {
+      for (const host of [SITE, APP]) {
+        expect(hostRedirectTarget(host, "/api/stripe/webhook")).toBeNull();
+        expect(hostRedirectTarget(host, "/api/revolut/webhook")).toBeNull();
+        expect(hostRedirectTarget(host, "/api/cron/reminders")).toBeNull();
+        expect(hostRedirectTarget(host, "/api/mcp")).toBeNull();
+      }
+    });
+  });
+
+  it("never redirects a link already out in the world", () => {
+    // Portal links, booking pages, hosted forms and share links live in emails
+    // we cannot go back and edit.
+    withAppHost(APP, () => {
+      for (const p of [
+        "/portal/abc123", "/book/some-slug", "/f/enquiry", "/embed/enquiry",
+        "/jobs/tok", "/invoice/tok", "/quote/tok", "/unsubscribe/tok",
+        "/privacy", "/support", "/.well-known/oauth-authorization-server",
+      ]) {
+        expect(hostRedirectTarget(SITE, p)).toBeNull();
+        expect(hostRedirectTarget(APP, p)).toBeNull();
+      }
+    });
+  });
+});
+
+describe("other hosts are left alone", () => {
+  it("ignores previews and localhost", () => {
+    // A preview deployment must keep serving everything from one origin, or it
+    // stops being testable — which is how this would ship unverified.
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget("localhost:3000", "/dashboard")).toBeNull();
+      expect(hostRedirectTarget("invoicer-abc123.vercel.app", "/dashboard")).toBeNull();
+      expect(hostRedirectTarget("invoicer.crownroofers.com.au", "/dashboard")).toBeNull();
+    });
+  });
+
+  it("ignores the port when matching", () => {
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(`${SITE}:443`, "/dashboard")).toBe(`https://${APP}/dashboard`);
+    });
+  });
+
+  it("tolerates a missing Host header", () => {
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(null, "/dashboard")).toBeNull();
+    });
+  });
+});
+
+describe("helpers", () => {
+  it("derives the marketing host from the app host", () => {
+    expect(marketingHostFor("app.kireihq.com")).toBe("kireihq.com");
+    expect(marketingHostFor("kireihq.com")).toBe("kireihq.com");
+  });
+
+  it("knows which paths are marketing", () => {
+    expect(isMarketingPath("/pricing")).toBe(true);
+    expect(isMarketingPath("/dashboard")).toBe(false);
+  });
+});

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -1,0 +1,106 @@
+/**
+ * Splitting the marketing site from the product by hostname.
+ *
+ *   kireihq.com      → the public site
+ *   app.kireihq.com  → the product
+ *
+ * **Inert until NEXT_PUBLIC_APP_HOST is set.** With no value, every function
+ * here returns null and the app behaves exactly as it does today on one
+ * domain. That makes the switch an environment variable rather than a deploy,
+ * and the rollback the same — which matters, because getting this wrong locks
+ * people out of their own business.
+ *
+ * Three rules, each learned from what breaks:
+ *
+ *  1. **Never redirect /api.** Stripe and Revolut webhooks are registered
+ *     against the current host. A 308 on a POST is not reliably followed, and
+ *     a missed webhook is a payment that never gets recorded. API routes keep
+ *     answering on both hosts, forever.
+ *
+ *  2. **Never redirect a public customer surface.** Portal links, booking
+ *     pages, hosted forms and job share links are already out in the world in
+ *     emails we cannot edit. They keep working on whichever host they were
+ *     minted with.
+ *
+ *  3. **Sessions are NOT shared across the two hosts.** Cookies stay
+ *     host-only rather than being widened to .kireihq.com. Widening them is
+ *     the step that risks invalidating every existing session, and the only
+ *     thing it buys is the marketing header knowing you are signed in. The
+ *     cost is one re-login at the new host, once.
+ */
+
+/** e.g. "app.kireihq.com". Empty/unset disables host routing entirely. */
+export function appHost(): string | null {
+  const h = process.env.NEXT_PUBLIC_APP_HOST?.trim().toLowerCase();
+  return h ? h.replace(/^https?:\/\//, "").replace(/\/$/, "") : null;
+}
+
+/** Pages that belong to the public site. */
+const MARKETING_PATHS = new Set([
+  "/", "/trades", "/agencies", "/pricing", "/contact-sales",
+]);
+
+/**
+ * Paths that must answer on BOTH hosts and never be redirected: machine
+ * callers and links already in the wild. Rules 1 and 2 above.
+ */
+function isSharedPath(pathname: string): boolean {
+  return (
+    pathname.startsWith("/api/")
+    || pathname.startsWith("/_next/")
+    || pathname.startsWith("/.well-known/")
+    || pathname.startsWith("/portal/")
+    || pathname.startsWith("/book/")
+    || pathname.startsWith("/f/")
+    || pathname.startsWith("/embed/")
+    || pathname.startsWith("/jobs/")
+    || pathname.startsWith("/invoice/")
+    || pathname.startsWith("/quote/")
+    || pathname.startsWith("/unsubscribe/")
+    // Legal pages are linked from the app stores and from emails; leaving them
+    // on both hosts costs nothing and avoids breaking a listing.
+    || pathname === "/privacy"
+    || pathname === "/support"
+  );
+}
+
+export function isMarketingPath(pathname: string): boolean {
+  return MARKETING_PATHS.has(pathname);
+}
+
+/**
+ * Where this request should be sent, or null to serve it here.
+ *
+ * @param host      the request's Host header
+ * @param pathname  the request path
+ */
+export function hostRedirectTarget(host: string | null, pathname: string): string | null {
+  const app = appHost();
+  if (!app || !host) return null;
+
+  const h = host.toLowerCase().split(":")[0];
+  // Previews, localhost and any other host are left alone: a preview
+  // deployment must keep serving the whole app from one origin, or it stops
+  // being testable.
+  const isApp = h === app;
+  const isMarketing = h === marketingHostFor(app);
+  if (!isApp && !isMarketing) return null;
+
+  if (isSharedPath(pathname)) return null;
+
+  if (isMarketing && !isMarketingPath(pathname)) {
+    return `https://${app}${pathname}`;
+  }
+  if (isApp && isMarketingPath(pathname)) {
+    // The app's own root is the dashboard, not the sales pitch.
+    if (pathname === "/") return null;
+    return `https://${marketingHostFor(app)}${pathname}`;
+  }
+  return null;
+}
+
+/** "app.kireihq.com" → "kireihq.com". */
+export function marketingHostFor(app: string): string {
+  const parts = app.split(".");
+  return parts.length > 2 ? parts.slice(1).join(".") : app;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,24 @@
-import { type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
+import { hostRedirectTarget } from "@/lib/host-routing";
 
 export async function proxy(request: NextRequest) {
+  // Split the public site from the product by hostname, BEFORE the auth
+  // middleware runs — otherwise a signed-out visitor hitting the app host is
+  // bounced to login on the wrong origin. Inert until NEXT_PUBLIC_APP_HOST is
+  // set, so this deploy changes nothing until the env var does.
+  const target = hostRedirectTarget(
+    request.headers.get("host"),
+    request.nextUrl.pathname,
+  );
+  if (target) {
+    const url = new URL(target);
+    url.search = request.nextUrl.search;   // keep ?invite=, ?solution=, …
+    // 307, not 308: a permanent redirect gets cached by browsers and would
+    // outlive a rollback, stranding people on a host we had moved away from.
+    return NextResponse.redirect(url, 307);
+  }
+
   return await updateSession(request);
 }
 


### PR DESCRIPTION
`kireihq.com` serves the public site; `app.kireihq.com` serves the product. One Next app, one deployment, split in the proxy by `Host`.

## Merging this changes nothing

**Inert until `NEXT_PUBLIC_APP_HOST` is set.** With no value every function returns null and the app behaves exactly as today. The switch is an environment variable, and so is the rollback — which matters, because getting host routing wrong locks people out of their own business.

## Three rules, each from what actually breaks

1. **`/api` is never redirected.** Stripe and Revolut webhooks are registered against the current host, a 307 on a POST isn't reliably followed, and a missed webhook is a payment that never gets recorded. API routes answer on both hosts permanently.
2. **Public customer surfaces are never redirected** — portal links, booking pages, hosted forms, job share links, `/privacy`, `/support`. Those URLs are already in emails and app-store listings nobody can go back and edit.
3. **Sessions are not shared between hosts.** Cookies stay host-only rather than widening to `.kireihq.com`. Widening is the step that risks invalidating every existing session, and all it buys is the marketing header knowing you're signed in. **Cost: one re-login at the new host, once.**

307 not 308, deliberately — a permanent redirect gets cached by the browser and would outlive a rollback, stranding people on a host we'd moved away from. Query strings survive, so `?solution=trades` makes it from the marketing site into signup.

Previews, localhost and the crownroofers alias are left alone; otherwise a preview would stop serving everything from one origin and become untestable.

---

## What you need to do, in this order

**1. Add the DNS record** at your provider (kireihq.com is on third-party nameservers, so Vercel can't do it):

```
CNAME   app   18f028cd997d5a10.vercel-dns-017.com.
```

The domain is already attached to the project and ownership-verified.

**2. Allow the new origin in Supabase** — Authentication → URL Configuration → add `https://app.kireihq.com/**` to Redirect URLs. **Do this before step 3**, or sign-in on the new host will fail.

**3. Set `NEXT_PUBLIC_APP_HOST=app.kireihq.com`** on Vercel production and redeploy. The split goes live here. Everyone signs in again once.

**4. Then update the origin-dependent integrations:**

| Where | What |
|---|---|
| Vercel env | `NEXT_PUBLIC_APP_URL` → `https://app.kireihq.com` (invite links, PDFs, Stripe return URLs) |
| Google Cloud | GSC OAuth redirect URI → `https://app.kireihq.com/api/seo/gsc/callback` |
| GitHub App | Callback URL → `https://app.kireihq.com/api/seo/github/callback` |
| claude.ai | Reconnect the MCP connector — the issuer origin changes |

Steps 1–3 are the move. Step 4 can follow; until it's done those specific integrations keep working against the old origin because `/api` still answers there.

## Verification

12 tests covering the split, both never-redirect lists, port handling, a missing `Host` header and the inert default. 291 tests total · `tsc` · production build, exit code checked.

**Not verified end to end** — that needs the DNS record to exist. Once step 3 is done, check: sign in at `app.kireihq.com`, `kireihq.com/dashboard` redirects to it, `kireihq.com/pricing` still serves, and an existing portal link still opens on the old host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)