### PR TITLE
fix(routing): www is the marketing host too

### DIFF
--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -91,6 +91,25 @@ describe("what must never be redirected", () => {
   });
 });
 
+describe("www counts as the marketing host", () => {
+  it("redirects app paths on www, not just the apex", () => {
+    // The apex 307s to www, so www IS the public host. Matching only the apex
+    // let /dashboard on www fall through to the login page instead of hopping
+    // to the app - which is exactly what happened in production.
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(`www.${SITE}`, "/dashboard")).toBe(`https://${APP}/dashboard`);
+      expect(hostRedirectTarget(`www.${SITE}`, "/auth/login")).toBe(`https://${APP}/auth/login`);
+    });
+  });
+
+  it("still leaves marketing pages alone on www", () => {
+    withAppHost(APP, () => {
+      expect(hostRedirectTarget(`www.${SITE}`, "/pricing")).toBeNull();
+      expect(hostRedirectTarget(`www.${SITE}`, "/")).toBeNull();
+    });
+  });
+});
+
 describe("other hosts are left alone", () => {
   it("ignores previews and localhost", () => {
     // A preview deployment must keep serving everything from one origin, or it

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -83,7 +83,7 @@ export function hostRedirectTarget(host: string | null, pathname: string): strin
   // deployment must keep serving the whole app from one origin, or it stops
   // being testable.
   const isApp = h === app;
-  const isMarketing = h === marketingHostFor(app);
+  const isMarketing = isMarketingHost(h, app);
   if (!isApp && !isMarketing) return null;
 
   if (isSharedPath(pathname)) return null;
@@ -94,7 +94,7 @@ export function hostRedirectTarget(host: string | null, pathname: string): strin
   if (isApp && isMarketingPath(pathname)) {
     // The app's own root is the dashboard, not the sales pitch.
     if (pathname === "/") return null;
-    return `https://${marketingHostFor(app)}${pathname}`;
+    return `https://${siteHost(app)}${pathname}`;
   }
   return null;
 }
@@ -103,4 +103,28 @@ export function hostRedirectTarget(host: string | null, pathname: string): strin
 export function marketingHostFor(app: string): string {
   const parts = app.split(".");
   return parts.length > 2 ? parts.slice(1).join(".") : app;
+}
+
+/**
+ * Where to send someone who lands on a marketing path at the app host.
+ *
+ * NEXT_PUBLIC_SITE_HOST exists because the canonical public host is not always
+ * the bare apex: kireihq.com 307s to www.kireihq.com, so redirecting to the
+ * apex would cost an extra hop on every link.
+ */
+export function siteHost(app: string): string {
+  const explicit = process.env.NEXT_PUBLIC_SITE_HOST?.trim().toLowerCase();
+  return explicit ? explicit.replace(/^https?:\/\//, "").replace(/\/$/, "") : marketingHostFor(app);
+}
+
+/**
+ * Is this the public site?
+ *
+ * Both the apex and its www form count. Matching only the apex is what let
+ * app paths on www.kireihq.com fall through to the login page instead of
+ * hopping to the app — the site is actually served on www.
+ */
+export function isMarketingHost(h: string, app: string): boolean {
+  const apex = marketingHostFor(app);
+  return h === apex || h === `www.${apex}` || h === siteHost(app);
 }


### PR DESCRIPTION
Found by testing the live split rather than trusting the host I'd assumed.

`kireihq.com` **307s to `www.kireihq.com`** — so www is the host people actually reach. My matcher only knew the bare apex, which meant:

```
www.kireihq.com/dashboard  →  307 /auth/login     ✗ should hop to the app
www.kireihq.com/auth/login →  200                 ✗ should hop to the app
```

App paths on the real marketing host weren't being redirected at all.

Both the apex and its `www` form now count as the public site. `NEXT_PUBLIC_SITE_HOST` names the canonical public host for redirects *back* from the app, so a marketing link doesn't pay an extra apex→www hop.

Two tests pin it, including the exact case that failed in production.

293 tests · `tsc` · build (exit code checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)