### PR TITLE
fix(routing): app.kireihq.com/ goes to the dashboard, not the sales page

### DIFF
--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -45,10 +45,12 @@ describe("splitting the two hosts", () => {
     });
   });
 
-  it("keeps the app's own root on the app host", () => {
-    // app.kireihq.com/ must reach the dashboard, not bounce to the sales page.
+  it("sends the app host's root to the dashboard, never the sales page", () => {
+    // The page at "/" is the marketing home; it only forwards to the dashboard
+    // when already signed in. Left alone, a logged-out visitor to
+    // app.kireihq.com was shown the pitch instead of a login screen.
     withAppHost(APP, () => {
-      expect(hostRedirectTarget(APP, "/")).toBeNull();
+      expect(hostRedirectTarget(APP, "/")).toBe(`https://${APP}/dashboard`);
     });
   });
 

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -92,8 +92,11 @@ export function hostRedirectTarget(host: string | null, pathname: string): strin
     return `https://${app}${pathname}`;
   }
   if (isApp && isMarketingPath(pathname)) {
-    // The app's own root is the dashboard, not the sales pitch.
-    if (pathname === "/") return null;
+    // The app host's root is the dashboard, not the sales pitch. Returning
+    // null here was wrong: the page AT "/" is the marketing home, which only
+    // forwards to the dashboard when you are already signed in — so a
+    // logged-out visitor to app.kireihq.com got the pitch instead of a login.
+    if (pathname === "/") return `https://${app}/dashboard`;
     return `https://${siteHost(app)}${pathname}`;
   }
   return null;


### PR DESCRIPTION
`app.kireihq.com/` was serving the **marketing homepage**.

My rule said "keep the app's own root on the app host", which reads as correct and wasn't: the page *at* `/` is the marketing home, and it only forwards to the dashboard when you're **already signed in**. So a logged-out visitor to the app host got the sales pitch — the product's front door selling the product to someone who'd already bought it.

The app host's root now redirects to `/dashboard`, which the auth middleware sends on to login when there's no session.

```
app.kireihq.com/  →  /dashboard  →  /auth/login   (signed out)
app.kireihq.com/  →  /dashboard                   (signed in)
www.kireihq.com/  →  marketing home               (unchanged)
```

Found by fetching the page and reading what came back, not by re-reading the rule — the rule looked right.

293 tests · `tsc` · build (exit code checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)