### PR TITLE
feat(leads): reach a lead's quotes and onboarding from the pipeline

### DIFF
--- a/src/components/leads/lead-drawer-billing.tsx
+++ b/src/components/leads/lead-drawer-billing.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * What's been raised against a lead, shown inside the pipeline drawer.
+ *
+ * The drawer had pipeline stage, tags and notes — and no link to the full
+ * lead — so quotes, invoices and onboarding forms were invisible from the one
+ * screen people actually work in. This puts the answer to "have we quoted
+ * them yet?" where the question gets asked.
+ *
+ * Loads only when the drawer is open: the leads board renders one drawer at a
+ * time, but fetching on mount would still mean a request for a panel nobody
+ * opened.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { FileCheck, FileText, Loader2 } from "@/components/ui/icons";
+import { getLeadDocuments, type LeadDocuments } from "@/lib/actions/lead-billing";
+
+export function LeadDrawerBilling({ leadId, open }: { leadId: string; open: boolean }) {
+  const [docs, setDocs] = useState<LeadDocuments | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    getLeadDocuments(leadId)
+      .then((d) => { if (!cancelled) setDocs(d); })
+      // Silent: this is a supporting panel, and a failure here must not put an
+      // error toast over someone trying to move a lead down the pipeline.
+      .catch(() => { if (!cancelled) setDocs(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [leadId, open]);
+
+  if (loading && !docs) {
+    return (
+      <section>
+        <Label />
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" /> Checking…
+        </p>
+      </section>
+    );
+  }
+
+  const quotes = docs?.quotes ?? [];
+  const invoices = docs?.invoices ?? [];
+
+  return (
+    <section>
+      <Label />
+      {quotes.length === 0 && invoices.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nothing raised yet.{" "}
+          <Link href={`/leads/${leadId}`} className="text-primary hover:underline">
+            Quote them
+          </Link>
+          .
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {quotes.map((q) => (
+            <Link key={q.id} href={`/quotes/${q.id}`}
+              className="flex items-center gap-2.5 rounded-xl border border-border px-3 py-2 text-sm transition-colors hover:border-border-strong">
+              <FileCheck className="h-3.5 w-3.5 shrink-0 text-accent-2" />
+              <span className="font-mono text-xs text-muted-foreground">{q.number}</span>
+              <span className="ml-auto text-xs capitalize text-muted-foreground">{q.status}</span>
+            </Link>
+          ))}
+          {invoices.map((inv) => (
+            <Link key={inv.id} href={`/invoices/${inv.id}`}
+              className="flex items-center gap-2.5 rounded-xl border border-border px-3 py-2 text-sm transition-colors hover:border-border-strong">
+              <FileText className="h-3.5 w-3.5 shrink-0 text-primary" />
+              <span className="font-mono text-xs text-muted-foreground">{inv.number}</span>
+              <span className="ml-auto text-xs capitalize text-muted-foreground">{inv.status}</span>
+            </Link>
+          ))}
+          {docs?.isClient && (
+            <p className="pt-1 text-xs text-ok">They&rsquo;ve paid — this one&rsquo;s a client now.</p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Label() {
+  return (
+    <p className="mb-2 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">
+      Quotes &amp; invoices
+    </p>
+  );
+}

--- a/src/components/leads/lead-drawer.tsx
+++ b/src/components/leads/lead-drawer.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Phone, Mail, MapPin, Plus, X, Trash2, Clock } from "@/components/ui/icons";
+import Link from "next/link";
+import { Phone, Mail, MapPin, Plus, X, Trash2, Clock, ArrowRight } from "@/components/ui/icons";
+import { LeadDrawerBilling } from "@/components/leads/lead-drawer-billing";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -135,9 +137,21 @@ export function LeadDrawer({
             {lead.email && <a href={`mailto:${lead.email}`} className="inline-flex items-center gap-1.5 hover:text-foreground"><Mail className="h-3.5 w-3.5" />{lead.email}</a>}
             {lead.suburb && <span className="inline-flex items-center gap-1.5"><MapPin className="h-3.5 w-3.5" />{lead.suburb}</span>}
           </div>
+          <Link
+            href={`/leads/${lead.id}`}
+            className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            Open full lead <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
         </SheetHeader>
 
         <div className="space-y-6 p-5">
+          {/* What has been raised against this lead. The drawer showed stage,
+              tags and notes only, and nothing linked to the full lead — so
+              quotes, invoices and onboarding forms were effectively invisible
+              from the pipeline, which is where you actually work. */}
+          <LeadDrawerBilling leadId={lead.id} open={open} />
+
           {/* Status */}
           <section>
             <p className="mb-2 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">Pipeline stage</p>


### PR DESCRIPTION
Clicking a lead on the board opens a drawer with **pipeline stage, tags and notes — and no link to the full lead at all**.

Everything added recently (quotes, invoices, onboarding forms, public forms) lives on `/leads/[id]`, and **nothing linked there**. It was reachable only by typing the URL, which is why it felt like it wasn't there.

## Two changes

**"Open full lead"** in the drawer header. The absence of this was the actual bug; the rest is convenience.

**A Quotes & invoices panel** in the drawer, so "have we quoted them yet?" is answered where the question gets asked rather than two navigations away. The empty state links straight to quoting them.

It loads only while the drawer is open, and fails silently — a supporting panel must not put an error toast over someone moving a lead down the pipeline.

300 tests · `tsc` · production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)