### PR TITLE
feat: recurring costs, modules grouped by what they're for, and the Studio theme

### DIFF
--- a/src/app/(dashboard)/expenses/recurring/loading.tsx
+++ b/src/app/(dashboard)/expenses/recurring/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading";

--- a/src/app/(dashboard)/expenses/recurring/page.tsx
+++ b/src/app/(dashboard)/expenses/recurring/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { canEdit, type Role } from "@/lib/permissions";
+import { getRecurringExpenses } from "@/lib/actions/recurring-expenses";
+import { RecurringExpensesClient } from "@/components/expenses/recurring-expenses-client";
+
+export default async function RecurringExpensesPage() {
+  const supabase = await createClient();
+  const user = await getUser();
+  if (!user) redirect("/auth/login");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const businessId = await getActiveBizId(supabase as any, user.id);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: biz } = await (supabase as any).from("businesses")
+    .select("user_id, currency").eq("id", businessId).single();
+
+  let role: Role = "owner";
+  if (biz?.user_id !== user.id) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: m } = await (supabase as any).from("business_members")
+      .select("role").eq("business_id", businessId).eq("user_id", user.id)
+      .eq("status", "active").maybeSingle();
+    role = (m?.role ?? "viewer") as Role;
+  }
+  // Costs are money out. Viewers read the books; they don't schedule spending.
+  if (!canEdit(role)) redirect("/expenses");
+
+  return (
+    <RecurringExpensesClient
+      initial={await getRecurringExpenses()}
+      currency={biz?.currency ?? "AUD"}
+    />
+  );
+}

--- a/src/app/(dashboard)/settings/customisation/page.tsx
+++ b/src/app/(dashboard)/settings/customisation/page.tsx
@@ -39,7 +39,7 @@ const GROUPS: Array<{ title: string; blurb: string; items: Item[] }> = [
     title: "Look and feel",
     blurb: "How Kirei looks, and what things are called.",
     items: [
-      { href: "/settings?tab=appearance", label: "Theme", hint: "Midnight, Daylight, Azure or Orchid — applies everywhere.", icon: Palette },
+      { href: "/settings?tab=appearance", label: "Theme", hint: "Midnight, Daylight, Azure, Orchid or Studio — applies everywhere.", icon: Palette },
       { href: "/settings/navigation", label: "Navigation", hint: "Rename, reorder and hide the items in your sidebar.", icon: Columns3 },
     ],
   },

--- a/src/app/api/cron/recurring-expenses/route.ts
+++ b/src/app/api/cron/recurring-expenses/route.ts
@@ -1,0 +1,100 @@
+/**
+ * GET /api/cron/recurring-expenses
+ *
+ * Posts the costs that arrive whether anyone remembers them: rent, insurance,
+ * subscriptions. Runs daily; multi-tenant from the start, unlike the reminders
+ * cron which had one business id baked in.
+ *
+ * Catches up rather than skipping: if the runner was down for a week, every
+ * missed occurrence is posted on its own date, so the books show the rent in
+ * the month it was actually due. Bounded at 12 per schedule so a long-stale
+ * row can't post years of history in one go.
+ *
+ * Duplicate-safe at the DATABASE, not here: a unique index on
+ * (recurring_expense_id, spent_on) means a retry or an overlapping run cannot
+ * post the rent twice. A duplicate cost is a wrong profit figure, silently.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCron } from "@/lib/cron-auth";
+import { dueDatesUpTo, type ExpenseCadence } from "@/lib/recurring/expense-schedule";
+
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const denied = requireCron(req);
+  if (denied) return denied;
+
+  const sb = createAdminClient();
+  const today = new Date().toISOString().slice(0, 10);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: schedules, error } = await (sb as any)
+    .from("recurring_expenses")
+    .select("*")
+    .eq("active", true)
+    .lte("next_run_on", today)
+    .limit(500);
+  if (error) {
+    console.error("[recurring-expenses] load failed", error.message);
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  let posted = 0, skipped = 0, ended = 0;
+
+  for (const sch of (schedules ?? []) as Array<Record<string, unknown>>) {
+    const cadence = String(sch.cadence) as ExpenseCadence;
+    const endsOn = sch.ends_on ? String(sch.ends_on) : null;
+    const day = sch.preferred_day_of_month as number | null;
+
+    const due = dueDatesUpTo(String(sch.next_run_on), today, cadence, day)
+      .filter((d) => !endsOn || d <= endsOn);
+
+    for (const spentOn of due) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: insErr } = await (sb as any).from("expenses").insert({
+        business_id: sch.business_id,
+        user_id: sch.user_id,
+        recurring_expense_id: sch.id,
+        vendor: sch.vendor,
+        category: sch.category,
+        description: sch.description ?? sch.name,
+        amount: sch.amount,
+        tax_amount: sch.tax_amount,
+        spent_on: spentOn,
+        payment_method: sch.payment_method,
+        billable: sch.billable,
+        status: "recorded",
+      });
+      if (insErr) {
+        // 23505 = the unique index did its job; this occurrence already
+        // exists. Not an error, and not a reason to stop the schedule.
+        if (insErr.code === "23505") { skipped++; continue; }
+        console.error("[recurring-expenses] insert failed", sch.id, spentOn, insErr.message);
+        continue;
+      }
+      posted++;
+    }
+
+    // Advance past everything just handled, even the duplicates — otherwise a
+    // schedule that hit the unique index would retry the same date forever.
+    let nextRun = String(sch.next_run_on);
+    const { nextDueDate } = await import("@/lib/recurring/expense-schedule");
+    while (nextRun <= today) nextRun = nextDueDate(nextRun, cadence, day);
+
+    const finished = Boolean(endsOn && nextRun > endsOn);
+    if (finished) ended++;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (sb as any).from("recurring_expenses").update({
+      next_run_on: nextRun,
+      last_run_at: new Date().toISOString(),
+      ...(finished ? { active: false } : {}),
+    }).eq("id", sch.id);
+  }
+
+  return NextResponse.json({
+    ok: true, date: today,
+    schedules: (schedules ?? []).length, posted, skipped_duplicates: skipped, ended,
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -469,6 +469,74 @@
   color-scheme: dark;
 }
 
+/* Studio — built from the Connected Studio logo: slate blue #35576B
+   (hsl 202.2 33.8% 31.4%), lime #C4F000 (hsl 71 100% 47.1%), white type.
+   The two logo colours are the anchors; the surfaces are the same slate hue
+   held at 33.8% saturation and walked down in lightness, so the whole shell
+   reads as one material rather than four blues that nearly match.
+
+   The one deliberate departure: --ok is a teal-green, NOT the lime. Lime is
+   the accent, and if "paid" is also lime then every status pill on the page
+   is the brand colour and none of them mean anything. */
+[data-theme="Studio"] {
+  --background: 202.2 33.8% 16.5%;
+  --foreground: 202.0 30.0% 96.0%;
+  --card: 202.2 33.8% 21.0%;
+  --card-foreground: 202.0 30.0% 96.0%;
+  --popover: 202.2 33.8% 21.0%;
+  --popover-foreground: 202.0 30.0% 96.0%;
+  --primary: 71.0 100.0% 47.1%;
+  /* Lime is bright enough that only a near-black sits on it legibly — the
+     logo does the same thing with its own type. */
+  --primary-foreground: 202.2 40.0% 11.0%;
+  --nav: 202.2 33.8% 16.5%;
+  --nav-foreground: 202.0 30.0% 96.0%;
+  --secondary: 202.2 30.0% 26.5%;
+  --secondary-foreground: 202.0 30.0% 96.0%;
+  --muted: 202.2 30.0% 26.5%;
+  --muted-foreground: 202.0 20.0% 72.0%;
+  --accent: 71.0 100.0% 47.1%;
+  --accent-foreground: 202.2 40.0% 11.0%;
+  --destructive: 0.0 84.0% 80.1%;
+  --destructive-foreground: 202.2 40.0% 11.0%;
+  --border: 202.2 26.0% 29.5%;
+  --input: 202.2 26.0% 29.5%;
+  --ring: 71.0 100.0% 47.1%;
+  --radius: 0.875rem;                 /* 14px - the mock's card radius */
+
+  /* Design tokens the new shell and dashboard use directly. Kept under their
+     own names so they can't collide with the shadcn contract above. */
+  --canvas-deep: 202.2 36.0% 11.5%;
+  --surface-3: 202.2 30.0% 26.5%;
+  --border-strong: 202.2 22.0% 38.0%;
+  --accent-2: 71.0 85.0% 65.0%;
+  --accent-soft: rgba(196,240,0,.16);
+  /* Status lightness is solved against THIS theme's card, not copied from the
+     others: Studio's card is a light slate (21% L) where the other dark
+     palettes sit near 11-17%, so the usual values landed ~2 points of contrast
+     short. These match the house standard (ok ~8.3, warn ~9, bad ~6). */
+  --ok: 158.0 64.0% 75.0%;
+  --warn: 38.0 92.0% 82.1%;
+  --bad: 0.0 84.0% 80.1%;
+  --lime: 71.0 100.0% 47.1%;
+  --glow: rgba(196,240,0,.20);
+  --shadow-panel: 0 24px 60px rgba(6,18,26,.5);
+  /* The sidebar follows the theme rather than the older data-sidebar-theme
+     presets: in the mock the rail is the same panel as the shell, lit by an
+     accent wash at the top. Mapping the sidebar tokens here means the existing
+     bg-sidebar / text-sidebar-foreground classes need no changes. */
+  --sidebar: var(--background);
+  --sidebar-foreground: var(--muted-foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--surface-3);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  color-scheme: dark;
+}
+
 /* ─── Appearance is the theme, and only the theme ─────────────
    The former data-accent / data-sidebar-theme / data-pattern preset layers
    lived here. Each was written as :root[data-...], which outranks

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { PWARegister } from "@/components/pwa-register";
 import { IconProvider } from "@/components/ui/icon-provider";
+import { UI_THEME_KEYS, LIGHT_THEMES, UI_THEME_STORAGE_KEY } from "@/lib/ui-themes";
 
 // One typeface across the app. Plus Jakarta is a variable font (weights
 // 200–800), so both the UI stack (--font-sans) and the heavier display stack
@@ -59,18 +60,23 @@ export default function RootLayout({
     <html lang="en" data-theme="Midnight" suppressHydrationWarning>
       <head>
         {/* Paint the business's theme before first render.
-            Three of the four palettes are dark, so without this every cold
-            load flashes the Midnight default (or white) before the provider
+            Most of the palettes are dark, so without this every cold load
+            flashes the Midnight default (or white) before the provider
             catches up - the one thing a dark theme must not do. The provider
-            mirrors the choice into localStorage; this only reads it. */}
+            mirrors the choice into localStorage; this only reads it.
+
+            Both lists are generated from UI_THEMES rather than typed out. They
+            used to be literals, which meant adding a palette silently left it
+            out of the pre-paint step: pick it, reload, and watch the app flash
+            Midnight before correcting itself. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('kirei.ui-theme');`
-              + `if(t&&['Midnight','Daylight','Azure','Orchid'].indexOf(t)>-1){`
+            __html: `(function(){try{var t=localStorage.getItem('${UI_THEME_STORAGE_KEY}');`
+              + `if(t&&${JSON.stringify(UI_THEME_KEYS)}.indexOf(t)>-1){`
               + `document.documentElement.dataset.theme=t;`
               // Keep the .dark class in step before paint too, or `dark:`
               // styles flash the wrong way round on a light theme.
-              + `document.documentElement.classList.toggle('dark',t!=='Daylight');`
+              + `document.documentElement.classList.toggle('dark',${JSON.stringify(LIGHT_THEMES)}.indexOf(t)<0);`
               + `}}catch(e){}})();`,
           }}
         />

--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -40,7 +40,7 @@ import {
   type AgentInstall,
 } from "@/lib/actions/agents";
 import { setPluginEnabled, applyPresetToActiveBusiness } from "@/lib/actions/plugins";
-import { PLUGIN_REGISTRY, PLUGINS_BY_ID, OPTIONAL_PLUGINS, type PluginDefinition } from "@/lib/plugins/registry";
+import { PLUGIN_REGISTRY, PLUGIN_CATEGORIES, PLUGINS_BY_ID, OPTIONAL_PLUGINS, type PluginDefinition } from "@/lib/plugins/registry";
 import { INDUSTRY_PRESETS, type IndustryPreset } from "@/lib/plugins/presets";
 
 // ── Icon map ──────────────────────────────────────────────────────────────────
@@ -93,6 +93,12 @@ const AGENT_CARD_IDS = new Set(AGENT_CATALOG.map((a) => a.id));
 const MODULES: PluginDefinition[] = PLUGIN_REGISTRY.filter(
   (p) => p.kind === "module" && !AGENT_CARD_IDS.has(p.id)
 );
+
+// Grouped by what the modules are FOR. Empty groups are dropped so removing
+// the last module in a category doesn't leave a heading over nothing.
+const MODULE_GROUPS = PLUGIN_CATEGORIES
+  .map((c) => ({ ...c, modules: MODULES.filter((m) => m.category === c.id) }))
+  .filter((g) => g.modules.length > 0);
 
 function AgentIcon({ name, className }: { name: string; className?: string }) {
   const Icon = ICON_MAP[name] ?? Zap;
@@ -323,11 +329,18 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
         </p>
       </div>
 
-      {/* Modules — the app's building blocks */}
+      {/* Modules — grouped by the job they do, not by where they live in the
+          code. A flat wall of thirty toggles told nobody what to turn on. */}
       <div className="mb-10">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Modules</h2>
+        {MODULE_GROUPS.map((group) => (
+        <div key={group.id} className="mb-6">
+        <div className="mb-2.5">
+          <p className="text-sm font-semibold">{group.label}</p>
+          <p className="text-xs text-muted-foreground">{group.blurb}</p>
+        </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {MODULES.map((m) => {
+          {group.modules.map((m) => {
             const enabled = m.core ? true : (modules[m.id] ?? m.defaultEnabled);
             return (
               <div key={m.id} className="rounded-xl border border-border bg-card p-4 flex items-start gap-3">
@@ -354,6 +367,8 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
             );
           })}
         </div>
+        </div>
+        ))}
         <p className="text-[11px] text-muted-foreground mt-2">Turning a module off only hides it — nothing is deleted, and re-enabling brings everything back.</p>
       </div>
 

--- a/src/components/expenses/expenses-view.tsx
+++ b/src/components/expenses/expenses-view.tsx
@@ -22,6 +22,7 @@ import { PERIOD_LABELS, type PeriodKind } from "@/lib/expenses/period";
 import type { BooksSummary } from "@/lib/actions/books";
 import { putSignedUpload } from "@/lib/uploads-client";
 import type { Expense } from "@/types/database";
+import { CATEGORY_GROUPS, CATEGORIES, catLabel } from "@/lib/expenses/categories";
 
 interface WO { id: string; number: string | null; title: string | null }
 interface Props {
@@ -33,15 +34,6 @@ interface Props {
   workOrders: WO[];
 }
 
-// Grouped so the dropdown reads as: job costs, overheads/bills, payroll.
-const CATEGORY_GROUPS: { label: string; options: string[] }[] = [
-  { label: "Job costs", options: ["materials", "subcontractor", "equipment-hire", "permits", "fuel", "vehicle", "travel", "tools"] },
-  { label: "Overheads & bills", options: ["rent", "utilities", "insurance", "software", "subscriptions", "phone-internet", "marketing", "accounting", "bank-fees", "office", "tax"] },
-  { label: "Payroll", options: ["wages", "superannuation"] },
-  { label: "Other", options: ["other"] },
-];
-const CATEGORIES = CATEGORY_GROUPS.flatMap((g) => g.options);
-const catLabel = (c: string) => c.replace(/-/g, " ");
 const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
 const money = (n: number) => `$${(Number(n) || 0).toFixed(2)}`;
 const woLabel = (w?: WO) => w ? (w.title || w.number || "Job") : null;

--- a/src/components/expenses/recurring-expenses-client.tsx
+++ b/src/components/expenses/recurring-expenses-client.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+/**
+ * Costs that arrive whether or not anyone remembers them — rent, insurance,
+ * subscriptions, finance.
+ *
+ * The point is that a business's real monthly outgoings show up in the books
+ * without someone re-typing them twelve times a year. Each schedule posts a
+ * normal expense row on its due date, so everything downstream (Spend by
+ * category, the books summary, CSV export) works with no changes.
+ */
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Repeat, Plus, Trash2, Edit, Play, Receipt } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { PageHeader } from "@/components/layout/page-header";
+import { DatePicker } from "@/components/ui/date-picker";
+import { useConfirm } from "@/components/ui/confirm";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { CATEGORY_GROUPS, catLabel } from "@/lib/expenses/categories";
+import { EXPENSE_CADENCES, type ExpenseCadence } from "@/lib/recurring/expense-schedule";
+import {
+  saveRecurringExpense, deleteRecurringExpense,
+  setRecurringExpenseActive, runRecurringExpenseNow,
+  type RecurringExpense,
+} from "@/lib/actions/recurring-expenses";
+
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+const money = (n: number) => `$${(Number(n) || 0).toFixed(2)}`;
+const CADENCE_LABEL: Record<string, string> =
+  Object.fromEntries(EXPENSE_CADENCES.map((c) => [c.value, c.label]));
+
+/** What this schedule costs in a year — the number that makes a subscription
+ *  list uncomfortable enough to be useful. */
+const PER_YEAR: Record<ExpenseCadence, number> = {
+  weekly: 52, fortnightly: 26, monthly: 12, quarterly: 4, yearly: 1,
+};
+function annualised(r: RecurringExpense): number {
+  return (Number(r.amount) + Number(r.tax_amount)) * PER_YEAR[r.cadence];
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const BLANK: Partial<RecurringExpense> = {
+  name: "", vendor: "", category: "subscriptions", description: "",
+  amount: 0, tax_amount: 0, payment_method: "card", billable: false,
+  cadence: "monthly", preferred_day_of_month: null,
+  next_run_on: today(), ends_on: null, active: true,
+};
+
+export function RecurringExpensesClient({
+  initial, currency,
+}: { initial: RecurringExpense[]; currency: string }) {
+  const router = useRouter();
+  const confirm = useConfirm();
+  const [pending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [form, setForm] = useState<Partial<RecurringExpense>>(BLANK);
+
+  const active = initial.filter((r) => r.active);
+  const monthlyRun = active.reduce((sum, r) => sum + annualised(r) / 12, 0);
+
+  function openNew() { setEditing(null); setForm({ ...BLANK }); setOpen(true); }
+  function openEdit(r: RecurringExpense) { setEditing(r.id); setForm({ ...r }); setOpen(true); }
+
+  function save() {
+    startTransition(async () => {
+      const res = await saveRecurringExpense(editing, form);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success(editing ? "Saved" : "Recurring cost added");
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  function toggle(r: RecurringExpense, next: boolean) {
+    startTransition(async () => {
+      const res = await setRecurringExpenseActive(r.id, next);
+      if (!res.ok) { toast.error(res.error); return; }
+      router.refresh();
+    });
+  }
+
+  function postNow(r: RecurringExpense) {
+    startTransition(async () => {
+      const res = await runRecurringExpenseNow(r.id);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success(`Posted ${r.name}`);
+      router.refresh();
+    });
+  }
+
+  async function remove(r: RecurringExpense) {
+    const ok = await confirm({
+      title: `Delete "${r.name}"?`,
+      body: "The schedule stops. Costs it already posted stay in the books — they really were spent.",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!ok) return;
+    startTransition(async () => {
+      const res = await deleteRecurringExpense(r.id);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success("Deleted");
+      router.refresh();
+    });
+  }
+
+  const set = <K extends keyof RecurringExpense>(k: K, v: RecurringExpense[K]) =>
+    setForm((f) => ({ ...f, [k]: v }));
+
+  return (
+    <>
+      <PageHeader
+        title="Recurring costs"
+        subtitle="Rent, insurance, subscriptions — posted to the books on their due date"
+        actions={<Button onClick={openNew}><Plus className="h-4 w-4" /> New recurring cost</Button>}
+      />
+
+      {initial.length > 0 && (
+        <div className="mb-5 grid gap-3 sm:grid-cols-3">
+          <Stat label="Active schedules" value={String(active.length)} />
+          <Stat label="Per month" value={money(monthlyRun)} hint={currency} />
+          <Stat label="Per year" value={money(monthlyRun * 12)} hint={currency} />
+        </div>
+      )}
+
+      {initial.length === 0 ? (
+        <div className="rounded-xl border border-border bg-card px-6 py-14 text-center">
+          <Repeat className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-semibold">No recurring costs yet</p>
+          <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+            Add the ones that turn up every month — rent, insurance, phone, software.
+            They&rsquo;ll post themselves so your profit figure is honest.
+          </p>
+          <Button className="mt-4" onClick={openNew}><Plus className="h-4 w-4" /> New recurring cost</Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {initial.map((r) => (
+            <div key={r.id}
+              className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card px-4 py-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+                <Receipt className="h-4 w-4 text-foreground/70" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="break-words text-sm font-semibold">{r.name}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  <span className="capitalize">{catLabel(r.category)}</span>
+                  {r.vendor && <> · {r.vendor}</>}
+                  {" · "}{CADENCE_LABEL[r.cadence] ?? r.cadence}
+                  {r.active ? <> · next {r.next_run_on}</> : <> · paused</>}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-semibold tabular-nums">
+                  {money(Number(r.amount) + Number(r.tax_amount))}
+                </p>
+                <p className="text-[11px] tabular-nums text-muted-foreground">{money(annualised(r))}/yr</p>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <Switch checked={r.active} onCheckedChange={(v) => toggle(r, v)} disabled={pending}
+                  aria-label={r.active ? `Pause ${r.name}` : `Resume ${r.name}`} />
+                <Button variant="ghost" size="icon" onClick={() => postNow(r)} disabled={pending}
+                  aria-label={`Post ${r.name} now`} title="Post this one now">
+                  <Play className="h-4 w-4" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => openEdit(r)} disabled={pending}
+                  aria-label={`Edit ${r.name}`}>
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => remove(r)} disabled={pending}
+                  aria-label={`Delete ${r.name}`}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{editing ? "Edit recurring cost" : "New recurring cost"}</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="rx-name">Name</Label>
+              <Input id="rx-name" placeholder="Office rent, Xero, public liability…"
+                value={form.name ?? ""} onChange={(e) => set("name", e.target.value)} />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-amount">Amount (ex-tax)</Label>
+                <Input id="rx-amount" type="number" step="0.01" value={String(form.amount ?? "")}
+                  onChange={(e) => set("amount", Number(e.target.value))} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-tax">Tax</Label>
+                <Input id="rx-tax" type="number" step="0.01" value={String(form.tax_amount ?? "")}
+                  onChange={(e) => set("tax_amount", Number(e.target.value))} />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-cat">Category</Label>
+                <select id="rx-cat" className={selectCls} value={form.category ?? "subscriptions"}
+                  onChange={(e) => set("category", e.target.value)}>
+                  {CATEGORY_GROUPS.map((g) => (
+                    <optgroup key={g.label} label={g.label}>
+                      {g.options.map((c) => (
+                        <option key={c} value={c} className="capitalize">{catLabel(c)}</option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-vendor">Vendor</Label>
+                <Input id="rx-vendor" placeholder="Who it goes to"
+                  value={form.vendor ?? ""} onChange={(e) => set("vendor", e.target.value)} />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-cadence">Repeats</Label>
+                <select id="rx-cadence" className={selectCls} value={form.cadence ?? "monthly"}
+                  onChange={(e) => set("cadence", e.target.value as ExpenseCadence)}>
+                  {EXPENSE_CADENCES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-next">Next due</Label>
+                <DatePicker id="rx-next" value={form.next_run_on ?? today()}
+                  onChange={(v) => set("next_run_on", v)} />
+              </div>
+            </div>
+
+            {form.cadence !== "weekly" && form.cadence !== "fortnightly" && (
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-day">Day of the month (optional)</Label>
+                <Input id="rx-day" type="number" min={1} max={31} placeholder="e.g. 1"
+                  value={form.preferred_day_of_month == null ? "" : String(form.preferred_day_of_month)}
+                  onChange={(e) => set("preferred_day_of_month",
+                    e.target.value === "" ? null : Number(e.target.value))} />
+                <p className="text-[11px] text-muted-foreground">
+                  31 lands on the last day of a short month, not the 3rd of the next one.
+                </p>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-pm">Paid by</Label>
+                <select id="rx-pm" className={selectCls} value={form.payment_method ?? "card"}
+                  onChange={(e) => set("payment_method", e.target.value)}>
+                  <option value="card">Card</option>
+                  <option value="bank">Bank</option>
+                  <option value="cash">Cash</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="rx-ends">Ends on (optional)</Label>
+                <DatePicker id="rx-ends" value={form.ends_on ?? ""}
+                  onChange={(v) => set("ends_on", v || null)} />
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={pending}>Cancel</Button>
+            <Button onClick={save} disabled={pending}>{pending ? "Saving…" : "Save"}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card px-4 py-3">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="mt-1 text-xl font-semibold tabular-nums">{value}</p>
+      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}

--- a/src/components/layout/appearance-provider.tsx
+++ b/src/components/layout/appearance-provider.tsx
@@ -2,31 +2,15 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 import { useTheme as useNextTheme } from "next-themes";
+import { UI_THEMES, DEFAULT_UI_THEME, UI_THEME_STORAGE_KEY, isUiTheme, type UiThemeKey } from "@/lib/ui-themes";
 
-/**
- * The Kirei Dashboard v2 palettes.
- *
- * Light vs dark is a property of the theme, not a separate switch — Daylight
- * is the light one. `swatch`/`ring` mirror the design's own theme picker so
- * the dot in the header reads as the theme it selects.
- */
-export const UI_THEMES = [
-  { key: "Midnight", label: "Midnight", swatch: "#3B82F6", ring: "#111A29", dark: true  },
-  { key: "Daylight", label: "Daylight", swatch: "#2563EB", ring: "#FFFFFF", dark: false },
-  { key: "Azure",    label: "Azure",    swatch: "#7DD3FC", ring: "#0C2A56", dark: true  },
-  { key: "Orchid",   label: "Orchid",   swatch: "#8B5CF6", ring: "#1B1030", dark: true  },
-] as const;
-
-export type UiThemeKey = (typeof UI_THEMES)[number]["key"];
-
-export const DEFAULT_UI_THEME: UiThemeKey = "Midnight";
-
-/** Where the no-flash boot script in the root layout stashes the choice. */
-export const UI_THEME_STORAGE_KEY = "kirei.ui-theme";
-
-export function isUiTheme(v: unknown): v is UiThemeKey {
-  return typeof v === "string" && UI_THEMES.some((t) => t.key === v);
-}
+// The palette list itself lives in a plain module so the root layout (a server
+// component) can read it for the no-flash boot script. Re-exported here
+// because every existing caller imports it from this file.
+export {
+  UI_THEMES, LIGHT_THEMES, UI_THEME_KEYS, DEFAULT_UI_THEME,
+  UI_THEME_STORAGE_KEY, isUiTheme, type UiThemeKey,
+} from "@/lib/ui-themes";
 
 export const ACCENT_PRESETS = [
   { key: "teal",    label: "Teal",    hex: "#3a847e" },

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -24,24 +24,31 @@ export const navSections: NavSection[] = [
     { label: "Tasks",      href: "/tasks",      icon: Columns3                      },
     { label: "Automations",href: "/automations",icon: Zap,             plugin: "automations" },
   ]},
+  // Sections follow the same needs the Plugins store groups by: win the work,
+  // do the work, get paid. Expenses used to sit under "Sales", which is the
+  // one place money going OUT does not belong.
   { section: "Sales", items: [
     { label: "Leads",         href: "/leads",         icon: UserPlus,     plugin: "leads"             },
     { label: "Forms",         href: "/forms",         icon: ListChecks,   plugin: "form-builder"      },
     { label: "Quoting Agent", href: "/quoting-agent", icon: Sparkles,     plugin: "quoting-agent"     },
     { label: "Quotes",        href: "/quotes",        icon: FileCheck,    plugin: "quotes"            },
-    { label: "Invoices",      href: "/invoices",      icon: FileText,     plugin: "invoicing"         },
     { label: "Contracts",     href: "/contracts",     icon: FileStack,    plugin: "contracts"         },
-    { label: "Site Reports",  href: "/reports",       icon: ClipboardList, plugin: "site-reports"     },
-    { label: "Recurring",     href: "/recurring",     icon: Repeat,       plugin: "recurring-jobs"    },
-    { label: "Recurring billing", href: "/recurring-invoices", icon: Repeat, plugin: "recurring-billing" },
-    { label: "Expenses",      href: "/expenses",      icon: Receipt,      plugin: "expenses"          },
   ]},
   { section: "Service", items: [
     { label: "Work Orders",    href: "/work-orders",     icon: Wrench,        worker: true, plugin: "jobs" },
     { label: "Schedule",       href: "/schedule",        icon: CalendarDays,  worker: true, plugin: "scheduling" },
+    { label: "Recurring",      href: "/recurring",       icon: Repeat,        plugin: "recurring-jobs" },
+    { label: "Site Reports",   href: "/reports",         icon: ClipboardList, plugin: "site-reports" },
     { label: "Bookings",       href: "/bookings",        icon: CalendarDays,  plugin: "booking" },
     { label: "Online Booking", href: "/settings/booking", icon: CalendarDays,  plugin: "booking" },
     { label: "Assets",         href: "/assets",          icon: Hammer,        plugin: "assets" },
+  ]},
+  { section: "Money", items: [
+    { label: "Invoices",      href: "/invoices",      icon: FileText,     plugin: "invoicing"         },
+    { label: "Recurring billing", href: "/recurring-invoices", icon: Repeat, plugin: "recurring-billing" },
+    { label: "Expenses",      href: "/expenses",      icon: Receipt,      plugin: "expenses"          },
+    { label: "Recurring costs", href: "/expenses/recurring", icon: Repeat, plugin: "expenses"        },
+    { label: "Payroll",       href: "/payroll",       icon: DollarSign,   plugin: "payroll"           },
   ]},
   { section: "Contacts", items: [
     { label: "Prospects",  href: "/prospects",  icon: Target,        plugin: "prospects" },
@@ -60,7 +67,6 @@ export const navSections: NavSection[] = [
   { section: "Workforce", items: [
     { label: "Team",       href: "/team",       icon: Users2                        },
     { label: "Timesheets", href: "/timesheets", icon: Clock,        plugin: "timesheets" },
-    { label: "Payroll",    href: "/payroll",    icon: DollarSign,   plugin: "payroll" },
     { label: "Plugins",    href: "/agents",     icon: Bot                           },
   ]},
   { section: "SEO", items: [

--- a/src/lib/actions/appearance.ts
+++ b/src/lib/actions/appearance.ts
@@ -15,7 +15,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 
-const THEMES = ["Midnight", "Daylight", "Azure", "Orchid"];
+const THEMES = ["Midnight", "Daylight", "Azure", "Orchid", "Studio"];
 
 export type ThemeResult = { ok: true } | { ok: false; error: string };
 

--- a/src/lib/actions/recurring-expenses.ts
+++ b/src/lib/actions/recurring-expenses.ts
@@ -1,0 +1,167 @@
+"use server";
+
+/**
+ * Recurring costs: rent, insurance, subscriptions, finance.
+ *
+ * Expected failures are RETURNED — Next masks thrown server-action messages
+ * in production, and "the end date is before the first charge" is a message
+ * someone needs to read.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import {
+  validateSchedule, nextDueDate, type ExpenseCadence,
+} from "@/lib/recurring/expense-schedule";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+export interface RecurringExpense {
+  id: string;
+  name: string;
+  vendor: string | null;
+  category: string;
+  description: string | null;
+  amount: number;
+  tax_amount: number;
+  payment_method: string | null;
+  billable: boolean;
+  cadence: ExpenseCadence;
+  preferred_day_of_month: number | null;
+  next_run_on: string;
+  ends_on: string | null;
+  active: boolean;
+  last_run_at: string | null;
+}
+
+export type RecurringExpenseResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string };
+
+export async function getRecurringExpenses(): Promise<RecurringExpense[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data, error } = await tbl(supabase, "recurring_expenses")
+    .select("*").eq("business_id", businessId)
+    .order("active", { ascending: false })
+    .order("next_run_on", { ascending: true })
+    .limit(500);
+  if (error) { console.error("[recurring-expenses] list", error.message); return []; }
+
+  // PostgREST returns numerics as strings; plain arithmetic downstream gives
+  // NaN, which has bitten this codebase before.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((data ?? []) as any[]).map((r) => ({
+    ...r, amount: Number(r.amount ?? 0), tax_amount: Number(r.tax_amount ?? 0),
+  })) as RecurringExpense[];
+}
+
+export async function saveRecurringExpense(
+  id: string | null,
+  input: Partial<RecurringExpense>,
+): Promise<RecurringExpenseResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const problem = validateSchedule(input);
+  if (problem) return { ok: false, error: problem };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row: Record<string, any> = {
+    business_id: businessId,
+    name: String(input.name).trim(),
+    vendor: input.vendor?.trim() || null,
+    category: input.category?.trim() || "other",
+    description: input.description?.trim() || null,
+    amount: Number(input.amount),
+    tax_amount: Number(input.tax_amount ?? 0) || 0,
+    payment_method: input.payment_method?.trim() || null,
+    billable: Boolean(input.billable),
+    cadence: input.cadence ?? "monthly",
+    preferred_day_of_month: input.preferred_day_of_month ?? null,
+    next_run_on: input.next_run_on,
+    ends_on: input.ends_on || null,
+    active: input.active ?? true,
+  };
+
+  if (id) {
+    const { error } = await tbl(supabase, "recurring_expenses")
+      .update(row).eq("id", id).eq("business_id", businessId);
+    if (error) return { ok: false, error: error.message };
+    revalidatePath("/expenses/recurring");
+    return { ok: true, id };
+  }
+
+  row.user_id = user.id;
+  const { data, error } = await tbl(supabase, "recurring_expenses")
+    .insert(row).select("id").single();
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/expenses/recurring");
+  return { ok: true, id: data.id };
+}
+
+export async function setRecurringExpenseActive(
+  id: string, active: boolean,
+): Promise<RecurringExpenseResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { error } = await tbl(supabase, "recurring_expenses")
+    .update({ active }).eq("id", id).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/expenses/recurring");
+  return { ok: true, id };
+}
+
+export async function deleteRecurringExpense(id: string): Promise<RecurringExpenseResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { error } = await tbl(supabase, "recurring_expenses")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/expenses/recurring");
+  // Expenses already posted are left alone: they are real costs that were
+  // really incurred, and deleting the schedule is not a claim they weren't.
+  return { ok: true, id };
+}
+
+/** Post this schedule's next occurrence now, without waiting for the cron. */
+export async function runRecurringExpenseNow(id: string): Promise<RecurringExpenseResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const { data: sch } = await tbl(supabase, "recurring_expenses")
+    .select("*").eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (!sch) return { ok: false, error: "Not found" };
+
+  const spentOn = String(sch.next_run_on);
+  const { error: insErr } = await tbl(supabase, "expenses").insert({
+    business_id: businessId, user_id: user.id, recurring_expense_id: sch.id,
+    vendor: sch.vendor, category: sch.category,
+    description: sch.description ?? sch.name,
+    amount: sch.amount, tax_amount: sch.tax_amount, spent_on: spentOn,
+    payment_method: sch.payment_method, billable: sch.billable, status: "recorded",
+  });
+  if (insErr) {
+    if (insErr.code === "23505") return { ok: false, error: "That one's already been posted." };
+    return { ok: false, error: insErr.message };
+  }
+
+  const next = nextDueDate(spentOn, sch.cadence as ExpenseCadence, sch.preferred_day_of_month);
+  await tbl(supabase, "recurring_expenses")
+    .update({ next_run_on: next, last_run_at: new Date().toISOString() })
+    .eq("id", id).eq("business_id", businessId);
+
+  revalidatePath("/expenses/recurring");
+  revalidatePath("/expenses");
+  return { ok: true, id };
+}

--- a/src/lib/expenses/categories.ts
+++ b/src/lib/expenses/categories.ts
@@ -1,0 +1,19 @@
+/**
+ * The expense category list, in one place.
+ *
+ * Both the expenses table and the recurring-cost scheduler write to the same
+ * `expenses.category` column, so they have to offer the same words — two lists
+ * that drift means "rent" in one place and "Rent" in the other, and a Spend-by-
+ * category breakdown that reports them as different things.
+ */
+
+export const CATEGORY_GROUPS: { label: string; options: string[] }[] = [
+  { label: "Job costs", options: ["materials", "subcontractor", "equipment-hire", "permits", "fuel", "vehicle", "travel", "tools"] },
+  { label: "Overheads & bills", options: ["rent", "utilities", "insurance", "software", "subscriptions", "phone-internet", "marketing", "accounting", "bank-fees", "office", "tax"] },
+  { label: "Payroll", options: ["wages", "superannuation"] },
+  { label: "Other", options: ["other"] },
+];
+
+export const CATEGORIES = CATEGORY_GROUPS.flatMap((g) => g.options);
+
+export const catLabel = (c: string) => c.replace(/-/g, " ");

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -35,7 +35,7 @@ import { ctxFrom, appBase, UUID, getOrMintPortalToken, type ToolFn } from "./too
 import { registerPluginFormTools } from "./tools/plugin-form-tools";
 import { registerSeoTools } from "./tools/seo-tools";
 import { registerContentTools } from "./tools/content-tools";
-import { registerExpenseTools } from "./tools/expenses-tools";
+import { registerExpenseTools, registerRecurringExpenseTools } from "./tools/expenses-tools";
 import { registerMaterialTools } from "./tools/materials-tools";
 import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
@@ -1811,6 +1811,7 @@ export function registerTools(register: ToolFn): void {
 
   // ===== EXPENSES & JOB COSTING =====
   registerExpenseTools(tool);
+  registerRecurringExpenseTools(tool);
 
   registerMaterialTools(tool);
 

--- a/src/lib/mcp/tools/expenses-tools.ts
+++ b/src/lib/mcp/tools/expenses-tools.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { nextDueDate, validateSchedule, type ExpenseCadence } from "@/lib/recurring/expense-schedule";
 
 export function registerExpenseTools(tool: ToolFn): void {
   tool("list_expenses", "List expenses (optionally for one job), newest first.",
@@ -126,5 +127,127 @@ export function registerExpenseTools(tool: ToolFn): void {
           .sort((a, b) => b.total - a.total),
         note: "Cash basis. GST collected is estimated as 1/11th of payments received.",
       });
+    });
+}
+
+// ── Recurring costs ─────────────────────────────────────────────────────────
+// Rent, insurance, subscriptions. The cron posts them; these tools let the
+// assistant set one up ("add our $180/mo insurance") and see what's committed.
+
+const CADENCE = z.enum(["weekly", "fortnightly", "monthly", "quarterly", "yearly"]);
+
+export function registerRecurringExpenseTools(tool: ToolFn): void {
+  tool("list_recurring_expenses", "List recurring costs (rent, insurance, subscriptions) and when each next falls due.",
+    { include_inactive: z.boolean().optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:read");
+      let q = t(ctx, "recurring_expenses")
+        .select("id, name, vendor, category, amount, tax_amount, cadence, preferred_day_of_month, next_run_on, ends_on, active, last_run_at")
+        .eq("business_id", ctx.businessId).order("next_run_on", { ascending: true }).limit(500);
+      if (!args.include_inactive) q = q.eq("active", true);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_recurring_expense", "Schedule a recurring cost. It posts an expense automatically on each due date.",
+    {
+      name: z.string(),
+      amount: z.number(),
+      cadence: CADENCE,
+      next_run_on: z.string().describe("YYYY-MM-DD — when it next falls due"),
+      category: z.string().optional(),
+      vendor: z.string().optional(),
+      description: z.string().optional(),
+      tax_amount: z.number().optional(),
+      payment_method: z.string().optional(),
+      preferred_day_of_month: z.number().int().min(1).max(31).optional()
+        .describe("For monthly and longer. 31 lands on the last day of a short month."),
+      ends_on: z.string().optional(),
+      billable: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const problem = validateSchedule(args);
+      if (problem) return errorText(problem);
+      const { data, error } = await t(ctx, "recurring_expenses").insert({
+        business_id: ctx.businessId, user_id: ctx.userId,
+        name: args.name.trim(), vendor: args.vendor?.trim() || null,
+        category: args.category?.trim() || "other",
+        description: args.description?.trim() || null,
+        amount: args.amount, tax_amount: args.tax_amount ?? 0,
+        payment_method: args.payment_method?.trim() || null,
+        billable: args.billable ?? false,
+        cadence: args.cadence, preferred_day_of_month: args.preferred_day_of_month ?? null,
+        next_run_on: args.next_run_on, ends_on: args.ends_on || null, active: true,
+      }).select("id, name, next_run_on").single();
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("update_recurring_expense", "Change a recurring cost — amount, cadence, next due date, or pause it.",
+    {
+      id: UUID,
+      name: z.string().optional(),
+      amount: z.number().optional(),
+      tax_amount: z.number().optional(),
+      category: z.string().optional(),
+      vendor: z.string().optional(),
+      cadence: CADENCE.optional(),
+      preferred_day_of_month: z.number().int().min(1).max(31).nullable().optional(),
+      next_run_on: z.string().optional(),
+      ends_on: z.string().nullable().optional(),
+      active: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const { id, ...rest } = args;
+      const patch = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
+      if (Object.keys(patch).length === 0) return errorText("Nothing to change.");
+      const { data, error } = await t(ctx, "recurring_expenses")
+        .update(patch).eq("id", id).eq("business_id", ctx.businessId)
+        .select("id, name, amount, cadence, next_run_on, active").single();
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("delete_recurring_expense", "Stop a recurring cost. Costs it already posted stay in the books.",
+    { id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const { error } = await t(ctx, "recurring_expenses")
+        .delete().eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ ok: true, id: args.id });
+    });
+
+  tool("run_recurring_expense_now", "Post this recurring cost's next occurrence immediately, without waiting for the daily run.",
+    { id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "expenses:write");
+      const { data: sch, error: readErr } = await t(ctx, "recurring_expenses")
+        .select("*").eq("id", args.id).eq("business_id", ctx.businessId).maybeSingle();
+      if (readErr) throw readErr;
+      if (!sch) return errorText("No such recurring cost.");
+
+      const spentOn = String(sch.next_run_on);
+      const { error: insErr } = await t(ctx, "expenses").insert({
+        business_id: ctx.businessId, user_id: ctx.userId, recurring_expense_id: sch.id,
+        vendor: sch.vendor, category: sch.category,
+        description: sch.description ?? sch.name,
+        amount: sch.amount, tax_amount: sch.tax_amount, spent_on: spentOn,
+        payment_method: sch.payment_method, billable: sch.billable, status: "recorded",
+      });
+      // The unique index is the guard against double-posting a cost.
+      if (insErr) {
+        if ((insErr as { code?: string }).code === "23505") return errorText("That occurrence has already been posted.");
+        throw insErr;
+      }
+
+      const next = nextDueDate(spentOn, sch.cadence as ExpenseCadence, sch.preferred_day_of_month);
+      await t(ctx, "recurring_expenses")
+        .update({ next_run_on: next, last_run_at: new Date().toISOString() })
+        .eq("id", args.id).eq("business_id", ctx.businessId);
+      return text({ ok: true, posted_on: spentOn, next_run_on: next });
     });
 }

--- a/src/lib/plugins/categories.test.ts
+++ b/src/lib/plugins/categories.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { PLUGIN_REGISTRY, PLUGIN_CATEGORIES } from "./registry";
+import { navSections } from "@/components/layout/nav-config";
+
+describe("plugin categories", () => {
+  it("gives every module a category the store knows how to display", () => {
+    // The store renders category-by-category. A module in a category that
+    // isn't listed is silently invisible — it can't be turned on at all.
+    const known = new Set(PLUGIN_CATEGORIES.map((c) => c.id));
+    for (const p of PLUGIN_REGISTRY) {
+      expect(known, `${p.id} has category "${p.category}"`).toContain(p.category);
+    }
+  });
+
+  it("has no empty category", () => {
+    // A heading with nothing under it reads as a broken page.
+    for (const c of PLUGIN_CATEGORIES) {
+      expect(
+        PLUGIN_REGISTRY.some((p) => p.category === c.id),
+        `category "${c.id}" has no modules`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps money-out out of the sales section", () => {
+    // Expenses lived under "Sales" for months. Money going out is not a sale.
+    const sales = navSections.find((s) => s.section === "Sales");
+    expect(sales?.items.map((i) => i.href)).not.toContain("/expenses");
+  });
+});
+
+describe("nav", () => {
+  it("points every item at a plugin that exists", () => {
+    // A typo'd plugin id makes the item vanish from the sidebar with no error.
+    const ids = new Set(PLUGIN_REGISTRY.map((p) => p.id));
+    for (const section of navSections) {
+      for (const item of section.items) {
+        if (!item.plugin) continue;
+        expect(ids, `${item.href} → plugin "${item.plugin}"`).toContain(item.plugin);
+      }
+    }
+  });
+
+  it("has no duplicate hrefs", () => {
+    const hrefs = navSections.flatMap((s) => s.items.map((i) => i.href));
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -19,9 +19,37 @@
  */
 
 export type PluginKind = "module" | "agent";
+
+/**
+ * Categories are grouped by the JOB a module does, not by the part of the
+ * codebase it lives in. Someone opening the Plugins store is asking "what do I
+ * need?", not "which table does this write to" — so Expenses sits with getting
+ * paid, and Timesheets sits with delivering the work, even though both are
+ * "service" code.
+ */
 export type PluginCategory =
-  | "core" | "sales" | "service" | "contacts" | "catalog"
-  | "communication" | "insights" | "automation" | "seo" | "content";
+  | "core"       // always on
+  | "win-work"   // finding and closing work
+  | "deliver"    // doing the work once it's won
+  | "money"      // money in and money out
+  | "clients"    // looking after the people you work for
+  | "catalog"    // what you sell and what it costs you
+  | "grow"       // making the business bigger
+  | "automate";  // making the busywork happen by itself
+
+/** Display order + the one line that says what the group is for. */
+export const PLUGIN_CATEGORIES: Array<{
+  id: PluginCategory; label: string; blurb: string;
+}> = [
+  { id: "core",     label: "Foundations",   blurb: "Always on — the parts every business uses." },
+  { id: "win-work", label: "Winning work",  blurb: "Finding leads, quoting them, and getting a yes." },
+  { id: "deliver",  label: "Doing the work", blurb: "Scheduling crews, running jobs, proving what was done." },
+  { id: "money",    label: "Money in & out", blurb: "Invoicing, getting paid, and knowing what it cost." },
+  { id: "clients",  label: "Your clients",  blurb: "Onboarding, conversations, and what you hold for them." },
+  { id: "catalog",  label: "What you sell", blurb: "Prices, materials and stock." },
+  { id: "grow",     label: "Growing",       blurb: "Marketing, search and the numbers behind them." },
+  { id: "automate", label: "Automation",    blurb: "Work that happens without anyone doing it." },
+];
 
 export interface PluginDefinition {
   id: string;
@@ -52,49 +80,49 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
   { id: "team", icon: "users-2",       name: "Team",          description: "Members, roles and workforce profiles.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/team"] },
   { id: "settings", icon: "settings",   name: "Settings",      description: "Business profile, appearance, API keys.", kind: "module", category: "core", core: true, defaultEnabled: true, routePrefixes: ["/settings", "/agents"] },
 
-  // ── Sales ──────────────────────────────────────────────────────────────────
-  { id: "prospects", icon: "target", name: "Prospects", description: "Cold-list of prospects — import, bulk-reach-out and convert to leads.", kind: "module", category: "contacts", defaultEnabled: false, routePrefixes: ["/prospects"] },
-  { id: "outreach", icon: "send", name: "Outreach Agent", description: "Automated multi-step cold-email sequences over your prospect list, with full open/click/bounce tracking.", kind: "module", category: "sales", defaultEnabled: false, dependencies: ["prospects"], routePrefixes: ["/outreach"] },
-  { id: "leads", icon: "user-plus",      name: "Leads",         description: "Capture and work the sales pipeline.",   kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/leads"] },
-  { id: "quotes", icon: "file-check",     name: "Quotes",        description: "Build and send quotes customers accept online.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/quotes"] },
-  { id: "invoicing", icon: "file-text",  name: "Invoices",      description: "Invoice, take payments, track balances.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/invoices"] },
-  { id: "recurring-billing", icon: "repeat", name: "Recurring billing", description: "Subscription invoices that bill (and auto-charge) on a schedule.", kind: "module", category: "sales", defaultEnabled: true, dependencies: ["invoicing"], routePrefixes: ["/recurring-invoices"] },
-  { id: "contracts", icon: "file-stack",  name: "Contracts",     description: "Contracts with free in-app e-signature.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/contracts"] },
-  { id: "site-reports", icon: "clipboard-list", name: "Site Reports", description: "Client-facing inspection / scope-of-work PDFs.", kind: "module", category: "sales", defaultEnabled: true, routePrefixes: ["/reports"] },
+  // ── Winning work ───────────────────────────────────────────────────────────
+  { id: "prospects", icon: "target", name: "Prospects", description: "Cold-list of prospects — import, bulk-reach-out and convert to leads.", kind: "module", category: "win-work", defaultEnabled: false, routePrefixes: ["/prospects"] },
+  { id: "outreach", icon: "send", name: "Outreach Agent", description: "Automated multi-step cold-email sequences over your prospect list, with full open/click/bounce tracking.", kind: "module", category: "win-work", defaultEnabled: false, dependencies: ["prospects"], routePrefixes: ["/outreach"] },
+  { id: "leads", icon: "user-plus",      name: "Leads",         description: "Capture and work the sales pipeline.",   kind: "module", category: "win-work", defaultEnabled: true, routePrefixes: ["/leads"] },
+  { id: "quotes", icon: "file-check",     name: "Quotes",        description: "Build and send quotes customers accept online.", kind: "module", category: "win-work", defaultEnabled: true, routePrefixes: ["/quotes"] },
+  { id: "invoicing", icon: "file-text",  name: "Invoices",      description: "Invoice, take payments, track balances.", kind: "module", category: "money", defaultEnabled: true, routePrefixes: ["/invoices"] },
+  { id: "recurring-billing", icon: "repeat", name: "Recurring billing", description: "Subscription invoices that bill (and auto-charge) on a schedule.", kind: "module", category: "money", defaultEnabled: true, dependencies: ["invoicing"], routePrefixes: ["/recurring-invoices"] },
+  { id: "contracts", icon: "file-stack",  name: "Contracts",     description: "Contracts with free in-app e-signature.", kind: "module", category: "win-work", defaultEnabled: true, routePrefixes: ["/contracts"] },
+  { id: "site-reports", icon: "clipboard-list", name: "Site Reports", description: "Client-facing inspection / scope-of-work PDFs.", kind: "module", category: "deliver", defaultEnabled: true, routePrefixes: ["/reports"] },
 
-  // ── Service / field ops ────────────────────────────────────────────────────
-  { id: "jobs", icon: "wrench",       name: "Work Orders",   description: "Jobs with photos, time, materials and timelines.", kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/work-orders"] },
-  { id: "scheduling", icon: "calendar-days", name: "Schedule",      description: "Calendar and dispatch board for the crew.", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/schedule"] },
-  { id: "recurring-jobs", icon: "repeat", name: "Recurring jobs", description: "Repeating jobs that generate work orders (and optionally invoices).", kind: "module", category: "service", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/recurring"] },
-  { id: "timesheets", icon: "clock", name: "Timesheets", description: "Weekly hours per worker from job time, with pay + CSV export.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/timesheets"] },
-  { id: "assets", icon: "hammer", name: "Assets & equipment", description: "Track tools, vehicles and equipment with service schedules.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/assets"] },
-  { id: "booking", icon: "calendar-days",    name: "Online booking", description: "Public booking pages with reminders.",   kind: "module", category: "service", defaultEnabled: true, routePrefixes: ["/bookings"] },
+  // ── Doing the work, and what it costs ──────────────────────────────────────
+  { id: "jobs", icon: "wrench",       name: "Work Orders",   description: "Jobs with photos, time, materials and timelines.", kind: "module", category: "deliver", defaultEnabled: true, routePrefixes: ["/work-orders"] },
+  { id: "scheduling", icon: "calendar-days", name: "Schedule",      description: "Calendar and dispatch board for the crew.", kind: "module", category: "deliver", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/schedule"] },
+  { id: "recurring-jobs", icon: "repeat", name: "Recurring jobs", description: "Repeating jobs that generate work orders (and optionally invoices).", kind: "module", category: "deliver", defaultEnabled: true, dependencies: ["jobs"], routePrefixes: ["/recurring"] },
+  { id: "timesheets", icon: "clock", name: "Timesheets", description: "Weekly hours per worker from job time, with pay + CSV export.", kind: "module", category: "deliver", defaultEnabled: false, routePrefixes: ["/timesheets"] },
+  { id: "assets", icon: "hammer", name: "Assets & equipment", description: "Track tools, vehicles and equipment with service schedules.", kind: "module", category: "deliver", defaultEnabled: false, routePrefixes: ["/assets"] },
+  { id: "booking", icon: "calendar-days",    name: "Online booking", description: "Public booking pages with reminders.",   kind: "module", category: "win-work", defaultEnabled: true, routePrefixes: ["/bookings"] },
 
-  { id: "expenses", icon: "receipt", name: "Expenses", description: "Track job & business costs with receipts — true profit per job.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/expenses"] },
-  { id: "payroll", icon: "dollar-sign", name: "Payroll", description: "Pay runs from timesheet hours — payslips, super, and wages posted to expenses.", kind: "module", category: "service", defaultEnabled: false, routePrefixes: ["/payroll"] },
+  { id: "expenses", icon: "receipt", name: "Expenses", description: "Track job & business costs with receipts — true profit per job.", kind: "module", category: "money", defaultEnabled: false, routePrefixes: ["/expenses"] },
+  { id: "payroll", icon: "dollar-sign", name: "Payroll", description: "Pay runs from timesheet hours — payslips, super, and wages posted to expenses.", kind: "module", category: "money", defaultEnabled: false, routePrefixes: ["/payroll"] },
 
-  // ── Catalog / comms / insights ────────────────────────────────────────────
+  // ── What you sell · client comms · the numbers ─────────────────────────────
   { id: "products", icon: "package",   name: "Products",      description: "Price list used across quotes and invoices.", kind: "module", category: "catalog", defaultEnabled: true, routePrefixes: ["/products"] },
   { id: "materials", icon: "package",  name: "Materials",     description: "Cost-price catalog of materials, used as an internal reference when pricing jobs.", kind: "module", category: "catalog", defaultEnabled: false, routePrefixes: ["/materials"] },
   { id: "inventory", icon: "boxes", name: "Inventory", description: "Track stock on hand, reorder points and usage per job.", kind: "module", category: "catalog", defaultEnabled: false, dependencies: ["products"], routePrefixes: ["/inventory"] },
-  { id: "telephony", icon: "phone", name: "Phone system (VoIPcloud)", description: "Log every call against the customer, turn missed calls and voicemail into follow-ups.", kind: "module", category: "communication", defaultEnabled: false, routePrefixes: ["/calls"] },
-  { id: "messages", icon: "message-square",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "communication", defaultEnabled: true, routePrefixes: ["/messages"] },
-  { id: "analytics", icon: "trending-up",  name: "Analytics",     description: "Revenue and pipeline insight.",          kind: "module", category: "insights", defaultEnabled: true, routePrefixes: ["/analytics"] },
+  { id: "telephony", icon: "phone", name: "Phone system (VoIPcloud)", description: "Log every call against the customer, turn missed calls and voicemail into follow-ups.", kind: "module", category: "clients", defaultEnabled: false, routePrefixes: ["/calls"] },
+  { id: "messages", icon: "message-square",   name: "Messages",      description: "Customer conversations in one inbox.",   kind: "module", category: "clients", defaultEnabled: true, routePrefixes: ["/messages"] },
+  { id: "analytics", icon: "trending-up",  name: "Analytics",     description: "Revenue and pipeline insight.",          kind: "module", category: "grow", defaultEnabled: true, routePrefixes: ["/analytics"] },
 
   // ── Feature-flagged verticals (existing plugins; settings table authoritative) ─
-  { id: "quoting-agent", icon: "sparkles",     name: "Quoting Agent",     description: "AI that learns your pricing and writes quotes.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "quoting_agent_settings", routePrefixes: ["/quoting-agent"] },
-  { id: "client-onboarding", icon: "clipboard-list", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
-  { id: "form-builder", icon: "list-checks",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "sales", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
+  { id: "quoting-agent", icon: "sparkles",     name: "Quoting Agent",     description: "AI that learns your pricing and writes quotes.", kind: "module", category: "automate", defaultEnabled: false, settingsTable: "quoting_agent_settings", routePrefixes: ["/quoting-agent"] },
+  { id: "client-onboarding", icon: "clipboard-list", name: "Client Onboarding", description: "Custom intake forms customers fill in via the portal.", kind: "module", category: "clients", defaultEnabled: false, settingsTable: "onboarding_settings", routePrefixes: ["/onboarding-forms"] },
+  { id: "form-builder", icon: "list-checks",      name: "Form Builder",      description: "Public lead-capture forms to share or embed.", kind: "module", category: "win-work", defaultEnabled: false, settingsTable: "form_builder_settings", routePrefixes: ["/forms"] },
 
-  { id: "agency-console", icon: "building-2", name: "Client accounts", description: "Every business you run on one screen — who is overdue, what is booked, who has gone quiet.", kind: "module", category: "contacts", defaultEnabled: false, routePrefixes: ["/agency"] },
-  { id: "vault", icon: "lock", name: "Password vault", description: "Store the account logins you hold for clients — encrypted, owner/admin only, every reveal logged.", kind: "module", category: "contacts", defaultEnabled: false, settingsTable: "vault_settings", routePrefixes: ["/vault"] },
-  { id: "automations", icon: "zap", name: "Automations", description: "When something happens, do something: email a new client their onboarding form, text a customer when a job is done.", kind: "module", category: "automation", defaultEnabled: false, settingsTable: "automations_settings", routePrefixes: ["/automations"] },
+  { id: "agency-console", icon: "building-2", name: "Client accounts", description: "Every business you run on one screen — who is overdue, what is booked, who has gone quiet.", kind: "module", category: "clients", defaultEnabled: false, routePrefixes: ["/agency"] },
+  { id: "vault", icon: "lock", name: "Password vault", description: "Store the account logins you hold for clients — encrypted, owner/admin only, every reveal logged.", kind: "module", category: "clients", defaultEnabled: false, settingsTable: "vault_settings", routePrefixes: ["/vault"] },
+  { id: "automations", icon: "zap", name: "Automations", description: "When something happens, do something: email a new client their onboarding form, text a customer when a job is done.", kind: "module", category: "automate", defaultEnabled: false, settingsTable: "automations_settings", routePrefixes: ["/automations"] },
 
   // ── SEO vertical (docs/SEO_AGENCY_PLAN.md, Phase 2) ─────────────────────────
-  { id: "seo-production", icon: "trending-up", name: "SEO Production", description: "Manage client sites: connectors, opportunity queue, content pipeline and reporting.", kind: "module", category: "seo", defaultEnabled: false, routePrefixes: ["/seo"] },
+  { id: "seo-production", icon: "trending-up", name: "SEO Production", description: "Manage client sites: connectors, opportunity queue, content pipeline and reporting.", kind: "module", category: "grow", defaultEnabled: false, routePrefixes: ["/seo"] },
 
   // ── Content Studio — social/marketing content for clients ───────────────────
-  { id: "content-studio", icon: "megaphone", name: "Content Studio", description: "Research a client's niche, then generate video scripts, posts, hooks and campaigns — multiple angles, rendered per platform.", kind: "module", category: "content", defaultEnabled: false, routePrefixes: ["/content"] },
+  { id: "content-studio", icon: "megaphone", name: "Content Studio", description: "Research a client's niche, then generate video scripts, posts, hooks and campaigns — multiple angles, rendered per platform.", kind: "module", category: "grow", defaultEnabled: false, routePrefixes: ["/content"] },
 ];
 
 export const PLUGINS_BY_ID: Record<string, PluginDefinition> =

--- a/src/lib/recurring/expense-schedule.test.ts
+++ b/src/lib/recurring/expense-schedule.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { nextDueDate, dueDatesUpTo, validateSchedule } from "./expense-schedule";
+
+describe("nextDueDate", () => {
+  it("clamps to the last day of a short month instead of spilling over", () => {
+    // The bug this file exists to avoid: JS `setMonth` turns 31 Jan into
+    // 3 March. Rent due on the 31st would land in the wrong month every
+    // February, forever.
+    expect(nextDueDate("2026-01-31", "monthly", 31)).toBe("2026-02-28");
+    expect(nextDueDate("2028-01-31", "monthly", 31)).toBe("2028-02-29"); // leap year
+    expect(nextDueDate("2026-03-31", "monthly", 31)).toBe("2026-04-30");
+  });
+
+  it("returns to the preferred day after a clamped month", () => {
+    // February clamped it to the 28th; March must go back to the 31st, not
+    // stay on the 28th forever.
+    expect(nextDueDate("2026-02-28", "monthly", 31)).toBe("2026-03-31");
+  });
+
+  it("rolls the year over in December", () => {
+    expect(nextDueDate("2026-12-15", "monthly", 15)).toBe("2027-01-15");
+    expect(nextDueDate("2026-11-30", "quarterly", 30)).toBe("2027-02-28");
+  });
+
+  it("handles the day-based cadences", () => {
+    expect(nextDueDate("2026-08-10", "weekly")).toBe("2026-08-17");
+    expect(nextDueDate("2026-08-10", "fortnightly")).toBe("2026-08-24");
+    expect(nextDueDate("2026-12-28", "weekly")).toBe("2027-01-04");
+  });
+
+  it("does yearly, which insurance needs", () => {
+    expect(nextDueDate("2026-06-01", "yearly", 1)).toBe("2027-06-01");
+    expect(nextDueDate("2028-02-29", "yearly", 29)).toBe("2029-02-28");
+  });
+
+  it("keeps the current day when no preference is set", () => {
+    expect(nextDueDate("2026-08-10", "monthly")).toBe("2026-09-10");
+  });
+
+  it("refuses a malformed date rather than inventing one", () => {
+    expect(() => nextDueDate("not-a-date", "monthly")).toThrow();
+  });
+});
+
+describe("dueDatesUpTo", () => {
+  it("catches up a schedule the runner missed", () => {
+    // A cron outage must not silently skip months of rent.
+    const dates = dueDatesUpTo("2026-05-01", "2026-08-01", "monthly", 1);
+    expect(dates).toEqual(["2026-05-01", "2026-06-01", "2026-07-01", "2026-08-01"]);
+  });
+
+  it("returns nothing when nothing is due yet", () => {
+    expect(dueDatesUpTo("2026-09-01", "2026-08-10", "monthly", 1)).toEqual([]);
+  });
+
+  it("bounds the catch-up so a stale schedule can't post hundreds of rows", () => {
+    const dates = dueDatesUpTo("2020-01-01", "2026-08-10", "monthly", 1, 12);
+    expect(dates).toHaveLength(12);
+  });
+});
+
+describe("validateSchedule", () => {
+  it("requires a name, a positive amount and a start date", () => {
+    expect(validateSchedule({ amount: 10, next_run_on: "2026-08-10" })).toMatch(/name/i);
+    expect(validateSchedule({ name: "Rent", amount: 0, next_run_on: "2026-08-10" })).toMatch(/greater than zero/i);
+    expect(validateSchedule({ name: "Rent", amount: 10 })).toMatch(/next falls due/i);
+  });
+
+  it("rejects an end date before the first charge", () => {
+    expect(validateSchedule({
+      name: "Rent", amount: 10, next_run_on: "2026-08-10", ends_on: "2026-01-01",
+    })).toMatch(/before the first charge/i);
+  });
+
+  it("accepts a sound schedule", () => {
+    expect(validateSchedule({
+      name: "Office rent", amount: 2200, next_run_on: "2026-09-01",
+      preferred_day_of_month: 1, ends_on: "2027-09-01",
+    })).toBeNull();
+  });
+});

--- a/src/lib/recurring/expense-schedule.ts
+++ b/src/lib/recurring/expense-schedule.ts
@@ -1,0 +1,114 @@
+/**
+ * When a recurring cost next falls due.
+ *
+ * Plain module: the form validates with it, the cron advances with it, and
+ * tests exercise it without a database.
+ *
+ * ⚠️ This does NOT reuse `advanceOccurrence` from ./cadence.ts, deliberately.
+ * That helper does `d.setMonth(d.getMonth() + 1)`, which turns 31 January into
+ * 3 March — JavaScript rolls the overflow forward instead of clamping. For a
+ * weekly job that never shows; for rent due on the 31st it silently moves the
+ * charge into the wrong month, every short month, forever. It also has no
+ * `yearly`, which insurance needs.
+ *
+ * (The same rollover affects recurring JOBS today. Flagged, not changed here —
+ * altering it would move existing schedules without anyone asking.)
+ */
+
+export type ExpenseCadence = "weekly" | "fortnightly" | "monthly" | "quarterly" | "yearly";
+
+export const EXPENSE_CADENCES: Array<{ value: ExpenseCadence; label: string }> = [
+  { value: "weekly", label: "Every week" },
+  { value: "fortnightly", label: "Every fortnight" },
+  { value: "monthly", label: "Every month" },
+  { value: "quarterly", label: "Every quarter" },
+  { value: "yearly", label: "Every year" },
+];
+
+/** Days in a given month. `month` is 0-indexed, as in the Date API. */
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/**
+ * The next due date after `current`.
+ *
+ * @param preferredDay  the day of the month a monthly-or-longer schedule
+ *                      should land on. 31 lands on the last day of a short
+ *                      month rather than spilling into the next one — which
+ *                      is what someone means by "the 31st".
+ */
+export function nextDueDate(
+  current: string,
+  cadence: ExpenseCadence,
+  preferredDay?: number | null,
+): string {
+  const [y, m, d] = current.split("-").map(Number);
+  if (!y || !m || !d) throw new Error(`Bad date: ${current}`);
+
+  // Day-based cadences are unambiguous — no month lengths involved.
+  if (cadence === "weekly" || cadence === "fortnightly") {
+    const dt = new Date(Date.UTC(y, m - 1, d));
+    dt.setUTCDate(dt.getUTCDate() + (cadence === "weekly" ? 7 : 14));
+    return dt.toISOString().slice(0, 10);
+  }
+
+  const step = cadence === "monthly" ? 1 : cadence === "quarterly" ? 3 : 12;
+  // Work in absolute months so December + 1 rolls the year properly.
+  const absolute = (y * 12 + (m - 1)) + step;
+  const year = Math.floor(absolute / 12);
+  const month = absolute % 12;
+
+  const wanted = preferredDay && preferredDay >= 1 && preferredDay <= 31 ? preferredDay : d;
+  const day = Math.min(wanted, daysInMonth(year, month));
+
+  return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * Every due date from `from` up to and including `until`.
+ *
+ * The cron uses this so a schedule that was missed — a cron outage, a
+ * business created while the runner was down — catches up rather than
+ * silently skipping months. Bounded, because an `active` schedule whose
+ * next_run_on is years stale would otherwise generate hundreds of rows.
+ */
+export function dueDatesUpTo(
+  nextRunOn: string,
+  until: string,
+  cadence: ExpenseCadence,
+  preferredDay?: number | null,
+  maxCatchUp = 12,
+): string[] {
+  const out: string[] = [];
+  let cursor = nextRunOn;
+  while (cursor <= until && out.length < maxCatchUp) {
+    out.push(cursor);
+    cursor = nextDueDate(cursor, cadence, preferredDay);
+  }
+  return out;
+}
+
+/** What's wrong with this schedule, or null when it's fine. */
+export function validateSchedule(input: {
+  name?: string | null;
+  amount?: number | string | null;
+  next_run_on?: string | null;
+  ends_on?: string | null;
+  preferred_day_of_month?: number | null;
+}): string | null {
+  if (!(input.name ?? "").trim()) return "Give it a name — “Office rent”, “Xero”, “Public liability”.";
+
+  const amount = Number(input.amount);
+  if (!Number.isFinite(amount) || amount <= 0) return "Enter an amount greater than zero.";
+
+  if (!input.next_run_on) return "Choose when it next falls due.";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.next_run_on)) return "That start date isn't valid.";
+
+  if (input.ends_on && input.ends_on < input.next_run_on) {
+    return "The end date is before the first charge.";
+  }
+  const day = input.preferred_day_of_month;
+  if (day != null && (day < 1 || day > 31)) return "Day of the month must be between 1 and 31.";
+  return null;
+}

--- a/src/lib/ui-themes.test.ts
+++ b/src/lib/ui-themes.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { UI_THEMES, UI_THEME_KEYS, LIGHT_THEMES, isUiTheme } from "./ui-themes";
+
+const css = readFileSync(join(process.cwd(), "src/app/globals.css"), "utf8");
+
+/** Every `--token:` declared inside one theme's block. */
+function tokensOf(theme: string): Set<string> {
+  const start = css.indexOf(`[data-theme="${theme}"] {`);
+  if (start === -1) return new Set();
+  const end = css.indexOf("\n}", start);
+  return new Set(
+    [...css.slice(start, end).matchAll(/^\s*(--[a-z0-9-]+)\s*:/gim)].map((m) => m[1]),
+  );
+}
+
+describe("theme palettes", () => {
+  it("gives every theme in the picker a block in globals.css", () => {
+    // A theme listed but not styled is selectable, saved, and then renders as
+    // whatever the previous theme was — the picker lies about what's applied.
+    for (const t of UI_THEMES) {
+      expect(css, `no [data-theme="${t.key}"] block`).toContain(`[data-theme="${t.key}"] {`);
+    }
+  });
+
+  it("declares the same token set in every theme", () => {
+    // A token defined in three palettes and missed in the fourth inherits
+    // whatever :root left behind — usually an invisible-on-invisible colour,
+    // and only on the one theme nobody tested.
+    const reference = tokensOf("Midnight");
+    expect(reference.size).toBeGreaterThan(30);
+    for (const t of UI_THEMES) {
+      if (t.key === "Midnight") continue;
+      const missing = [...reference].filter((tok) => !tokensOf(t.key).has(tok));
+      expect(missing, `${t.key} is missing`).toEqual([]);
+    }
+  });
+
+  it("keeps the accent distinct from the success colour", () => {
+    // Studio's accent IS lime. If --ok were lime too, every status pill would
+    // be the brand colour and "paid" would stop reading as good news.
+    const block = css.slice(css.indexOf('[data-theme="Studio"] {'));
+    const val = (tok: string) => block.match(new RegExp(`${tok}:\\s*([^;]+);`))?.[1].trim();
+    expect(val("--ok")).not.toBe(val("--primary"));
+  });
+
+  it("agrees with itself about which themes are light", () => {
+    expect(LIGHT_THEMES).toEqual(UI_THEMES.filter((t) => !t.dark).map((t) => t.key));
+    expect(UI_THEME_KEYS).toEqual(UI_THEMES.map((t) => t.key));
+  });
+
+  it("rejects anything not in the list", () => {
+    expect(isUiTheme("Studio")).toBe(true);
+    expect(isUiTheme("studio")).toBe(false);
+    expect(isUiTheme(null)).toBe(false);
+  });
+});

--- a/src/lib/ui-themes.ts
+++ b/src/lib/ui-themes.ts
@@ -1,0 +1,39 @@
+/**
+ * The Kirei Dashboard v2 palettes.
+ *
+ * Light vs dark is a property of the theme, not a separate switch — Daylight
+ * is the light one. `swatch`/`ring` mirror the design's own theme picker so
+ * the dot in the header reads as the theme it selects.
+ *
+ * Plain module, deliberately. This list also drives the no-flash boot script
+ * in the root layout, which is a SERVER component: importing it from the
+ * "use client" provider would hand the server a client-reference proxy rather
+ * than the array, and `.map()` on that throws at build time. So the data lives
+ * here and the provider re-exports it.
+ */
+
+export const UI_THEMES = [
+  { key: "Midnight", label: "Midnight", swatch: "#3B82F6", ring: "#111A29", dark: true  },
+  { key: "Daylight", label: "Daylight", swatch: "#2563EB", ring: "#FFFFFF", dark: false },
+  { key: "Azure",    label: "Azure",    swatch: "#7DD3FC", ring: "#0C2A56", dark: true  },
+  { key: "Orchid",   label: "Orchid",   swatch: "#8B5CF6", ring: "#1B1030", dark: true  },
+  // Built from the Connected Studio logo — slate blue plate, lime accent.
+  { key: "Studio",   label: "Studio",   swatch: "#C4F000", ring: "#35576B", dark: true  },
+] as const;
+
+export type UiThemeKey = (typeof UI_THEMES)[number]["key"];
+
+/** Themes whose surfaces are light. Everything else gets the `.dark` class. */
+export const LIGHT_THEMES: readonly string[] = UI_THEMES.filter((t) => !t.dark).map((t) => t.key);
+
+/** Every theme key, for the boot script's allow-list. */
+export const UI_THEME_KEYS: readonly string[] = UI_THEMES.map((t) => t.key);
+
+export const DEFAULT_UI_THEME: UiThemeKey = "Midnight";
+
+/** Where the no-flash boot script in the root layout stashes the choice. */
+export const UI_THEME_STORAGE_KEY = "kirei.ui-theme";
+
+export function isUiTheme(v: unknown): v is UiThemeKey {
+  return typeof v === "string" && UI_THEMES.some((t) => t.key === v);
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -57,7 +57,7 @@ export interface Business {
   accent_color: string;
   bg_pattern: string;
   sidebar_theme: string;
-  /** Kirei Dashboard v2 palette: Midnight | Daylight | Azure | Orchid. */
+  /** Kirei Dashboard v2 palette: Midnight | Daylight | Azure | Orchid | Studio. */
   ui_theme?: string;
   /** Industry preset id (src/lib/plugins/presets.ts); null = no preset applied. */
   industry_preset?: string | null;

--- a/supabase/migrations/20260810120000_recurring_expenses.sql
+++ b/supabase/migrations/20260810120000_recurring_expenses.sql
@@ -1,0 +1,92 @@
+-- Costs that arrive whether you think about them or not: rent, insurance,
+-- software subscriptions, vehicle finance, the phone bill.
+--
+-- Modelled on recurring_invoices rather than inventing a second cadence
+-- system: same cadence vocabulary, same next_run_on/ends_on/active shape, so
+-- the runner and the UI read the same way and one bug fix covers both.
+--
+-- Why this matters beyond convenience: expenses feed job costing and the
+-- books. A subscription nobody remembers to enter makes every profit figure
+-- flattering, which is the kind of wrong that is worse than missing.
+
+CREATE TABLE IF NOT EXISTS public.recurring_expenses (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id       UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  -- What gets copied onto each generated expense.
+  name          TEXT NOT NULL,
+  vendor        TEXT,
+  category      TEXT NOT NULL DEFAULT 'other',
+  description   TEXT,
+  amount        NUMERIC(12,2) NOT NULL CHECK (amount >= 0),
+  tax_amount    NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (tax_amount >= 0),
+  payment_method TEXT,
+  -- A recurring overhead is rarely billable to one job, but a subcontractor
+  -- retainer can be — so it is a choice, not an assumption.
+  billable      BOOLEAN NOT NULL DEFAULT FALSE,
+
+  cadence       TEXT NOT NULL DEFAULT 'monthly'
+                CHECK (cadence IN ('weekly','fortnightly','monthly','quarterly','yearly')),
+  -- For monthly-and-longer cadences: which day to land on. 31 on a short
+  -- month clamps to the last day rather than skipping it.
+  preferred_day_of_month INTEGER CHECK (preferred_day_of_month BETWEEN 1 AND 31),
+
+  next_run_on   DATE NOT NULL,
+  ends_on       DATE,
+  active        BOOLEAN NOT NULL DEFAULT TRUE,
+
+  last_expense_id UUID REFERENCES public.expenses(id) ON DELETE SET NULL,
+  last_run_at   TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The runner's hot path: what is due today, across every business.
+CREATE INDEX IF NOT EXISTS idx_recurring_expenses_due
+  ON public.recurring_expenses (next_run_on) WHERE active;
+CREATE INDEX IF NOT EXISTS idx_recurring_expenses_business
+  ON public.recurring_expenses (business_id, created_at DESC);
+
+-- Which schedule produced an expense, so a generated row can be traced back
+-- and a duplicate run can be detected.
+ALTER TABLE public.expenses
+  ADD COLUMN IF NOT EXISTS recurring_expense_id UUID
+    REFERENCES public.recurring_expenses(id) ON DELETE SET NULL;
+
+-- One expense per schedule per due date. The cron claims work by advancing
+-- next_run_on, but a retry or an overlapping run would otherwise double-post
+-- the rent — and a duplicate cost is a wrong profit figure, silently.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_expenses_recurring_once
+  ON public.expenses (recurring_expense_id, spent_on)
+  WHERE recurring_expense_id IS NOT NULL;
+
+ALTER TABLE public.recurring_expenses ENABLE ROW LEVEL SECURITY;
+
+-- Read: any active member except workers. Write: owner / admin / editor.
+-- Copied from recurring_invoices so the two behave identically.
+DROP POLICY IF EXISTS recurring_expenses_read ON public.recurring_expenses;
+CREATE POLICY recurring_expenses_read ON public.recurring_expenses FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members WHERE user_id = auth.uid() AND status='active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+DROP POLICY IF EXISTS recurring_expenses_write ON public.recurring_expenses;
+CREATE POLICY recurring_expenses_write ON public.recurring_expenses FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+  )
+);
+
+DROP TRIGGER IF EXISTS recurring_expenses_updated_at ON public.recurring_expenses;
+CREATE TRIGGER recurring_expenses_updated_at BEFORE UPDATE ON public.recurring_expenses
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();

--- a/vercel.json
+++ b/vercel.json
@@ -74,6 +74,10 @@
     {
       "path": "/api/cron/telephony-sync",
       "schedule": "30 5 * * *"
+    },
+    {
+      "path": "/api/cron/recurring-expenses",
+      "schedule": "0 19 * * *"
     }
   ]
 }


### PR DESCRIPTION
Three things the last few messages asked for.

## 1. Recurring costs

Rent, insurance, subscriptions — the outgoings that arrive whether or not anyone remembers them. They never made it into the books unless someone re-typed them twelve times a year, so every profit figure was flattering.

A recurring cost posts an ordinary expense row on its due date. Nothing downstream changes: spend-by-category, the books summary and the CSV export all just see expenses.

**Dates clamp, they don't roll.** `advanceOccurrence` in `recurring/cadence.ts` does `d.setMonth(d.getMonth() + 1)`, which turns 31 January into 3 March. For a weekly job that never shows; for rent due on the 31st it walks the charge into the wrong month every short month, forever. The new `expense-schedule.ts` clamps to the last day and returns to the preferred day afterwards, and it has `yearly`, which insurance needs. **The same rollover still affects recurring jobs** — flagged, not changed, because altering it would move existing schedules without anyone asking.

**Double-posting is refused by the database, not the runner.** A unique index on `(recurring_expense_id, spent_on)` means a retry or an overlapping cron cannot post the rent twice. A duplicated cost is a wrong profit figure nobody notices. The runner catches up rather than skipping — a week of downtime posts each missed occurrence on its own date, bounded at 12.

Five MCP tools ship with it.

## 2. Modules grouped by what they're for

The Plugins store was a flat wall of thirty toggles ordered by which part of the codebase they came from. Categories are now the job the module does — winning work, doing the work, money in and out, your clients, what you sell, growing, automation — each with a line saying what the group is for.

The nav follows: **Expenses had been sitting under "Sales"**, which is the one place money going *out* does not belong. It moves to a Money section with invoices, recurring billing, recurring costs and payroll.

## 3. Studio theme

Built from the Connected Studio logo — slate blue `#35576B`, lime `#C4F000`, white type. All surfaces are the same slate hue at 33.8% saturation walked down in lightness, so the shell reads as one material.

Two things needed deciding rather than copying:

- **`--ok` is a teal-green, not the lime.** Lime is the accent; if "paid" is also lime then every status pill is the brand colour and none of them mean anything.
- **Status lightness is solved against *this* theme's card.** Studio's card sits at 21% L where the other dark themes are near 11–17%, so the usual values landed ~2 points of contrast short. Measured in the browser and corrected: ok 8.3, warn 9.0, bad 6.0 — matching Midnight, Azure and Orchid. Text on canvas 12.9, lime button label 12.7.

While adding it: **the boot script no longer hardcodes the theme list.** Both the allow-list and the is-it-dark test in the root layout were literals, so adding a palette silently left it out of the pre-paint step — pick it, reload, watch the app flash Midnight before correcting itself. Both derive from `UI_THEMES` now, which meant moving the list to a plain module (the root layout is a server component; importing from the `"use client"` provider hands it a client-reference proxy, and `.map()` on that throws at build).

## Verified

`tsc`, 323 tests and `npm run build` pass. New guards: every theme in the picker has a CSS block and all five declare an identical token set; no module can land in a category the store won't render; no nav item can point at a plugin id that doesn't exist; 13 schedule tests covering 31 Jan → 28/29 Feb → back to the 31st, leap years, December rollover and catch-up.

The Studio palette was verified in the browser — every token resolves to its intended value and the contrast figures above are measured, not estimated.

Migration `20260810120000` is **already applied and recorded on the live database**.

## Not verified

`/expenses/recurring` and the regrouped `/agents` store have not been looked at by a human or by me — the dev browser has no signed-in session and I don't enter credentials. Mobile is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)