### PR TITLE
fix(nav): the rail's arrows were dead, and the icons were squares

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -21,8 +21,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { motion } from "framer-motion";
-import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Settings, X, ChevronUp, ChevronDown } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type { Business } from "@/types/database";
@@ -47,16 +47,21 @@ interface AppSidebarProps {
   onClose: () => void;
 }
 
-/** Icon button: 48px, generously rounded, with air around it. */
+/** Icon button: 56px and fully round. */
 const ICON_BTN =
-  "relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl transition-colors duration-200";
+  "relative flex h-14 w-14 shrink-0 items-center justify-center rounded-full transition-colors duration-200";
 
 /**
  * How many icons a page of the rail may hold. Groups are never split, so a
  * page can overshoot slightly rather than break a category in half — that is
  * the point of grouping them.
+ *
+ * Dropped 9 → 7 when the icons went from 48px to 56px. Each slot now costs
+ * ~66px including its gap, so nine of them plus group padding and the two
+ * chevrons no longer clear a ~800px viewport — and the whole reason this
+ * budget exists is that the rail must never scroll.
  */
-export const SLOTS_PER_PAGE = 9;
+export const SLOTS_PER_PAGE = 7;
 
 /**
  * Pack sections into pages without ever splitting one.
@@ -82,7 +87,7 @@ export function packSections<T extends { items: unknown[] }>(
 }
 
 const TOOLTIP =
-  "pointer-events-none absolute left-14 z-50 whitespace-nowrap rounded-lg border border-border bg-popover "
+  "pointer-events-none absolute left-16 z-50 whitespace-nowrap rounded-lg border border-border bg-popover "
   + "px-2.5 py-1.5 text-xs font-medium text-popover-foreground opacity-0 shadow-lg transition-opacity duration-150 "
   + "group-hover:opacity-100 group-focus-visible:opacity-100";
 
@@ -91,7 +96,7 @@ function ActiveChip() {
   return (
     <motion.span
       layoutId="rail-active"
-      className="absolute inset-0 rounded-2xl bg-primary"
+      className="absolute inset-0 rounded-full bg-primary"
       style={{ boxShadow: "0 10px 26px -6px hsl(var(--primary) / 0.55)" }}
       transition={{ type: "spring", stiffness: 420, damping: 34 }}
     />
@@ -103,7 +108,14 @@ export function AppSidebar({
 }: AppSidebarProps) {
   const pathname = usePathname();
   const workerView = isWorker(userRole);
-  const sections = filterNav(navSections, { workerView, features, nav: navConfig });
+  // Memoised for IDENTITY, not for speed. filterNav returns a fresh array
+  // every call; feeding that to useMemo below meant `pagesOfSections` was a
+  // new object on every render, which is what broke the paging arrows — see
+  // the effect further down.
+  const sections = useMemo(
+    () => filterNav(navSections, { workerView, features, nav: navConfig }),
+    [workerView, features, navConfig],
+  );
 
   // The rail groups by section, and pages by WHOLE groups: a category that
   // straddled a page boundary would defeat the point of grouping them.
@@ -118,6 +130,8 @@ export function AppSidebar({
   // hour of chasing stale state. A fixed budget is dumber, always behaves the
   // same, and is provable without a browser. Tune the number, not the logic.
   const [page, setPage] = useState(0);
+  // +1 paging down, -1 paging up. Drives which way the icons slide.
+  const [dir, setDir] = useState(1);
 
   const pagesOfSections = useMemo(
     () => packSections(sections, SLOTS_PER_PAGE),
@@ -130,12 +144,32 @@ export function AppSidebar({
   const hasOverflow = pages > 1;
 
   // Never strand someone on a page that doesn't hold where they are.
+  //
+  // 🔴 Keyed on `pathname` ALONE, deliberately. This used to list
+  // `pagesOfSections` too, which looked correct and silently broke the arrows:
+  // that array had a new identity on every render, so the effect ran after
+  // every render — including the one caused by clicking an arrow — and snapped
+  // the page straight back to whichever one holds the current route. The
+  // arrows appeared dead. `sections` is now memoised as well, but the honest
+  // dependency here is the route: "when I navigate, show me where I am."
+  const pagesRef = useRef(pagesOfSections);
+  pagesRef.current = pagesOfSections;
   useEffect(() => {
-    const idx = pagesOfSections.findIndex((secs) =>
-      secs.some((sec) => sec.items.some((i) => isActive(i.href))));
-    if (idx >= 0) setPage(idx);
+    const idx = pagesRef.current.findIndex((secs) =>
+      secs.some((sec) => sec.items.some((i) => (
+        i.href === "/dashboard" ? pathname === "/dashboard" : pathname.startsWith(i.href)
+      ))));
+    if (idx >= 0) {
+      setDir((d) => (idx === page ? d : idx > page ? 1 : -1));
+      setPage(idx);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname, pagesOfSections]);
+  }, [pathname]);
+
+  const goto = useCallback((next: number) => {
+    setDir(next > page ? 1 : -1);
+    setPage(Math.min(pages - 1, Math.max(0, next)));
+  }, [page, pages]);
 
   const railLink = (item: NavItem) => {
     const active = isActive(item.href);
@@ -162,49 +196,65 @@ export function AppSidebar({
     );
   };
 
-  const chevron = (dir: "up" | "down", disabled: boolean) => (
+  const chevron = (arrow: "up" | "down", disabled: boolean) => (
     <button
       type="button"
       disabled={disabled}
-      onClick={() => setPage((p) => Math.min(pages - 1, Math.max(0, p + (dir === "up" ? -1 : 1))))}
-      aria-label={dir === "up" ? "Previous menu items" : "More menu items"}
+      onClick={() => goto(safePage + (arrow === "up" ? -1 : 1))}
+      aria-label={arrow === "up" ? "Previous menu items" : "More menu items"}
       className={cn(
-        "flex h-7 w-12 shrink-0 items-center justify-center rounded-lg transition-colors",
+        "flex h-8 w-14 shrink-0 items-center justify-center rounded-full transition-colors",
         disabled ? "text-muted-foreground/40"
                  : "text-muted-foreground hover:bg-background hover:text-foreground",
       )}
     >
-      {dir === "up" ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      {arrow === "up" ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
     </button>
   );
 
   /* ── Desktop rail ──────────────────────────────────────────────────── */
   const rail = (
-    // Wider, with real padding: the reference gives the icons room rather
-    // than packing them against the edge.
-    <div className="hidden h-full w-[92px] shrink-0 flex-col items-center bg-background px-3 py-6 md:flex">
+    // w-28 (112px), not an arbitrary value: bracket widths compile in the
+    // production build but NOT under this dev server, so `w-[92px]` rendered
+    // with no width at all locally. Registered scale steps only, here.
+    <div className="hidden h-full w-28 shrink-0 flex-col items-center bg-background px-3 py-6 md:flex">
       {hasOverflow && chevron("up", safePage === 0)}
 
-      <div className="flex min-h-0 w-full flex-1 flex-col items-center gap-3.5 overflow-hidden">
-        {visibleSections.map((group) => (
-          // Each category sits on its own slightly raised panel, as in the
-          // reference — the grouping is what makes twenty icons legible
-          // without labels.
-          <div
-            key={group.section}
-            title={group.section}
-            className="flex w-full flex-col items-center gap-3 rounded-3xl bg-secondary px-2.5 py-3"
+      {/* The page slides in from the direction you asked for, so paging reads
+          as movement along one list rather than the icons being swapped out
+          underneath you. mode="wait" keeps the outgoing page from overlapping
+          the incoming one in a 112px column. */}
+      <div className="flex min-h-0 w-full flex-1 flex-col items-center overflow-hidden">
+        <AnimatePresence mode="wait" initial={false} custom={dir}>
+          <motion.div
+            key={safePage}
+            custom={dir}
+            initial={{ opacity: 0, y: dir * 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: dir * -18 }}
+            transition={{ type: "spring", stiffness: 420, damping: 38, mass: 0.7 }}
+            className="flex w-full flex-col items-center gap-3.5"
           >
-            {group.items.map((item) => railLink(item))}
-          </div>
-        ))}
+            {visibleSections.map((group) => (
+              // Each category sits on its own slightly raised panel — the
+              // grouping is what makes twenty icons legible without labels.
+              <div
+                key={group.section}
+                title={group.section}
+                className="flex w-full flex-col items-center gap-2.5 rounded-3xl bg-secondary px-2 py-3"
+              >
+                {group.items.map((item) => railLink(item))}
+              </div>
+            ))}
+          </motion.div>
+        </AnimatePresence>
       </div>
 
       {hasOverflow && chevron("down", safePage >= pages - 1)}
 
       {/* Bottom group — settings, then the account, on the same raised panel
           so it reads as one more category rather than a loose pair. */}
-      <div className="mt-4 flex w-full flex-col items-center gap-3 rounded-3xl bg-secondary px-2.5 py-3">
+      <div className="mt-4 flex w-full flex-col items-center gap-2.5 rounded-3xl bg-secondary px-2 py-3">
         {canManageSettings(userRole) && (
           <Link
             href="/settings"

--- a/src/lib/rail-identity.test.ts
+++ b/src/lib/rail-identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { packSections } from "@/components/layout/app-sidebar";
+
+/**
+ * Why the rail's paging arrows were dead.
+ *
+ * `packSections` builds a fresh array every call — correct for a pure
+ * function, and fatal as a React effect dependency. The rail listed its packed
+ * pages in an effect's dep array, so the effect ran after EVERY render,
+ * including the render caused by clicking an arrow, and immediately reset the
+ * page to whichever one holds the current route.
+ *
+ * The fix keys that effect on `pathname` alone. This test pins the property
+ * that made the old code wrong, so a future edit that reintroduces
+ * `pagesOfSections` as a dependency has this sitting next to it.
+ */
+describe("packSections identity", () => {
+  it("returns a new array for identical input — never use it as an effect dep", () => {
+    const secs = [
+      { section: "A", items: [{ href: "/a" }] },
+      { section: "B", items: [{ href: "/b" }] },
+    ];
+    const first = packSections(secs, 7);
+    const second = packSections(secs, 7);
+
+    expect(second).toEqual(first);   // same content
+    expect(second).not.toBe(first);  // different object, every single call
+  });
+});


### PR DESCRIPTION
Four asks, one of which turned out to be a genuine bug.

## The arrows did nothing — and it wasn't the button

`filterNav` returns a fresh array every call, so `useMemo(..., [sections])` never hit and `pagesOfSections` had a **new identity on every render**. The effect that keeps you on the page holding your current route listed that array as a dependency:

```js
useEffect(() => { /* find the page with the active route, setPage(it) */ },
          [pathname, pagesOfSections]);   // ← ran after every render
```

So: click the arrow → `setPage` → re-render → effect fires → page snaps back to the active route's page. The button was working perfectly and looked broken.

It's now keyed on `pathname` alone, which is the honest dependency — *"when I navigate, show me where I am"* — with the packed pages read through a ref. `sections` is memoised too, for identity rather than speed.

A regression test pins the property that made the old code wrong (`packSections` returns a new array for identical input), so anyone tempted to re-add that dependency has it sitting right next to them.

## Round icons

48px squares (`rounded-2xl`) → **56px circles** (`rounded-full`). The active chip follows suit, or a round icon would sit on a square highlight.

## Wider rail

92px → **112px** (`w-28`). Deliberately a registered scale step, not `w-[112px]`: arbitrary bracket widths compile in the production build but **not** under this dev server, which is why the old `w-[92px]` was rendering with no width at all locally.

## Paging animates

The outgoing page slides out and the incoming one slides in **from the direction you asked for**, spring-eased. Paging now reads as movement along one list rather than icons being swapped underneath you. `mode="wait"` — two pages overlapping in a 112px column looks like a glitch, not a transition.

Slots per page **9 → 7**: a 56px icon costs ~66px with its gap, and nine of them plus the two chevrons no longer clear a short viewport. The entire point of the budget is that the rail never scrolls, so it has to come down when the icons go up.

## Verified

`tsc`, lint, 337 tests and `npm run build` all pass.

## Not verified

**I could not click the arrow.** There's no jsdom/testing-library in this repo and I wasn't going to add a DOM-testing stack unasked, and the dev browser has no signed-in session to reach the dashboard. The bug is diagnosed from the code and the fix is sound by inspection, but the proof is you clicking it. Same for the width, the radius and the slide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)