### PR TITLE
fix(leads): quoting a lead failed on columns that don't exist

### DIFF
--- a/src/lib/leads/promote.test.ts
+++ b/src/lib/leads/promote.test.ts
@@ -91,6 +91,34 @@ describe("ensureContactForLead", () => {
     expect(state.leads.L1.customer_id).toBe(res.customerId);
   });
 
+  it("carries the lead's owner and suburb onto the contact", async () => {
+    // Both of these shipped broken and the mock never noticed:
+    //   customers.user_id is NOT NULL with no default — omitting it failed
+    //   every insert; and leads has `suburb`, not `city`, so the old code
+    //   selected three columns that do not exist at all.
+    const state = {
+      leads: {
+        L1: {
+          id: "L1", business_id: BIZ, user_id: "U7", name: "Acme",
+          email: "hi@acme.com", phone: "0400", address: "1 Main St",
+          suburb: "Bondi", customer_id: null, source: "form",
+        },
+      },
+      customers: {} as Record<string, Record<string, unknown>>,
+    };
+    const { sb } = makeSb(state);
+    const res = await ensureContactForLead(sb, BIZ, "L1");
+    const contact = state.customers[res.customerId];
+
+    expect(contact.user_id).toBe("U7");     // NOT NULL — insert dies without it
+    expect(contact.city).toBe("Bondi");     // leads.suburb → customers.city
+    expect(contact.address).toBe("1 Main St");
+    // Columns that do not exist on leads must never be written.
+    expect(contact).not.toHaveProperty("suburb");
+    expect(contact).not.toHaveProperty("postcode");
+    expect(contact).not.toHaveProperty("company");
+  });
+
   it("is idempotent — quoting twice does not create two contacts", async () => {
     const state = {
       leads: { L1: { id: "L1", business_id: BIZ, name: "Acme", email: "hi@acme.com", customer_id: "C9" } },

--- a/src/lib/leads/promote.ts
+++ b/src/lib/leads/promote.ts
@@ -17,10 +17,28 @@
  *                           because paying is what the user defines a client as.
  */
 
+import type { Lead } from "@/types/database";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Sb = any;
 
 const tbl = (sb: Sb, name: string) => sb.from(name);
+
+/**
+ * Exactly the lead columns this module reads.
+ *
+ * Typed as a Pick of the real Lead so a name that isn't a column cannot be
+ * written here without TypeScript objecting. `tbl()` returns `any`, which is
+ * how `city`, `postcode` and `company` — none of which exist on leads — got
+ * selected and shipped. The type in database.ts was right the whole time;
+ * nothing was reading it.
+ */
+type LeadForContact = Pick<
+  Lead, "id" | "user_id" | "name" | "email" | "phone" | "address" | "suburb" | "customer_id" | "source"
+>;
+const LEAD_CONTACT_COLUMNS: ReadonlyArray<keyof LeadForContact> = [
+  "id", "user_id", "name", "email", "phone", "address", "suburb", "customer_id", "source",
+];
 
 export interface LeadContactResult {
   customerId: string;
@@ -40,11 +58,12 @@ export interface LeadContactResult {
 export async function ensureContactForLead(
   sb: Sb, businessId: string, leadId: string,
 ): Promise<LeadContactResult> {
-  const { data: lead, error } = await tbl(sb, "leads")
-    .select("id, name, email, phone, address, city, postcode, company, customer_id, source")
+  const { data, error } = await tbl(sb, "leads")
+    .select(LEAD_CONTACT_COLUMNS.join(", "))
     .eq("id", leadId).eq("business_id", businessId).maybeSingle();
   if (error) throw new Error(error.message);
-  if (!lead) throw new Error("Lead not found");
+  if (!data) throw new Error("Lead not found");
+  const lead = data as LeadForContact;
 
   if (lead.customer_id) return { customerId: lead.customer_id, created: false };
 
@@ -63,13 +82,16 @@ export async function ensureContactForLead(
 
   const { data: created, error: insErr } = await tbl(sb, "customers").insert({
     business_id: businessId,
-    name: lead.name?.trim() || lead.company?.trim() || "Unnamed lead",
+    // NOT NULL with no default. Carry the lead's owner across — omitting it
+    // failed every insert with a null-violation, behind the column error.
+    user_id: lead.user_id,
+    name: lead.name?.trim() || "Unnamed lead",
     email: lead.email ?? null,
     phone: lead.phone ?? null,
     address: lead.address ?? null,
-    city: lead.city ?? null,
-    postcode: lead.postcode ?? null,
-    company: lead.company ?? null,
+    // leads.suburb is the city-level field; customers calls it `city`. There
+    // is no postcode or company on a lead to carry.
+    city: lead.suburb ?? null,
     // The point of the whole exercise: billable, but not yet a client.
     lifecycle_stage: "lead",
   }).select("id").single();


### PR DESCRIPTION
`column leads.city does not exist` — every attempt to quote or invoice a lead threw before doing anything.

## Two bugs, stacked

**1. Phantom columns.** `ensureContactForLead` selected `city`, `postcode` and `company` from `leads`. None of the three exist on that table. It has **`suburb`**, and no postcode or company at all.

**2. A null violation waiting behind it.** `customers.user_id` is `NOT NULL` with no default, and the insert never set it. The moment bug 1 was fixed, every insert would have died. The lead's own `user_id` is the right owner, so it's carried across.

Mapping is now `leads.suburb → customers.city`, which is what those two fields mean. Postcode and company have no source on a lead, so they're not written.

## Why nothing caught it

**The type was right and nothing read it.** `Lead` in `database.ts` correctly declares `suburb`, `address`, `user_id` and no `city`/`postcode`/`company`. The `tbl()` helper returns `any`, so the query was completely unchecked.

The column list is now a `Pick<Lead, …>` and the `select` is built from those keys — a name that isn't a column can't be written without TypeScript objecting.

**The tests passed the whole time, because they mock Supabase** and a mock will cheerfully return a column that doesn't exist. That's the real lesson here: for anything schema-shaped, a mocked test is not evidence.

## Verified against the live database, not the mock

| Check | Result |
|---|---|
| New `select` list run against `public.leads` | OK |
| `customers` NOT NULL columns with no default, beyond the three we set | none |
| Other selects on `leads` naming phantom columns | none — swept |

Plus a regression test asserting the insert carries `user_id` and maps `suburb → city`, and never writes `suburb`/`postcode`/`company`.

`tsc`, 338 tests and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)