### PR TITLE
feat(payments): bank details on file, for paying a client by hand

### DIFF
--- a/src/app/(dashboard)/customers/[id]/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getClientFieldConfig } from "@/lib/actions/client-fields";
 import { CustomerDetailClient, type CustomerOnboardingData } from "@/components/customers/customer-detail-client";
 import { listVaultItems, vaultReady } from "@/lib/actions/vault";
+import { listPaymentDetails, paymentDetailsReady, type PaymentDetailView } from "@/lib/actions/payment-details";
 import type { VaultItemView } from "@/lib/vault/items";
 
 /**
@@ -58,6 +59,26 @@ async function loadVault(customerId: string): Promise<{ items: VaultItemView[]; 
 
     const [items, ready] = await Promise.all([listVaultItems(customerId), vaultReady()]);
     return { items, ready };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stored bank details. Owner/admin only — `listPaymentDetails` already returns
+ * [] for anyone else, but returning null here removes the card entirely rather
+ * than showing an empty one that implies nothing is stored.
+ */
+async function loadPaymentDetails(
+  customerId: string,
+): Promise<{ details: PaymentDetailView[]; ready: boolean } | null> {
+  try {
+    const [details, ready] = await Promise.all([
+      listPaymentDetails(customerId), paymentDetailsReady(),
+    ]);
+    // No rows AND no key means there is nothing to show and nothing to add.
+    if (details.length === 0 && !ready) return null;
+    return { details, ready };
   } catch {
     return null;
   }
@@ -110,7 +131,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
 
 async function CustomerDetailContent({ id }: { id: string }) {
   try {
-    const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles, onboarding, fieldConfig, vault] = await Promise.all([
+    const [customer, invoices, quotes, business, workOrders, reports, properties, contacts, notes, billingProfiles, onboarding, fieldConfig, vault, paymentDetails] = await Promise.all([
       getCustomer(id),
       getInvoices({ customer_id: id }),
       getQuotes({ customer_id: id }),
@@ -124,6 +145,7 @@ async function CustomerDetailContent({ id }: { id: string }) {
       loadOnboarding(id),
       getClientFieldConfig().catch(() => null),
       loadVault(id),
+      loadPaymentDetails(id),
     ]);
     return (
       <CustomerDetailClient
@@ -140,6 +162,7 @@ async function CustomerDetailContent({ id }: { id: string }) {
         businessCountry={business.country ?? null}
         onboarding={onboarding}
         vault={vault}
+        paymentDetails={paymentDetails}
         clientFields={fieldConfig?.fields ?? []}
         accountTypes={fieldConfig?.accountTypes ?? []}
         cardProviders={{

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -8,7 +8,7 @@ import {
   FileCheck, Wrench, ClipboardList, StickyNote, User, Users, Home,
   Trash2, Star, Save, X, ChevronDown, ChevronUp, ImageIcon, MessageSquare,
   CreditCard, DollarSign, Paperclip, ListChecks,
-  Lock,
+  Lock, Landmark,
 } from "@/components/ui/icons";
 import { AttachmentsPanel } from "@/components/attachments/attachments-panel";
 import { ClientFieldsSummary } from "@/components/customers/client-fields";
@@ -49,6 +49,8 @@ import {
 import { CustomerOnboardingCard } from "@/components/onboarding/customer-onboarding-card";
 import { VaultClient } from "@/components/vault/vault-client";
 import type { VaultItemView } from "@/lib/vault/items";
+import { PaymentDetailsCard } from "@/components/customers/payment-details-card";
+import type { PaymentDetailView } from "@/lib/actions/payment-details";
 import type { OnboardingRequestRow } from "@/lib/actions/onboarding";
 import type {
   Customer, InvoiceWithCustomer, QuoteWithCustomer,
@@ -92,6 +94,8 @@ interface Props {
   /** Vault entries for THIS client; null when the plugin is off or the
    *  viewer isn't an owner/admin — the tab then doesn't exist at all. */
   vault?: { items: VaultItemView[]; ready: boolean } | null;
+  /** Bank details on file. Null when the caller isn't owner/admin. */
+  paymentDetails?: { details: PaymentDetailView[]; ready: boolean } | null;
 }
 
 // ── Property Modal ─────────────────────────────────────────────────────────────
@@ -523,6 +527,7 @@ export function CustomerDetailClient({
   accountTypes = [],
   cardProviders,
   vault,
+  paymentDetails,
 }: Props) {
   const [customer, setCustomer] = useState(initial);
   const [editing, setEditing] = useState(false);
@@ -766,7 +771,23 @@ export function CustomerDetailClient({
                     <Lock className="w-3.5 h-3.5" />Passwords ({vault.items.length})
                   </TabsTrigger>
                 )}
+                {paymentDetails && (
+                  <TabsTrigger value="payment-details" className="gap-1.5">
+                    <Landmark className="w-3.5 h-3.5" />Payment details ({paymentDetails.details.length})
+                  </TabsTrigger>
+                )}
               </TabsList>
+
+              {/* ── Payment details ── */}
+              {paymentDetails && (
+                <TabsContent value="payment-details" className="mt-3">
+                  <PaymentDetailsCard
+                    customerId={customer.id}
+                    details={paymentDetails.details}
+                    ready={paymentDetails.ready}
+                  />
+                </TabsContent>
+              )}
 
               {/* ── Passwords ── */}
               {vault && (

--- a/src/components/customers/payment-details-card.tsx
+++ b/src/components/customers/payment-details-card.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+/**
+ * Bank details held for a client, so someone can pay them by hand.
+ *
+ * Two things the UI has to get right:
+ *
+ *  1. **Nothing sensitive renders until asked.** The list shows a masked hint
+ *     and the account holder's name. The number arrives only on Reveal, which
+ *     is a server round-trip that writes an audit entry — so the value is
+ *     never sitting in a prop, an RSC payload or a devtools inspection.
+ *  2. **Revealed values do not linger.** They clear on close and after a
+ *     minute, because "I'll just leave that open" is how a bank account ends
+ *     up on a shared screen.
+ */
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Landmark, Plus, Trash2, Eye, EyeOff, Loader2, Copy, Check, Lock } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useConfirm } from "@/components/ui/confirm";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { PAYMENT_KINDS, kindDef, type PaymentDetailKind } from "@/lib/payments/details";
+import {
+  savePaymentDetail, deletePaymentDetail, revealPaymentDetail,
+  type PaymentDetailView,
+} from "@/lib/actions/payment-details";
+
+const selectCls = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+interface Props {
+  customerId: string;
+  details: PaymentDetailView[];
+  /** False when APP_ENCRYPTION_KEY is missing — saving is refused, not faked. */
+  ready: boolean;
+}
+
+const BLANK = {
+  kind: "bank_au" as PaymentDetailKind,
+  label: "", holder_name: "", bank_name: "",
+  account: "", routing: "", notes: "", is_default: false,
+};
+
+export function PaymentDetailsCard({ customerId, details, ready }: Props) {
+  const router = useRouter();
+  const confirm = useConfirm();
+  const [pending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ ...BLANK });
+  const [shown, setShown] = useState<Record<string, { account: string | null; routing: string | null }>>({});
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  // Anything revealed clears itself after a minute. Leaving an account number
+  // on screen indefinitely is the failure mode this feature invites.
+  useEffect(() => {
+    if (Object.keys(shown).length === 0) return;
+    const t = setTimeout(() => setShown({}), 60_000);
+    return () => clearTimeout(t);
+  }, [shown]);
+
+  const def = kindDef(form.kind);
+
+  function save() {
+    startTransition(async () => {
+      const res = await savePaymentDetail(null, customerId, form);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success("Saved");
+      setOpen(false); setForm({ ...BLANK });
+      router.refresh();
+    });
+  }
+
+  function reveal(d: PaymentDetailView) {
+    if (shown[d.id]) { setShown((s) => { const n = { ...s }; delete n[d.id]; return n; }); return; }
+    setBusyId(d.id);
+    startTransition(async () => {
+      const res = await revealPaymentDetail(d.id);
+      setBusyId(null);
+      if (!res.ok) { toast.error(res.error); return; }
+      setShown((s) => ({ ...s, [d.id]: res.data }));
+    });
+  }
+
+  async function remove(d: PaymentDetailView) {
+    const ok = await confirm({
+      title: `Delete ${d.label ?? "these details"}?`,
+      body: "The stored account number is destroyed. You'd need to ask the client for it again.",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!ok) return;
+    startTransition(async () => {
+      const res = await deletePaymentDetail(d.id);
+      if (!res.ok) { toast.error(res.error); return; }
+      toast.success("Deleted");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-5">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2.5">
+          <Landmark className="h-4 w-4 text-muted-foreground" />
+          <p className="text-sm font-semibold">Payment details</p>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => setOpen(true)} disabled={!ready}>
+          <Plus className="h-3.5 w-3.5" /> Add
+        </Button>
+      </div>
+
+      {!ready && (
+        <p className="mb-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          APP_ENCRYPTION_KEY isn&rsquo;t set on the server, so these can&rsquo;t be stored safely.
+          Saving is disabled rather than writing bank details in the clear.
+        </p>
+      )}
+
+      {details.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nothing stored. Add the client&rsquo;s bank details once and they&rsquo;re here when you pay them.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {details.map((d) => {
+            const revealed = shown[d.id];
+            const kd = kindDef(d.kind);
+            return (
+              <div key={d.id} className="rounded-lg border border-border/60 px-3 py-2.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="flex items-center gap-2 text-sm font-medium">
+                      {d.label ?? kd.label}
+                      {d.is_default && (
+                        <span className="rounded-full bg-secondary px-1.5 py-0.5 text-[10px] font-semibold uppercase text-muted-foreground">
+                          Default
+                        </span>
+                      )}
+                    </p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {kd.label}
+                      {d.holder_name && <> · {d.holder_name}</>}
+                      {d.hint && <> · <span className="font-mono">{d.hint}</span></>}
+                    </p>
+                  </div>
+                  <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => reveal(d)}
+                    disabled={pending && busyId === d.id}>
+                    {busyId === d.id ? <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                      : revealed ? <EyeOff className="mr-1 h-3 w-3" /> : <Eye className="mr-1 h-3 w-3" />}
+                    {revealed ? "Hide" : "Reveal"}
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => remove(d)}
+                    disabled={pending} aria-label={`Delete ${d.label ?? "details"}`}>
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+
+                {revealed && (
+                  <div className="mt-2.5 space-y-1.5 rounded-md bg-muted/50 p-2.5">
+                    {kd.routingLabel && (
+                      <RevealRow label={kd.routingLabel} value={revealed.routing}
+                        copied={copied} setCopied={setCopied} />
+                    )}
+                    <RevealRow label={kd.accountLabel} value={revealed.account}
+                      copied={copied} setCopied={setCopied} />
+                    <p className="pt-0.5 text-[11px] text-muted-foreground">
+                      Logged against your name. Hides itself in a minute.
+                    </p>
+                  </div>
+                )}
+
+                {d.notes && <p className="mt-1.5 text-xs text-muted-foreground">{d.notes}</p>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+        <Lock className="mt-0.5 h-3 w-3 shrink-0" />
+        Encrypted at rest. Owner and admin only, and every reveal is logged.
+        Card numbers can&rsquo;t be stored here.
+      </p>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader><DialogTitle>Add payment details</DialogTitle></DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="pd-kind">Type</Label>
+              <select id="pd-kind" className={selectCls} value={form.kind}
+                onChange={(e) => setForm((f) => ({ ...f, kind: e.target.value as PaymentDetailKind }))}>
+                {PAYMENT_KINDS.map((k) => <option key={k.value} value={k.value}>{k.label}</option>)}
+              </select>
+              <p className="text-[11px] text-muted-foreground">{def.hintText}</p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="pd-holder">Account name</Label>
+              <Input id="pd-holder" value={form.holder_name} placeholder="Whose account it is"
+                onChange={(e) => setForm((f) => ({ ...f, holder_name: e.target.value }))} />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              {def.routingLabel && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="pd-routing">{def.routingLabel}</Label>
+                  <Input id="pd-routing" value={form.routing} inputMode="numeric"
+                    onChange={(e) => setForm((f) => ({ ...f, routing: e.target.value }))} />
+                </div>
+              )}
+              <div className={def.routingLabel ? "space-y-1.5" : "col-span-2 space-y-1.5"}>
+                <Label htmlFor="pd-account">{def.accountLabel}</Label>
+                <Input id="pd-account" value={form.account}
+                  onChange={(e) => setForm((f) => ({ ...f, account: e.target.value }))} />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="pd-bank">Bank / institution</Label>
+              <Input id="pd-bank" value={form.bank_name}
+                onChange={(e) => setForm((f) => ({ ...f, bank_name: e.target.value }))} />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="pd-notes">Notes</Label>
+              <Input id="pd-notes" value={form.notes} placeholder="Reference to quote, when they pay…"
+                onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))} />
+            </div>
+
+            <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+              <Label htmlFor="pd-default" className="text-sm font-normal">Use as the default</Label>
+              <Switch id="pd-default" checked={form.is_default}
+                onCheckedChange={(v) => setForm((f) => ({ ...f, is_default: v }))} />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={pending}>Cancel</Button>
+            <Button onClick={save} disabled={pending || !ready}>
+              {pending ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function RevealRow({
+  label, value, copied, setCopied,
+}: {
+  label: string; value: string | null;
+  copied: string | null; setCopied: (v: string | null) => void;
+}) {
+  if (!value) return null;
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-28 shrink-0 text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
+      <code className="min-w-0 flex-1 truncate font-mono text-sm">{value}</code>
+      <Button
+        size="sm" variant="ghost" className="h-6 shrink-0 px-2 text-[11px]"
+        onClick={async () => {
+          await navigator.clipboard.writeText(value);
+          setCopied(value);
+          setTimeout(() => setCopied(null), 1500);
+        }}
+      >
+        {copied === value ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/actions/payment-details.ts
+++ b/src/lib/actions/payment-details.ts
@@ -1,0 +1,298 @@
+"use server";
+
+/**
+ * Payment details on file — the only path in or out of
+ * customer_payment_details.
+ *
+ * Same three rules as the password vault, for the same reasons:
+ *
+ *  1. **Ciphertext never leaves the server.** The list returns a masked hint
+ *     and `has_account: boolean`, never the encrypted blob. A browser holding
+ *     ciphertext means a cached RSC payload carries a secret it didn't need.
+ *  2. **Plaintext only on an explicit reveal**, by an owner or admin, and the
+ *     reveal is logged. RLS already limits these tables to owner/admin; reveal
+ *     re-checks in application code, which is the one place worth paying for
+ *     defence in depth.
+ *  3. **No key, no save.** Without APP_ENCRYPTION_KEY this refuses rather than
+ *     writing bank details in the clear.
+ *
+ * 🔴 And one of its own: no card numbers. `validatePaymentDetail` runs a Luhn
+ * check on what's typed and rejects a PAN, the DB CHECK allows no card kind,
+ * and there is no CVV field anywhere in the shape.
+ *
+ * Expected failures are RETURNED, not thrown — Next masks thrown server-action
+ * messages in production.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { encryptSecret, decryptSecret, encryptionAvailable } from "@/lib/crypto";
+import {
+  validatePaymentDetail, maskAccount, kindDef,
+  type PaymentDetailInput, type PaymentDetailKind,
+} from "@/lib/payments/details";
+import type { Role } from "@/lib/permissions";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uid = (v: string | null | undefined) => (v && UUID_RE.test(v.trim()) ? v.trim() : null);
+const str = (v: string | null | undefined) => {
+  const t = (v ?? "").trim();
+  return t.length ? t : null;
+};
+
+export type PaymentResult<T = undefined> =
+  | ({ ok: true } & (T extends undefined ? object : { data: T }))
+  | { ok: false; error: string };
+
+/** Safe to send to a browser: no ciphertext, no plaintext. */
+export interface PaymentDetailView {
+  id: string;
+  customer_id: string;
+  kind: PaymentDetailKind;
+  label: string | null;
+  holder_name: string | null;
+  bank_name: string | null;
+  hint: string | null;
+  notes: string | null;
+  is_default: boolean;
+  has_account: boolean;
+  created_at: string;
+}
+
+export interface PaymentLogEntry {
+  id: string;
+  detail_label: string | null;
+  user_email: string | null;
+  action: string;
+  created_at: string;
+}
+
+async function callerRole(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any, userId: string, businessId: string,
+): Promise<Role> {
+  const { data: biz } = await tbl(supabase, "businesses").select("user_id").eq("id", businessId).single();
+  if (biz?.user_id === userId) return "owner";
+  const { data: member } = await tbl(supabase, "business_members")
+    .select("role").eq("business_id", businessId).eq("user_id", userId)
+    .eq("status", "active").maybeSingle();
+  return (member?.role ?? "viewer") as Role;
+}
+
+const canUse = (role: Role) => role === "owner" || role === "admin";
+
+/** Record who did what. Never records the number itself. */
+async function log(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any, businessId: string,
+  entry: {
+    detail_id: string | null; detail_label: string | null; customer_id: string | null;
+    user_id: string; user_email: string | null; action: string;
+  },
+) {
+  // Awaited, not floating: a promise left dangling in a serverless function is
+  // an audit entry that may simply never be written.
+  const { error } = await tbl(supabase, "payment_detail_access_log")
+    .insert({ business_id: businessId, ...entry });
+  if (error) console.error("[payment-details] audit write failed", error.message);
+}
+
+/** Details for one customer (or all). Masked only — never ciphertext. */
+export async function listPaymentDetails(customerId?: string): Promise<PaymentDetailView[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!canUse(await callerRole(supabase, user.id, businessId))) return [];
+
+  let q = tbl(supabase, "customer_payment_details")
+    .select("id, customer_id, kind, label, holder_name, bank_name, hint, notes, is_default, account_enc, created_at")
+    .eq("business_id", businessId)
+    .order("is_default", { ascending: false })
+    .order("created_at", { ascending: false })
+    .limit(200);
+  const cid = uid(customerId);
+  if (cid) q = q.eq("customer_id", cid);
+
+  const { data, error } = await q;
+  if (error) { console.error("[payment-details] list", error.message); return []; }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((data ?? []) as any[]).map((r) => ({
+    id: r.id, customer_id: r.customer_id, kind: r.kind,
+    label: r.label, holder_name: r.holder_name, bank_name: r.bank_name,
+    hint: r.hint, notes: r.notes, is_default: r.is_default,
+    has_account: Boolean(r.account_enc),   // the blob itself stays here
+    created_at: r.created_at,
+  }));
+}
+
+export async function savePaymentDetail(
+  detailId: string | null,
+  customerId: string,
+  input: PaymentDetailInput,
+): Promise<PaymentResult<{ id: string }>> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!canUse(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can store payment details" };
+  }
+  if (!encryptionAvailable()) {
+    return {
+      ok: false,
+      error: "APP_ENCRYPTION_KEY isn't set on the server, so these can't be stored safely. "
+        + "Set it before saving bank details.",
+    };
+  }
+  const cid = uid(customerId);
+  if (!cid) return { ok: false, error: "Pick a client first" };
+
+  const problem = validatePaymentDetail(input);
+  if (problem) return { ok: false, error: problem };
+
+  const kind = (input.kind ?? "bank_au") as PaymentDetailKind;
+  const account = (input.account ?? "").trim();
+  const routing = (input.routing ?? "").trim();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row: Record<string, any> = {
+    business_id: businessId,
+    customer_id: cid,
+    kind,
+    label: str(input.label) ?? kindDef(kind).label,
+    holder_name: str(input.holder_name),
+    bank_name: str(input.bank_name),
+    notes: str(input.notes),
+    is_default: Boolean(input.is_default),
+    account_enc: encryptSecret(account),
+    routing_enc: routing ? encryptSecret(routing) : null,
+    hint: maskAccount(account),
+    updated_at: new Date().toISOString(),
+  };
+
+  const existing = uid(detailId);
+  let id: string;
+  if (existing) {
+    const { error } = await tbl(supabase, "customer_payment_details")
+      .update(row).eq("id", existing).eq("business_id", businessId);
+    if (error) return { ok: false, error: error.message };
+    id = existing;
+  } else {
+    row.created_by = user.id;
+    const { data, error } = await tbl(supabase, "customer_payment_details")
+      .insert(row).select("id").single();
+    if (error) return { ok: false, error: error.message };
+    id = data.id;
+  }
+
+  // One default per customer, enforced here rather than by a partial unique
+  // index: flipping a new row to default should demote the old one, not fail.
+  if (row.is_default) {
+    await tbl(supabase, "customer_payment_details")
+      .update({ is_default: false })
+      .eq("business_id", businessId).eq("customer_id", cid).neq("id", id);
+  }
+
+  await log(supabase, businessId, {
+    detail_id: id, detail_label: row.label, customer_id: cid,
+    user_id: user.id, user_email: user.email ?? null,
+    action: existing ? "update" : "create",
+  });
+
+  revalidatePath(`/customers/${cid}`);
+  return { ok: true, data: { id } };
+}
+
+/**
+ * The plaintext, for keying into a bank portal. Owner/admin only, logged.
+ *
+ * This is the one call that returns a real account number, which is why it is
+ * separate from the list rather than a flag on it.
+ */
+export async function revealPaymentDetail(
+  detailId: string,
+): Promise<PaymentResult<{ account: string | null; routing: string | null }>> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!canUse(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can reveal payment details" };
+  }
+  const id = uid(detailId);
+  if (!id) return { ok: false, error: "Not found" };
+
+  const { data, error } = await tbl(supabase, "customer_payment_details")
+    .select("id, label, customer_id, account_enc, routing_enc")
+    .eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: "Not found" };
+
+  let account: string | null = null;
+  let routing: string | null = null;
+  try {
+    if (data.account_enc) account = decryptSecret(data.account_enc);
+    if (data.routing_enc) routing = decryptSecret(data.routing_enc);
+  } catch {
+    return {
+      ok: false,
+      error: "This couldn't be decrypted. It was saved with a different APP_ENCRYPTION_KEY than the server is using now.",
+    };
+  }
+
+  await log(supabase, businessId, {
+    detail_id: id, detail_label: data.label, customer_id: data.customer_id,
+    user_id: user.id, user_email: user.email ?? null, action: "reveal",
+  });
+  return { ok: true, data: { account, routing } };
+}
+
+export async function deletePaymentDetail(detailId: string): Promise<PaymentResult> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  if (!canUse(await callerRole(supabase, user.id, businessId))) {
+    return { ok: false, error: "Only the owner or an admin can delete payment details" };
+  }
+  const id = uid(detailId);
+  if (!id) return { ok: false, error: "Not found" };
+
+  const { data: row } = await tbl(supabase, "customer_payment_details")
+    .select("label, customer_id").eq("id", id).eq("business_id", businessId).maybeSingle();
+
+  const { error } = await tbl(supabase, "customer_payment_details")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) return { ok: false, error: error.message };
+
+  await log(supabase, businessId, {
+    detail_id: null, detail_label: row?.label ?? null, customer_id: row?.customer_id ?? null,
+    user_id: user.id, user_email: user.email ?? null, action: "delete",
+  });
+  if (row?.customer_id) revalidatePath(`/customers/${row.customer_id}`);
+  return { ok: true };
+}
+
+/** Who looked at what. Owner/admin only, like everything else here. */
+export async function getPaymentDetailLog(limit = 100): Promise<PaymentLogEntry[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  if (!canUse(await callerRole(supabase, user.id, businessId))) return [];
+
+  const { data } = await tbl(supabase, "payment_detail_access_log")
+    .select("id, detail_label, user_email, action, created_at")
+    .eq("business_id", businessId)
+    .order("created_at", { ascending: false }).limit(limit);
+  return (data ?? []) as PaymentLogEntry[];
+}
+
+/** Whether the server can encrypt — the UI disables saving without it. */
+export async function paymentDetailsReady(): Promise<boolean> {
+  return encryptionAvailable();
+}

--- a/src/lib/assistant/scopes.ts
+++ b/src/lib/assistant/scopes.ts
@@ -26,16 +26,19 @@ import type { Role } from "@/lib/permissions";
  *
  * READ_SCOPES/WRITE_SCOPES are derived from ALL_API_SCOPES, so adding a scope
  * to that list silently grants it to editors and viewers. For an ordinary
- * entity that's the intent. For the password vault it is not: those tables are
- * owner/admin-only in the database precisely because the entries are other
- * people's account credentials, and the assistant runs on the admin client
- * that bypasses exactly that check.
+ * entity that's the intent. For the password vault and stored payment details
+ * it is not: those tables are owner/admin-only in the database precisely
+ * because the entries are other people's credentials and bank accounts, and
+ * the assistant runs on the admin client that bypasses exactly that check.
  *
- * (No tool ever returns a decrypted password — reveal is a cookie-authed
- * server action only. This keeps even the entry list away from roles that
- * can't see it in the UI.)
+ * (No tool ever returns a decrypted password or account number — reveal is a
+ * cookie-authed server action only. This keeps even the masked list away from
+ * roles that can't see it in the UI.)
  */
-const NEVER_AUTO_GRANTED: readonly string[] = ["vault:read", "vault:write"];
+const NEVER_AUTO_GRANTED: readonly string[] = [
+  "vault:read", "vault:write",
+  "payment_details:read", "payment_details:write",
+];
 
 const EVERY_SCOPE = ALL_API_SCOPES.map((s) => s.value)
   .filter((s) => s !== "admin" && !NEVER_AUTO_GRANTED.includes(s));

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -42,6 +42,7 @@ import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
 import { registerProspectTools } from "./tools/prospects-tools";
 import { registerVaultTools } from "./tools/vault-tools";
+import { registerPaymentDetailTools } from "./tools/payment-detail-tools";
 import { registerOutreachTools } from "./tools/outreach-tools";
 import { registerTelephonyTools } from "./tools/telephony-tools";
 import { registerAssistantTools } from "./tools/assistant-tools";
@@ -1831,6 +1832,7 @@ export function registerTools(register: ToolFn): void {
   // ===== PROSPECTS =====
   registerProspectTools(tool);
   registerVaultTools(tool);
+  registerPaymentDetailTools(tool);
   registerOutreachTools(tool);
   registerTelephonyTools(tool);
 

--- a/src/lib/mcp/tools/payment-detail-tools.ts
+++ b/src/lib/mcp/tools/payment-detail-tools.ts
@@ -1,0 +1,121 @@
+/**
+ * MCP tools for payment details held on file.
+ *
+ * ⚠️ **There is deliberately no `reveal` tool, and there never should be.**
+ *
+ * Same exception, same reasoning, as the password vault: revealing a stored
+ * account number would put it into a model context, a conversation transcript
+ * and an `assistant_messages` row — outside the encryption and the audit log
+ * that justify storing it at all. Reading one is a deliberate human act at a
+ * screen; `revealPaymentDetail` (a cookie-authed server action, owner/admin
+ * only, logged) is the only path.
+ *
+ * What these give you is the daily question — "do we have bank details for
+ * Acme?" — answerable by chat, with the number itself never leaving the
+ * database.
+ *
+ * Writing IS allowed: recording details someone reads to you is useful and
+ * one-directional. The value goes in encrypted and cannot come back out here.
+ *
+ * 🔴 No card numbers. `validatePaymentDetail` Luhn-checks what's passed and
+ * rejects a PAN, and the DB CHECK permits no card kind — so this route is no
+ * softer than the form.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { encryptSecret, encryptionAvailable } from "@/lib/crypto";
+import {
+  validatePaymentDetail, maskAccount, kindDef, PAYMENT_KINDS,
+} from "@/lib/payments/details";
+
+const KIND = z.enum(["bank_au", "bank_intl", "payid", "bpay", "other"]);
+
+export function registerPaymentDetailTools(tool: ToolFn): void {
+  tool("list_payment_details",
+    "Payment details held on file for a customer — MASKED. Shows which accounts exist and their last four digits; the full number is never returned here.",
+    { customer_id: UUID.optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "payment_details:read");
+      let q = t(ctx, "customer_payment_details")
+        .select("id, customer_id, kind, label, holder_name, bank_name, hint, notes, is_default, created_at, customers(name)")
+        .eq("business_id", ctx.businessId)
+        .order("created_at", { ascending: false }).limit(200);
+      if (args.customer_id) q = q.eq("customer_id", args.customer_id);
+      const { data, error } = await q;
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("list_payment_detail_kinds",
+    "The kinds of payment detail that can be stored, and what each one's fields mean. Card numbers are not among them and cannot be stored.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "payment_details:read");
+      return text(PAYMENT_KINDS);
+    });
+
+  tool("create_payment_detail",
+    "Store bank/transfer details for a customer, for manual payment. Encrypted at rest. NEVER pass a card number — it will be rejected.",
+    {
+      customer_id: UUID,
+      kind: KIND.optional(),
+      account: z.string().describe("Account number, IBAN, PayID or reference"),
+      routing: z.string().optional().describe("BSB, sort code, SWIFT or biller code"),
+      label: z.string().optional(),
+      holder_name: z.string().optional(),
+      bank_name: z.string().optional(),
+      notes: z.string().optional(),
+      is_default: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "payment_details:write");
+      if (!encryptionAvailable()) {
+        return errorText("APP_ENCRYPTION_KEY isn't set on this server, so payment details can't be stored safely.");
+      }
+      const problem = validatePaymentDetail(args);
+      if (problem) return errorText(problem);
+
+      const kind = args.kind ?? "bank_au";
+      const account = args.account.trim();
+      const routing = (args.routing ?? "").trim();
+
+      const { data, error } = await t(ctx, "customer_payment_details").insert({
+        business_id: ctx.businessId,
+        customer_id: args.customer_id,
+        kind,
+        label: args.label?.trim() || kindDef(kind).label,
+        holder_name: args.holder_name?.trim() || null,
+        bank_name: args.bank_name?.trim() || null,
+        notes: args.notes?.trim() || null,
+        is_default: args.is_default ?? false,
+        account_enc: encryptSecret(account),
+        routing_enc: routing ? encryptSecret(routing) : null,
+        hint: maskAccount(account),
+        created_by: ctx.userId ?? null,
+      }).select("id, kind, label, hint").single();
+      if (error) throw error;
+
+      await t(ctx, "payment_detail_access_log").insert({
+        business_id: ctx.businessId, detail_id: data.id, detail_label: data.label,
+        customer_id: args.customer_id, user_id: ctx.userId ?? null, action: "create (mcp)",
+      });
+      return text(data);
+    });
+
+  tool("delete_payment_detail", "Remove a stored payment detail.",
+    { id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "payment_details:write");
+      const { data: row } = await t(ctx, "customer_payment_details")
+        .select("label, customer_id").eq("id", args.id).eq("business_id", ctx.businessId).maybeSingle();
+      const { error } = await t(ctx, "customer_payment_details")
+        .delete().eq("id", args.id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      await t(ctx, "payment_detail_access_log").insert({
+        business_id: ctx.businessId, detail_id: null, detail_label: row?.label ?? null,
+        customer_id: row?.customer_id ?? null, user_id: ctx.userId ?? null, action: "delete (mcp)",
+      });
+      return text({ deleted: true });
+    });
+}

--- a/src/lib/payments/details.test.ts
+++ b/src/lib/payments/details.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  maskAccount, looksLikeCardNumber, validatePaymentDetail, PAYMENT_KINDS, kindDef,
+} from "./details";
+
+describe("no cards, ever", () => {
+  it("rejects a card number typed into the account field", () => {
+    // The obvious mistake: it's the only box on screen, so someone types the
+    // card into it. These are the standard published test PANs.
+    for (const pan of ["4242424242424242", "5555555555554444", "378282246310005", "4111 1111 1111 1111"]) {
+      expect(looksLikeCardNumber(pan), pan).toBe(true);
+      const problem = validatePaymentDetail({ kind: "bank_au", account: pan, routing: "062000" });
+      expect(problem, pan).toMatch(/card number/i);
+    }
+  });
+
+  it("does not mistake a bank account number for a card", () => {
+    // A false positive costs someone a retype for no reason, so the guard has
+    // to leave ordinary account numbers alone. AU accounts are 6-10 digits.
+    for (const acct of ["12345678", "123456789", "1234567890", "00123456"]) {
+      expect(looksLikeCardNumber(acct), acct).toBe(false);
+    }
+  });
+
+  it("rejects a card number in the routing field too", () => {
+    const problem = validatePaymentDetail({
+      kind: "bank_au", account: "12345678", routing: "4242424242424242",
+    });
+    expect(problem).toMatch(/card number/i);
+  });
+
+  it("refuses card details smuggled into notes", () => {
+    // There is no CVV field, so the improvisation is the notes box.
+    for (const note of ["cvv 123", "CVC is 456", "card number on file", "security code 999"]) {
+      const problem = validatePaymentDetail({
+        kind: "bank_au", account: "12345678", routing: "062000", notes: note,
+      });
+      expect(problem, note).toMatch(/can't be stored/i);
+    }
+  });
+
+  it("offers no card kind at all", () => {
+    // The DB CHECK is the real enforcement; this is the UI's half.
+    const values = PAYMENT_KINDS.map((k) => k.value);
+    expect(values).not.toContain("card");
+    expect(values.some((v) => /card/i.test(v))).toBe(false);
+  });
+});
+
+describe("masking", () => {
+  it("shows the last four and nothing more", () => {
+    expect(maskAccount("123456789")).toBe("•••• 6789");
+    expect(maskAccount("1234 5678")).toBe("•••• 5678");
+  });
+
+  it("reveals nothing at all for a short value", () => {
+    // Masking that shows five of six digits is not masking.
+    expect(maskAccount("1234")).toBe("••••");
+    expect(maskAccount("12")).toBe("••");
+    expect(maskAccount("")).toBe("");
+  });
+});
+
+describe("validation", () => {
+  it("requires an account value", () => {
+    expect(validatePaymentDetail({ kind: "bank_au", account: "" })).toMatch(/account number/i);
+  });
+
+  it("requires the routing value when the kind has one", () => {
+    expect(validatePaymentDetail({ kind: "bank_au", account: "12345678" })).toMatch(/bsb/i);
+    // PayID has no routing value, so it must not be demanded.
+    expect(validatePaymentDetail({ kind: "payid", account: "sam@example.com" })).toBeNull();
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(validatePaymentDetail({ kind: "card", account: "12345678" })).toMatch(/valid type/i);
+  });
+
+  it("falls back to a real kind rather than throwing", () => {
+    expect(kindDef("nonsense").value).toBe("other");
+  });
+});

--- a/src/lib/payments/details.ts
+++ b/src/lib/payments/details.ts
@@ -1,0 +1,137 @@
+/**
+ * Payment details held on file, for paying a client by hand.
+ *
+ * Plain module — no "use server" — so the form, the server actions and the
+ * tests all share one definition of what a kind is and how a number is masked.
+ *
+ * 🔴 There is no card kind, and there must never be one. A stored card number
+ * puts this database, its backups and its logs inside PCI-DSS audit scope, and
+ * a stored CVV is prohibited outright at every compliance level. The database
+ * CHECK is the real enforcement; this list is what the UI offers.
+ */
+
+export type PaymentDetailKind = "bank_au" | "bank_intl" | "payid" | "bpay" | "other";
+
+export interface PaymentKindDef {
+  value: PaymentDetailKind;
+  label: string;
+  /** What the encrypted `account` field holds for this kind. */
+  accountLabel: string;
+  /** What `routing` holds, or null when the kind has no routing value. */
+  routingLabel: string | null;
+  /** Shown under the fields — what someone is expected to type. */
+  hintText: string;
+}
+
+export const PAYMENT_KINDS: PaymentKindDef[] = [
+  {
+    value: "bank_au", label: "Australian bank account",
+    accountLabel: "Account number", routingLabel: "BSB",
+    hintText: "Six-digit BSB and the account number.",
+  },
+  {
+    value: "bank_intl", label: "International bank account",
+    accountLabel: "IBAN / account number", routingLabel: "SWIFT / BIC",
+    hintText: "IBAN where the country uses one, otherwise the account number and SWIFT.",
+  },
+  {
+    value: "payid", label: "PayID",
+    accountLabel: "PayID (email, phone or ABN)", routingLabel: null,
+    hintText: "The identifier the client's PayID is registered against.",
+  },
+  {
+    value: "bpay", label: "BPAY",
+    accountLabel: "Reference number", routingLabel: "Biller code",
+    hintText: "Biller code and the customer reference from their bill.",
+  },
+  {
+    value: "other", label: "Other",
+    accountLabel: "Reference", routingLabel: "Institution / code",
+    hintText: "Anything that doesn't fit the above. Never a card number.",
+  },
+];
+
+export const PAYMENT_KIND_LABELS: Record<PaymentDetailKind, string> =
+  Object.fromEntries(PAYMENT_KINDS.map((k) => [k.value, k.label])) as Record<PaymentDetailKind, string>;
+
+export function kindDef(kind: string): PaymentKindDef {
+  return PAYMENT_KINDS.find((k) => k.value === kind) ?? PAYMENT_KINDS[PAYMENT_KINDS.length - 1];
+}
+
+/**
+ * The masked value stored in plaintext so a list can be rendered without
+ * decrypting anything.
+ *
+ * Last four for anything long enough to have four to spare; for a short value
+ * we show nothing rather than most of it — masking that reveals five of six
+ * digits is not masking.
+ */
+export function maskAccount(value: string): string {
+  const clean = value.replace(/\s+/g, "");
+  if (clean.length === 0) return "";
+  if (clean.length <= 4) return "•".repeat(clean.length);
+  return `•••• ${clean.slice(-4)}`;
+}
+
+/**
+ * Does this look like a payment card rather than a bank account?
+ *
+ * A guard against the obvious mistake — someone typing a card number into the
+ * account field because it's the only box on screen. 13-19 digits that pass
+ * the Luhn check is the standard test for a PAN.
+ *
+ * Deliberately conservative: bank account numbers are typically 6-10 digits
+ * and won't reach 13, so a false positive here is rare and the cost of one
+ * (retyping into the right place) is far below the cost of a miss.
+ */
+export function looksLikeCardNumber(value: string): boolean {
+  const digits = value.replace(/[\s-]/g, "");
+  if (!/^\d{13,19}$/.test(digits)) return false;
+
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = Number(digits[i]);
+    if (double) { d *= 2; if (d > 9) d -= 9; }
+    sum += d;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+export interface PaymentDetailInput {
+  kind?: string;
+  label?: string | null;
+  holder_name?: string | null;
+  bank_name?: string | null;
+  account?: string | null;
+  routing?: string | null;
+  notes?: string | null;
+  is_default?: boolean;
+}
+
+/** What's wrong with this entry, or null when it's fine. */
+export function validatePaymentDetail(input: PaymentDetailInput): string | null {
+  const account = (input.account ?? "").trim();
+  if (!account) return "Enter the account number or reference.";
+
+  if (looksLikeCardNumber(account)) {
+    return "That looks like a card number. Card numbers can't be stored here — "
+      + "use the client's bank account details instead.";
+  }
+  if (input.routing && looksLikeCardNumber(input.routing)) {
+    return "That looks like a card number. Card numbers can't be stored here.";
+  }
+  // A CVV has nowhere to go in this shape, but people improvise with notes.
+  if (/\b(cvv|cvc|security code|card number)\b/i.test(input.notes ?? "")) {
+    return "Card details — including the CVV — can't be stored, even in notes.";
+  }
+
+  const kind = input.kind ?? "bank_au";
+  if (!PAYMENT_KINDS.some((k) => k.value === kind)) return "Pick a valid type.";
+
+  if (kindDef(kind).routingLabel && !(input.routing ?? "").trim()) {
+    return `Enter the ${kindDef(kind).routingLabel!.toLowerCase()}.`;
+  }
+  return null;
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1635,6 +1635,8 @@ export interface WebhookDelivery {
 export type ApiScope =
   | 'vault:read'
   | 'vault:write'
+  | 'payment_details:read'
+  | 'payment_details:write'
   | 'leads:read'
   | 'leads:write'
   | 'customers:read'
@@ -1707,6 +1709,8 @@ export const ALL_API_SCOPES: { value: ApiScope; label: string; group: string }[]
   { value: 'materials:write',  label: 'Create / edit materials', group: 'Materials' },
   { value: 'vault:read',       label: 'List vault entries (never the passwords)', group: 'Vault' },
   { value: 'vault:write',      label: 'Create / edit vault entries', group: 'Vault' },
+  { value: 'payment_details:read',  label: 'List stored payment details (masked only, never the number)', group: 'Payment details' },
+  { value: 'payment_details:write', label: 'Store / delete payment details', group: 'Payment details' },
   { value: 'settings:read',    label: 'Read settings',     group: 'Settings' },
   { value: 'settings:write',   label: 'Edit settings & preferences', group: 'Settings' },
   { value: 'bookings:read',    label: 'Read bookings & config', group: 'Bookings' },

--- a/supabase/migrations/20260810200000_customer_payment_details.sql
+++ b/supabase/migrations/20260810200000_customer_payment_details.sql
@@ -1,0 +1,131 @@
+-- Payment details held on file for a customer, for MANUAL processing.
+--
+-- The business's Stripe account was closed, so there is no processor to
+-- tokenise against. What they need is the boring thing: the bank details
+-- written down once, safely, so someone can key the payment into their bank
+-- portal instead of asking the client for them again every month.
+--
+-- 🔴 DELIBERATELY NOT CARDS. There is no kind for a card number and there
+-- must never be one. Storing a PAN drags this database, its backups and its
+-- logs into PCI-DSS audit scope; storing a CVV after authorisation is
+-- prohibited outright at every compliance level. The CHECK below is the
+-- enforcement, not a comment — a card kind cannot be inserted without a
+-- migration that someone has to justify.
+--
+-- Modelled on vault_items (20260808 vault migration): same AES-256-GCM via
+-- lib/crypto.ts, same owner/admin-only reveal, same access log. A payment
+-- detail is a secret with an audit trail, which is exactly what the vault
+-- already solved.
+
+CREATE TABLE IF NOT EXISTS public.customer_payment_details (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  -- CASCADE: deleting a client must not leave their bank details behind with
+  -- nothing to say whose they were.
+  customer_id   UUID NOT NULL REFERENCES public.customers(id) ON DELETE CASCADE,
+
+  -- Constrained, unlike vault_items.category. The whole safety property of
+  -- this table is which kinds of number may live in it.
+  kind          TEXT NOT NULL DEFAULT 'bank_au',
+  CONSTRAINT customer_payment_details_kind_check
+    CHECK (kind IN ('bank_au', 'bank_intl', 'payid', 'bpay', 'other')),
+
+  label         TEXT,
+  holder_name   TEXT,
+  bank_name     TEXT,
+
+  -- The sensitive parts. Account number / IBAN / PayID / BPAY reference, and
+  -- the routing value (BSB, sort code, SWIFT). Encrypted rather than stored
+  -- plainly for the same reason the vault encrypts a password: a database
+  -- dump should not be a list of everyone's bank accounts.
+  account_enc   TEXT,
+  routing_enc   TEXT,
+
+  -- Masked, plaintext, safe to render in a list: "•••• 4321". Lets the UI
+  -- show which account is which without decrypting anything.
+  hint          TEXT,
+
+  -- Non-secret free text: "use reference INV number", "pays on the 1st".
+  notes         TEXT,
+
+  is_default    BOOLEAN NOT NULL DEFAULT FALSE,
+  created_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.customer_payment_details IS
+  'Bank/transfer details held for manual processing. NEVER card numbers or CVV — see the kind CHECK.';
+COMMENT ON COLUMN public.customer_payment_details.account_enc IS
+  'AES-256-GCM ciphertext (lib/crypto.ts). NEVER store or return plaintext.';
+COMMENT ON COLUMN public.customer_payment_details.routing_enc IS
+  'AES-256-GCM ciphertext. BSB / sort code / SWIFT.';
+COMMENT ON COLUMN public.customer_payment_details.hint IS
+  'Masked display value only, e.g. "•••• 4321". Safe to render without decrypting.';
+
+CREATE INDEX IF NOT EXISTS idx_customer_payment_details_business
+  ON public.customer_payment_details (business_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_customer_payment_details_customer
+  ON public.customer_payment_details (business_id, customer_id);
+
+-- Who looked at what, and when.
+--
+-- Same reasoning as vault_access_log: the justification for holding these
+-- centrally is being able to answer "who saw this account number". Reveals
+-- are logged; the plaintext never is.
+CREATE TABLE IF NOT EXISTS public.payment_detail_access_log (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  -- SET NULL + a label snapshot, so the trail outlives the row it describes.
+  detail_id   UUID REFERENCES public.customer_payment_details(id) ON DELETE SET NULL,
+  detail_label TEXT,
+  customer_id UUID REFERENCES public.customers(id) ON DELETE SET NULL,
+  user_id     UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  user_email  TEXT,
+  action      TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_detail_log_business
+  ON public.payment_detail_access_log (business_id, created_at DESC);
+
+ALTER TABLE public.customer_payment_details ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payment_detail_access_log ENABLE ROW LEVEL SECURITY;
+
+-- Owner/admin only, both tables — narrower than the usual member read.
+-- Bank details are not something an editor or viewer needs, and workers are
+-- excluded from customers entirely.
+DROP POLICY IF EXISTS customer_payment_details_rw ON public.customer_payment_details;
+CREATE POLICY customer_payment_details_rw ON public.customer_payment_details FOR ALL USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+  )
+) WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+  )
+);
+
+DROP POLICY IF EXISTS payment_detail_access_log_read ON public.payment_detail_access_log;
+CREATE POLICY payment_detail_access_log_read ON public.payment_detail_access_log FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+  )
+);
+
+-- Append-only from the app's perspective: entries are written by the
+-- server action, and nobody gets to edit or delete the trail.
+DROP POLICY IF EXISTS payment_detail_access_log_insert ON public.payment_detail_access_log;
+CREATE POLICY payment_detail_access_log_insert ON public.payment_detail_access_log FOR INSERT WITH CHECK (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status='active' AND role = 'admin'
+  )
+);


### PR DESCRIPTION
Stripe closed the account, so there's no processor to tokenise against. The answer to *"what do you need to do with the stored details"* was **record it for manual processing** — so this stores bank details safely and moves no money.

## 🔴 No cards, enforced three ways

There is no card kind and there must never be one. A stored PAN drags this database, its backups and its logs into PCI-DSS audit scope; a stored CVV is prohibited outright at every compliance level.

| Layer | What it does |
|---|---|
| DB `CHECK` | permits only `bank_au`, `bank_intl`, `payid`, `bpay`, `other` |
| `validatePaymentDetail` | Luhn-checks input, rejects a PAN in the account *or* routing field |
| notes screening | blocks "cvv", "cvc", "security code", "card number" — with no CVV field, the notes box is the improvisation |

Verified against the live database: `INSERT ... kind='card'` is refused and leaves no row. Tests cover four real published test PANs being rejected and ordinary 6–10 digit account numbers being left alone (a false positive here costs a pointless retype, so the guard has to be precise in both directions).

## Modelled on the password vault

That already solved this exact shape, so the discipline is copied rather than reinvented:

- AES-256-GCM via `lib/crypto.ts`; **ciphertext never leaves the server** — the list returns a masked hint and `has_account: boolean`
- **Plaintext only on an explicit reveal**, owner/admin, which writes an audit entry
- Revealed values **clear after a minute** — leaving an account number on a shared screen is the failure mode this invites
- **No key, no save**: without `APP_ENCRYPTION_KEY` it refuses rather than writing bank details in the clear

## MCP

`list_payment_details` (masked), `list_payment_detail_kinds`, `create_payment_detail`, `delete_payment_detail` — and **no reveal**, the same standing exception as `revealVaultSecret`.

The new `payment_details:*` scopes are added to `NEVER_AUTO_GRANTED` in `assistant/scopes.ts`. That file's own comment warns that adding a scope silently grants it to editors and viewers via the blanket expansion — which would have handed them a table the database restricts to owner/admin.

## Where it is

A **Payment details** tab on the customer page, next to Passwords. Owner/admin only — the tab doesn't render for anyone else, rather than showing an empty one that implies nothing is stored.

## Verified

`tsc`, 349 tests, `npm run build`. Migration `20260810200000` applied and recorded; both tables, all three RLS policies and the kind CHECK confirmed present on the live database.

## Not verified

The rendered tab — no signed-in dev session.

## Note on scope

If you later want to *charge* rather than record, that needs a processor that will onboard you, and the honest options after a Stripe closure are direct debit (GoCardless-style) or a high-risk-friendly gateway. Worth a separate conversation — the storage here is compatible with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)