### PR TITLE
feat(leads): give a lead the customer end of their hub

### DIFF
--- a/src/components/leads/lead-detail-client.tsx
+++ b/src/components/leads/lead-detail-client.tsx
@@ -20,6 +20,7 @@ import {
 import type { GradientName } from "@/components/ui/kirei";
 import { LeadOnboardingCard, type LeadOnboardingData } from "@/components/leads/lead-onboarding-card";
 import { LeadBillingCard } from "@/components/leads/lead-billing-card";
+import { LeadPortalCard } from "@/components/leads/lead-portal-card";
 import type { LeadDocuments } from "@/lib/actions/lead-billing";
 import type { Lead, LeadStatus } from "@/types/database";
 
@@ -230,6 +231,10 @@ export function LeadDetailClient({ lead: initial, onboarding, billing, currency 
         </FadeIn>
       )}
 
+      {/* The hub: everything raised against this lead, and the page they see.
+          Grouped rather than tabbed — a lead has a fraction of a customer's
+          history, and three short cards read faster than three tabs you have
+          to click through to discover are nearly empty. */}
       {billing && (
         <section className="space-y-3">
           <h2 className="text-base font-semibold">Quotes &amp; invoices</h2>
@@ -238,6 +243,8 @@ export function LeadDetailClient({ lead: initial, onboarding, billing, currency 
       )}
 
       {onboarding && <LeadOnboardingCard leadId={lead.id} data={onboarding} />}
+
+      <LeadPortalCard leadId={lead.id} />
 
       {/* Convert actions */}
       <FadeIn delay={260}>

--- a/src/components/leads/lead-portal-card.tsx
+++ b/src/components/leads/lead-portal-card.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * The lead's own view — the customer end of their hub.
+ *
+ * Nothing here is new machinery. `/portal/<token>` already renders quotes,
+ * invoices, work orders, reports and appointments off a contact row; a lead
+ * that has been quoted already HAS that contact. What was missing was a way to
+ * reach it, so this mints the link on demand.
+ *
+ * Deliberately on demand rather than eagerly: minting a portal token creates a
+ * live, unauthenticated URL to someone's documents. That should happen when
+ * you decide to share it, not because a page was loaded.
+ */
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { ExternalLink, Copy, Check, Loader2, Globe } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { GradientTile, FadeIn } from "@/components/ui/kirei";
+import { getLeadPortalLink } from "@/lib/actions/lead-billing";
+
+export function LeadPortalCard({ leadId, delay = 250 }: { leadId: string; delay?: number }) {
+  const [pending, startTransition] = useTransition();
+  const [url, setUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function make() {
+    startTransition(async () => {
+      const res = await getLeadPortalLink(leadId);
+      if (!res.ok) { toast.error(res.error); return; }
+      setUrl(res.url);
+    });
+  }
+
+  return (
+    <FadeIn delay={delay}>
+      <div className="rounded-xl border border-border bg-card p-5">
+        <div className="mb-3 flex items-center gap-2.5">
+          <GradientTile gradient="ocean" size={28} radius={8}>
+            <Globe className="h-3.5 w-3.5" />
+          </GradientTile>
+          <p className="text-sm font-semibold">Their view</p>
+        </div>
+
+        {url ? (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-2">
+              <code className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{url}</code>
+              <Button
+                size="sm" variant="ghost" className="h-7 shrink-0 text-xs"
+                onClick={async () => {
+                  await navigator.clipboard.writeText(url);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 1500);
+                }}
+              >
+                {copied ? <Check className="mr-1 h-3 w-3" /> : <Copy className="mr-1 h-3 w-3" />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+              <Button size="sm" variant="outline" className="h-7 shrink-0 text-xs" asChild>
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="mr-1 h-3 w-3" /> Open
+                </a>
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Their quotes, invoices, jobs and reports, in one page. Anyone with this link can
+              open it &mdash; send it to them, not to a group chat.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Give this lead a single page showing everything you&rsquo;ve sent them &mdash;
+              quotes, invoices, jobs and reports. They stay a lead; only a payment makes a client.
+            </p>
+            <Button size="sm" variant="outline" onClick={make} disabled={pending}>
+              {pending ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                       : <Globe className="mr-1.5 h-3.5 w-3.5" />}
+              Create their link
+            </Button>
+          </div>
+        )}
+      </div>
+    </FadeIn>
+  );
+}

--- a/src/lib/actions/lead-billing.ts
+++ b/src/lib/actions/lead-billing.ts
@@ -90,3 +90,33 @@ export async function getLeadDocuments(leadId: string): Promise<LeadDocuments> {
     isClient: contact?.lifecycle_stage === "client",
   };
 }
+
+/**
+ * A portal link for a lead — the customer end of their hub.
+ *
+ * The portal is keyed on a contact, so this mints the lead's contact row the
+ * same way quoting them does, then reuses the existing portal token. Once they
+ * have one, /portal/<token> already shows their quotes, invoices, work orders
+ * and reports: none of that needed building, it needed reaching.
+ *
+ * **They stay a lead.** ensureContactForLead creates the contact at stage
+ * 'lead'; only a payment promotes anyone.
+ */
+export async function getLeadPortalLink(
+  leadId: string,
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  try {
+    const { customerId } = await ensureContactForLead(supabase, businessId, leadId);
+    const { mintPortalTokenFor } = await import("@/lib/onboarding/send");
+    const token = await mintPortalTokenFor(supabase, businessId, customerId, user.id);
+    const { appUrl } = await import("@/lib/app-url");
+    revalidatePath(`/leads/${leadId}`);
+    return { ok: true, url: `${appUrl()}/portal/${token}` };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Could not create a portal link" };
+  }
+}


### PR DESCRIPTION
## Most of this already existed — it just wasn't reachable

Our end was largely there: the lead page already shows quotes, invoices and forms, and #482 added sending them one. The gap was the lead's **own** view — the page a customer gets and a lead didn't.

And `/portal/<token>` already renders quotes, invoices, work orders, reports and appointments off a contact row. A lead that's been quoted **already has that contact** (`leads.customer_id`, written by `ensureContactForLead`). The portal wasn't absent for leads; it was unreachable.

So this mints the link and surfaces it, reusing `ensureContactForLead` + `mintPortalTokenFor` rather than adding a second token system.

## Two decisions worth reviewing

**On demand, not eagerly.** Minting a portal token creates a live, *unauthenticated* URL to somebody's documents. That should happen when you decide to share it, not because a page was rendered. The card says so next to the link.

**They stay a lead.** The contact is created at stage `lead`; only a payment promotes anyone — the rule you set, unchanged.

## What I did NOT do

**I left the lead page as grouped cards rather than converting it to tabs like the customer hub.** A lead has a fraction of a customer's history — no properties, no work-order archive, usually one quote — and three short cards read faster than three tabs you have to click through to discover are nearly empty.

If you'd rather have literal tab parity with `/customers/[id]`, say so and I'll convert it; I just didn't think the click cost was worth paying on a page with this much less on it.

## Verified

`tsc`, 338 tests, `npm run build`.

## Not verified

The rendered card and the minted link — no signed-in dev session. The portal page it points at is long-standing and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)