### PR TITLE
feat(prospects): an agent that goes and finds them

### DIFF
--- a/src/app/(dashboard)/prospects/hunts/[id]/page.tsx
+++ b/src/app/(dashboard)/prospects/hunts/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from "next/navigation";
+import { getHunt, listHuntRuns, listCandidates } from "@/lib/actions/prospecting";
+import { HuntDetail } from "@/components/prospects/hunt-detail";
+
+export default async function HuntPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const hunt = await getHunt(id);
+  if (!hunt) notFound();
+
+  const [runs, candidates] = await Promise.all([
+    listHuntRuns(id),
+    listCandidates({ hunt_id: id, status: "verified" }),
+  ]);
+
+  return <HuntDetail hunt={hunt} runs={runs} candidates={candidates} />;
+}

--- a/src/app/(dashboard)/prospects/hunts/page.tsx
+++ b/src/app/(dashboard)/prospects/hunts/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { listHunts } from "@/lib/actions/prospecting";
+import { HuntsView } from "@/components/prospects/hunts-view";
+
+export default async function HuntsPage() {
+  const supabase = await createClient();
+  let businessId: string;
+  try {
+    const user = await getUser();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    businessId = await getActiveBizId(supabase as any, user.id);
+  } catch {
+    redirect("/auth/login");
+  }
+
+  const [hunts, review, settings] = await Promise.all([
+    listHunts(),
+    supabase.from("prospect_candidates")
+      .select("id", { count: "exact", head: true })
+      .eq("business_id", businessId).eq("status", "verified"),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (supabase as any).from("outreach_settings")
+      .select("places_api_key_enc").eq("business_id", businessId).maybeSingle(),
+  ]);
+
+  return (
+    <HuntsView
+      hunts={hunts}
+      pendingReview={review.count ?? 0}
+      hasPlacesKey={Boolean(settings.data?.places_api_key_enc)}
+    />
+  );
+}

--- a/src/app/(dashboard)/prospects/review/page.tsx
+++ b/src/app/(dashboard)/prospects/review/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "@/components/ui/icons";
+import { CandidateQueue } from "@/components/prospects/candidate-queue";
+import { listCandidates, listHunts } from "@/lib/actions/prospecting";
+
+/** Everything every hunt has verified, in one queue. */
+export default async function ReviewPage() {
+  const [candidates, hunts] = await Promise.all([
+    listCandidates({ status: "verified", limit: 300 }),
+    listHunts(),
+  ]);
+  const nameOf = new Map(hunts.map((h) => [h.id, h.name]));
+
+  return (
+    <>
+      <PageHeader
+        title="Review"
+        subtitle="Businesses your hunts found and verified. Add the good ones to your prospect list."
+        actions={
+          <Button variant="outline" asChild>
+            <Link href="/prospects/hunts"><ArrowLeft className="w-4 h-4 mr-1.5" /> Hunts</Link>
+          </Button>
+        }
+      />
+      <CandidateQueue
+        candidates={candidates}
+        emptyMessage="No hunt has anything waiting. Run one to go looking."
+        labelFor={(c) => nameOf.get(c.hunt_id) ?? null}
+      />
+    </>
+  );
+}

--- a/src/components/prospects/candidate-queue.tsx
+++ b/src/components/prospects/candidate-queue.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * The review queue — the one place a found business becomes a prospect.
+ *
+ * Shared by a single hunt's page and the all-hunts queue, so approving works
+ * identically in both. Every row carries the agent's reasoning: if the picks
+ * are wrong, the fix is the hunt's criteria, and you can only see that if the
+ * reasoning is on screen next to the business.
+ */
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useMutation } from "@/components/layout/use-mutation";
+import { Button } from "@/components/ui/button";
+import { Target, MapPin, Globe, Phone, Star, Check } from "@/components/ui/icons";
+import { addCandidates, dismissCandidates } from "@/lib/actions/prospecting";
+import type { ProspectCandidate } from "@/types/database";
+
+interface Props {
+  candidates: ProspectCandidate[];
+  /** Shown when the queue is empty. */
+  emptyMessage: string;
+  /** Optional per-row label, e.g. which hunt found it. */
+  labelFor?: (c: ProspectCandidate) => string | null;
+}
+
+export function CandidateQueue({ candidates, emptyMessage, labelFor }: Props) {
+  const { run, pending } = useMutation();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function handleAdd(ids: string[]) {
+    if (!ids.length) return;
+    void run(async () => {
+      const { added } = await addCandidates(ids);
+      setSelected(new Set());
+      if (!added) toast.info("Those are already in your prospect list");
+    }, { busy: "Adding to prospects…", success: "Added to prospects", error: "Couldn't add" });
+  }
+
+  function handleDismiss(ids: string[]) {
+    if (!ids.length) return;
+    void run(async () => {
+      await dismissCandidates(ids);
+      setSelected(new Set());
+    }, { busy: "Dismissing…", success: "Dismissed", error: "Couldn't dismiss" });
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <div className="ch-empty">
+        <Target className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
+        <p className="font-medium">Nothing waiting</p>
+        <p className="text-sm text-muted-foreground mt-1">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {selected.size > 0 && (
+        <div className="mb-3 flex flex-wrap items-center justify-end gap-2">
+          <Button variant="outline" size="sm" disabled={pending}
+            onClick={() => handleDismiss([...selected])}>
+            Dismiss {selected.size}
+          </Button>
+          <Button size="sm" disabled={pending} onClick={() => handleAdd([...selected])}>
+            <Check className="w-4 h-4 mr-1.5" /> Add {selected.size} to prospects
+          </Button>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {candidates.map((c) => {
+          const label = labelFor?.(c) ?? null;
+          return (
+            <div key={c.id}
+              className="flex items-start gap-3 rounded-xl border border-border bg-card p-4 shadow-sm">
+              <input
+                type="checkbox"
+                className="mt-1"
+                checked={selected.has(c.id)}
+                onChange={() => toggle(c.id)}
+                aria-label={`Select ${c.name}`}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium break-words">{c.name}</p>
+                  {c.score != null && <span className="ch-pill accepted">{c.score}% fit</span>}
+                  {c.category && <span className="text-xs text-muted-foreground">{c.category}</span>}
+                  {label && <span className="text-xs text-muted-foreground">· {label}</span>}
+                </div>
+
+                {c.reasoning && (
+                  <p className="mt-1 text-sm text-muted-foreground break-words">{c.reasoning}</p>
+                )}
+
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                  {c.address && (
+                    <span className="flex items-center gap-1">
+                      <MapPin className="w-3 h-3 shrink-0" /> {c.address}
+                    </span>
+                  )}
+                  {c.phone && (
+                    <span className="flex items-center gap-1">
+                      <Phone className="w-3 h-3 shrink-0" /> {c.phone}
+                    </span>
+                  )}
+                  <span className="flex items-center gap-1">
+                    <Globe className="w-3 h-3 shrink-0" />
+                    {c.website
+                      ? <a href={c.website} target="_blank" rel="noopener noreferrer"
+                          className="underline break-all">{c.website}</a>
+                      : "No website"}
+                  </span>
+                  {c.rating != null && (
+                    <span className="flex items-center gap-1">
+                      <Star className="w-3 h-3 shrink-0" /> {c.rating} ({c.review_count ?? 0})
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex shrink-0 gap-2">
+                <Button variant="outline" size="sm" disabled={pending}
+                  onClick={() => handleDismiss([c.id])}>Skip</Button>
+                <Button size="sm" disabled={pending} onClick={() => handleAdd([c.id])}>Add</Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/prospects/hunt-detail.tsx
+++ b/src/components/prospects/hunt-detail.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * One hunt: run it, see where the funnel lost people, work its review queue.
+ *
+ * The funnel numbers are shown because "found 60, 4 to review" is the honest
+ * story of a hunt — hiding the filtering makes a thin result look like a
+ * broken search rather than a narrow criteria string.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { useMutation } from "@/components/layout/use-mutation";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Play, MapPin, ArrowLeft, Trash2 } from "@/components/ui/icons";
+import { CandidateQueue } from "@/components/prospects/candidate-queue";
+import { runHuntNow, deleteHunt } from "@/lib/actions/prospecting";
+import type { ProspectHunt, ProspectHuntRun, ProspectCandidate } from "@/types/database";
+
+interface Props {
+  hunt: ProspectHunt;
+  runs: ProspectHuntRun[];
+  candidates: ProspectCandidate[];
+}
+
+export function HuntDetail({ hunt, runs, candidates }: Props) {
+  const { run, pending } = useMutation();
+  const [hunting, setHunting] = useState(false);
+  const last = runs[0];
+
+  function handleRun() {
+    setHunting(true);
+    void run(async () => {
+      const result = await runHuntNow(hunt.id);
+      if (result.error) throw new Error(result.error);
+      toast.success(
+        result.verified > 0
+          ? `${result.verified} to review — ${result.found} found, ${result.screened_out + result.rejected} filtered out`
+          : `Nothing matched — ${result.found} found, all filtered out`,
+      );
+    }, {
+      busy: "Hunting… searching, screening, then judging each one",
+      error: "The hunt failed",
+    }).finally(() => setHunting(false));
+  }
+
+  function handleDelete() {
+    if (!confirm(`Delete "${hunt.name}" and everything it found?`)) return;
+    void run(() => deleteHunt(hunt.id), {
+      busy: "Deleting…", success: "Hunt deleted", error: "Couldn't delete", refresh: false,
+    }).then(() => { window.location.href = "/prospects/hunts"; });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={hunt.name}
+        subtitle={hunt.criteria}
+        actions={
+          <>
+            <Button variant="outline" asChild>
+              <Link href="/prospects/hunts"><ArrowLeft className="w-4 h-4 mr-1.5" /> All hunts</Link>
+            </Button>
+            <Button variant="outline" onClick={handleDelete} disabled={pending} aria-label="Delete hunt">
+              <Trash2 className="w-4 h-4" />
+            </Button>
+            <Button onClick={handleRun} disabled={pending || hunting}>
+              {hunting ? <Spinner size="sm" className="mr-1.5" /> : <Play className="w-4 h-4 mr-1.5" />}
+              {hunting ? "Hunting…" : "Run hunt"}
+            </Button>
+          </>
+        }
+      />
+
+      <div className="mb-6 flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <MapPin className="w-4 h-4" />
+          {hunt.centre_label ?? "No area set"} · {Math.round(hunt.radius_m / 1000)}km
+        </span>
+        <span className="break-words">Searching: {hunt.queries.join(" · ")}</span>
+      </div>
+
+      {last && (
+        <div className="ch-stat-grid mb-6">
+          <div className="ch-stat"><span>Found</span><strong>{last.found}</strong></div>
+          <div className="ch-stat"><span>Filtered out</span><strong>{last.screened_out}</strong></div>
+          <div className="ch-stat"><span>Not a fit</span><strong>{last.rejected}</strong></div>
+          <div className="ch-stat"><span>To review</span><strong>{last.verified}</strong></div>
+        </div>
+      )}
+
+      {last?.error && (
+        <p className="mb-4 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+          {last.error}
+        </p>
+      )}
+
+      <h2 className="mb-3 text-lg font-semibold">
+        Review queue{" "}
+        {candidates.length > 0 && <span className="text-muted-foreground">({candidates.length})</span>}
+      </h2>
+
+      <CandidateQueue
+        candidates={candidates}
+        emptyMessage={runs.length === 0
+          ? "Run the hunt to find businesses in your area."
+          : "Everything from the last run has been dealt with. Run it again to look for new listings."}
+      />
+    </>
+  );
+}

--- a/src/components/prospects/hunts-view.tsx
+++ b/src/components/prospects/hunts-view.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+/**
+ * The hunt list — saved searches, and the form that creates one.
+ *
+ * The form is mostly one big free-text box, and that's deliberate: `criteria`
+ * is the whole feature. Everything else (terms, area, radius) narrows WHERE to
+ * look; the criteria decide WHO counts, and they're handed to the verifying
+ * agent word for word.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { useMutation } from "@/components/layout/use-mutation";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import { Target, Plus, MapPin, Search, Globe, Star } from "@/components/ui/icons";
+import { createHunt } from "@/lib/actions/prospecting";
+import type { ProspectHunt } from "@/types/database";
+
+interface Props {
+  hunts: ProspectHunt[];
+  pendingReview: number;
+  hasPlacesKey: boolean;
+}
+
+export function HuntsView({ hunts, pendingReview, hasPlacesKey }: Props) {
+  const { run, pending } = useMutation();
+  const [open, setOpen] = useState(false);
+
+  const [name, setName] = useState("");
+  const [queries, setQueries] = useState("");
+  const [criteria, setCriteria] = useState("");
+  const [area, setArea] = useState("");
+  const [radius, setRadius] = useState("25");
+  const [noWebsite, setNoWebsite] = useState(false);
+  const [requirePhone, setRequirePhone] = useState(true);
+
+  function handleCreate() {
+    const terms = queries.split(/[,\n]/).map((q) => q.trim()).filter(Boolean);
+    if (!name.trim()) { toast.error("Give the hunt a name"); return; }
+    if (!terms.length) { toast.error("Add at least one search term"); return; }
+    if (!criteria.trim()) { toast.error("Describe what makes a business a prospect"); return; }
+
+    void run(async () => {
+      await createHunt({
+        name, queries: terms, criteria, area,
+        radius_km: Number(radius) || 25,
+        filters: { no_website: noWebsite || undefined, require_phone: requirePhone || undefined },
+      });
+      setOpen(false);
+      setName(""); setQueries(""); setCriteria(""); setArea("");
+    }, { busy: "Creating hunt…", success: "Hunt created", error: "Couldn't create the hunt" });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Prospecting"
+        subtitle="Describe who you want to find. The agent searches your area, checks each business, and queues the matches for you."
+        actions={
+          <Button onClick={() => setOpen(true)} disabled={pending}>
+            <Plus className="w-4 h-4 mr-1.5" /> New hunt
+          </Button>
+        }
+      />
+
+      {!hasPlacesKey && (
+        <div className="ch-empty mb-4 border-amber-300 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+          <p className="font-medium">A Google Places API key is needed to run hunts.</p>
+          <p className="text-sm mt-1">
+            Hunts search Google directly, so the key — and its billing — stay yours.
+            Add one under <Link href="/outreach/settings" className="underline">Outreach settings</Link>.
+          </p>
+        </div>
+      )}
+
+      {pendingReview > 0 && (
+        <Link
+          href="/prospects/review"
+          className="ch-quick-action mb-4 flex items-center justify-between rounded-xl border border-border bg-card p-4 hover:bg-muted/50"
+        >
+          <span className="flex items-center gap-2 font-medium">
+            <Target className="w-4 h-4 text-primary" />
+            {pendingReview} {pendingReview === 1 ? "business is" : "businesses are"} waiting for review
+          </span>
+          <span className="text-sm text-muted-foreground">Review →</span>
+        </Link>
+      )}
+
+      {hunts.length === 0 ? (
+        <div className="ch-empty">
+          <Target className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
+          <p className="font-medium">No hunts yet</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            A hunt is a saved search: what to look for, where, and what makes a business worth your time.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {hunts.map((h) => (
+            <Link
+              key={h.id}
+              href={`/prospects/hunts/${h.id}`}
+              className="rounded-xl border border-border bg-card p-4 shadow-sm transition hover:border-primary/40"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="font-medium break-words">{h.name}</p>
+                {!h.active && <span className="ch-pill draft">Paused</span>}
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground break-words line-clamp-2">{h.criteria}</p>
+              <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Search className="w-3 h-3" /> {h.queries.length} {h.queries.length === 1 ? "term" : "terms"}
+                </span>
+                <span className="flex items-center gap-1">
+                  <MapPin className="w-3 h-3" />
+                  {h.centre_label ?? "No area set"} · {Math.round(h.radius_m / 1000)}km
+                </span>
+                {h.filters?.no_website && (
+                  <span className="flex items-center gap-1"><Globe className="w-3 h-3" /> No website</span>
+                )}
+                {h.filters?.min_rating != null && (
+                  <span className="flex items-center gap-1"><Star className="w-3 h-3" /> {h.filters.min_rating}+</span>
+                )}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>New hunt</DialogTitle>
+            <DialogDescription>
+              Search terms find businesses. The criteria decide which ones are worth your time.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="hunt-name">Name</Label>
+              <Input id="hunt-name" value={name} onChange={(e) => setName(e.target.value)}
+                placeholder="Western Sydney tradies" />
+            </div>
+
+            <div>
+              <Label htmlFor="hunt-queries">Search terms</Label>
+              <Textarea id="hunt-queries" rows={2} value={queries} onChange={(e) => setQueries(e.target.value)}
+                placeholder="plumber, electrician, roofing contractor" />
+              <p className="mt-1 text-xs text-muted-foreground">
+                One per line or comma-separated. These go to Google as-is.
+              </p>
+            </div>
+
+            <div>
+              <Label htmlFor="hunt-criteria">What makes them a prospect?</Label>
+              <Textarea id="hunt-criteria" rows={3} value={criteria} onChange={(e) => setCriteria(e.target.value)}
+                placeholder="Service-based tradies who look like owner-operators or small crews — not franchises or national chains." />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Plain English. An agent reads every listing and judges it against this.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="hunt-area">Area</Label>
+                <Input id="hunt-area" value={area} onChange={(e) => setArea(e.target.value)}
+                  placeholder="Parramatta NSW" />
+              </div>
+              <div>
+                <Label htmlFor="hunt-radius">Radius (km)</Label>
+                <Input id="hunt-radius" type="number" min={1} max={50} value={radius}
+                  onChange={(e) => setRadius(e.target.value)} />
+              </div>
+            </div>
+
+            <div className="space-y-2 rounded-lg border border-border p-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Hard filters — applied before anything is judged
+              </p>
+              <label className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={noWebsite} onChange={(e) => setNoWebsite(e.target.checked)} />
+                Only businesses with no real website
+                <span className="text-xs text-muted-foreground">(a Facebook page doesn&apos;t count)</span>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={requirePhone} onChange={(e) => setRequirePhone(e.target.checked)} />
+                Must have a phone number
+              </label>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={pending}>Cancel</Button>
+            <Button onClick={handleCreate} disabled={pending}>Create hunt</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/prospects/prospects-view.tsx
+++ b/src/components/prospects/prospects-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useMutation } from "@/components/layout/use-mutation";
@@ -76,6 +77,7 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
         subtitle="Your cold-outreach list — import, reach out, and convert the good ones to leads"
         actions={
           <>
+            <Button variant="outline" asChild><Link href="/prospects/hunts"><Target className="w-4 h-4 mr-1.5" /> Find prospects</Link></Button>
             <Button variant="outline" onClick={() => setImportOpen(true)} disabled={isPending}><Upload className="w-4 h-4 mr-1.5" /> Import</Button>
             <Button onClick={() => setOpen(true)} disabled={isPending}><Plus className="w-4 h-4 mr-1.5" /> Add prospect</Button>
           </>

--- a/src/lib/actions/prospecting.ts
+++ b/src/lib/actions/prospecting.ts
@@ -1,0 +1,263 @@
+"use server";
+
+/**
+ * The prospecting agent's server actions — hunts, runs, and the review queue.
+ *
+ * The deliberate shape: `runHuntNow` finds and judges, but nothing becomes a
+ * prospect until `addCandidates` is called. The operator is the gate. An agent
+ * that writes straight into the prospect list is one bad criteria string away
+ * from a list nobody trusts.
+ *
+ * Scopes on the MCP side: prospects:read / prospects:write.
+ */
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { geocodeArea } from "@/lib/prospecting/places";
+import { getPlacesKey, runHunt, type HuntRow, type RunResult } from "@/lib/prospecting/run";
+import type {
+  ProspectHunt, ProspectHuntRun, ProspectCandidate, ProspectHuntFilters,
+} from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tbl = (sb: any, name: string) => sb.from(name);
+const clean = (v: string | null | undefined) => (v?.trim() ? v.trim() : null);
+
+async function ctx() {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+  return { supabase, user, businessId };
+}
+
+export interface HuntInput {
+  name: string;
+  queries: string[];
+  criteria: string;
+  /** A suburb or city — geocoded to a centre point if lat/lng aren't given. */
+  area?: string | null;
+  centre_lat?: number | null;
+  centre_lng?: number | null;
+  radius_km?: number;
+  filters?: ProspectHuntFilters;
+  active?: boolean;
+}
+
+// ── Hunts ───────────────────────────────────────────────────────────────────
+
+export async function listHunts(): Promise<ProspectHunt[]> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "prospect_hunts").select("*")
+    .eq("business_id", businessId).order("created_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as ProspectHunt[];
+}
+
+export async function getHunt(id: string): Promise<ProspectHunt | null> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "prospect_hunts").select("*")
+    .eq("id", id).eq("business_id", businessId).maybeSingle();
+  if (error) throw error;
+  return (data as ProspectHunt) ?? null;
+}
+
+/**
+ * Resolve a place name to coordinates using the business's own Places key.
+ * Returns null when there's no key — the hunt saves without a centre, and
+ * `runHuntNow` is where that's reported, with the fix in the message.
+ */
+async function resolveArea(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any, businessId: string, label: string,
+): Promise<{ lat: number; lng: number } | null> {
+  const key = await getPlacesKey(supabase, businessId);
+  return key ? geocodeArea(key, label) : null;
+}
+
+export async function createHunt(input: HuntInput): Promise<ProspectHunt> {
+  const { supabase, user, businessId } = await ctx();
+
+  let lat = input.centre_lat ?? null;
+  let lng = input.centre_lng ?? null;
+  const label = clean(input.area);
+  if ((lat == null || lng == null) && label) {
+    const found = await resolveArea(supabase, businessId, label);
+    if (found) { lat = found.lat; lng = found.lng; }
+  }
+
+  const { data, error } = await tbl(supabase, "prospect_hunts").insert({
+    business_id: businessId,
+    created_by: user.id,
+    name: input.name.trim() || "Untitled hunt",
+    queries: input.queries.map((q) => q.trim()).filter(Boolean),
+    criteria: input.criteria.trim(),
+    centre_label: label,
+    centre_lat: lat,
+    centre_lng: lng,
+    radius_m: Math.round(Math.min(Math.max(input.radius_km ?? 25, 1), 50) * 1000),
+    filters: input.filters ?? {},
+    active: input.active ?? true,
+  }).select().single();
+  if (error) throw error;
+
+  revalidatePath("/prospects/hunts");
+  return data as ProspectHunt;
+}
+
+export async function updateHunt(id: string, input: Partial<HuntInput>): Promise<ProspectHunt> {
+  const { supabase, businessId } = await ctx();
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+  if (input.name !== undefined) patch.name = input.name.trim();
+  if (input.queries !== undefined) patch.queries = input.queries.map((q) => q.trim()).filter(Boolean);
+  if (input.criteria !== undefined) patch.criteria = input.criteria.trim();
+  if (input.filters !== undefined) patch.filters = input.filters;
+  if (input.active !== undefined) patch.active = input.active;
+  if (input.radius_km !== undefined) {
+    patch.radius_m = Math.round(Math.min(Math.max(input.radius_km, 1), 50) * 1000);
+  }
+  if (input.centre_lat !== undefined) patch.centre_lat = input.centre_lat;
+  if (input.centre_lng !== undefined) patch.centre_lng = input.centre_lng;
+  if (input.area !== undefined) {
+    const label = clean(input.area);
+    patch.centre_label = label;
+    // Re-geocode when the area changed but no explicit coordinates came with it.
+    if (label && input.centre_lat === undefined) {
+      const found = await resolveArea(supabase, businessId, label);
+      if (found) { patch.centre_lat = found.lat; patch.centre_lng = found.lng; }
+    }
+  }
+
+  const { data, error } = await tbl(supabase, "prospect_hunts").update(patch)
+    .eq("id", id).eq("business_id", businessId).select().single();
+  if (error) throw error;
+
+  revalidatePath("/prospects/hunts");
+  revalidatePath(`/prospects/hunts/${id}`);
+  return data as ProspectHunt;
+}
+
+export async function deleteHunt(id: string): Promise<void> {
+  const { supabase, businessId } = await ctx();
+  const { error } = await tbl(supabase, "prospect_hunts").delete()
+    .eq("id", id).eq("business_id", businessId);
+  if (error) throw error;
+  revalidatePath("/prospects/hunts");
+}
+
+// ── Runs ────────────────────────────────────────────────────────────────────
+
+export async function runHuntNow(id: string): Promise<RunResult> {
+  const { supabase, businessId } = await ctx();
+  const { data: hunt, error } = await tbl(supabase, "prospect_hunts").select("*")
+    .eq("id", id).eq("business_id", businessId).single();
+  if (error) throw error;
+
+  const result = await runHunt(supabase, hunt as HuntRow);
+
+  revalidatePath("/prospects/hunts");
+  revalidatePath(`/prospects/hunts/${id}`);
+  return result;
+}
+
+export async function listHuntRuns(huntId: string, limit = 20): Promise<ProspectHuntRun[]> {
+  const { supabase, businessId } = await ctx();
+  const { data, error } = await tbl(supabase, "prospect_hunt_runs").select("*")
+    .eq("business_id", businessId).eq("hunt_id", huntId)
+    .order("started_at", { ascending: false }).limit(limit);
+  if (error) throw error;
+  return (data ?? []) as ProspectHuntRun[];
+}
+
+// ── The review queue ────────────────────────────────────────────────────────
+
+export interface CandidateFilters {
+  hunt_id?: string;
+  /** Defaults to the queue that matters: verified fits awaiting a decision. */
+  status?: ProspectCandidate["status"];
+  limit?: number;
+}
+
+export async function listCandidates(filters: CandidateFilters = {}): Promise<ProspectCandidate[]> {
+  const { supabase, businessId } = await ctx();
+  let q = tbl(supabase, "prospect_candidates").select("*").eq("business_id", businessId);
+  if (filters.hunt_id) q = q.eq("hunt_id", filters.hunt_id);
+  q = q.eq("status", filters.status ?? "verified");
+  const { data, error } = await q
+    .order("score", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(filters.limit ?? 200);
+  if (error) throw error;
+  return (data ?? []) as ProspectCandidate[];
+}
+
+/**
+ * Approve candidates — this is the only path from "the agent found it" to
+ * "it's in my prospect list".
+ */
+export async function addCandidates(ids: string[]): Promise<{ added: number }> {
+  const { supabase, user, businessId } = await ctx();
+  if (!ids.length) return { added: 0 };
+
+  const { data: rows, error } = await tbl(supabase, "prospect_candidates").select("*")
+    .eq("business_id", businessId).in("id", ids);
+  if (error) throw error;
+
+  const candidates = (rows ?? []) as ProspectCandidate[];
+  // Already-added rows carry a prospect_id; adding twice would duplicate.
+  const fresh = candidates.filter((c) => !c.prospect_id);
+  if (!fresh.length) return { added: 0 };
+
+  const { data: created, error: insertErr } = await tbl(supabase, "prospects").insert(
+    fresh.map((c) => ({
+      business_id: businessId,
+      user_id: user.id,
+      company: c.name,
+      name: null,
+      email: null,                      // Places never returns one
+      phone: c.phone,
+      website: c.website,
+      source: "hunt",
+      status: "new",
+      tags: c.category ? [c.category] : [],
+      notes: [
+        c.address,
+        c.reasoning ? `Why it matched: ${c.reasoning}` : null,
+      ].filter(Boolean).join(" · ") || null,
+      custom_fields: {
+        place_id: c.place_id,
+        hunt_id: c.hunt_id,
+        fit_score: c.score,
+        rating: c.rating,
+        review_count: c.review_count,
+      },
+    })),
+  ).select("id");
+  if (insertErr) throw insertErr;
+
+  // Pair each candidate with its new prospect — same order as inserted.
+  const newIds = (created ?? []) as { id: string }[];
+  await Promise.all(fresh.map((c, i) =>
+    tbl(supabase, "prospect_candidates").update({
+      status: "added",
+      prospect_id: newIds[i]?.id ?? null,
+      updated_at: new Date().toISOString(),
+    }).eq("id", c.id).eq("business_id", businessId),
+  ));
+
+  revalidatePath("/prospects");
+  revalidatePath("/prospects/hunts");
+  return { added: fresh.length };
+}
+
+export async function dismissCandidates(ids: string[]): Promise<{ dismissed: number }> {
+  const { supabase, businessId } = await ctx();
+  if (!ids.length) return { dismissed: 0 };
+  const { error } = await tbl(supabase, "prospect_candidates").update({
+    status: "dismissed", updated_at: new Date().toISOString(),
+  }).eq("business_id", businessId).in("id", ids);
+  if (error) throw error;
+  revalidatePath("/prospects/hunts");
+  return { dismissed: ids.length };
+}

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -41,6 +41,7 @@ import { registerInventoryTools } from "./tools/inventory-tools";
 import { registerTimesheetTools } from "./tools/timesheets-tools";
 import { registerAssetTools } from "./tools/assets-tools";
 import { registerProspectTools } from "./tools/prospects-tools";
+import { registerHuntTools } from "./tools/hunt-tools";
 import { registerVaultTools } from "./tools/vault-tools";
 import { registerPaymentDetailTools } from "./tools/payment-detail-tools";
 import { registerOutreachTools } from "./tools/outreach-tools";
@@ -1847,6 +1848,7 @@ export function registerTools(register: ToolFn): void {
 
   // ===== PROSPECTS =====
   registerProspectTools(tool);
+  registerHuntTools(tool);
   registerVaultTools(tool);
   registerPaymentDetailTools(tool);
   registerOutreachTools(tool);

--- a/src/lib/mcp/tools/hunt-tools.ts
+++ b/src/lib/mcp/tools/hunt-tools.ts
@@ -1,0 +1,237 @@
+/**
+ * MCP tools for the prospecting agent — hunts, runs, and the review queue.
+ * Scopes: prospects:read / prospects:write.
+ *
+ * Note what is NOT here: no tool turns a candidate into a prospect without
+ * naming the candidates. `add_prospect_candidates` takes explicit ids, so an
+ * assistant has to show the operator what it found before anything is added.
+ */
+import { z } from "zod";
+import { assertScope, t, text, errorText } from "../context";
+import { ctxFrom, UUID, type ToolFn } from "./shared";
+import { geocodeArea } from "@/lib/prospecting/places";
+import { getPlacesKey, runHunt, type HuntRow } from "@/lib/prospecting/run";
+
+const FILTERS = z.object({
+  no_website: z.boolean().optional(),
+  has_website: z.boolean().optional(),
+  min_rating: z.number().min(0).max(5).optional(),
+  max_rating: z.number().min(0).max(5).optional(),
+  min_reviews: z.number().int().min(0).optional(),
+  max_reviews: z.number().int().min(0).optional(),
+  require_phone: z.boolean().optional(),
+});
+
+const CANDIDATE_STATUS = z.enum([
+  "pending", "screened_out", "verified", "rejected", "added", "dismissed",
+]);
+
+const clean = (v?: string) => (v?.trim() ? v.trim() : null);
+const radiusM = (km?: number) => Math.round(Math.min(Math.max(km ?? 25, 1), 50) * 1000);
+
+export function registerHuntTools(tool: ToolFn): void {
+  tool("list_prospect_hunts",
+    "List saved prospecting hunts (search terms + area + the criteria a business must meet).",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");
+      const { data, error } = await t(ctx, "prospect_hunts").select("*")
+        .eq("business_id", ctx.businessId).order("created_at", { ascending: false });
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("create_prospect_hunt",
+    "Create a prospecting hunt. `criteria` is free text describing what makes a business a prospect (e.g. 'service-based tradies with no website') — an agent judges every result against it. `filters` are cheap hard rules applied before any judging.",
+    {
+      name: z.string().min(1),
+      queries: z.array(z.string().min(1)).min(1).max(10)
+        .describe("Google Places search terms, e.g. ['roof repair', 'roofing contractor']"),
+      criteria: z.string().min(3),
+      area: z.string().optional().describe("Suburb or city to centre the search on"),
+      centre_lat: z.number().optional(),
+      centre_lng: z.number().optional(),
+      radius_km: z.number().min(1).max(50).optional(),
+      filters: FILTERS.optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+
+      let lat = args.centre_lat ?? null;
+      let lng = args.centre_lng ?? null;
+      const label = clean(args.area);
+      if ((lat == null || lng == null) && label) {
+        const key = await getPlacesKey(ctx.sb, ctx.businessId);
+        const found = key ? await geocodeArea(key, label) : null;
+        if (found) { lat = found.lat; lng = found.lng; }
+      }
+
+      const { data, error } = await t(ctx, "prospect_hunts").insert({
+        business_id: ctx.businessId,
+        created_by: ctx.userId,
+        name: args.name.trim(),
+        queries: args.queries.map((q: string) => q.trim()).filter(Boolean),
+        criteria: args.criteria.trim(),
+        centre_label: label,
+        centre_lat: lat,
+        centre_lng: lng,
+        radius_m: radiusM(args.radius_km),
+        filters: args.filters ?? {},
+      }).select("id").single();
+      if (error) throw error;
+
+      return text({
+        created: true,
+        hunt_id: data.id,
+        located: lat != null,
+        note: lat == null
+          ? "No search area resolved — set centre_lat/centre_lng, or add a Google Places API key under Outreach settings so area names can be geocoded."
+          : undefined,
+      });
+    });
+
+  tool("update_prospect_hunt", "Update a hunt's name, search terms, criteria, area or filters.",
+    {
+      hunt_id: UUID,
+      name: z.string().optional(),
+      queries: z.array(z.string()).optional(),
+      criteria: z.string().optional(),
+      area: z.string().optional(),
+      centre_lat: z.number().optional(),
+      centre_lng: z.number().optional(),
+      radius_km: z.number().min(1).max(50).optional(),
+      filters: FILTERS.optional(),
+      active: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+      if (args.name !== undefined) patch.name = args.name.trim();
+      if (args.queries !== undefined) patch.queries = args.queries.map((q: string) => q.trim()).filter(Boolean);
+      if (args.criteria !== undefined) patch.criteria = args.criteria.trim();
+      if (args.filters !== undefined) patch.filters = args.filters;
+      if (args.active !== undefined) patch.active = args.active;
+      if (args.radius_km !== undefined) patch.radius_m = radiusM(args.radius_km);
+      if (args.centre_lat !== undefined) patch.centre_lat = args.centre_lat;
+      if (args.centre_lng !== undefined) patch.centre_lng = args.centre_lng;
+      if (args.area !== undefined) {
+        const label = clean(args.area);
+        patch.centre_label = label;
+        if (label && args.centre_lat === undefined) {
+          const key = await getPlacesKey(ctx.sb, ctx.businessId);
+          const found = key ? await geocodeArea(key, label) : null;
+          if (found) { patch.centre_lat = found.lat; patch.centre_lng = found.lng; }
+        }
+      }
+      const { error } = await t(ctx, "prospect_hunts").update(patch)
+        .eq("id", args.hunt_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ updated: true });
+    });
+
+  tool("delete_prospect_hunt", "Delete a hunt and everything it found.",
+    { hunt_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { error } = await t(ctx, "prospect_hunts").delete()
+        .eq("id", args.hunt_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({ deleted: true });
+    });
+
+  tool("run_prospect_hunt",
+    "Run a hunt now: search Google Places in the area, screen the results against the filters, then have an agent judge each survivor against the criteria. Results land in the review queue — nothing becomes a prospect until it's approved. Slow: one model call per candidate.",
+    { hunt_id: UUID },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { data: hunt } = await t(ctx, "prospect_hunts").select("*")
+        .eq("id", args.hunt_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (!hunt) return errorText("Hunt not found");
+      const result = await runHunt(ctx.sb, hunt as HuntRow);
+      if (result.error) return errorText(result.error);
+      return text(result);
+    });
+
+  tool("list_prospect_hunt_runs", "Run history for a hunt, with the funnel counts and what each run cost.",
+    { hunt_id: UUID, limit: z.number().int().min(1).max(100).optional() },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");
+      const { data, error } = await t(ctx, "prospect_hunt_runs").select("*")
+        .eq("business_id", ctx.businessId).eq("hunt_id", args.hunt_id)
+        .order("started_at", { ascending: false }).limit(args.limit ?? 20);
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("list_prospect_candidates",
+    "The review queue: businesses a hunt found, with the agent's fit score and its reasoning. Defaults to `verified` — the ones judged a match and awaiting a decision.",
+    {
+      hunt_id: UUID.optional(),
+      status: CANDIDATE_STATUS.optional(),
+      limit: z.number().int().min(1).max(500).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");
+      let q = t(ctx, "prospect_candidates")
+        .select("id, name, address, phone, website, category, rating, review_count, status, score, reasoning, checks, prospect_id, created_at")
+        .eq("business_id", ctx.businessId).eq("status", args.status ?? "verified");
+      if (args.hunt_id) q = q.eq("hunt_id", args.hunt_id);
+      const { data, error } = await q
+        .order("score", { ascending: false, nullsFirst: false })
+        .limit(args.limit ?? 100);
+      if (error) throw error;
+      return text(data);
+    });
+
+  tool("add_prospect_candidates",
+    "Approve candidates from the review queue and add them to the prospect list. Takes explicit ids — show the operator what was found before calling this.",
+    { candidate_ids: z.array(UUID).min(1).max(200) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { data: rows, error } = await t(ctx, "prospect_candidates").select("*")
+        .eq("business_id", ctx.businessId).in("id", args.candidate_ids);
+      if (error) throw error;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fresh = ((rows ?? []) as any[]).filter((c) => !c.prospect_id);
+      if (!fresh.length) return text({ added: 0, note: "Nothing new — those are already added." });
+
+      const { data: created, error: insErr } = await t(ctx, "prospects").insert(
+        fresh.map((c) => ({
+          business_id: ctx.businessId, user_id: ctx.userId,
+          company: c.name, name: null, email: null,
+          phone: c.phone, website: c.website,
+          source: "hunt", status: "new",
+          tags: c.category ? [c.category] : [],
+          notes: [c.address, c.reasoning ? `Why it matched: ${c.reasoning}` : null]
+            .filter(Boolean).join(" · ") || null,
+          custom_fields: {
+            place_id: c.place_id, hunt_id: c.hunt_id, fit_score: c.score,
+            rating: c.rating, review_count: c.review_count,
+          },
+        })),
+      ).select("id");
+      if (insErr) throw insErr;
+
+      const newIds = (created ?? []) as { id: string }[];
+      await Promise.all(fresh.map((c, i) =>
+        t(ctx, "prospect_candidates").update({
+          status: "added", prospect_id: newIds[i]?.id ?? null,
+          updated_at: new Date().toISOString(),
+        }).eq("id", c.id).eq("business_id", ctx.businessId),
+      ));
+
+      return text({ added: fresh.length });
+    });
+
+  tool("dismiss_prospect_candidates", "Dismiss candidates from the review queue so they stop appearing.",
+    { candidate_ids: z.array(UUID).min(1).max(500) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { error } = await t(ctx, "prospect_candidates").update({
+        status: "dismissed", updated_at: new Date().toISOString(),
+      }).eq("business_id", ctx.businessId).in("id", args.candidate_ids);
+      if (error) throw error;
+      return text({ dismissed: args.candidate_ids.length });
+    });
+}

--- a/src/lib/prospecting/__tests__/screen.test.ts
+++ b/src/lib/prospecting/__tests__/screen.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { isRealWebsite, phoneKey, screenCandidate } from "../screen";
+import type { PlaceHit } from "../places";
+
+function hit(over: Partial<PlaceHit> = {}): PlaceHit {
+  return {
+    place_id: "p1", name: "Ace Plumbing", address: "1 Test St", phone: "02 9000 0000",
+    website: null, category: "Plumber", rating: 4.6, review_count: 30,
+    lat: null, lng: null, raw: {}, ...over,
+  };
+}
+
+const nothingKnown = { phones: new Set<string>(), websites: new Set<string>() };
+
+describe("isRealWebsite", () => {
+  it("treats a normal domain as a website", () => {
+    expect(isRealWebsite("https://aceplumbing.com.au")).toBe(true);
+    expect(isRealWebsite("https://www.aceplumbing.com.au/contact")).toBe(true);
+  });
+
+  // The whole "no website" hunt depends on this: a tradie whose only web
+  // presence is a Facebook page IS the prospect, not a miss.
+  it("does not count social or directory profiles", () => {
+    for (const url of [
+      "https://facebook.com/aceplumbing",
+      "https://www.facebook.com/aceplumbing",
+      "https://m.facebook.com/aceplumbing",
+      "https://instagram.com/aceplumbing",
+      "https://hipages.com.au/connect/aceplumbing",
+      "https://aceplumbing.business.site",
+      "https://linktr.ee/ace",
+    ]) {
+      expect(isRealWebsite(url), url).toBe(false);
+    }
+  });
+
+  it("handles absent and malformed values", () => {
+    expect(isRealWebsite(null)).toBe(false);
+    expect(isRealWebsite("")).toBe(false);
+    expect(isRealWebsite("not a url")).toBe(false);
+  });
+});
+
+describe("phoneKey", () => {
+  it("matches the generated phone_digits column: last 9 digits", () => {
+    expect(phoneKey("02 9000 0000")).toBe("290000000");
+    expect(phoneKey("+61 2 9000 0000")).toBe("290000000");
+  });
+  it("rejects anything too short to be a real match", () => {
+    expect(phoneKey("12345")).toBeNull();
+    expect(phoneKey(null)).toBeNull();
+  });
+});
+
+describe("screenCandidate", () => {
+  it("keeps a plain candidate when no filters are set", () => {
+    expect(screenCandidate(hit(), {}, nothingKnown).keep).toBe(true);
+  });
+
+  it("drops a real website under no_website", () => {
+    const r = screenCandidate(hit({ website: "https://ace.com.au" }), { no_website: true }, nothingKnown);
+    expect(r.keep).toBe(false);
+  });
+
+  it("keeps a Facebook-only listing under no_website", () => {
+    const r = screenCandidate(
+      hit({ website: "https://facebook.com/ace" }), { no_website: true }, nothingKnown);
+    expect(r.keep).toBe(true);
+  });
+
+  it("applies rating and review bounds", () => {
+    expect(screenCandidate(hit({ rating: 3.2 }), { min_rating: 4 }, nothingKnown).keep).toBe(false);
+    expect(screenCandidate(hit({ review_count: 2 }), { min_reviews: 10 }, nothingKnown).keep).toBe(false);
+    expect(screenCandidate(hit({ review_count: 900 }), { max_reviews: 100 }, nothingKnown).keep).toBe(false);
+  });
+
+  it("requires a phone when asked", () => {
+    expect(screenCandidate(hit({ phone: null }), { require_phone: true }, nothingKnown).keep).toBe(false);
+  });
+
+  // Surfacing your own customer as a "prospect" is the failure that makes
+  // people stop trusting the tool.
+  it("drops anyone already in your contacts, by phone", () => {
+    const known = { phones: new Set(["290000000"]), websites: new Set<string>() };
+    const r = screenCandidate(hit(), {}, known);
+    expect(r.keep).toBe(false);
+    if (!r.keep) expect(r.reason).toMatch(/already/i);
+  });
+
+  it("drops anyone already in your contacts, by website host", () => {
+    const known = { phones: new Set<string>(), websites: new Set(["ace.com.au"]) };
+    const r = screenCandidate(hit({ website: "https://www.ace.com.au/about" }), {}, known);
+    expect(r.keep).toBe(false);
+  });
+
+  it("records why it was dropped so the funnel can be explained", () => {
+    const r = screenCandidate(hit({ website: "https://ace.com.au" }), { no_website: true }, nothingKnown);
+    expect(r.keep).toBe(false);
+    if (!r.keep) {
+      expect(r.reason).toBeTruthy();
+      expect(r.checks.website_is_real).toBe(true);
+    }
+  });
+});

--- a/src/lib/prospecting/places.ts
+++ b/src/lib/prospecting/places.ts
@@ -1,0 +1,159 @@
+/**
+ * Finding businesses in an area, via Google Places.
+ *
+ * Places rather than web search, for one decisive reason: it returns a
+ * `websiteUri` field. "Has no website" is then a FACT from the source, not a
+ * model's inference from failing to find one — and that is exactly the sort of
+ * criterion this feature exists to hunt on. It also takes a circle natively,
+ * so "within 25km of Parramatta" is one request rather than a guess.
+ *
+ * What it will never give you is an email address. Prospects arrive with a
+ * phone and an address; email is the outreach system's problem.
+ *
+ * Plain module — no session. The runner and the cron both use it.
+ */
+
+export interface PlaceHit {
+  place_id: string;
+  name: string;
+  address: string | null;
+  phone: string | null;
+  website: string | null;
+  category: string | null;
+  rating: number | null;
+  review_count: number | null;
+  lat: number | null;
+  lng: number | null;
+  raw: Record<string, unknown>;
+}
+
+/**
+ * The fields to ask for. Places bills by field mask, so asking for everything
+ * costs materially more per call — this is the minimum that supports the
+ * filters and the review screen.
+ */
+const FIELD_MASK = [
+  "places.id",
+  "places.displayName",
+  "places.formattedAddress",
+  "places.nationalPhoneNumber",
+  "places.websiteUri",
+  "places.primaryTypeDisplayName",
+  "places.rating",
+  "places.userRatingCount",
+  "places.location",
+].join(",");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toHit(p: any): PlaceHit {
+  return {
+    place_id: String(p.id),
+    name: p.displayName?.text ?? "Unnamed",
+    address: p.formattedAddress ?? null,
+    phone: p.nationalPhoneNumber ?? null,
+    website: p.websiteUri ?? null,
+    category: p.primaryTypeDisplayName?.text ?? null,
+    rating: typeof p.rating === "number" ? p.rating : null,
+    review_count: typeof p.userRatingCount === "number" ? p.userRatingCount : null,
+    lat: p.location?.latitude ?? null,
+    lng: p.location?.longitude ?? null,
+    raw: p,
+  };
+}
+
+export interface SearchArea {
+  lat: number;
+  lng: number;
+  radiusM: number;
+}
+
+/**
+ * One text query, biased to a circle.
+ *
+ * `locationRestriction` rather than `locationBias`: a bias is a suggestion and
+ * Places will happily return results from the next state if it likes them
+ * better. A hunt with a 10km radius means 10km.
+ *
+ * Paginated to `maxPages` because Places returns 20 per page and a broad query
+ * in a city can run to hundreds — each page is a billed request, and the run
+ * has a budget.
+ */
+export async function searchPlaces(
+  apiKey: string,
+  query: string,
+  area: SearchArea,
+  maxPages = 3,
+): Promise<{ hits: PlaceHit[]; error: string | null }> {
+  const hits: PlaceHit[] = [];
+  let pageToken: string | undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const body: Record<string, any> = {
+      textQuery: query,
+      locationRestriction: {
+        circle: {
+          center: { latitude: area.lat, longitude: area.lng },
+          // Places caps the radius at 50km; asking for more is a 400.
+          radius: Math.min(Math.max(area.radiusM, 1), 50_000),
+        },
+      },
+      maxResultCount: 20,
+    };
+    if (pageToken) body.pageToken = pageToken;
+
+    let res: Response;
+    try {
+      res = await fetch("https://places.googleapis.com/v1/places:searchText", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Goog-Api-Key": apiKey,
+          "X-Goog-FieldMask": `${FIELD_MASK},nextPageToken`,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (e) {
+      return { hits, error: e instanceof Error ? e.message : "Places request failed" };
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      // Surface Google's own message — "API key not valid" and "billing not
+      // enabled" are the two everyone hits, and both are actionable.
+      return { hits, error: `Places ${res.status}: ${text.slice(0, 300)}` };
+    }
+
+    const json = await res.json().catch(() => ({}));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const p of (json.places ?? []) as any[]) hits.push(toHit(p));
+
+    pageToken = json.nextPageToken;
+    if (!pageToken) break;
+  }
+
+  return { hits, error: null };
+}
+
+/** Turn a place name into coordinates, so a hunt can be defined by suburb. */
+export async function geocodeArea(
+  apiKey: string, label: string,
+): Promise<{ lat: number; lng: number } | null> {
+  try {
+    const res = await fetch("https://places.googleapis.com/v1/places:searchText", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask": "places.location",
+      },
+      body: JSON.stringify({ textQuery: label, maxResultCount: 1 }),
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const loc = json.places?.[0]?.location;
+    return loc ? { lat: loc.latitude, lng: loc.longitude } : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/prospecting/run.ts
+++ b/src/lib/prospecting/run.ts
@@ -1,0 +1,246 @@
+/**
+ * The hunt orchestrator: search → screen → verify → queue for review.
+ *
+ * The order is the whole design. Places is billed per request, the verifying
+ * agent is billed per candidate, and the operator's attention is the scarcest
+ * of the three — so each stage is cheaper than the one it feeds, and nothing
+ * reaches a human that a filter could have thrown away.
+ *
+ * Nothing here creates a prospect. Candidates land in a review queue and a
+ * person approves them. An agent that silently filled your prospect list with
+ * its own guesses would be worse than no agent at all.
+ */
+
+import { decryptSecret } from "@/lib/crypto";
+import { searchPlaces, type PlaceHit, type SearchArea } from "./places";
+import { screenCandidate, phoneKey, type HuntFilters } from "./screen";
+import { verifyCandidate } from "./verify";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SB = any;
+
+export interface HuntRow {
+  id: string;
+  business_id: string;
+  name: string;
+  queries: string[];
+  centre_label: string | null;
+  centre_lat: number | null;
+  centre_lng: number | null;
+  radius_m: number;
+  criteria: string;
+  filters: HuntFilters;
+}
+
+export interface RunResult {
+  run_id: string | null;
+  found: number;
+  screened_out: number;
+  verified: number;
+  rejected: number;
+  cost_cents: number;
+  error: string | null;
+}
+
+/** How many survivors we're willing to pay a model to judge in one run. */
+const VERIFY_CAP = 60;
+
+/** Read the Places key a business configured for outreach sourcing. */
+export async function getPlacesKey(sb: SB, businessId: string): Promise<string | null> {
+  const { data } = await sb.from("outreach_settings")
+    .select("places_api_key_enc").eq("business_id", businessId).maybeSingle();
+  if (!data?.places_api_key_enc) return null;
+  try { return decryptSecret(data.places_api_key_enc); } catch { return null; }
+}
+
+/**
+ * Everything this business already knows about, so the hunt only surfaces new
+ * names. Prospects AND customers — finding your own client and calling them a
+ * prospect is the failure that makes people stop trusting the tool.
+ */
+async function knownContacts(sb: SB, businessId: string) {
+  const phones = new Set<string>();
+  const websites = new Set<string>();
+  const placeIds = new Set<string>();
+
+  const add = (phone: unknown, website: unknown) => {
+    const pk = phoneKey(typeof phone === "string" ? phone : null);
+    if (pk) phones.add(pk);
+    if (typeof website === "string" && website) {
+      try {
+        websites.add(new URL(website).hostname.toLowerCase().replace(/^www\./, ""));
+      } catch { /* not a URL — nothing to dedupe on */ }
+    }
+  };
+
+  const { data: prospects } = await sb.from("prospects")
+    .select("phone, website, custom_fields").eq("business_id", businessId).limit(5000);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const p of ((prospects ?? []) as any[])) {
+    add(p.phone, p.website);
+    const pid = (p.custom_fields ?? {}).place_id;
+    if (pid) placeIds.add(String(pid));
+  }
+
+  const { data: customers } = await sb.from("customers")
+    .select("phone, website").eq("business_id", businessId).limit(5000);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const c of ((customers ?? []) as any[])) add(c.phone, c.website);
+
+  // Candidates already seen by a previous run of any hunt — the unique index
+  // would reject them anyway, and re-verifying them would be paid-for waste.
+  const { data: seen } = await sb.from("prospect_candidates")
+    .select("place_id").eq("business_id", businessId).limit(10000);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const c of ((seen ?? []) as any[])) if (c.place_id) placeIds.add(String(c.place_id));
+
+  return { phones, websites, placeIds };
+}
+
+/**
+ * Execute one hunt.
+ *
+ * Long-running by nature (one model call per survivor), so callers should
+ * treat it as a job, not a request handler.
+ */
+export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
+  const result: RunResult = {
+    run_id: null, found: 0, screened_out: 0, verified: 0, rejected: 0,
+    cost_cents: 0, error: null,
+  };
+
+  const { data: run } = await sb.from("prospect_hunt_runs").insert({
+    business_id: hunt.business_id, hunt_id: hunt.id, status: "running",
+  }).select("id").single();
+  result.run_id = run?.id ?? null;
+
+  const fail = async (message: string) => {
+    result.error = message;
+    if (result.run_id) {
+      await sb.from("prospect_hunt_runs").update({
+        status: "failed", error: message, finished_at: new Date().toISOString(),
+      }).eq("id", result.run_id);
+    }
+    return result;
+  };
+
+  const apiKey = await getPlacesKey(sb, hunt.business_id);
+  if (!apiKey) {
+    return fail("No Google Places API key. Add one under Outreach settings — hunts search Google, so the key and its billing stay yours.");
+  }
+  if (hunt.centre_lat == null || hunt.centre_lng == null) {
+    return fail("This hunt has no search area. Set a centre point and radius.");
+  }
+  if (!hunt.queries?.length) {
+    return fail("This hunt has no search terms.");
+  }
+
+  const area: SearchArea = {
+    lat: hunt.centre_lat, lng: hunt.centre_lng, radiusM: hunt.radius_m || 25000,
+  };
+  const known = await knownContacts(sb, hunt.business_id);
+
+  // ── 1. Search ────────────────────────────────────────────────────────────
+  const hits = new Map<string, PlaceHit>();
+  const searchErrors: string[] = [];
+  for (const query of hunt.queries) {
+    const { hits: batch, error } = await searchPlaces(apiKey, query, area);
+    if (error) searchErrors.push(error);
+    // Overlapping queries ("roof repair" / "roofing contractor") return the
+    // same businesses; the map means each is judged once, not once per query.
+    for (const h of batch) if (!hits.has(h.place_id)) hits.set(h.place_id, h);
+  }
+  if (!hits.size && searchErrors.length) return fail(searchErrors[0]);
+  result.found = hits.size;
+
+  // ── 2. Screen ────────────────────────────────────────────────────────────
+  const survivors: PlaceHit[] = [];
+  const rejects: { hit: PlaceHit; reason: string; checks: Record<string, unknown> }[] = [];
+
+  for (const hit of hits.values()) {
+    if (known.placeIds.has(hit.place_id)) { result.screened_out++; continue; }
+    const verdict = screenCandidate(hit, hunt.filters ?? {}, known);
+    if (verdict.keep) survivors.push(hit);
+    else {
+      result.screened_out++;
+      rejects.push({ hit, reason: verdict.reason, checks: verdict.checks });
+    }
+  }
+
+  // Screened-out rows are still written: they're why the funnel numbers add up,
+  // and they stop the next run re-finding the same rejects.
+  if (rejects.length) {
+    await sb.from("prospect_candidates").upsert(
+      rejects.map(({ hit, reason, checks }) => ({
+        ...candidateRow(hunt, result.run_id, hit),
+        status: "screened_out", reasoning: reason, checks,
+      })),
+      { onConflict: "business_id,place_id", ignoreDuplicates: true },
+    );
+  }
+
+  // ── 3. Verify ────────────────────────────────────────────────────────────
+  const toVerify = survivors.slice(0, VERIFY_CAP);
+  const overflow = survivors.length - toVerify.length;
+
+  for (const hit of toVerify) {
+    let verdict;
+    try {
+      verdict = await verifyCandidate(hit, hunt.criteria);
+    } catch (e) {
+      // One failed judgement shouldn't lose the rest of the run. It stays
+      // pending so a re-run can pick it up.
+      verdict = {
+        fit: false, score: 0, cost_cents: 0,
+        reasoning: e instanceof Error ? e.message : "Verification failed",
+      };
+    }
+    result.cost_cents += verdict.cost_cents;
+    if (verdict.fit) result.verified++; else result.rejected++;
+
+    await sb.from("prospect_candidates").upsert({
+      ...candidateRow(hunt, result.run_id, hit),
+      status: verdict.fit ? "verified" : "rejected",
+      score: verdict.score,
+      reasoning: verdict.reasoning,
+      checks: { screened: "passed" },
+    }, { onConflict: "business_id,place_id", ignoreDuplicates: true });
+  }
+
+  if (result.run_id) {
+    await sb.from("prospect_hunt_runs").update({
+      status: "done",
+      found: result.found,
+      screened_out: result.screened_out,
+      verified: result.verified,
+      rejected: result.rejected,
+      cost_cents: Number(result.cost_cents.toFixed(3)),
+      // Never silently drop coverage: if the cap bit, say so on the run.
+      error: overflow > 0
+        ? `${overflow} more matched the filters but weren't verified this run (cap ${VERIFY_CAP}). Run again to continue.`
+        : searchErrors[0] ?? null,
+      finished_at: new Date().toISOString(),
+    }).eq("id", result.run_id);
+  }
+
+  return result;
+}
+
+function candidateRow(hunt: HuntRow, runId: string | null, hit: PlaceHit) {
+  return {
+    business_id: hunt.business_id,
+    hunt_id: hunt.id,
+    run_id: runId,
+    place_id: hit.place_id,
+    name: hit.name,
+    address: hit.address,
+    phone: hit.phone,
+    website: hit.website,
+    category: hit.category,
+    rating: hit.rating,
+    review_count: hit.review_count,
+    lat: hit.lat,
+    lng: hit.lng,
+    raw: hit.raw,
+  };
+}

--- a/src/lib/prospecting/screen.ts
+++ b/src/lib/prospecting/screen.ts
@@ -1,0 +1,136 @@
+/**
+ * The cheap pass, before any model is called.
+ *
+ * Verification costs money per candidate, and most of what Places returns is
+ * disqualified by facts a model shouldn't be asked to establish: it already
+ * exists in your list, the hard filter says no, the "website" is a Facebook
+ * page. Screening in code first is roughly a tenth the cost of judging
+ * everything, and it is also more RELIABLE — "is this already a customer" is a
+ * database question, and a model asked to answer it will sometimes guess.
+ *
+ * Plain module. No session, no network for the deterministic parts.
+ */
+
+import type { PlaceHit } from "./places";
+
+export interface HuntFilters {
+  /** Only businesses with no real website. The headline use case. */
+  no_website?: boolean;
+  /** Only businesses WITH a website (the inverse hunt). */
+  has_website?: boolean;
+  min_rating?: number;
+  max_rating?: number;
+  min_reviews?: number;
+  max_reviews?: number;
+  /** Skip anything without a phone — nothing to reach them on. */
+  require_phone?: boolean;
+}
+
+export type ScreenResult =
+  | { keep: true; checks: Record<string, unknown> }
+  | { keep: false; reason: string; checks: Record<string, unknown> };
+
+/**
+ * Hosts that are a social or directory presence, not a website.
+ *
+ * A tradie whose Places listing points at their Facebook page is exactly the
+ * lead a "no website" hunt is looking for — treating that as "has a website"
+ * would filter out the best candidates. This is the difference between the
+ * feature working and not.
+ */
+const NOT_A_WEBSITE = [
+  "facebook.com", "instagram.com", "linkedin.com", "twitter.com", "x.com",
+  "tiktok.com", "youtube.com", "wa.me", "linktr.ee",
+  "yellowpages.com", "truelocal.com", "hotfrog.com", "localsearch.com",
+  "oneflare.com", "hipages.com", "airtasker.com", "serviceseeking.com",
+  "google.com", "business.site", "sites.google.com",
+];
+
+/**
+ * Country variants of the same platform: hipages.com.au, facebook.com.au.
+ * Stripping the ccTLD lets one entry above cover every country's copy —
+ * without it, `hipages.com.au` (the actual Australian domain) sails straight
+ * past a list that only knows `hipages.com`.
+ */
+const CC_TLD = /\.(au|nz|uk|ca|za|in|sg|ie|my|ph)$/;
+
+/** Is this URL a real site of their own, or a profile on someone else's? */
+export function isRealWebsite(url: string | null | undefined): boolean {
+  if (!url) return false;
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  const base = host.replace(CC_TLD, "");
+  return !NOT_A_WEBSITE.some((bad) =>
+    base === bad || base.endsWith(`.${bad}`) || host === bad || host.endsWith(`.${bad}`),
+  );
+}
+
+/** Last 9 digits, matching the generated phone_digits column. */
+export function phoneKey(phone: string | null | undefined): string | null {
+  const d = (phone ?? "").replace(/\D/g, "").slice(-9);
+  return d.length >= 6 ? d : null;
+}
+
+/**
+ * Apply the hard filters and the known-already checks.
+ *
+ * @param known  phone keys and normalised names already in prospects/customers
+ */
+export function screenCandidate(
+  hit: PlaceHit,
+  filters: HuntFilters,
+  known: { phones: Set<string>; websites: Set<string> },
+): ScreenResult {
+  const real = isRealWebsite(hit.website);
+  const checks: Record<string, unknown> = {
+    has_listing_website: Boolean(hit.website),
+    website_is_real: real,
+    phone: Boolean(hit.phone),
+  };
+
+  if (filters.no_website && real) {
+    return { keep: false, reason: "Has a real website", checks };
+  }
+  if (filters.has_website && !real) {
+    return { keep: false, reason: "No real website", checks };
+  }
+  if (filters.require_phone && !hit.phone) {
+    return { keep: false, reason: "No phone number", checks };
+  }
+  if (filters.min_rating != null && (hit.rating ?? 0) < filters.min_rating) {
+    return { keep: false, reason: `Rating below ${filters.min_rating}`, checks };
+  }
+  if (filters.max_rating != null && hit.rating != null && hit.rating > filters.max_rating) {
+    return { keep: false, reason: `Rating above ${filters.max_rating}`, checks };
+  }
+  if (filters.min_reviews != null && (hit.review_count ?? 0) < filters.min_reviews) {
+    return { keep: false, reason: `Fewer than ${filters.min_reviews} reviews`, checks };
+  }
+  if (filters.max_reviews != null && (hit.review_count ?? 0) > filters.max_reviews) {
+    return { keep: false, reason: `More than ${filters.max_reviews} reviews`, checks };
+  }
+
+  // Already yours — a prospect, or a customer you're already working with.
+  // Presenting these for review wastes the operator's attention, which is the
+  // scarcest thing in the whole loop.
+  const pk = phoneKey(hit.phone);
+  if (pk && known.phones.has(pk)) {
+    checks.already_known = "phone";
+    return { keep: false, reason: "Already in your contacts or prospects", checks };
+  }
+  if (real && hit.website) {
+    try {
+      const host = new URL(hit.website).hostname.toLowerCase().replace(/^www\./, "");
+      if (known.websites.has(host)) {
+        checks.already_known = "website";
+        return { keep: false, reason: "Already in your contacts or prospects", checks };
+      }
+    } catch { /* unparseable — treat as new */ }
+  }
+
+  return { keep: true, checks };
+}

--- a/src/lib/prospecting/verify.ts
+++ b/src/lib/prospecting/verify.ts
@@ -1,0 +1,102 @@
+/**
+ * The verifying agent — one call per candidate that survived screening.
+ *
+ * Its whole job is the judgement a filter can't make: "is this actually a
+ * service-based tradie?" Places says a business is called "Apex Solutions" in
+ * the "contractor" category; whether that's a sole-trader sparky or a
+ * 200-person facilities firm is a reading task.
+ *
+ * Deliberately narrow: it gets the listing and the criteria, and returns a
+ * fit/no-fit with a score and a sentence of reasoning. It does NOT decide
+ * whether to add anyone — that's the operator's call in the review queue.
+ *
+ * Cheap model on purpose. This runs per candidate and a hunt can return
+ * hundreds; the reasoning required is "does this description match those
+ * words", which does not need the expensive tier. The cost model is the whole
+ * reason screening runs first.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { AI_MODELS } from "@/lib/ai/models";
+import type { PlaceHit } from "./places";
+
+const anthropic = new Anthropic();
+
+export interface Verdict {
+  fit: boolean;
+  score: number;        // 0-100
+  reasoning: string;
+  cost_cents: number;
+}
+
+/** Sonnet rates, cents per 1k tokens. Matches the content engine's model. */
+const RATE = { in: 0.3, out: 1.5 };
+
+function costOf(u: { input_tokens: number; output_tokens: number }): number {
+  return (u.input_tokens / 1000) * RATE.in + (u.output_tokens / 1000) * RATE.out;
+}
+
+const SYSTEM = `You screen business listings against a prospecting brief.
+
+You will be given one business listing and the operator's criteria. Decide
+whether this business matches the criteria.
+
+Rules:
+- Judge ONLY from the listing. Do not speculate about what the business might
+  also do. If the listing is too thin to tell, that is a low score, not a guess.
+- "No website" has already been verified in code before you see this. Never
+  contradict it, and never treat a Facebook or directory page as a website.
+- Be decisive. A score of 50 helps nobody — commit to a judgement.
+- Reasoning is ONE sentence, written for the operator, naming the specific
+  thing that decided it. Not "appears to match the criteria".
+
+Respond with JSON only:
+{"fit": boolean, "score": 0-100, "reasoning": "one sentence"}`;
+
+function listingText(hit: PlaceHit): string {
+  return [
+    `Name: ${hit.name}`,
+    hit.category ? `Category: ${hit.category}` : null,
+    hit.address ? `Address: ${hit.address}` : null,
+    hit.phone ? `Phone: ${hit.phone}` : "Phone: none listed",
+    hit.website ? `Website on listing: ${hit.website}` : "Website: NONE",
+    hit.rating != null ? `Rating: ${hit.rating} from ${hit.review_count ?? 0} reviews` : "No rating",
+  ].filter(Boolean).join("\n");
+}
+
+export async function verifyCandidate(
+  hit: PlaceHit, criteria: string,
+): Promise<Verdict> {
+  const res = await anthropic.messages.create({
+    model: AI_MODELS.balanced,
+    max_tokens: 300,
+    system: SYSTEM,
+    messages: [{
+      role: "user",
+      content: `CRITERIA:\n${criteria}\n\nLISTING:\n${listingText(hit)}`,
+    }],
+  });
+
+  const cost = costOf(res.usage);
+  const text = res.content.find((b) => b.type === "text");
+  const raw = text && text.type === "text" ? text.text : "";
+
+  // The model is asked for bare JSON but sometimes wraps it in a fence. Pull
+  // the first object rather than failing the whole candidate over formatting.
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) {
+    return { fit: false, score: 0, reasoning: "Could not read the verdict.", cost_cents: cost };
+  }
+  try {
+    const v = JSON.parse(match[0]);
+    const score = Math.max(0, Math.min(100, Number(v.score) || 0));
+    return {
+      fit: Boolean(v.fit),
+      score,
+      reasoning: String(v.reasoning ?? "").slice(0, 500) || "No reason given.",
+      cost_cents: cost,
+    };
+  } catch {
+    return { fit: false, score: 0, reasoning: "Verdict was not valid JSON.", cost_cents: cost };
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -751,6 +751,78 @@ export interface Prospect {
   updated_at: string;
 }
 
+// ── Prospecting agent (hunts → candidates → reviewed into prospects) ────────
+export interface ProspectHuntFilters {
+  no_website?: boolean;
+  has_website?: boolean;
+  min_rating?: number;
+  max_rating?: number;
+  min_reviews?: number;
+  max_reviews?: number;
+  require_phone?: boolean;
+}
+
+export interface ProspectHunt {
+  id: string;
+  business_id: string;
+  name: string;
+  queries: string[];
+  centre_label: string | null;
+  centre_lat: number | null;
+  centre_lng: number | null;
+  radius_m: number;
+  /** Free text handed to the verifying agent verbatim. Deliberately not an enum. */
+  criteria: string;
+  filters: ProspectHuntFilters;
+  active: boolean;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type ProspectHuntRunStatus = 'running' | 'done' | 'failed' | 'cancelled';
+export interface ProspectHuntRun {
+  id: string;
+  business_id: string;
+  hunt_id: string;
+  status: ProspectHuntRunStatus;
+  found: number;
+  screened_out: number;
+  verified: number;
+  rejected: number;
+  cost_cents: number;
+  error: string | null;
+  started_at: string;
+  finished_at: string | null;
+}
+
+export type ProspectCandidateStatus =
+  | 'pending' | 'screened_out' | 'verified' | 'rejected' | 'added' | 'dismissed';
+export interface ProspectCandidate {
+  id: string;
+  business_id: string;
+  hunt_id: string;
+  run_id: string | null;
+  place_id: string | null;
+  name: string;
+  address: string | null;
+  phone: string | null;
+  website: string | null;
+  category: string | null;
+  rating: number | null;
+  review_count: number | null;
+  lat: number | null;
+  lng: number | null;
+  raw: Record<string, unknown>;
+  status: ProspectCandidateStatus;
+  score: number | null;
+  reasoning: string | null;
+  checks: Record<string, unknown>;
+  prospect_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // ── Assets & equipment (field-services plugin) ──────────────────────────────
 export type AssetCategory = 'tool' | 'vehicle' | 'equipment' | 'other';
 export type AssetStatus = 'active' | 'in_repair' | 'retired';

--- a/supabase/migrations/20260811100000_prospect_hunts.sql
+++ b/supabase/migrations/20260811100000_prospect_hunts.sql
@@ -1,0 +1,163 @@
+-- The prospecting agent: a saved hunt, its runs, and what it found.
+--
+-- Sourcing already existed (outreach_settings.sourcing_queries + locations →
+-- Google Places) but it was a single static list per business with no notion
+-- of "who counts as a prospect". This adds the missing half: named hunts with
+-- their own area and criteria, and a verification pass that judges each
+-- candidate against those criteria before anything reaches your prospect list.
+--
+-- Three tables, because the three things have genuinely different lifetimes:
+-- a hunt is edited over months, a run is a moment, a candidate is reviewed
+-- once and then either becomes a prospect or doesn't.
+
+-- ── The saved parameter set ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.prospect_hunts (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+
+  -- What to search Places for: ["roof repair", "roofing contractor"].
+  queries      JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Where. Places takes a circle, so this is a centre and a radius rather
+  -- than a suburb name — "within 25km of Parramatta" is the actual question
+  -- being asked, and a suburb list can't express it.
+  centre_label TEXT,
+  centre_lat   DOUBLE PRECISION,
+  centre_lng   DOUBLE PRECISION,
+  radius_m     INTEGER NOT NULL DEFAULT 25000,
+
+  -- 🔴 The dynamic part, and the reason this table exists. Free text, handed
+  -- to the verifying agent verbatim: "service-based tradies with no website",
+  -- "gyms with fewer than 3 locations", whatever the business is hunting.
+  -- NOT an enum: the whole point is that the operator changes their mind
+  -- without a migration.
+  criteria     TEXT NOT NULL,
+
+  -- Hard filters applied in code before any model is called, because they are
+  -- cheap and unambiguous. { "no_website": true, "min_rating": 4 }
+  filters      JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  active       BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_prospect_hunts_business
+  ON public.prospect_hunts (business_id, created_at DESC);
+
+COMMENT ON COLUMN public.prospect_hunts.criteria IS
+  'Free text, given to the verifying agent as-is. Deliberately not an enum.';
+
+-- ── One execution ──────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.prospect_hunt_runs (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  hunt_id       UUID NOT NULL REFERENCES public.prospect_hunts(id) ON DELETE CASCADE,
+  status        TEXT NOT NULL DEFAULT 'running',
+  CONSTRAINT prospect_hunt_runs_status_check
+    CHECK (status IN ('running', 'done', 'failed', 'cancelled')),
+
+  -- The funnel, so the run tells you where candidates were lost rather than
+  -- just how many survived.
+  found         INTEGER NOT NULL DEFAULT 0,   -- returned by Places
+  screened_out  INTEGER NOT NULL DEFAULT 0,   -- failed a cheap check
+  verified      INTEGER NOT NULL DEFAULT 0,   -- an agent judged them a fit
+  rejected      INTEGER NOT NULL DEFAULT 0,   -- an agent judged them not
+
+  cost_cents    NUMERIC(10,3) NOT NULL DEFAULT 0,
+  error         TEXT,
+  started_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  finished_at   TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_prospect_hunt_runs_hunt
+  ON public.prospect_hunt_runs (hunt_id, started_at DESC);
+
+-- ── What it found ──────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.prospect_candidates (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  hunt_id      UUID NOT NULL REFERENCES public.prospect_hunts(id) ON DELETE CASCADE,
+  run_id       UUID REFERENCES public.prospect_hunt_runs(id) ON DELETE SET NULL,
+
+  -- Places' own id. The unique index below is what stops the same business
+  -- being re-surfaced every single run.
+  place_id     TEXT,
+
+  name         TEXT NOT NULL,
+  address      TEXT,
+  phone        TEXT,
+  website      TEXT,
+  category     TEXT,
+  rating       NUMERIC(2,1),
+  review_count INTEGER,
+  lat          DOUBLE PRECISION,
+  lng          DOUBLE PRECISION,
+  raw          JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Verification output.
+  status       TEXT NOT NULL DEFAULT 'pending',
+  CONSTRAINT prospect_candidates_status_check
+    CHECK (status IN ('pending', 'screened_out', 'verified', 'rejected', 'added', 'dismissed')),
+  score        INTEGER,          -- 0-100, the agent's confidence in the fit
+  reasoning    TEXT,             -- why. Shown in the review queue verbatim.
+  checks       JSONB NOT NULL DEFAULT '{}'::jsonb,  -- cheap-check results
+
+  -- Set once someone approves it and it becomes a real prospect.
+  prospect_id  UUID REFERENCES public.prospects(id) ON DELETE SET NULL,
+
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One row per business per place, ever. Re-running a hunt weekly should
+-- surface what is NEW, not re-present everything you already rejected.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_prospect_candidates_place
+  ON public.prospect_candidates (business_id, place_id)
+  WHERE place_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_prospect_candidates_review
+  ON public.prospect_candidates (business_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_prospect_candidates_run
+  ON public.prospect_candidates (run_id);
+
+-- ── RLS: members except workers read, owner/admin/editor write ─────────────
+ALTER TABLE public.prospect_hunts       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.prospect_hunt_runs   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.prospect_candidates  ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['prospect_hunts','prospect_hunt_runs','prospect_candidates'] LOOP
+    EXECUTE format($f$
+      DROP POLICY IF EXISTS %1$s_read ON public.%1$s;
+      CREATE POLICY %1$s_read ON public.%1$s FOR SELECT USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members
+            WHERE user_id = auth.uid() AND status='active'
+        ) AND NOT public.is_business_worker(business_id)
+      );
+      DROP POLICY IF EXISTS %1$s_write ON public.%1$s;
+      CREATE POLICY %1$s_write ON public.%1$s FOR ALL USING (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members
+            WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      ) WITH CHECK (
+        business_id IN (
+          SELECT id FROM public.businesses WHERE user_id = auth.uid()
+          UNION SELECT business_id FROM public.business_members
+            WHERE user_id = auth.uid() AND status='active' AND role IN ('admin','editor')
+        )
+      );
+    $f$, t);
+  END LOOP;
+END $$;
+
+COMMENT ON TABLE public.prospect_candidates IS
+  'Businesses a hunt found. Nothing here is a prospect until someone approves it.';


### PR DESCRIPTION
Describe who you want — *"service-based tradies who have no website"* — and a hunt goes looking.

## How it works

Three stages, cheapest first, because each one costs more than the last.

**1. Find** (`src/lib/prospecting/places.ts`) — Google Places text search restricted to a circle, not biased to one, so a 10km radius means 10km. Places is the source rather than web search for one decisive reason: it returns `websiteUri`, so *"has no website"* is a fact from the source instead of a model failing to find one.

**2. Screen** (`src/lib/prospecting/screen.ts`) — deterministic, no model involved. Hard filters (no website / rating / reviews / has a phone), plus anything already in your prospects or customers. A Facebook page is **not** a website: a tradie whose only web presence is a Facebook page is exactly the prospect a "no website" hunt wants, and counting it as a site would filter out the best candidates. Country variants are handled too (`hipages.com.au`, not just `hipages.com` — caught by a test).

**3. Verify** (`src/lib/prospecting/verify.ts`) — one agent call per survivor, judging the listing against your criteria verbatim and returning a fit score plus the one sentence that decided it.

## The review queue is the gate

Nothing becomes a prospect on its own. Candidates land in a queue with the agent's reasoning next to each business, and you approve them one at a time or in bulk. An agent writing straight into the prospect list is one bad criteria string away from a list nobody trusts — and the reasoning is what tells you to fix the *criteria* rather than the results.

Per-run funnel counts are shown honestly ("found 60, 4 to review"), and if the verify cap bites, the run says so rather than quietly returning less.

## Data model

`prospect_hunts` / `prospect_hunt_runs` / `prospect_candidates` (migration `20260811100000`, **applied and recorded on remote**). `criteria` is free TEXT on purpose — the whole point is changing your mind without a migration. A unique index on `(business_id, place_id)` means re-running a hunt surfaces what's *new*, not everything you already rejected.

## Surfaces

- `/prospects/hunts` — hunt list + create
- `/prospects/hunts/[id]` — run it, funnel, that hunt's queue
- `/prospects/review` — every hunt's verified candidates in one queue
- "Find prospects" button on `/prospects`

## MCP

9 tools (`prospects:read` / `prospects:write`): list/create/update/delete hunt, run hunt, list runs, list candidates, add candidates, dismiss candidates. Approval takes **explicit ids**, so an assistant has to show you what it found before anything is added.

## Setup note

Hunts need a Google Places API key under Outreach settings — the key and its billing stay with the business. The UI says so up front when one isn't set, and `runHuntNow` reports it with the fix rather than failing blankly.

## Verification

`npx tsc --noEmit` clean · `npm test` 354 passed (13 new for the screening logic — one of them caught a real bug in the directory-domain matching) · `npm run build` clean, 5 prospects routes.

Not yet exercised against a live Places key — no business has one configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)