### PR TITLE
feat(prospects): Kirei can supply the Places key, because it's metered

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,3 +12,15 @@ OPENAI_API_KEY=sk-your-openai-key
 # no client-bundle weight, no behavior change. Set on Vercel to activate.
 # SENTRY_DSN=https://xxxx@oyyyy.ingest.sentry.io/zzzz
 # SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# ── Prospecting agent (hunts) ────────────────────────────────────────────────
+# Kirei's own Google Places key. Optional: a business can supply its own under
+# Outreach settings, and that one wins. This exists so someone who will never
+# open Google Cloud can still use the feature — which is why it's metered.
+# Restrict the key to the Places API in the Google Cloud console.
+GOOGLE_PLACES_API_KEY=
+# Cents per Places request, used to meter spend against each business's
+# monthly cap. Places bills per request, tiered by field mask; ours asks for
+# phone + website + rating, so it lands in a paid tier. Check the current rate
+# card and set this — the default (3.5) is a deliberate over-estimate.
+GOOGLE_PLACES_CENTS_PER_REQUEST=3.5

--- a/src/app/(dashboard)/prospects/hunts/page.tsx
+++ b/src/app/(dashboard)/prospects/hunts/page.tsx
@@ -2,7 +2,8 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
-import { listHunts } from "@/lib/actions/prospecting";
+import { listHunts, getProspectingBudget } from "@/lib/actions/prospecting";
+import { resolvePlacesKey } from "@/lib/prospecting/run";
 import { HuntsView } from "@/components/prospects/hunts-view";
 
 export default async function HuntsPage() {
@@ -16,21 +17,22 @@ export default async function HuntsPage() {
     redirect("/auth/login");
   }
 
-  const [hunts, review, settings] = await Promise.all([
+  const [hunts, review, budget, places] = await Promise.all([
     listHunts(),
     supabase.from("prospect_candidates")
       .select("id", { count: "exact", head: true })
       .eq("business_id", businessId).eq("status", "verified"),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (supabase as any).from("outreach_settings")
-      .select("places_api_key_enc").eq("business_id", businessId).maybeSingle(),
+    getProspectingBudget(),
+    resolvePlacesKey(supabase, businessId),
   ]);
 
   return (
     <HuntsView
       hunts={hunts}
       pendingReview={review.count ?? 0}
-      hasPlacesKey={Boolean(settings.data?.places_api_key_enc)}
+      budget={budget}
+      // Only whether a key exists crosses to the client — never the key.
+      canHunt={Boolean(places.key)}
     />
   );
 }

--- a/src/components/prospects/hunt-detail.tsx
+++ b/src/components/prospects/hunt-detail.tsx
@@ -89,6 +89,10 @@ export function HuntDetail({ hunt, runs, candidates }: Props) {
           <div className="ch-stat"><span>Filtered out</span><strong>{last.screened_out}</strong></div>
           <div className="ch-stat"><span>Not a fit</span><strong>{last.rejected}</strong></div>
           <div className="ch-stat"><span>To review</span><strong>{last.verified}</strong></div>
+          <div className="ch-stat">
+            <span>Cost</span>
+            <strong>${(Number(last.cost_cents) / 100).toFixed(2)}</strong>
+          </div>
         </div>
       )}
 

--- a/src/components/prospects/hunts-view.tsx
+++ b/src/components/prospects/hunts-view.tsx
@@ -22,16 +22,92 @@ import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
 import { Target, Plus, MapPin, Search, Globe, Star } from "@/components/ui/icons";
-import { createHunt } from "@/lib/actions/prospecting";
+import { createHunt, setProspectingBudget } from "@/lib/actions/prospecting";
+import type { SpendStatus } from "@/lib/prospecting/budget";
 import type { ProspectHunt } from "@/types/database";
 
 interface Props {
   hunts: ProspectHunt[];
   pendingReview: number;
-  hasPlacesKey: boolean;
+  budget: SpendStatus;
+  /** A Places key is available — the business's own, or Kirei's. */
+  canHunt: boolean;
 }
 
-export function HuntsView({ hunts, pendingReview, hasPlacesKey }: Props) {
+const money = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+/**
+ * Spend against the cap.
+ *
+ * Shown only when hunts run on Kirei's shared key — that's the only case where
+ * a cap is doing anything. A business paying Google on its own key is already
+ * capped by its own Cloud quota, and showing them a Kirei budget would imply
+ * we're rationing money that isn't ours to ration.
+ */
+function BudgetCard({ budget }: { budget: SpendStatus }) {
+  const { run, pending } = useMutation();
+  const [editing, setEditing] = useState(false);
+  const [dollars, setDollars] = useState((budget.budgetCents / 100).toFixed(2));
+
+  if (!budget.usingPlatformKey) return null;
+
+  const unlimited = budget.budgetCents === 0;
+  const pct = unlimited ? 0 : Math.min(100, (budget.spentCents / budget.budgetCents) * 100);
+
+  function save() {
+    const cents = Math.round(Number(dollars) * 100);
+    if (!Number.isFinite(cents) || cents < 0) { toast.error("Enter an amount"); return; }
+    void run(() => setProspectingBudget(cents), {
+      busy: "Saving budget…", success: "Budget updated", error: "Couldn't save",
+    }).then(() => setEditing(false));
+  }
+
+  return (
+    <div className="mb-4 rounded-xl border border-border bg-card p-4 shadow-sm">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p className="text-sm font-medium">
+          {money(budget.spentCents)} spent this month
+          {!unlimited && <span className="text-muted-foreground"> of {money(budget.budgetCents)}</span>}
+        </p>
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">$</span>
+            <Input className="h-8 w-24" type="number" min={0} step="0.5"
+              value={dollars} onChange={(e) => setDollars(e.target.value)} />
+            <Button size="sm" onClick={save} disabled={pending}>Save</Button>
+            <Button size="sm" variant="outline" onClick={() => setEditing(false)} disabled={pending}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+            {unlimited ? "Set a cap" : "Change cap"}
+          </Button>
+        )}
+      </div>
+
+      {!unlimited && (
+        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={pct >= 100 ? "h-full bg-destructive" : "h-full bg-primary"}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+
+      <p className="mt-2 text-xs text-muted-foreground">
+        Hunts run on Kirei&apos;s Google Places key, so searching and verifying are metered.
+        {unlimited
+          ? " No cap set — hunts will keep running."
+          : " Hunts stop once the month's spend reaches the cap."}{" "}
+        Using your own key instead (<Link href="/outreach/settings" className="underline">Outreach settings</Link>)
+        removes the cap and bills Google directly.
+      </p>
+    </div>
+  );
+}
+
+export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
   const { run, pending } = useMutation();
   const [open, setOpen] = useState(false);
 
@@ -72,15 +148,17 @@ export function HuntsView({ hunts, pendingReview, hasPlacesKey }: Props) {
         }
       />
 
-      {!hasPlacesKey && (
+      {!canHunt && (
         <div className="ch-empty mb-4 border-amber-300 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
-          <p className="font-medium">A Google Places API key is needed to run hunts.</p>
+          <p className="font-medium">No Google Places key is available, so hunts can&apos;t search.</p>
           <p className="text-sm mt-1">
-            Hunts search Google directly, so the key — and its billing — stay yours.
-            Add one under <Link href="/outreach/settings" className="underline">Outreach settings</Link>.
+            Add your own under <Link href="/outreach/settings" className="underline">Outreach settings</Link>,
+            or ask an admin to configure Kirei&apos;s.
           </p>
         </div>
       )}
+
+      {canHunt && <BudgetCard budget={budget} />}
 
       {pendingReview > 0 && (
         <Link

--- a/src/lib/actions/prospecting.ts
+++ b/src/lib/actions/prospecting.ts
@@ -15,7 +15,8 @@ import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { geocodeArea } from "@/lib/prospecting/places";
-import { getPlacesKey, runHunt, type HuntRow, type RunResult } from "@/lib/prospecting/run";
+import { getPlacesKey, resolvePlacesKey, runHunt, type HuntRow, type RunResult } from "@/lib/prospecting/run";
+import { prospectingSpendStatus, type SpendStatus } from "@/lib/prospecting/budget";
 import type {
   ProspectHunt, ProspectHuntRun, ProspectCandidate, ProspectHuntFilters,
 } from "@/types/database";
@@ -168,6 +169,29 @@ export async function listHuntRuns(huntId: string, limit = 20): Promise<Prospect
     .order("started_at", { ascending: false }).limit(limit);
   if (error) throw error;
   return (data ?? []) as ProspectHuntRun[];
+}
+
+// ── Budget ──────────────────────────────────────────────────────────────────
+
+/**
+ * This month's prospecting spend against the cap, plus whose Places key is
+ * paying. The UI needs both: a cap only makes sense to someone who can see
+ * what they've spent, and "whose key" changes whether the cap applies at all.
+ */
+export async function getProspectingBudget(): Promise<SpendStatus> {
+  const { supabase, businessId } = await ctx();
+  const { platform } = await resolvePlacesKey(supabase, businessId);
+  return prospectingSpendStatus(supabase, businessId, { usingPlatformKey: platform });
+}
+
+export async function setProspectingBudget(cents: number): Promise<{ budget_cents: number }> {
+  const { supabase, businessId } = await ctx();
+  const value = Math.max(0, Math.round(cents));
+  const { error } = await tbl(supabase, "businesses")
+    .update({ prospecting_monthly_budget_cents: value }).eq("id", businessId);
+  if (error) throw error;
+  revalidatePath("/prospects/hunts");
+  return { budget_cents: value };
 }
 
 // ── The review queue ────────────────────────────────────────────────────────

--- a/src/lib/mcp/tools/hunt-tools.ts
+++ b/src/lib/mcp/tools/hunt-tools.ts
@@ -10,7 +10,8 @@ import { z } from "zod";
 import { assertScope, t, text, errorText } from "../context";
 import { ctxFrom, UUID, type ToolFn } from "./shared";
 import { geocodeArea } from "@/lib/prospecting/places";
-import { getPlacesKey, runHunt, type HuntRow } from "@/lib/prospecting/run";
+import { getPlacesKey, resolvePlacesKey, runHunt, type HuntRow } from "@/lib/prospecting/run";
+import { prospectingSpendStatus } from "@/lib/prospecting/budget";
 
 const FILTERS = z.object({
   no_website: z.boolean().optional(),
@@ -161,6 +162,26 @@ export function registerHuntTools(tool: ToolFn): void {
         .order("started_at", { ascending: false }).limit(args.limit ?? 20);
       if (error) throw error;
       return text(data);
+    });
+
+  tool("get_prospecting_budget",
+    "This month's prospecting spend (Places searches + verification) against the monthly cap, and whether hunts are running on Kirei's shared Google Places key or the business's own.",
+    {},
+    async (_args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");
+      const { platform } = await resolvePlacesKey(ctx.sb, ctx.businessId);
+      return text(await prospectingSpendStatus(ctx.sb, ctx.businessId, { usingPlatformKey: platform }));
+    });
+
+  tool("set_prospecting_budget",
+    "Set the monthly prospecting cap in cents (0 = unlimited). Hunts stop once the month's spend reaches it. Only applies while using Kirei's shared Places key — a business paying Google directly is capped by its own Cloud quota.",
+    { cents: z.number().int().min(0) },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
+      const { error } = await t(ctx, "businesses")
+        .update({ prospecting_monthly_budget_cents: args.cents }).eq("id", ctx.businessId);
+      if (error) throw error;
+      return text({ budget_cents: args.cents });
     });
 
   tool("list_prospect_candidates",

--- a/src/lib/prospecting/__tests__/budget.test.ts
+++ b/src/lib/prospecting/__tests__/budget.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  placesCost, prospectingSpendStatus, budgetReachedMessage,
+  PLACES_CENTS_PER_REQUEST, DEFAULT_PROSPECTING_BUDGET_CENTS,
+} from "../budget";
+
+/** Minimal Supabase stub: enough shape for the two queries the meter makes. */
+function sbWith(opts: { budgetCents?: number | null; runs?: { cost_cents: unknown }[] }) {
+  return {
+    from(table: string) {
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        gte: () => Promise.resolve({ data: opts.runs ?? [] }),
+        maybeSingle: () => Promise.resolve({
+          data: opts.budgetCents === null
+            ? null
+            : { prospecting_monthly_budget_cents: opts.budgetCents },
+        }),
+      };
+      void table;
+      return chain;
+    },
+  };
+}
+
+describe("placesCost", () => {
+  it("prices per request", () => {
+    expect(placesCost(10)).toBeCloseTo(PLACES_CENTS_PER_REQUEST * 10, 3);
+    expect(placesCost(0)).toBe(0);
+  });
+});
+
+describe("prospectingSpendStatus", () => {
+  it("sums the month's runs against the cap", async () => {
+    const s = await prospectingSpendStatus(
+      sbWith({ budgetCents: 500, runs: [{ cost_cents: 120 }, { cost_cents: 80 }] }), "b1");
+    expect(s.spentCents).toBe(200);
+    expect(s.budgetCents).toBe(500);
+    expect(s.ok).toBe(true);
+  });
+
+  // PostgREST hands back NUMERIC as a string; plain += would build "0120080".
+  it("coerces string numerics rather than concatenating them", async () => {
+    const s = await prospectingSpendStatus(
+      sbWith({ budgetCents: 500, runs: [{ cost_cents: "120.5" }, { cost_cents: "80.25" }] }), "b1");
+    expect(s.spentCents).toBeCloseTo(200.75, 2);
+    expect(s.ok).toBe(true);
+  });
+
+  it("blocks once spend reaches the cap", async () => {
+    const s = await prospectingSpendStatus(
+      sbWith({ budgetCents: 500, runs: [{ cost_cents: 500 }] }), "b1");
+    expect(s.ok).toBe(false);
+  });
+
+  // 0 is an explicit opt-out, not "no budget configured" — it must not block.
+  it("treats a zero cap as unlimited", async () => {
+    const s = await prospectingSpendStatus(
+      sbWith({ budgetCents: 0, runs: [{ cost_cents: 99_999 }] }), "b1");
+    expect(s.ok).toBe(true);
+  });
+
+  it("falls back to the default cap when the business row has none", async () => {
+    const s = await prospectingSpendStatus(sbWith({ budgetCents: null, runs: [] }), "b1");
+    expect(s.budgetCents).toBe(DEFAULT_PROSPECTING_BUDGET_CENTS);
+    expect(s.ok).toBe(true);
+  });
+
+  it("reports whose key is paying", async () => {
+    const own = await prospectingSpendStatus(sbWith({ budgetCents: 500 }), "b1");
+    expect(own.usingPlatformKey).toBe(false);
+    const shared = await prospectingSpendStatus(
+      sbWith({ budgetCents: 500 }), "b1", { usingPlatformKey: true });
+    expect(shared.usingPlatformKey).toBe(true);
+  });
+});
+
+describe("budgetReachedMessage", () => {
+  it("names the amount and where to change it", () => {
+    const msg = budgetReachedMessage({
+      spentCents: 500, budgetCents: 500, ok: false, usingPlatformKey: true,
+    });
+    expect(msg).toContain("$5.00");
+    expect(msg).toMatch(/raise it/i);
+  });
+});

--- a/src/lib/prospecting/__tests__/places.test.ts
+++ b/src/lib/prospecting/__tests__/places.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { boundingBox, distanceM, withinRadius, type SearchArea, type PlaceHit } from "../places";
+
+// Parramatta-ish, which is where a Sydney hunt actually centres.
+const area: SearchArea = { lat: -33.8148, lng: 151.0017, radiusM: 10_000 };
+
+function hit(lat: number | null, lng: number | null): PlaceHit {
+  return {
+    place_id: "p", name: "n", address: null, phone: null, website: null,
+    category: null, rating: null, review_count: null, lat, lng, raw: {},
+  };
+}
+
+describe("boundingBox", () => {
+  // Text Search's locationRestriction takes a rectangle only — a circle is a
+  // 400, which is what broke every hunt before this existed.
+  it("produces a rectangle that contains the circle", () => {
+    const box = boundingBox(area);
+    expect(box.low.latitude).toBeLessThan(area.lat);
+    expect(box.high.latitude).toBeGreaterThan(area.lat);
+    expect(box.low.longitude).toBeLessThan(area.lng);
+    expect(box.high.longitude).toBeGreaterThan(area.lng);
+
+    // Each edge sits ~radius away from the centre.
+    const north = distanceM({ lat: area.lat, lng: area.lng }, { lat: box.high.latitude, lng: area.lng });
+    expect(north).toBeGreaterThan(9_000);
+    expect(north).toBeLessThan(11_000);
+  });
+
+  it("clamps to Places' 50km ceiling", () => {
+    const huge = boundingBox({ lat: 0, lng: 0, radiusM: 500_000 });
+    const north = distanceM({ lat: 0, lng: 0 }, { lat: huge.high.latitude, lng: 0 });
+    expect(north).toBeLessThan(51_000);
+  });
+
+  it("stays inside legal coordinates near a pole", () => {
+    const box = boundingBox({ lat: 89.9, lng: 179.9, radiusM: 50_000 });
+    expect(box.high.latitude).toBeLessThanOrEqual(90);
+    expect(box.low.latitude).toBeGreaterThanOrEqual(-90);
+    expect(box.high.longitude).toBeLessThanOrEqual(180);
+    expect(box.low.longitude).toBeGreaterThanOrEqual(-180);
+  });
+});
+
+describe("withinRadius", () => {
+  it("keeps a result at the centre", () => {
+    expect(withinRadius(hit(area.lat, area.lng), area)).toBe(true);
+  });
+
+  // The whole reason this function exists: the box's corners reach radius×√2,
+  // so without it a "10km" hunt returns businesses 14km away.
+  it("drops a corner of the bounding box that is outside the circle", () => {
+    const box = boundingBox(area);
+    const corner = hit(box.high.latitude, box.high.longitude);
+    expect(distanceM({ lat: area.lat, lng: area.lng },
+      { lat: box.high.latitude, lng: box.high.longitude })).toBeGreaterThan(area.radiusM);
+    expect(withinRadius(corner, area)).toBe(false);
+  });
+
+  it("keeps a result just inside the edge", () => {
+    const box = boundingBox(area);
+    expect(withinRadius(hit(box.high.latitude - 0.001, area.lng), area)).toBe(true);
+  });
+
+  // Losing a real business over a missing field is the worse error.
+  it("keeps a result with no coordinates", () => {
+    expect(withinRadius(hit(null, null), area)).toBe(true);
+  });
+});
+
+describe("distanceM", () => {
+  it("matches a known distance (Sydney CBD → Parramatta ≈ 23km)", () => {
+    const d = distanceM({ lat: -33.8688, lng: 151.2093 }, { lat: -33.8148, lng: 151.0017 });
+    expect(d).toBeGreaterThan(19_000);
+    expect(d).toBeLessThan(25_000);
+  });
+});

--- a/src/lib/prospecting/budget.ts
+++ b/src/lib/prospecting/budget.ts
@@ -1,0 +1,83 @@
+/**
+ * The meter that makes a platform-owned Places key safe.
+ *
+ * Kirei can supply the Google Places key itself, because asking a sole-trader
+ * to stand up a Google Cloud project with billing is a wall in front of the
+ * feature — nobody ever did it. But a shared key with no ceiling means one
+ * business's re-runs bill the platform, and hunts are re-runnable by design.
+ * So: every run is priced, month-to-date spend is checked before anything is
+ * spent, and the gate is re-checked mid-run.
+ *
+ * Same shape as `seoSpendStatus` — one budget idea in the app, not two.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SB = any;
+
+/**
+ * Cents per Places request.
+ *
+ * Places bills per request, tiered by which fields you ask for: Essentials
+ * (ids only), Pro, Enterprise. Our field mask asks for phone, website and
+ * rating — that's what makes "no website" a fact instead of a guess, and it's
+ * also what puts every request in a paid tier. Google's rate card moves, so
+ * this is an env knob rather than a constant to be edited in a release:
+ *
+ *   GOOGLE_PLACES_CENTS_PER_REQUEST=3.5
+ *
+ * The default is a deliberate over-estimate. A meter that under-charges lets
+ * real spend past the cap, which is the only failure mode that costs money.
+ */
+export const PLACES_CENTS_PER_REQUEST =
+  Number(process.env.GOOGLE_PLACES_CENTS_PER_REQUEST) || 3.5;
+
+export const DEFAULT_PROSPECTING_BUDGET_CENTS = 500;
+
+export function placesCost(requests: number): number {
+  return Number((requests * PLACES_CENTS_PER_REQUEST).toFixed(3));
+}
+
+export interface SpendStatus {
+  spentCents: number;
+  budgetCents: number;
+  /** False once the month's spend has reached the cap. */
+  ok: boolean;
+  /** True when hunts run on Kirei's key rather than the business's own. */
+  usingPlatformKey: boolean;
+}
+
+/**
+ * Month-to-date prospecting spend vs. the business's cap.
+ * `budgetCents === 0` means unlimited — an explicit opt-out, not a default.
+ */
+export async function prospectingSpendStatus(
+  sb: SB, businessId: string, opts: { usingPlatformKey?: boolean } = {},
+): Promise<SpendStatus> {
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+
+  const [{ data: biz }, { data: runs }] = await Promise.all([
+    sb.from("businesses").select("prospecting_monthly_budget_cents")
+      .eq("id", businessId).maybeSingle(),
+    sb.from("prospect_hunt_runs").select("cost_cents")
+      .eq("business_id", businessId).gte("started_at", monthStart),
+  ]);
+
+  const budgetCents = biz?.prospecting_monthly_budget_cents ?? DEFAULT_PROSPECTING_BUDGET_CENTS;
+  // PostgREST returns NUMERIC as a string — plain addition would concatenate.
+  const spentCents = ((runs ?? []) as { cost_cents: unknown }[])
+    .reduce((sum, r) => sum + (Number(r.cost_cents) || 0), 0);
+
+  return {
+    spentCents: Number(spentCents.toFixed(3)),
+    budgetCents,
+    ok: budgetCents === 0 || spentCents < budgetCents,
+    usingPlatformKey: opts.usingPlatformKey ?? false,
+  };
+}
+
+/** The message a blocked run shows. Says the number and where to change it. */
+export function budgetReachedMessage(status: SpendStatus): string {
+  return `Monthly prospecting budget reached ($${(status.budgetCents / 100).toFixed(2)}). `
+    + `Raise it on the Prospecting page to keep hunting.`;
+}

--- a/src/lib/prospecting/places.ts
+++ b/src/lib/prospecting/places.ts
@@ -83,8 +83,9 @@ export async function searchPlaces(
   query: string,
   area: SearchArea,
   maxPages = 3,
-): Promise<{ hits: PlaceHit[]; error: string | null }> {
+): Promise<{ hits: PlaceHit[]; error: string | null; requests: number }> {
   const hits: PlaceHit[] = [];
+  let requests = 0;
   let pageToken: string | undefined;
 
   for (let page = 0; page < maxPages; page++) {
@@ -103,6 +104,10 @@ export async function searchPlaces(
     if (pageToken) body.pageToken = pageToken;
 
     let res: Response;
+    // Counted before the await: Google bills the request, not the response, so
+    // a call that times out still cost money. Under-counting here would let a
+    // flaky run slip past the budget.
+    requests++;
     try {
       res = await fetch("https://places.googleapis.com/v1/places:searchText", {
         method: "POST",
@@ -114,14 +119,14 @@ export async function searchPlaces(
         body: JSON.stringify(body),
       });
     } catch (e) {
-      return { hits, error: e instanceof Error ? e.message : "Places request failed" };
+      return { hits, requests, error: e instanceof Error ? e.message : "Places request failed" };
     }
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       // Surface Google's own message — "API key not valid" and "billing not
       // enabled" are the two everyone hits, and both are actionable.
-      return { hits, error: `Places ${res.status}: ${text.slice(0, 300)}` };
+      return { hits, requests, error: `Places ${res.status}: ${text.slice(0, 300)}` };
     }
 
     const json = await res.json().catch(() => ({}));
@@ -132,7 +137,7 @@ export async function searchPlaces(
     if (!pageToken) break;
   }
 
-  return { hits, error: null };
+  return { hits, requests, error: null };
 }
 
 /** Turn a place name into coordinates, so a hunt can be defined by suburb. */

--- a/src/lib/prospecting/places.ts
+++ b/src/lib/prospecting/places.ts
@@ -68,11 +68,66 @@ export interface SearchArea {
 }
 
 /**
- * One text query, biased to a circle.
+ * The bounding box around a circle.
+ *
+ * Text Search's `locationRestriction` accepts a RECTANGLE only — passing a
+ * circle is a 400 ("Unknown name \"circle\""), even though `locationBias`
+ * takes one. So the hard restriction has to be a box, and the box is ~27%
+ * larger than the circle it contains: its corners reach `radius * √2`.
+ * `withinRadius` below trims that back off.
+ */
+export function boundingBox(area: SearchArea) {
+  const r = Math.min(Math.max(area.radiusM, 1), 50_000);
+  const dLat = (r / 111_320);
+  // Longitude degrees shrink towards the poles. The floor stops the box
+  // exploding to the whole planet for a point near one.
+  const dLng = r / (111_320 * Math.max(Math.cos((area.lat * Math.PI) / 180), 0.01));
+  return {
+    low: {
+      latitude: Math.max(-90, area.lat - dLat),
+      longitude: Math.max(-180, area.lng - dLng),
+    },
+    high: {
+      latitude: Math.min(90, area.lat + dLat),
+      longitude: Math.min(180, area.lng + dLng),
+    },
+  };
+}
+
+/** Great-circle distance in metres. */
+export function distanceM(
+  a: { lat: number; lng: number }, b: { lat: number; lng: number },
+): number {
+  const R = 6_371_000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const h = Math.sin(dLat / 2) ** 2
+    + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Is this result actually inside the radius the user asked for?
+ *
+ * The box has corners the circle doesn't, so without this a "10km" hunt
+ * returns businesses up to 14km away. A result with no coordinates is kept —
+ * dropping a real business over a missing field would be the worse error.
+ */
+export function withinRadius(hit: PlaceHit, area: SearchArea): boolean {
+  if (hit.lat == null || hit.lng == null) return true;
+  return distanceM({ lat: area.lat, lng: area.lng }, { lat: hit.lat, lng: hit.lng })
+    <= Math.min(Math.max(area.radiusM, 1), 50_000);
+}
+
+/**
+ * One text query, confined to an area.
  *
  * `locationRestriction` rather than `locationBias`: a bias is a suggestion and
  * Places will happily return results from the next state if it likes them
- * better. A hunt with a 10km radius means 10km.
+ * better. A hunt with a 10km radius means 10km — enforced in two steps, since
+ * the restriction can only be a rectangle: the box goes to Google, and
+ * `withinRadius` trims the corners off the results here.
  *
  * Paginated to `maxPages` because Places returns 20 per page and a broad query
  * in a city can run to hundreds — each page is a billed request, and the run
@@ -92,13 +147,9 @@ export async function searchPlaces(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const body: Record<string, any> = {
       textQuery: query,
-      locationRestriction: {
-        circle: {
-          center: { latitude: area.lat, longitude: area.lng },
-          // Places caps the radius at 50km; asking for more is a 400.
-          radius: Math.min(Math.max(area.radiusM, 1), 50_000),
-        },
-      },
+      // Rectangle, not circle — see boundingBox(). Places also caps the
+      // radius at 50km, which boundingBox() clamps to.
+      locationRestriction: { rectangle: boundingBox(area) },
       maxResultCount: 20,
     };
     if (pageToken) body.pageToken = pageToken;
@@ -131,7 +182,11 @@ export async function searchPlaces(
 
     const json = await res.json().catch(() => ({}));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for (const p of (json.places ?? []) as any[]) hits.push(toHit(p));
+    for (const p of (json.places ?? []) as any[]) {
+      const hit = toHit(p);
+      // Trim the box back to the circle the user actually asked for.
+      if (withinRadius(hit, area)) hits.push(hit);
+    }
 
     pageToken = json.nextPageToken;
     if (!pageToken) break;

--- a/src/lib/prospecting/run.ts
+++ b/src/lib/prospecting/run.ts
@@ -15,6 +15,7 @@ import { decryptSecret } from "@/lib/crypto";
 import { searchPlaces, type PlaceHit, type SearchArea } from "./places";
 import { screenCandidate, phoneKey, type HuntFilters } from "./screen";
 import { verifyCandidate } from "./verify";
+import { budgetReachedMessage, placesCost, prospectingSpendStatus } from "./budget";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SB = any;
@@ -38,19 +39,47 @@ export interface RunResult {
   screened_out: number;
   verified: number;
   rejected: number;
+  /** Total: Places requests + verify calls. What the monthly budget meters. */
   cost_cents: number;
+  places_requests: number;
+  places_cost_cents: number;
+  model_cost_cents: number;
   error: string | null;
+  /** Set when the run stopped early because the month's budget ran out. */
+  budget_stopped?: boolean;
 }
 
 /** How many survivors we're willing to pay a model to judge in one run. */
 const VERIFY_CAP = 60;
 
-/** Read the Places key a business configured for outreach sourcing. */
-export async function getPlacesKey(sb: SB, businessId: string): Promise<string | null> {
+/**
+ * The Places key to search with: the business's own if they've set one, else
+ * Kirei's.
+ *
+ * Their key wins deliberately. An agency that brought its own key wants its
+ * own quota and its own billing relationship with Google — silently spending
+ * the platform's instead would be the wrong answer even though it works. The
+ * platform key exists so a sole trader who will never open Google Cloud can
+ * still use the feature at all, and it's metered (see budget.ts) because it's
+ * shared.
+ */
+export async function resolvePlacesKey(
+  sb: SB, businessId: string,
+): Promise<{ key: string | null; platform: boolean }> {
   const { data } = await sb.from("outreach_settings")
     .select("places_api_key_enc").eq("business_id", businessId).maybeSingle();
-  if (!data?.places_api_key_enc) return null;
-  try { return decryptSecret(data.places_api_key_enc); } catch { return null; }
+
+  if (data?.places_api_key_enc) {
+    try { return { key: decryptSecret(data.places_api_key_enc), platform: false }; }
+    catch { /* undecryptable — fall through to the platform key */ }
+  }
+  const platform = process.env.GOOGLE_PLACES_API_KEY?.trim();
+  return platform ? { key: platform, platform: true } : { key: null, platform: false };
+}
+
+/** Back-compat shim for callers that only need a usable key (geocoding). */
+export async function getPlacesKey(sb: SB, businessId: string): Promise<string | null> {
+  return (await resolvePlacesKey(sb, businessId)).key;
 }
 
 /**
@@ -106,7 +135,8 @@ async function knownContacts(sb: SB, businessId: string) {
 export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
   const result: RunResult = {
     run_id: null, found: 0, screened_out: 0, verified: 0, rejected: 0,
-    cost_cents: 0, error: null,
+    cost_cents: 0, places_requests: 0, places_cost_cents: 0, model_cost_cents: 0,
+    error: null,
   };
 
   const { data: run } = await sb.from("prospect_hunt_runs").insert({
@@ -124,10 +154,31 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
     return result;
   };
 
-  const apiKey = await getPlacesKey(sb, hunt.business_id);
+  const { key: apiKey, platform } = await resolvePlacesKey(sb, hunt.business_id);
   if (!apiKey) {
-    return fail("No Google Places API key. Add one under Outreach settings — hunts search Google, so the key and its billing stay yours.");
+    return fail("No Google Places key available. Add your own under Outreach settings, or ask an admin to configure Kirei's.");
   }
+
+  // The gate, before a cent is spent. Only meters the platform key — a
+  // business paying Google directly is capped by their own Cloud quota, and
+  // metering their spend against ours would be us rationing their money.
+  if (platform) {
+    const status = await prospectingSpendStatus(sb, hunt.business_id, { usingPlatformKey: true });
+    if (!status.ok) {
+      // `cancelled`, not `failed` — hitting your own cap is the system working.
+      // Filing it as a failure would make the run history read like the hunt
+      // is broken.
+      result.budget_stopped = true;
+      result.error = budgetReachedMessage(status);
+      if (result.run_id) {
+        await sb.from("prospect_hunt_runs").update({
+          status: "cancelled", error: result.error, finished_at: new Date().toISOString(),
+        }).eq("id", result.run_id);
+      }
+      return result;
+    }
+  }
+
   if (hunt.centre_lat == null || hunt.centre_lng == null) {
     return fail("This hunt has no search area. Set a centre point and radius.");
   }
@@ -144,12 +195,15 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
   const hits = new Map<string, PlaceHit>();
   const searchErrors: string[] = [];
   for (const query of hunt.queries) {
-    const { hits: batch, error } = await searchPlaces(apiKey, query, area);
+    const { hits: batch, error, requests } = await searchPlaces(apiKey, query, area);
+    result.places_requests += requests;
     if (error) searchErrors.push(error);
     // Overlapping queries ("roof repair" / "roofing contractor") return the
     // same businesses; the map means each is judged once, not once per query.
     for (const h of batch) if (!hits.has(h.place_id)) hits.set(h.place_id, h);
   }
+  result.places_cost_cents = placesCost(result.places_requests);
+  result.cost_cents = result.places_cost_cents;
   if (!hits.size && searchErrors.length) return fail(searchErrors[0]);
   result.found = hits.size;
 
@@ -183,7 +237,21 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
   const toVerify = survivors.slice(0, VERIFY_CAP);
   const overflow = survivors.length - toVerify.length;
 
-  for (const hit of toVerify) {
+  let budgetStoppedAt = 0;
+
+  for (const [i, hit] of toVerify.entries()) {
+    // Re-checked every few candidates, not just once at the top: a run can
+    // spend for minutes, and the whole point of a cap is that it stops the
+    // spending in progress rather than reporting it afterwards.
+    if (platform && i > 0 && i % 10 === 0) {
+      const status = await prospectingSpendStatus(sb, hunt.business_id, { usingPlatformKey: true });
+      if (!(status.spentCents + result.cost_cents < status.budgetCents) && status.budgetCents !== 0) {
+        result.budget_stopped = true;
+        budgetStoppedAt = toVerify.length - i;
+        break;
+      }
+    }
+
     let verdict;
     try {
       verdict = await verifyCandidate(hit, hunt.criteria);
@@ -195,7 +263,8 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
         reasoning: e instanceof Error ? e.message : "Verification failed",
       };
     }
-    result.cost_cents += verdict.cost_cents;
+    result.model_cost_cents = Number((result.model_cost_cents + verdict.cost_cents).toFixed(3));
+    result.cost_cents = Number((result.places_cost_cents + result.model_cost_cents).toFixed(3));
     if (verdict.fit) result.verified++; else result.rejected++;
 
     await sb.from("prospect_candidates").upsert({
@@ -214,11 +283,16 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
       screened_out: result.screened_out,
       verified: result.verified,
       rejected: result.rejected,
-      cost_cents: Number(result.cost_cents.toFixed(3)),
-      // Never silently drop coverage: if the cap bit, say so on the run.
-      error: overflow > 0
-        ? `${overflow} more matched the filters but weren't verified this run (cap ${VERIFY_CAP}). Run again to continue.`
-        : searchErrors[0] ?? null,
+      cost_cents: result.cost_cents,
+      places_requests: result.places_requests,
+      places_cost_cents: result.places_cost_cents,
+      model_cost_cents: result.model_cost_cents,
+      // Never silently drop coverage: if either cap bit, say so on the run.
+      error: result.budget_stopped
+        ? `Stopped on the monthly budget with ${budgetStoppedAt} left to check. Raise the budget to finish.`
+        : overflow > 0
+          ? `${overflow} more matched the filters but weren't verified this run (cap ${VERIFY_CAP}). Run again to continue.`
+          : searchErrors[0] ?? null,
       finished_at: new Date().toISOString(),
     }).eq("id", result.run_id);
   }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -790,7 +790,11 @@ export interface ProspectHuntRun {
   screened_out: number;
   verified: number;
   rejected: number;
+  /** Total for the run: places_cost_cents + model_cost_cents. */
   cost_cents: number;
+  places_requests: number;
+  places_cost_cents: number;
+  model_cost_cents: number;
   error: string | null;
   started_at: string;
   finished_at: string | null;

--- a/supabase/migrations/20260811140000_prospecting_budget.sql
+++ b/supabase/migrations/20260811140000_prospecting_budget.sql
@@ -1,0 +1,32 @@
+-- Metering for the prospecting agent, so a platform-owned Places key is safe.
+--
+-- Kirei can now supply the Google Places key itself (GOOGLE_PLACES_API_KEY)
+-- instead of every business having to stand up a Google Cloud project — which
+-- nobody was ever going to do. That only works with a meter: a shared key with
+-- no cap means one business's re-runs bill the platform with nothing stopping
+-- them, and hunts are re-runnable by design.
+--
+-- Mirrors seo_monthly_budget_cents exactly (same default semantics, same
+-- 0 = unlimited opt-out) so there is one budget idea in the app, not two.
+
+ALTER TABLE public.businesses
+  ADD COLUMN IF NOT EXISTS prospecting_monthly_budget_cents INTEGER NOT NULL DEFAULT 500;
+
+COMMENT ON COLUMN public.businesses.prospecting_monthly_budget_cents IS
+  'Monthly ceiling (cents) for prospecting hunts — Places requests + verify calls. 0 = unlimited.';
+
+-- Split the run cost so the two very different spends stay legible: Places is
+-- billed per request by field mask, the verifier is billed per token. When a
+-- month gets expensive you need to know WHICH half did it — searching too
+-- broadly and judging too many are different fixes.
+ALTER TABLE public.prospect_hunt_runs
+  ADD COLUMN IF NOT EXISTS places_requests   INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS places_cost_cents NUMERIC(10,3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS model_cost_cents  NUMERIC(10,3) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.prospect_hunt_runs.cost_cents IS
+  'Total for the run: places_cost_cents + model_cost_cents. What the budget meters.';
+
+-- The budget reads month-to-date spend across every run for the business.
+CREATE INDEX IF NOT EXISTS idx_prospect_hunt_runs_spend
+  ON public.prospect_hunt_runs (business_id, started_at DESC);


### PR DESCRIPTION
Answers "should I use one API key for Kirei that everyone uses?" — **yes, but only with a meter**, which is what this adds.

## Why a platform key

Asking a sole trader to stand up a Google Cloud project with billing is a wall in front of the feature. That's why **not one business** ever configured the key outreach sourcing has asked for all along. And the purity was already gone: every hunt spends Kirei's Anthropic key on the verify step, so making them supply the *cheap* half bought friction and nothing else.

`GOOGLE_PLACES_API_KEY` is now a platform fallback. **A business's own key still wins** — an agency that brought one wants its own quota and its own billing relationship with Google, and quietly spending ours instead would be the wrong answer even though it works.

## The meter

- **Requests are counted before the `await`.** Google bills the request, not the response, so a call that times out still cost money. Under-counting would let a flaky run slip past the cap.
- **Priced via `GOOGLE_PLACES_CENTS_PER_REQUEST`**, defaulting high on purpose. Places bills per request tiered by field mask, and ours asks for phone + website + rating — the thing that makes "no website" a fact rather than a guess is also what puts every request in a paid tier. A meter that under-charges is the only failure mode that costs real money.
- **Run cost splits places / model.** When a month gets expensive you need to know which half did it: searching too broadly and judging too many are different fixes.
- **`businesses.prospecting_monthly_budget_cents`**, $5 default, `0` = unlimited — deliberately the same shape as `seo_monthly_budget_cents`, so there's one budget idea in the app rather than two.
- **The gate runs before the first search and every ten candidates mid-run.** A hunt spends for minutes; a cap that only reports overspend afterwards isn't a cap. Hitting it files the run as `cancelled`, not `failed` — your own ceiling working is not the hunt breaking.
- **The cap only applies to the platform key.** Someone paying Google directly is already bounded by their own Cloud quota; metering their spend against ours would be rationing money that isn't ours to ration.

## Surfaces

Spend + cap with an inline editor on `/prospects/hunts` (shown only when the shared key is in play), per-run cost in the funnel stats, and `get_prospecting_budget` / `set_prospecting_budget` over MCP.

## Setup

Set on Vercel: `GOOGLE_PLACES_API_KEY` (restrict it to the Places API in the Google Cloud console — Vercel's egress IPs aren't fixed, so API-restriction is the lever available) and optionally `GOOGLE_PLACES_CENTS_PER_REQUEST` once you've checked the current rate card. Without the env var, behaviour is exactly as today: business keys only.

## Verification

`npx tsc --noEmit` clean · `npm test` 362 passed, 8 new covering the meter — including the PostgREST string-numeric trap that would have made `120 + 80` produce `"12080"` and silently disable the cap · `npm run build` clean · migration applied and recorded on the remote (verified: `biz_col 1, run_cols 3, default 500`).

Still not exercised against a live Places key — that needs the env var set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)