### PR TITLE
feat(prospects): say how many, say what counts, and watch it work

### DIFF
--- a/src/app/(dashboard)/prospects/hunts/[id]/page.tsx
+++ b/src/app/(dashboard)/prospects/hunts/[id]/page.tsx
@@ -13,5 +13,17 @@ export default async function HuntPage({ params }: { params: Promise<{ id: strin
     listCandidates({ hunt_id: id, status: "verified" }),
   ]);
 
-  return <HuntDetail hunt={hunt} runs={runs} candidates={candidates} />;
+  // A run started in another tab (or before a reload) is rejoined rather than
+  // orphaned — the work continues server-side either way, so the page should
+  // pick the progress back up instead of pretending nothing is happening.
+  const active = runs.find((r) => r.status === "running") ?? null;
+
+  return (
+    <HuntDetail
+      hunt={hunt}
+      runs={runs}
+      candidates={candidates}
+      activeRunId={active?.id ?? null}
+    />
+  );
 }

--- a/src/app/api/prospecting/run/route.ts
+++ b/src/app/api/prospecting/run/route.ts
@@ -1,0 +1,83 @@
+/**
+ * Start a hunt and return immediately.
+ *
+ * A hunt is minutes of work — searches, then one model call per candidate,
+ * then the audit. As a blocking server action that meant a spinner with no
+ * information for two minutes, which is indistinguishable from a hang, and
+ * anything that outlived the function limit lost its results entirely.
+ *
+ * So: authorise, create the run row, hand back its id, and do the work in
+ * `after()`. The client polls the run's stage/processed/total and its event
+ * feed, which is where the progress bar and the live log come from.
+ *
+ * The background half uses the ADMIN client on purpose — the cookie-bound
+ * client's session isn't reliably usable once the response has been sent. It
+ * is scoped to the business_id resolved from the caller's own session BEFORE
+ * backgrounding, never from anything the request body claims.
+ */
+import { after, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getActiveBizId } from "@/lib/active-business";
+import { getUser } from "@/lib/auth";
+import { runHunt, type HuntRow } from "@/lib/prospecting/run";
+
+export const maxDuration = 300;
+
+export async function POST(request: Request) {
+  let businessId: string;
+  try {
+    const supabase = await createClient();
+    const user = await getUser();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    businessId = await getActiveBizId(supabase as any, user.id);
+  } catch {
+    return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const huntId = typeof body.hunt_id === "string" ? body.hunt_id : null;
+  if (!huntId) return NextResponse.json({ error: "hunt_id is required" }, { status: 400 });
+
+  // The generated Database type predates these tables, same as everywhere else
+  // that touches them (see `tbl()` in lib/actions and `t()` in lib/mcp).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const admin = createAdminClient() as any;
+
+  // Scoped by the session's business, so a guessed id from another tenant
+  // simply isn't found.
+  const { data: hunt } = await admin.from("prospect_hunts").select("*")
+    .eq("id", huntId).eq("business_id", businessId).maybeSingle();
+  if (!hunt) return NextResponse.json({ error: "Hunt not found" }, { status: 404 });
+
+  // One run at a time per hunt. Two concurrent runs would double-spend and
+  // race each other on the same place_id upserts.
+  const { data: active } = await admin.from("prospect_hunt_runs").select("id")
+    .eq("hunt_id", huntId).eq("status", "running").limit(1).maybeSingle();
+  if (active) {
+    return NextResponse.json({ run_id: active.id, already_running: true });
+  }
+
+  const { data: run, error } = await admin.from("prospect_hunt_runs").insert({
+    business_id: businessId, hunt_id: huntId, status: "running", stage: "queued",
+  }).select("id").single();
+  if (error || !run) {
+    return NextResponse.json({ error: "Couldn't start the run" }, { status: 500 });
+  }
+
+  after(async () => {
+    try {
+      await runHunt(admin, hunt as HuntRow, run.id);
+    } catch (e) {
+      // The run row is the only place a background failure can surface.
+      await admin.from("prospect_hunt_runs").update({
+        status: "failed",
+        stage: "finished",
+        error: e instanceof Error ? e.message : "The hunt failed unexpectedly",
+        finished_at: new Date().toISOString(),
+      }).eq("id", run.id);
+    }
+  });
+
+  return NextResponse.json({ run_id: run.id });
+}

--- a/src/components/prospects/hunt-builder.tsx
+++ b/src/components/prospects/hunt-builder.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+/**
+ * Building a hunt.
+ *
+ * The shape of this form is the feature. v1 was a textarea of comma-separated
+ * terms and a single radius, which made the two things that actually decide
+ * your results — what you search for and who counts — feel like afterthoughts.
+ *
+ * Here each search term is its own chip you add and remove, the area is either
+ * a radius or an explicit list of suburbs, the target is a number you set, and
+ * named requirements are rows you add one at a time. Everything the agent will
+ * be judged on is visible at once.
+ */
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Plus, X, Trash2, MapPin, Search, Target } from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
+import type {
+  ProspectHunt, ProspectHuntParam, ProspectHuntAreaMode, ProspectHuntFilters,
+} from "@/types/database";
+
+export interface HuntDraft {
+  name: string;
+  queries: string[];
+  criteria: string;
+  target_count: number;
+  area_mode: ProspectHuntAreaMode;
+  area: string;
+  radius_km: number;
+  suburb_labels: string[];
+  custom_params: ProspectHuntParam[];
+  filters: ProspectHuntFilters;
+}
+
+export function emptyDraft(): HuntDraft {
+  return {
+    name: "", queries: [], criteria: "", target_count: 20,
+    area_mode: "radius", area: "", radius_km: 25, suburb_labels: [],
+    custom_params: [], filters: { require_phone: true },
+  };
+}
+
+export function draftFrom(h: ProspectHunt): HuntDraft {
+  return {
+    name: h.name,
+    queries: h.queries ?? [],
+    criteria: h.criteria,
+    target_count: h.target_count ?? 20,
+    area_mode: h.area_mode ?? "radius",
+    area: h.centre_label ?? "",
+    radius_km: Math.round((h.radius_m ?? 25000) / 1000),
+    suburb_labels: (h.suburbs ?? []).map((s) => s.label),
+    custom_params: h.custom_params ?? [],
+    filters: h.filters ?? {},
+  };
+}
+
+/**
+ * A list you build one item at a time.
+ *
+ * Comma-separated text in a box looks simpler but hides the model: you can't
+ * see that "roof repair, roofing" is two searches and therefore twice the
+ * cost. Chips make the count obvious, which matters when each one is billed.
+ */
+function ChipList({ label, hint, items, placeholder, onChange }: {
+  label: string;
+  hint?: string;
+  items: string[];
+  placeholder: string;
+  onChange: (next: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  function add() {
+    const value = draft.trim();
+    if (!value) return;
+    if (items.some((i) => i.toLowerCase() === value.toLowerCase())) {
+      toast.info("Already on the list");
+      setDraft("");
+      return;
+    }
+    onChange([...items, value]);
+    setDraft("");
+  }
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2">
+        <Label>{label}</Label>
+        <span className="text-xs text-muted-foreground">
+          {items.length} {items.length === 1 ? "item" : "items"}
+        </span>
+      </div>
+
+      <div className="mt-1 flex gap-2">
+        <Input
+          value={draft}
+          placeholder={placeholder}
+          onChange={(e) => setDraft(e.target.value)}
+          // Enter adds, and does NOT submit the dialog — losing a half-typed
+          // list to an accidental save is the obvious way to make this annoying.
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); add(); } }}
+        />
+        <Button type="button" variant="outline" onClick={add} aria-label={`Add ${label}`}>
+          <Plus className="w-4 h-4" />
+        </Button>
+      </div>
+
+      {hint && <p className="mt-1 text-xs text-muted-foreground">{hint}</p>}
+
+      {items.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {items.map((item) => (
+            <span key={item}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 py-1 pl-3 pr-1 text-sm">
+              <span className="break-all">{item}</span>
+              <button
+                type="button"
+                onClick={() => onChange(items.filter((i) => i !== item))}
+                className="rounded-full p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
+                aria-label={`Remove ${item}`}
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Named requirements — the thing that makes a rejection explain itself. */
+function ParamEditor({ params, onChange }: {
+  params: ProspectHuntParam[];
+  onChange: (next: ProspectHuntParam[]) => void;
+}) {
+  function add() {
+    if (params.length >= 12) { toast.info("Twelve requirements is plenty"); return; }
+    onChange([...params, {
+      id: `p${Date.now().toString(36)}`, label: "", requirement: "", required: false,
+    }]);
+  }
+
+  function patch(id: string, fields: Partial<ProspectHuntParam>) {
+    onChange(params.map((p) => (p.id === id ? { ...p, ...fields } : p)));
+  }
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2">
+        <Label>Requirements</Label>
+        <Button type="button" size="sm" variant="outline" onClick={add}>
+          <Plus className="w-4 h-4 mr-1" /> Add
+        </Button>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Each one is checked separately, so a rejection tells you which requirement failed
+        instead of just &ldquo;not a fit&rdquo;.
+      </p>
+
+      {params.length === 0 ? (
+        <p className="mt-2 rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
+          None yet — the overall criteria above will be used on its own.
+        </p>
+      ) : (
+        <div className="mt-2 space-y-2">
+          {params.map((p) => (
+            <div key={p.id} className="rounded-lg border border-border p-3">
+              <div className="flex gap-2">
+                <Input
+                  className="h-9"
+                  value={p.label}
+                  placeholder="Owner-operator"
+                  onChange={(e) => patch(p.id, { label: e.target.value })}
+                  aria-label="Requirement name"
+                />
+                <Button type="button" variant="outline" size="sm"
+                  onClick={() => onChange(params.filter((x) => x.id !== p.id))}
+                  aria-label="Remove requirement">
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              </div>
+              <Textarea
+                className="mt-2"
+                rows={2}
+                value={p.requirement}
+                placeholder="Looks like a sole trader or a small crew — not a franchise or a national chain."
+                onChange={(e) => patch(p.id, { requirement: e.target.value })}
+                aria-label="What to check"
+              />
+              <label className="mt-2 flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={p.required}
+                  onChange={(e) => patch(p.id, { required: e.target.checked })}
+                />
+                Must pass — failing this disqualifies the business outright
+              </label>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function HuntBuilder({ draft, onChange }: {
+  draft: HuntDraft;
+  onChange: (next: HuntDraft) => void;
+}) {
+  const set = <K extends keyof HuntDraft>(key: K, value: HuntDraft[K]) =>
+    onChange({ ...draft, [key]: value });
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Label htmlFor="hunt-name">Name</Label>
+        <Input id="hunt-name" value={draft.name} placeholder="Western Sydney tradies"
+          onChange={(e) => set("name", e.target.value)} />
+      </div>
+
+      <ChipList
+        label="Search terms"
+        hint="Each term is a separate Google search, so each one adds to the cost."
+        items={draft.queries}
+        placeholder="roofing contractor"
+        onChange={(next) => set("queries", next)}
+      />
+
+      {/* ── How many ─────────────────────────────────────────────────── */}
+      <div>
+        <div className="flex items-baseline justify-between gap-2">
+          <Label htmlFor="hunt-target" className="flex items-center gap-1.5">
+            <Target className="w-3.5 h-3.5" /> How many do you want?
+          </Label>
+          <span className="text-sm font-medium tabular-nums">{draft.target_count}</span>
+        </div>
+        <input
+          id="hunt-target"
+          type="range"
+          min={1}
+          max={100}
+          value={draft.target_count}
+          onChange={(e) => set("target_count", Number(e.target.value))}
+          className="mt-2 w-full accent-primary"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          The run stops once it has this many, so you only pay to judge what you asked for.
+        </p>
+      </div>
+
+      {/* ── Where ────────────────────────────────────────────────────── */}
+      <div>
+        <Label className="flex items-center gap-1.5"><MapPin className="w-3.5 h-3.5" /> Where</Label>
+        <div className="mt-1 inline-flex rounded-md border border-border p-0.5">
+          {(["radius", "suburbs"] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => set("area_mode", mode)}
+              className={cn(
+                "rounded px-3 py-1 text-sm transition",
+                draft.area_mode === mode
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {mode === "radius" ? "Radius" : "Suburb list"}
+            </button>
+          ))}
+        </div>
+
+        {draft.area_mode === "radius" ? (
+          <div className="mt-2 grid grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor="hunt-area" className="text-xs">Centre</Label>
+              <Input id="hunt-area" value={draft.area} placeholder="Parramatta NSW"
+                onChange={(e) => set("area", e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="hunt-radius" className="text-xs">Radius (km)</Label>
+              <Input id="hunt-radius" type="number" min={1} max={50} value={draft.radius_km}
+                onChange={(e) => set("radius_km", Number(e.target.value))} />
+            </div>
+          </div>
+        ) : (
+          <div className="mt-2">
+            <ChipList
+              label="Suburbs"
+              hint="Each is searched in its own right — a service area is usually a list of suburbs, not a circle."
+              items={draft.suburb_labels}
+              placeholder="Parramatta NSW"
+              onChange={(next) => set("suburb_labels", next)}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* ── Who counts ───────────────────────────────────────────────── */}
+      <div>
+        <Label htmlFor="hunt-criteria" className="flex items-center gap-1.5">
+          <Search className="w-3.5 h-3.5" /> What makes them a prospect?
+        </Label>
+        <Textarea id="hunt-criteria" rows={3} value={draft.criteria}
+          placeholder="Service-based tradies who look like owner-operators or small crews — not franchises or national chains."
+          onChange={(e) => set("criteria", e.target.value)} />
+        <p className="mt-1 text-xs text-muted-foreground">
+          Plain English. An agent reads every listing and judges it against this.
+        </p>
+      </div>
+
+      <ParamEditor
+        params={draft.custom_params}
+        onChange={(next) => set("custom_params", next)}
+      />
+
+      {/* ── Hard filters ─────────────────────────────────────────────── */}
+      <div className="space-y-2 rounded-lg border border-border p-3">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Hard filters — applied before anything is judged, so they cost nothing
+        </p>
+        <label className="flex flex-wrap items-center gap-2 text-sm">
+          <input type="checkbox" checked={Boolean(draft.filters.no_website)}
+            onChange={(e) => set("filters", { ...draft.filters, no_website: e.target.checked || undefined })} />
+          Only businesses with no real website
+          <span className="text-xs text-muted-foreground">(a Facebook page doesn&apos;t count)</span>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={Boolean(draft.filters.require_phone)}
+            onChange={(e) => set("filters", { ...draft.filters, require_phone: e.target.checked || undefined })} />
+          Must have a phone number
+        </label>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <label className="flex items-center gap-2">
+            Minimum rating
+            <Input
+              className="h-8 w-20" type="number" min={0} max={5} step="0.1"
+              value={draft.filters.min_rating ?? ""}
+              onChange={(e) => set("filters", {
+                ...draft.filters,
+                min_rating: e.target.value === "" ? undefined : Number(e.target.value),
+              })}
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            Max reviews
+            <Input
+              className="h-8 w-24" type="number" min={0}
+              value={draft.filters.max_reviews ?? ""}
+              onChange={(e) => set("filters", {
+                ...draft.filters,
+                max_reviews: e.target.value === "" ? undefined : Number(e.target.value),
+              })}
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Shared validation — the same rules whether you're creating or editing. */
+export function validateDraft(draft: HuntDraft): string | null {
+  if (!draft.name.trim()) return "Give the hunt a name";
+  if (!draft.queries.length) return "Add at least one search term";
+  if (!draft.criteria.trim()) return "Describe what makes a business a prospect";
+  if (draft.area_mode === "radius" && !draft.area.trim()) return "Set an area to search";
+  if (draft.area_mode === "suburbs" && !draft.suburb_labels.length) return "Add at least one suburb";
+  if (draft.custom_params.some((p) => !p.label.trim() || !p.requirement.trim())) {
+    return "Every requirement needs a name and something to check";
+  }
+  return null;
+}

--- a/src/components/prospects/hunt-detail.tsx
+++ b/src/components/prospects/hunt-detail.tsx
@@ -1,58 +1,129 @@
 "use client";
 
 /**
- * One hunt: run it, see where the funnel lost people, work its review queue.
+ * One hunt: run it, watch it, read what the auditor made of it, work the queue.
  *
- * The funnel numbers are shown because "found 60, 4 to review" is the honest
- * story of a hunt — hiding the filtering makes a thin result look like a
- * broken search rather than a narrow criteria string.
+ * The audit panel is the part that earns its place. A run that returns 3 when
+ * you asked for 40 used to be a number and a shrug; now the run says which
+ * stage lost them and what to change. That is the difference between tuning a
+ * hunt and abandoning it.
  */
 
 import { useState } from "react";
 import Link from "next/link";
-import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 import { useMutation } from "@/components/layout/use-mutation";
 import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
-import { Play, MapPin, ArrowLeft, Trash2 } from "@/components/ui/icons";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import {
+  Play, MapPin, ArrowLeft, Trash2, Edit, Target, AlertTriangle, CheckCircle,
+} from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
 import { CandidateQueue } from "@/components/prospects/candidate-queue";
-import { runHuntNow, deleteHunt } from "@/lib/actions/prospecting";
-import type { ProspectHunt, ProspectHuntRun, ProspectCandidate } from "@/types/database";
+import { HuntProgress, startHunt } from "@/components/prospects/hunt-progress";
+import { HuntBuilder, draftFrom, validateDraft, type HuntDraft } from "@/components/prospects/hunt-builder";
+import { deleteHunt, updateHunt } from "@/lib/actions/prospecting";
+import type {
+  ProspectHunt, ProspectHuntRun, ProspectCandidate, ProspectAudit,
+} from "@/types/database";
 
 interface Props {
   hunt: ProspectHunt;
   runs: ProspectHuntRun[];
   candidates: ProspectCandidate[];
+  /** A run already in flight when the page loaded, so reopening rejoins it. */
+  activeRunId: string | null;
 }
 
-export function HuntDetail({ hunt, runs, candidates }: Props) {
-  const { run, pending } = useMutation();
-  const [hunting, setHunting] = useState(false);
-  const last = runs[0];
+const SEVERITY: Record<string, string> = {
+  high: "border-destructive/40 bg-destructive/5",
+  medium: "border-amber-400/40 bg-amber-50 dark:bg-amber-950/20",
+  low: "border-border bg-muted/30",
+};
 
-  function handleRun() {
-    setHunting(true);
-    void run(async () => {
-      const result = await runHuntNow(hunt.id);
-      if (result.error) throw new Error(result.error);
-      toast.success(
-        result.verified > 0
-          ? `${result.verified} to review — ${result.found} found, ${result.screened_out + result.rejected} filtered out`
-          : `Nothing matched — ${result.found} found, all filtered out`,
-      );
-    }, {
-      busy: "Hunting… searching, screening, then judging each one",
-      error: "The hunt failed",
-    }).finally(() => setHunting(false));
+function AuditPanel({ audit, shortfall }: { audit: ProspectAudit; shortfall: boolean }) {
+  if (!audit.summary && !audit.problems?.length) return null;
+
+  return (
+    <div className="mb-6 rounded-xl border border-border bg-card p-4 shadow-sm">
+      <p className="flex items-center gap-2 font-medium">
+        {shortfall
+          ? <AlertTriangle className="w-4 h-4 text-amber-500" />
+          : <CheckCircle className="w-4 h-4 text-emerald-500" />}
+        What the auditor made of this run
+      </p>
+
+      {audit.summary && (
+        <p className="mt-2 text-sm text-muted-foreground break-words">{audit.summary}</p>
+      )}
+
+      {audit.problems?.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {audit.problems.map((p, i) => (
+            <div key={i} className={cn("rounded-lg border p-3", SEVERITY[p.severity] ?? SEVERITY.low)}>
+              <p className="text-sm font-medium break-words">{p.title}</p>
+              <p className="mt-1 text-sm text-muted-foreground break-words">{p.detail}</p>
+              <p className="mt-1.5 text-sm break-words">
+                <span className="font-medium">Fix: </span>{p.fix}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function HuntDetail({ hunt, runs, candidates, activeRunId }: Props) {
+  const router = useRouter();
+  const { run: mutate, pending } = useMutation();
+  const [runId, setRunId] = useState<string | null>(activeRunId);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<HuntDraft>(() => draftFrom(hunt));
+
+  const last = runs[0];
+  const audit = (last?.audit ?? null) as ProspectAudit | null;
+  const shortfall = Boolean(last && last.verified < (hunt.target_count ?? 20));
+
+  async function handleRun() {
+    const id = await startHunt(hunt.id);
+    if (id) setRunId(id);
+  }
+
+  function handleSave() {
+    const problem = validateDraft(draft);
+    if (problem) { toast.error(problem); return; }
+    void mutate(async () => {
+      await updateHunt(hunt.id, {
+        name: draft.name,
+        queries: draft.queries,
+        criteria: draft.criteria,
+        target_count: draft.target_count,
+        area_mode: draft.area_mode,
+        area: draft.area,
+        radius_km: draft.radius_km,
+        suburb_labels: draft.suburb_labels,
+        custom_params: draft.custom_params,
+        filters: draft.filters,
+      });
+      setEditing(false);
+    }, { busy: "Saving hunt…", success: "Hunt updated", error: "Couldn't save" });
   }
 
   function handleDelete() {
     if (!confirm(`Delete "${hunt.name}" and everything it found?`)) return;
-    void run(() => deleteHunt(hunt.id), {
+    void mutate(() => deleteHunt(hunt.id), {
       busy: "Deleting…", success: "Hunt deleted", error: "Couldn't delete", refresh: false,
-    }).then(() => { window.location.href = "/prospects/hunts"; });
+    }).then(() => router.push("/prospects/hunts"));
   }
+
+  const areaText = hunt.area_mode === "suburbs"
+    ? (hunt.suburbs ?? []).map((s) => s.label).join(" · ") || "No suburbs set"
+    : `${hunt.centre_label ?? "No area set"} · ${Math.round(hunt.radius_m / 1000)}km`;
 
   return (
     <>
@@ -64,39 +135,45 @@ export function HuntDetail({ hunt, runs, candidates }: Props) {
             <Button variant="outline" asChild>
               <Link href="/prospects/hunts"><ArrowLeft className="w-4 h-4 mr-1.5" /> All hunts</Link>
             </Button>
+            <Button variant="outline" onClick={() => { setDraft(draftFrom(hunt)); setEditing(true); }}>
+              <Edit className="w-4 h-4 mr-1.5" /> Edit
+            </Button>
             <Button variant="outline" onClick={handleDelete} disabled={pending} aria-label="Delete hunt">
               <Trash2 className="w-4 h-4" />
             </Button>
-            <Button onClick={handleRun} disabled={pending || hunting}>
-              {hunting ? <Spinner size="sm" className="mr-1.5" /> : <Play className="w-4 h-4 mr-1.5" />}
-              {hunting ? "Hunting…" : "Run hunt"}
+            <Button onClick={handleRun} disabled={pending}>
+              <Play className="w-4 h-4 mr-1.5" /> Run hunt
             </Button>
           </>
         }
       />
 
       <div className="mb-6 flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground">
-        <span className="flex items-center gap-1.5">
-          <MapPin className="w-4 h-4" />
-          {hunt.centre_label ?? "No area set"} · {Math.round(hunt.radius_m / 1000)}km
-        </span>
+        <span className="flex items-center gap-1.5"><Target className="w-4 h-4" /> Wants {hunt.target_count ?? 20}</span>
+        <span className="flex items-center gap-1.5 break-words"><MapPin className="w-4 h-4" /> {areaText}</span>
         <span className="break-words">Searching: {hunt.queries.join(" · ")}</span>
+        {hunt.custom_params?.length > 0 && (
+          <span>{hunt.custom_params.length} named {hunt.custom_params.length === 1 ? "requirement" : "requirements"}</span>
+        )}
       </div>
 
-      {last && (
-        <div className="ch-stat-grid mb-6">
-          <div className="ch-stat"><span>Found</span><strong>{last.found}</strong></div>
-          <div className="ch-stat"><span>Filtered out</span><strong>{last.screened_out}</strong></div>
-          <div className="ch-stat"><span>Not a fit</span><strong>{last.rejected}</strong></div>
-          <div className="ch-stat"><span>To review</span><strong>{last.verified}</strong></div>
-          <div className="ch-stat">
-            <span>Cost</span>
-            <strong>${(Number(last.cost_cents) / 100).toFixed(2)}</strong>
-          </div>
-        </div>
+      {runId && (
+        <HuntProgress
+          runId={runId}
+          onFinished={(finishedRun) => {
+            toast[finishedRun.status === "done" ? "success" : "error"](
+              finishedRun.status === "done"
+                ? `${finishedRun.verified} to review`
+                : finishedRun.error ?? "The hunt stopped",
+            );
+            router.refresh();
+          }}
+        />
       )}
 
-      {last?.error && (
+      {!runId && audit && <AuditPanel audit={audit} shortfall={shortfall} />}
+
+      {!runId && last?.error && !audit?.problems?.length && (
         <p className="mb-4 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
           {last.error}
         </p>
@@ -113,6 +190,17 @@ export function HuntDetail({ hunt, runs, candidates }: Props) {
           ? "Run the hunt to find businesses in your area."
           : "Everything from the last run has been dealt with. Run it again to look for new listings."}
       />
+
+      <Dialog open={editing} onOpenChange={setEditing}>
+        <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
+          <DialogHeader><DialogTitle>Edit hunt</DialogTitle></DialogHeader>
+          <HuntBuilder draft={draft} onChange={setDraft} />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditing(false)} disabled={pending}>Cancel</Button>
+            <Button onClick={handleSave} disabled={pending}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/components/prospects/hunt-progress.tsx
+++ b/src/components/prospects/hunt-progress.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * Watching a hunt run.
+ *
+ * A hunt is minutes of work and used to show nothing until it finished, which
+ * is indistinguishable from a hang — the user's words were "we need a progress
+ * bar to show what's happening".
+ *
+ * So the run is started on the server and this polls it: a bar for the current
+ * stage, and the agent's own narration underneath. The log is the honest part —
+ * "12 found, 3 new" and "Ace Plumbing — 82% · sole trader, no website" tell you
+ * the thing is working AND whether it's finding the right sort of business,
+ * while there's still time to stop it.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/spinner";
+import { CheckCircle, AlertTriangle, XCircle, Info } from "@/components/ui/icons";
+import { getRunProgress } from "@/lib/actions/prospecting";
+import type {
+  ProspectHuntRun, ProspectHuntEvent, ProspectHuntStage, ProspectCandidate,
+} from "@/types/database";
+
+const STAGES: { key: ProspectHuntStage; label: string }[] = [
+  { key: "queued", label: "Starting" },
+  { key: "searching", label: "Searching" },
+  { key: "screening", label: "Filtering" },
+  { key: "verifying", label: "Checking each one" },
+  { key: "auditing", label: "Reviewing the run" },
+];
+
+const LEVEL_ICON = {
+  success: CheckCircle,
+  warn: AlertTriangle,
+  error: XCircle,
+  info: Info,
+} as const;
+
+const LEVEL_TONE = {
+  success: "text-emerald-600 dark:text-emerald-400",
+  warn: "text-amber-600 dark:text-amber-400",
+  error: "text-destructive",
+  info: "text-muted-foreground",
+} as const;
+
+interface Props {
+  runId: string;
+  /** Fires once the run reaches a terminal state, so the page can refresh. */
+  onFinished?: (run: ProspectHuntRun) => void;
+}
+
+export function HuntProgress({ runId, onFinished }: Props) {
+  const [run, setRun] = useState<ProspectHuntRun | null>(null);
+  const [events, setEvents] = useState<ProspectHuntEvent[]>([]);
+  const [verified, setVerified] = useState<ProspectCandidate[]>([]);
+  const since = useRef<string | undefined>(undefined);
+  const finished = useRef(false);
+  const logEnd = useRef<HTMLDivElement>(null);
+
+  const poll = useCallback(async () => {
+    try {
+      const p = await getRunProgress(runId, since.current);
+      if (p.run) setRun(p.run);
+      if (p.verified.length) setVerified(p.verified);
+      if (p.events.length) {
+        since.current = p.events[p.events.length - 1].created_at;
+        setEvents((prev) => [...prev, ...p.events]);
+      }
+      // Terminal states only. `stage` reaching "finished" without the status
+      // moving would leave the poller running forever.
+      if (p.run && p.run.status !== "running" && !finished.current) {
+        finished.current = true;
+        onFinished?.(p.run);
+      }
+    } catch {
+      // A dropped poll is not worth a toast — the next tick recovers.
+    }
+  }, [runId, onFinished]);
+
+  useEffect(() => {
+    void poll();
+    const id = setInterval(() => {
+      if (finished.current) { clearInterval(id); return; }
+      void poll();
+    }, 2000);
+    return () => clearInterval(id);
+  }, [poll]);
+
+  // Follow the log, the way a terminal does.
+  useEffect(() => { logEnd.current?.scrollIntoView({ behavior: "smooth" }); }, [events.length]);
+
+  const stage = run?.stage ?? "queued";
+  const stageIndex = Math.max(0, STAGES.findIndex((s) => s.key === stage));
+  const isRunning = !run || run.status === "running";
+
+  // Within-stage progress where we have it; otherwise the stage itself is the
+  // unit. A bar that sits at 0 through the slowest stage is worse than none.
+  const pct = run && run.total > 0
+    ? Math.min(100, (run.processed / run.total) * 100)
+    : ((stageIndex + (isRunning ? 0.5 : 1)) / STAGES.length) * 100;
+
+  return (
+    <div className="mb-6 rounded-xl border border-border bg-card p-4 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="flex items-center gap-2 font-medium">
+          {isRunning && <Spinner size="sm" />}
+          {isRunning
+            ? STAGES[stageIndex]?.label ?? "Working"
+            : run?.status === "done" ? "Finished" : run?.status === "cancelled" ? "Stopped" : "Failed"}
+        </p>
+        {run && run.total > 0 && isRunning && (
+          <span className="text-sm tabular-nums text-muted-foreground">
+            {run.processed} / {run.total}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full transition-[width] duration-500",
+            run?.status === "failed" ? "bg-destructive"
+              : run?.status === "cancelled" ? "bg-amber-500" : "bg-primary",
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        {STAGES.map((s, i) => (
+          <span key={s.key} className={cn(i === stageIndex && isRunning && "text-foreground font-medium",
+            i < stageIndex && "line-through opacity-60")}>
+            {s.label}
+          </span>
+        ))}
+      </div>
+
+      {run && !isRunning && (
+        <div className="ch-stat-grid mt-4">
+          <div className="ch-stat"><span>Found</span><strong>{run.found}</strong></div>
+          <div className="ch-stat"><span>Filtered out</span><strong>{run.screened_out}</strong></div>
+          <div className="ch-stat"><span>Not a fit</span><strong>{run.rejected}</strong></div>
+          <div className="ch-stat"><span>To review</span><strong>{run.verified}</strong></div>
+          <div className="ch-stat">
+            <span>Cost</span><strong>${(Number(run.cost_cents) / 100).toFixed(2)}</strong>
+          </div>
+        </div>
+      )}
+
+      {events.length > 0 && (
+        <div className="ch-scroll mt-3 max-h-56 overflow-y-auto rounded-lg border border-border bg-muted/30 p-3">
+          <ul className="space-y-1.5 text-sm">
+            {events.map((e) => {
+              const Icon = LEVEL_ICON[e.level] ?? Info;
+              return (
+                <li key={e.id} className="flex items-start gap-2">
+                  <Icon className={cn("mt-0.5 w-3.5 h-3.5 shrink-0", LEVEL_TONE[e.level])} />
+                  <span className="break-words">{e.message}</span>
+                </li>
+              );
+            })}
+          </ul>
+          <div ref={logEnd} />
+        </div>
+      )}
+
+      {isRunning && verified.length > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          {verified.length} queued for review so far.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Kick off a run. Returns the run id to watch, or null if it couldn't start. */
+export async function startHunt(huntId: string): Promise<string | null> {
+  try {
+    const res = await fetch("/api/prospecting/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hunt_id: huntId }),
+    });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast.error(json.error ?? "Couldn't start the hunt");
+      return null;
+    }
+    if (json.already_running) toast.info("That hunt is already running — showing it");
+    return json.run_id ?? null;
+  } catch {
+    toast.error("Couldn't reach the server");
+    return null;
+  }
+}

--- a/src/components/prospects/hunts-view.tsx
+++ b/src/components/prospects/hunts-view.tsx
@@ -23,6 +23,9 @@ import {
 } from "@/components/ui/dialog";
 import { Target, Plus, MapPin, Search, Globe, Star } from "@/components/ui/icons";
 import { createHunt, setProspectingBudget } from "@/lib/actions/prospecting";
+import {
+  HuntBuilder, emptyDraft, validateDraft, type HuntDraft,
+} from "@/components/prospects/hunt-builder";
 import type { SpendStatus } from "@/lib/prospecting/budget";
 import type { ProspectHunt } from "@/types/database";
 
@@ -111,28 +114,27 @@ export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
   const { run, pending } = useMutation();
   const [open, setOpen] = useState(false);
 
-  const [name, setName] = useState("");
-  const [queries, setQueries] = useState("");
-  const [criteria, setCriteria] = useState("");
-  const [area, setArea] = useState("");
-  const [radius, setRadius] = useState("25");
-  const [noWebsite, setNoWebsite] = useState(false);
-  const [requirePhone, setRequirePhone] = useState(true);
+  const [draft, setDraft] = useState<HuntDraft>(emptyDraft);
 
   function handleCreate() {
-    const terms = queries.split(/[,\n]/).map((q) => q.trim()).filter(Boolean);
-    if (!name.trim()) { toast.error("Give the hunt a name"); return; }
-    if (!terms.length) { toast.error("Add at least one search term"); return; }
-    if (!criteria.trim()) { toast.error("Describe what makes a business a prospect"); return; }
+    const problem = validateDraft(draft);
+    if (problem) { toast.error(problem); return; }
 
     void run(async () => {
       await createHunt({
-        name, queries: terms, criteria, area,
-        radius_km: Number(radius) || 25,
-        filters: { no_website: noWebsite || undefined, require_phone: requirePhone || undefined },
+        name: draft.name,
+        queries: draft.queries,
+        criteria: draft.criteria,
+        target_count: draft.target_count,
+        area_mode: draft.area_mode,
+        area: draft.area,
+        radius_km: draft.radius_km,
+        suburb_labels: draft.suburb_labels,
+        custom_params: draft.custom_params,
+        filters: draft.filters,
       });
       setOpen(false);
-      setName(""); setQueries(""); setCriteria(""); setArea("");
+      setDraft(emptyDraft());
     }, { busy: "Creating hunt…", success: "Hunt created", error: "Couldn't create the hunt" });
   }
 
@@ -215,7 +217,7 @@ export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
       )}
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
           <DialogHeader>
             <DialogTitle>New hunt</DialogTitle>
             <DialogDescription>
@@ -223,59 +225,7 @@ export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
-            <div>
-              <Label htmlFor="hunt-name">Name</Label>
-              <Input id="hunt-name" value={name} onChange={(e) => setName(e.target.value)}
-                placeholder="Western Sydney tradies" />
-            </div>
-
-            <div>
-              <Label htmlFor="hunt-queries">Search terms</Label>
-              <Textarea id="hunt-queries" rows={2} value={queries} onChange={(e) => setQueries(e.target.value)}
-                placeholder="plumber, electrician, roofing contractor" />
-              <p className="mt-1 text-xs text-muted-foreground">
-                One per line or comma-separated. These go to Google as-is.
-              </p>
-            </div>
-
-            <div>
-              <Label htmlFor="hunt-criteria">What makes them a prospect?</Label>
-              <Textarea id="hunt-criteria" rows={3} value={criteria} onChange={(e) => setCriteria(e.target.value)}
-                placeholder="Service-based tradies who look like owner-operators or small crews — not franchises or national chains." />
-              <p className="mt-1 text-xs text-muted-foreground">
-                Plain English. An agent reads every listing and judges it against this.
-              </p>
-            </div>
-
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <Label htmlFor="hunt-area">Area</Label>
-                <Input id="hunt-area" value={area} onChange={(e) => setArea(e.target.value)}
-                  placeholder="Parramatta NSW" />
-              </div>
-              <div>
-                <Label htmlFor="hunt-radius">Radius (km)</Label>
-                <Input id="hunt-radius" type="number" min={1} max={50} value={radius}
-                  onChange={(e) => setRadius(e.target.value)} />
-              </div>
-            </div>
-
-            <div className="space-y-2 rounded-lg border border-border p-3">
-              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Hard filters — applied before anything is judged
-              </p>
-              <label className="flex items-center gap-2 text-sm">
-                <input type="checkbox" checked={noWebsite} onChange={(e) => setNoWebsite(e.target.checked)} />
-                Only businesses with no real website
-                <span className="text-xs text-muted-foreground">(a Facebook page doesn&apos;t count)</span>
-              </label>
-              <label className="flex items-center gap-2 text-sm">
-                <input type="checkbox" checked={requirePhone} onChange={(e) => setRequirePhone(e.target.checked)} />
-                Must have a phone number
-              </label>
-            </div>
-          </div>
+          <HuntBuilder draft={draft} onChange={setDraft} />
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)} disabled={pending}>Cancel</Button>

--- a/src/lib/actions/prospecting.ts
+++ b/src/lib/actions/prospecting.ts
@@ -19,6 +19,7 @@ import { getPlacesKey, resolvePlacesKey, runHunt, type HuntRow, type RunResult }
 import { prospectingSpendStatus, type SpendStatus } from "@/lib/prospecting/budget";
 import type {
   ProspectHunt, ProspectHuntRun, ProspectCandidate, ProspectHuntFilters,
+  ProspectHuntParam, ProspectHuntSuburb, ProspectHuntAreaMode, ProspectHuntEvent,
 } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,7 +43,28 @@ export interface HuntInput {
   centre_lng?: number | null;
   radius_km?: number;
   filters?: ProspectHuntFilters;
+  /** How many verified prospects a run should aim for (1-100). */
+  target_count?: number;
+  area_mode?: ProspectHuntAreaMode;
+  /** Named areas, geocoded on save so a run never pays to look them up. */
+  suburb_labels?: string[];
+  custom_params?: ProspectHuntParam[];
   active?: boolean;
+}
+
+const clampTarget = (n?: number) => Math.min(Math.max(Math.round(n ?? 20), 1), 100);
+
+/** Give every param a stable id — the verifier answers by id, not by label. */
+function normaliseParams(params: ProspectHuntParam[]): ProspectHuntParam[] {
+  return params
+    .filter((p) => p.label?.trim() && p.requirement?.trim())
+    .slice(0, 12)
+    .map((p, i) => ({
+      id: p.id?.trim() || `p${i + 1}`,
+      label: p.label.trim().slice(0, 60),
+      requirement: p.requirement.trim().slice(0, 400),
+      required: Boolean(p.required),
+    }));
 }
 
 // ── Hunts ───────────────────────────────────────────────────────────────────
@@ -76,6 +98,29 @@ async function resolveArea(
   return key ? geocodeArea(key, label) : null;
 }
 
+/**
+ * Geocode each named suburb once, at save time.
+ *
+ * Doing it per run would bill a Places request per suburb per run for an
+ * answer that never changes. A suburb that can't be found is kept with null
+ * coordinates so the operator can see it was dropped, rather than silently
+ * vanishing from their service area.
+ */
+async function geocodeSuburbs(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any, businessId: string, labels: string[],
+): Promise<ProspectHuntSuburb[]> {
+  const key = await getPlacesKey(supabase, businessId);
+  const out: ProspectHuntSuburb[] = [];
+  for (const raw of labels.slice(0, 25)) {
+    const label = raw.trim();
+    if (!label) continue;
+    const found = key ? await geocodeArea(key, label) : null;
+    out.push({ label, lat: found?.lat ?? null, lng: found?.lng ?? null, radius_m: 5000 });
+  }
+  return out;
+}
+
 export async function createHunt(input: HuntInput): Promise<ProspectHunt> {
   const { supabase, user, businessId } = await ctx();
 
@@ -98,6 +143,12 @@ export async function createHunt(input: HuntInput): Promise<ProspectHunt> {
     centre_lng: lng,
     radius_m: Math.round(Math.min(Math.max(input.radius_km ?? 25, 1), 50) * 1000),
     filters: input.filters ?? {},
+    target_count: clampTarget(input.target_count),
+    area_mode: input.area_mode ?? "radius",
+    suburbs: input.area_mode === "suburbs" && input.suburb_labels?.length
+      ? await geocodeSuburbs(supabase, businessId, input.suburb_labels)
+      : [],
+    custom_params: normaliseParams(input.custom_params ?? []),
     active: input.active ?? true,
   }).select().single();
   if (error) throw error;
@@ -115,6 +166,12 @@ export async function updateHunt(id: string, input: Partial<HuntInput>): Promise
   if (input.criteria !== undefined) patch.criteria = input.criteria.trim();
   if (input.filters !== undefined) patch.filters = input.filters;
   if (input.active !== undefined) patch.active = input.active;
+  if (input.target_count !== undefined) patch.target_count = clampTarget(input.target_count);
+  if (input.area_mode !== undefined) patch.area_mode = input.area_mode;
+  if (input.custom_params !== undefined) patch.custom_params = normaliseParams(input.custom_params);
+  if (input.suburb_labels !== undefined) {
+    patch.suburbs = await geocodeSuburbs(supabase, businessId, input.suburb_labels);
+  }
   if (input.radius_km !== undefined) {
     patch.radius_m = Math.round(Math.min(Math.max(input.radius_km, 1), 50) * 1000);
   }
@@ -149,6 +206,14 @@ export async function deleteHunt(id: string): Promise<void> {
 
 // ── Runs ────────────────────────────────────────────────────────────────────
 
+/**
+ * Run a hunt synchronously and wait for it.
+ *
+ * Kept for MCP and any caller that genuinely wants the finished result in
+ * hand. The UI does NOT use this — it POSTs to /api/prospecting/run and polls,
+ * because a hunt takes minutes and a blocking call is a spinner with no
+ * information, plus anything past the function limit loses its results.
+ */
 export async function runHuntNow(id: string): Promise<RunResult> {
   const { supabase, businessId } = await ctx();
   const { data: hunt, error } = await tbl(supabase, "prospect_hunts").select("*")
@@ -160,6 +225,54 @@ export async function runHuntNow(id: string): Promise<RunResult> {
   revalidatePath("/prospects/hunts");
   revalidatePath(`/prospects/hunts/${id}`);
   return result;
+}
+
+export interface RunProgress {
+  run: ProspectHuntRun | null;
+  events: ProspectHuntEvent[];
+  /** New candidates already queued by this run, so the queue fills live. */
+  verified: ProspectCandidate[];
+}
+
+/**
+ * One poll of a running hunt: the run row (stage + counters), the events since
+ * the last one the client saw, and whatever has been verified so far.
+ *
+ * `sinceIso` rather than an offset — events are append-only and timestamped,
+ * so the client can ask for "anything newer than the last line I have" without
+ * the server tracking cursors.
+ */
+export async function getRunProgress(runId: string, sinceIso?: string): Promise<RunProgress> {
+  const { supabase, businessId } = await ctx();
+
+  const { data: run } = await tbl(supabase, "prospect_hunt_runs").select("*")
+    .eq("id", runId).eq("business_id", businessId).maybeSingle();
+  if (!run) return { run: null, events: [], verified: [] };
+
+  let q = tbl(supabase, "prospect_hunt_events").select("*")
+    .eq("run_id", runId).eq("business_id", businessId)
+    .order("created_at", { ascending: true }).limit(300);
+  if (sinceIso) q = q.gt("created_at", sinceIso);
+  const { data: events } = await q;
+
+  const { data: verified } = await tbl(supabase, "prospect_candidates").select("*")
+    .eq("run_id", runId).eq("business_id", businessId).eq("status", "verified")
+    .order("score", { ascending: false, nullsFirst: false }).limit(100);
+
+  return {
+    run: run as ProspectHuntRun,
+    events: (events ?? []) as ProspectHuntEvent[],
+    verified: (verified ?? []) as ProspectCandidate[],
+  };
+}
+
+/** The most recent run for a hunt — so a reopened page rejoins one in flight. */
+export async function getLatestRun(huntId: string): Promise<ProspectHuntRun | null> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "prospect_hunt_runs").select("*")
+    .eq("hunt_id", huntId).eq("business_id", businessId)
+    .order("started_at", { ascending: false }).limit(1).maybeSingle();
+  return (data as ProspectHuntRun) ?? null;
 }
 
 export async function listHuntRuns(huntId: string, limit = 20): Promise<ProspectHuntRun[]> {

--- a/src/lib/mcp/tools/hunt-tools.ts
+++ b/src/lib/mcp/tools/hunt-tools.ts
@@ -23,11 +23,47 @@ const FILTERS = z.object({
   require_phone: z.boolean().optional(),
 });
 
+const PARAMS = z.array(z.object({
+  id: z.string().optional(),
+  label: z.string().min(1).describe("Short name, e.g. 'Owner-operator'"),
+  requirement: z.string().min(1).describe("What to check, in plain words"),
+  required: z.boolean().optional().describe("A failure here disqualifies the business outright"),
+})).max(12);
+
 const CANDIDATE_STATUS = z.enum([
   "pending", "screened_out", "verified", "rejected", "added", "dismissed",
 ]);
 
 const clean = (v?: string) => (v?.trim() ? v.trim() : null);
+
+/** Stable ids — the verifier answers by id, not by label. */
+function normaliseParams(
+  params: { id?: string; label: string; requirement: string; required?: boolean }[],
+) {
+  return params.map((p, i) => ({
+    id: p.id?.trim() || `p${i + 1}`,
+    label: p.label.trim().slice(0, 60),
+    requirement: p.requirement.trim().slice(0, 400),
+    required: Boolean(p.required),
+  }));
+}
+
+/**
+ * Geocode named suburbs once, at save time — doing it per run would bill a
+ * Places request per suburb per run for an answer that never changes.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function geocodeSuburbs(sb: any, businessId: string, labels: string[]) {
+  const key = await getPlacesKey(sb, businessId);
+  const out = [];
+  for (const raw of labels) {
+    const label = raw.trim();
+    if (!label) continue;
+    const found = key ? await geocodeArea(key, label) : null;
+    out.push({ label, lat: found?.lat ?? null, lng: found?.lng ?? null, radius_m: 5000 });
+  }
+  return out;
+}
 const radiusM = (km?: number) => Math.round(Math.min(Math.max(km ?? 25, 1), 50) * 1000);
 
 export function registerHuntTools(tool: ToolFn): void {
@@ -54,6 +90,13 @@ export function registerHuntTools(tool: ToolFn): void {
       centre_lng: z.number().optional(),
       radius_km: z.number().min(1).max(50).optional(),
       filters: FILTERS.optional(),
+      target_count: z.number().int().min(1).max(100).optional()
+        .describe("How many verified prospects this run should aim for. The run stops there."),
+      area_mode: z.enum(["radius", "suburbs"]).optional(),
+      suburbs: z.array(z.string()).max(25).optional()
+        .describe("Named suburbs, each searched separately. Used when area_mode = suburbs."),
+      custom_params: PARAMS.optional()
+        .describe("Named requirements judged one by one, so a rejection says which failed."),
     },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
@@ -78,6 +121,12 @@ export function registerHuntTools(tool: ToolFn): void {
         centre_lng: lng,
         radius_m: radiusM(args.radius_km),
         filters: args.filters ?? {},
+        target_count: args.target_count ?? 20,
+        area_mode: args.area_mode ?? "radius",
+        suburbs: args.area_mode === "suburbs"
+          ? await geocodeSuburbs(ctx.sb, ctx.businessId, args.suburbs ?? [])
+          : [],
+        custom_params: normaliseParams(args.custom_params ?? []),
       }).select("id").single();
       if (error) throw error;
 
@@ -102,6 +151,10 @@ export function registerHuntTools(tool: ToolFn): void {
       centre_lng: z.number().optional(),
       radius_km: z.number().min(1).max(50).optional(),
       filters: FILTERS.optional(),
+      target_count: z.number().int().min(1).max(100).optional(),
+      area_mode: z.enum(["radius", "suburbs"]).optional(),
+      suburbs: z.array(z.string()).max(25).optional(),
+      custom_params: PARAMS.optional(),
       active: z.boolean().optional(),
     },
     async (args, extra) => {
@@ -113,6 +166,12 @@ export function registerHuntTools(tool: ToolFn): void {
       if (args.filters !== undefined) patch.filters = args.filters;
       if (args.active !== undefined) patch.active = args.active;
       if (args.radius_km !== undefined) patch.radius_m = radiusM(args.radius_km);
+      if (args.target_count !== undefined) patch.target_count = args.target_count;
+      if (args.area_mode !== undefined) patch.area_mode = args.area_mode;
+      if (args.custom_params !== undefined) patch.custom_params = normaliseParams(args.custom_params);
+      if (args.suburbs !== undefined) {
+        patch.suburbs = await geocodeSuburbs(ctx.sb, ctx.businessId, args.suburbs);
+      }
       if (args.centre_lat !== undefined) patch.centre_lat = args.centre_lat;
       if (args.centre_lng !== undefined) patch.centre_lng = args.centre_lng;
       if (args.area !== undefined) {
@@ -153,7 +212,8 @@ export function registerHuntTools(tool: ToolFn): void {
       return text(result);
     });
 
-  tool("list_prospect_hunt_runs", "Run history for a hunt, with the funnel counts and what each run cost.",
+  tool("list_prospect_hunt_runs",
+    "Run history for a hunt: the funnel counts, what each run cost, and the audit agent's verdict on WHY a run under-delivered (`audit.problems`, each with a concrete fix).",
     { hunt_id: UUID, limit: z.number().int().min(1).max(100).optional() },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "prospects:read");

--- a/src/lib/prospecting/__tests__/draft.test.ts
+++ b/src/lib/prospecting/__tests__/draft.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { emptyDraft, draftFrom, validateDraft } from "@/components/prospects/hunt-builder";
+import type { ProspectHunt } from "@/types/database";
+
+function validDraft() {
+  return {
+    ...emptyDraft(),
+    name: "Western Sydney tradies",
+    queries: ["plumber"],
+    criteria: "Owner-operators, not franchises",
+    area: "Parramatta NSW",
+  };
+}
+
+describe("validateDraft", () => {
+  it("accepts a complete radius hunt", () => {
+    expect(validateDraft(validDraft())).toBeNull();
+  });
+
+  it("names what is missing rather than failing generically", () => {
+    expect(validateDraft({ ...validDraft(), name: "  " })).toMatch(/name/i);
+    expect(validateDraft({ ...validDraft(), queries: [] })).toMatch(/search term/i);
+    expect(validateDraft({ ...validDraft(), criteria: "" })).toMatch(/prospect/i);
+  });
+
+  // The two area modes have different required fields — a radius hunt with no
+  // centre and a suburb hunt with no suburbs are both empty searches.
+  it("requires a centre in radius mode", () => {
+    expect(validateDraft({ ...validDraft(), area: "" })).toMatch(/area/i);
+  });
+
+  it("requires at least one suburb in suburb mode", () => {
+    const d = { ...validDraft(), area_mode: "suburbs" as const, area: "", suburb_labels: [] };
+    expect(validateDraft(d)).toMatch(/suburb/i);
+    expect(validateDraft({ ...d, suburb_labels: ["Parramatta NSW"] })).toBeNull();
+  });
+
+  it("rejects a half-filled requirement, which would be judged as blank", () => {
+    const d = {
+      ...validDraft(),
+      custom_params: [{ id: "p1", label: "Owner-operator", requirement: "", required: true }],
+    };
+    expect(validateDraft(d)).toMatch(/requirement/i);
+  });
+});
+
+describe("draftFrom", () => {
+  const hunt = {
+    id: "h", business_id: "b", name: "Hunt", queries: ["plumber"],
+    centre_label: "Parramatta NSW", centre_lat: -33.8, centre_lng: 151.0,
+    radius_m: 15000, criteria: "c", filters: { no_website: true },
+    target_count: 40, area_mode: "suburbs",
+    suburbs: [{ label: "Westmead", lat: -33.8, lng: 151.0, radius_m: 5000 }],
+    custom_params: [{ id: "p1", label: "L", requirement: "R", required: true }],
+    active: true, created_by: null, created_at: "", updated_at: "",
+  } as unknown as ProspectHunt;
+
+  it("round-trips an existing hunt into an editable draft", () => {
+    const d = draftFrom(hunt);
+    expect(d.target_count).toBe(40);
+    expect(d.area_mode).toBe("suburbs");
+    expect(d.suburb_labels).toEqual(["Westmead"]);
+    expect(d.radius_km).toBe(15);
+    expect(d.custom_params).toHaveLength(1);
+    expect(validateDraft(d)).toBeNull();
+  });
+
+  // Older hunts predate these columns; the editor must not open blank on them.
+  it("fills defaults for a hunt saved before v2", () => {
+    const legacy = { ...hunt, target_count: undefined, area_mode: undefined,
+      suburbs: undefined, custom_params: undefined } as unknown as ProspectHunt;
+    const d = draftFrom(legacy);
+    expect(d.target_count).toBe(20);
+    expect(d.area_mode).toBe("radius");
+    expect(d.suburb_labels).toEqual([]);
+    expect(d.custom_params).toEqual([]);
+  });
+});

--- a/src/lib/prospecting/audit.ts
+++ b/src/lib/prospecting/audit.ts
@@ -1,0 +1,164 @@
+/**
+ * The audit agent — it judges the RUN, not the businesses.
+ *
+ * A hunt that returns three prospects when you asked for fifty is the common
+ * case, and v1 just showed you the number. That leaves you guessing: were the
+ * search terms wrong, is the area too small, did the no-website filter eat
+ * everything, or are the criteria impossible? Those are four different fixes
+ * and the funnel counts alone don't distinguish them.
+ *
+ * So this reads the run's own evidence — where candidates were lost, which
+ * named requirement failed most often, what the rejections actually said — and
+ * names the problem with a fix. It runs once per run, so it can afford to
+ * think harder than the per-candidate verifier.
+ *
+ * It is diagnostic only. It never changes the hunt: a agent that silently
+ * rewrote your criteria would make the next run's results unexplainable.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { AI_MODELS } from "@/lib/ai/models";
+import type { ProspectHuntParam } from "@/types/database";
+
+const anthropic = new Anthropic();
+
+const RATE = { in: 0.3, out: 1.5 };
+
+export interface AuditProblem {
+  severity: "high" | "medium" | "low";
+  title: string;
+  detail: string;
+  /** The concrete change to make. Not advice — an instruction. */
+  fix: string;
+}
+
+export interface AuditReport {
+  summary: string;
+  problems: AuditProblem[];
+  cost_cents: number;
+}
+
+export interface AuditInput {
+  criteria: string;
+  params: ProspectHuntParam[];
+  queries: string[];
+  areaLabel: string;
+  filters: Record<string, unknown>;
+  target: number;
+  found: number;
+  screenedOut: number;
+  verified: number;
+  rejected: number;
+  /** Screening reasons, counted: { "Has a real website": 22 }. */
+  screenReasons: Record<string, number>;
+  /** Named requirements that failed, counted by label. */
+  paramFailures: Record<string, number>;
+  /** A handful of actual rejection sentences — the richest signal here. */
+  sampleRejections: string[];
+}
+
+const SYSTEM = `You audit a prospecting run and explain why it produced what it
+produced. You are talking to the small-business owner who set the hunt up, not
+to an engineer.
+
+You are given the hunt's configuration and the funnel: how many businesses
+Google returned, how many were filtered out and why, how many an agent judged
+a fit, and which named requirements failed most.
+
+Rules:
+- Diagnose from the numbers given. Never invent a cause you cannot see in them.
+- Rank by what actually cost the most prospects. If 22 of 30 were dropped by
+  one filter, that is the headline, not a stylistic note about the criteria.
+- Every problem needs a fix that is a specific change: which setting, and what
+  to change it to. "Broaden your criteria" is useless. "Drop 'no website' —
+  it removed 22 of 30" is useful.
+- If the run went well, say so plainly and return few or no problems. Do not
+  manufacture concerns to look thorough.
+- Plain words. No jargon, no hedging.
+
+Respond with JSON only:
+{"summary": "one or two sentences",
+ "problems": [{"severity":"high|medium|low","title":"short","detail":"why, citing the numbers","fix":"the specific change"}]}`;
+
+function brief(i: AuditInput): string {
+  const lines = [
+    `TARGET: ${i.target} prospects`,
+    `SEARCH TERMS: ${i.queries.join(", ") || "(none)"}`,
+    `AREA: ${i.areaLabel}`,
+    `FILTERS: ${JSON.stringify(i.filters)}`,
+    `CRITERIA: ${i.criteria}`,
+  ];
+
+  if (i.params.length) {
+    lines.push(`NAMED REQUIREMENTS:\n${i.params.map((p) =>
+      `  - ${p.label}${p.required ? " (required)" : ""}: ${p.requirement}`).join("\n")}`);
+  }
+
+  lines.push(
+    "",
+    "FUNNEL:",
+    `  ${i.found} returned by Google`,
+    `  ${i.screenedOut} removed by filters or already known`,
+    `  ${i.verified} judged a fit`,
+    `  ${i.rejected} judged not a fit`,
+  );
+
+  const reasons = Object.entries(i.screenReasons).sort((a, b) => b[1] - a[1]);
+  if (reasons.length) {
+    lines.push("", "WHY THEY WERE FILTERED OUT:",
+      ...reasons.map(([r, n]) => `  ${n} × ${r}`));
+  }
+
+  const fails = Object.entries(i.paramFailures).sort((a, b) => b[1] - a[1]);
+  if (fails.length) {
+    lines.push("", "REQUIREMENTS THAT FAILED MOST:",
+      ...fails.map(([r, n]) => `  ${n} × ${r}`));
+  }
+
+  if (i.sampleRejections.length) {
+    lines.push("", "SAMPLE REJECTIONS:",
+      ...i.sampleRejections.slice(0, 8).map((r) => `  - ${r}`));
+  }
+
+  return lines.join("\n");
+}
+
+export async function auditRun(input: AuditInput): Promise<AuditReport> {
+  try {
+    const res = await anthropic.messages.create({
+      model: AI_MODELS.balanced,
+      max_tokens: 1200,
+      system: SYSTEM,
+      messages: [{ role: "user", content: brief(input) }],
+    });
+
+    const cost = (res.usage.input_tokens / 1000) * RATE.in
+      + (res.usage.output_tokens / 1000) * RATE.out;
+
+    const text = res.content.find((b) => b.type === "text");
+    const raw = text && text.type === "text" ? text.text : "";
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) return { summary: "", problems: [], cost_cents: cost };
+
+    const parsed = JSON.parse(match[0]);
+    const problems: AuditProblem[] = Array.isArray(parsed.problems)
+      ? parsed.problems.slice(0, 6).map((p: Record<string, unknown>) => ({
+          severity: (["high", "medium", "low"] as const)
+            .includes(p.severity as "high") ? p.severity as AuditProblem["severity"] : "medium",
+          title: String(p.title ?? "").slice(0, 120),
+          detail: String(p.detail ?? "").slice(0, 600),
+          fix: String(p.fix ?? "").slice(0, 400),
+        })).filter((p: AuditProblem) => p.title)
+      : [];
+
+    return {
+      summary: String(parsed.summary ?? "").slice(0, 600),
+      problems,
+      cost_cents: cost,
+    };
+  } catch {
+    // The audit is commentary on work already done and paid for. Losing it
+    // must never lose the run's actual results.
+    return { summary: "", problems: [], cost_cents: 0 };
+  }
+}

--- a/src/lib/prospecting/run.ts
+++ b/src/lib/prospecting/run.ts
@@ -1,21 +1,33 @@
 /**
- * The hunt orchestrator: search → screen → verify → queue for review.
+ * The hunt orchestrator: search → screen → verify → audit.
  *
  * The order is the whole design. Places is billed per request, the verifying
  * agent is billed per candidate, and the operator's attention is the scarcest
  * of the three — so each stage is cheaper than the one it feeds, and nothing
  * reaches a human that a filter could have thrown away.
  *
+ * Two things shape the loop beyond that:
+ *
+ * - It stops at the TARGET, not at the end of the list. Asking for 10 and
+ *   paying to judge 200 is the failure mode that makes an agent expensive for
+ *   no benefit.
+ * - It narrates. A run takes minutes and used to return nothing until it was
+ *   done, which reads as a hang. Every stage writes events and progress
+ *   counters the UI polls.
+ *
  * Nothing here creates a prospect. Candidates land in a review queue and a
- * person approves them. An agent that silently filled your prospect list with
- * its own guesses would be worse than no agent at all.
+ * person approves them.
  */
 
 import { decryptSecret } from "@/lib/crypto";
 import { searchPlaces, type PlaceHit, type SearchArea } from "./places";
 import { screenCandidate, phoneKey, type HuntFilters } from "./screen";
 import { verifyCandidate } from "./verify";
+import { auditRun, type AuditInput } from "./audit";
 import { budgetReachedMessage, placesCost, prospectingSpendStatus } from "./budget";
+import type {
+  ProspectHuntParam, ProspectHuntSuburb, ProspectHuntAreaMode, ProspectHuntStage,
+} from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SB = any;
@@ -31,6 +43,10 @@ export interface HuntRow {
   radius_m: number;
   criteria: string;
   filters: HuntFilters;
+  target_count: number;
+  area_mode: ProspectHuntAreaMode;
+  suburbs: ProspectHuntSuburb[];
+  custom_params: ProspectHuntParam[];
 }
 
 export interface RunResult {
@@ -39,29 +55,29 @@ export interface RunResult {
   screened_out: number;
   verified: number;
   rejected: number;
-  /** Total: Places requests + verify calls. What the monthly budget meters. */
   cost_cents: number;
   places_requests: number;
   places_cost_cents: number;
   model_cost_cents: number;
   error: string | null;
-  /** Set when the run stopped early because the month's budget ran out. */
   budget_stopped?: boolean;
 }
 
-/** How many survivors we're willing to pay a model to judge in one run. */
-const VERIFY_CAP = 60;
+/**
+ * Hard ceiling on judgements per run, regardless of target.
+ *
+ * The target usually stops the loop first. This catches the case where almost
+ * nothing is a fit: asking for 100 in a suburb where 3 qualify would otherwise
+ * judge every business in the area looking for a 4th.
+ */
+const VERIFY_CEILING = 120;
 
 /**
- * The Places key to search with: the business's own if they've set one, else
- * Kirei's.
+ * The Places key: the business's own if set, else Kirei's.
  *
- * Their key wins deliberately. An agency that brought its own key wants its
- * own quota and its own billing relationship with Google — silently spending
- * the platform's instead would be the wrong answer even though it works. The
- * platform key exists so a sole trader who will never open Google Cloud can
- * still use the feature at all, and it's metered (see budget.ts) because it's
- * shared.
+ * Their key wins deliberately. An agency that brought its own wants its own
+ * quota and billing relationship with Google; silently spending the platform's
+ * would be wrong even though it works.
  */
 export async function resolvePlacesKey(
   sb: SB, businessId: string,
@@ -116,8 +132,6 @@ async function knownContacts(sb: SB, businessId: string) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   for (const c of ((customers ?? []) as any[])) add(c.phone, c.website);
 
-  // Candidates already seen by a previous run of any hunt — the unique index
-  // would reject them anyway, and re-verifying them would be paid-for waste.
   const { data: seen } = await sb.from("prospect_candidates")
     .select("place_id").eq("business_id", businessId).limit(10000);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,103 +140,183 @@ async function knownContacts(sb: SB, businessId: string) {
   return { phones, websites, placeIds };
 }
 
-/**
- * Execute one hunt.
- *
- * Long-running by nature (one model call per survivor), so callers should
- * treat it as a job, not a request handler.
- */
-export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
+/** The areas to search: one circle, or each named suburb in turn. */
+function areasFor(hunt: HuntRow): { label: string; area: SearchArea }[] {
+  if (hunt.area_mode === "suburbs") {
+    return (hunt.suburbs ?? [])
+      .filter((s) => s.lat != null && s.lng != null)
+      .map((s) => ({
+        label: s.label,
+        area: { lat: s.lat!, lng: s.lng!, radiusM: s.radius_m || 5000 },
+      }));
+  }
+  if (hunt.centre_lat == null || hunt.centre_lng == null) return [];
+  return [{
+    label: hunt.centre_label ?? "the search area",
+    area: { lat: hunt.centre_lat, lng: hunt.centre_lng, radiusM: hunt.radius_m || 25000 },
+  }];
+}
+
+export async function runHunt(sb: SB, hunt: HuntRow, existingRunId?: string): Promise<RunResult> {
   const result: RunResult = {
-    run_id: null, found: 0, screened_out: 0, verified: 0, rejected: 0,
+    run_id: existingRunId ?? null, found: 0, screened_out: 0, verified: 0, rejected: 0,
     cost_cents: 0, places_requests: 0, places_cost_cents: 0, model_cost_cents: 0,
     error: null,
   };
 
-  const { data: run } = await sb.from("prospect_hunt_runs").insert({
-    business_id: hunt.business_id, hunt_id: hunt.id, status: "running",
-  }).select("id").single();
-  result.run_id = run?.id ?? null;
+  if (!result.run_id) {
+    const { data: run } = await sb.from("prospect_hunt_runs").insert({
+      business_id: hunt.business_id, hunt_id: hunt.id, status: "running", stage: "queued",
+    }).select("id").single();
+    result.run_id = run?.id ?? null;
+  }
 
-  const fail = async (message: string) => {
+  /** Narration. Never throws — a logging failure must not lose a run. */
+  const say = async (message: string, level: "info" | "success" | "warn" | "error" = "info") => {
+    try {
+      await sb.from("prospect_hunt_events").insert({
+        business_id: hunt.business_id, hunt_id: hunt.id, run_id: result.run_id, level, message,
+      });
+    } catch { /* the run matters more than its commentary */ }
+  };
+
+  const progress = async (stage: ProspectHuntStage, processed = 0, total = 0) => {
+    try {
+      await sb.from("prospect_hunt_runs")
+        .update({ stage, processed, total }).eq("id", result.run_id);
+    } catch { /* same */ }
+  };
+
+  const finish = async (
+    status: "done" | "failed" | "cancelled", message: string | null,
+  ) => {
     result.error = message;
     if (result.run_id) {
       await sb.from("prospect_hunt_runs").update({
-        status: "failed", error: message, finished_at: new Date().toISOString(),
+        status,
+        stage: "finished",
+        found: result.found,
+        screened_out: result.screened_out,
+        verified: result.verified,
+        rejected: result.rejected,
+        cost_cents: result.cost_cents,
+        places_requests: result.places_requests,
+        places_cost_cents: result.places_cost_cents,
+        model_cost_cents: result.model_cost_cents,
+        error: message,
+        finished_at: new Date().toISOString(),
       }).eq("id", result.run_id);
     }
     return result;
   };
 
+  // ── Preflight ────────────────────────────────────────────────────────────
   const { key: apiKey, platform } = await resolvePlacesKey(sb, hunt.business_id);
   if (!apiKey) {
-    return fail("No Google Places key available. Add your own under Outreach settings, or ask an admin to configure Kirei's.");
+    await say("No Google Places key available.", "error");
+    return finish("failed", "No Google Places key available. Add your own under Outreach settings, or ask an admin to configure Kirei's.");
   }
 
-  // The gate, before a cent is spent. Only meters the platform key — a
-  // business paying Google directly is capped by their own Cloud quota, and
-  // metering their spend against ours would be us rationing their money.
   if (platform) {
     const status = await prospectingSpendStatus(sb, hunt.business_id, { usingPlatformKey: true });
     if (!status.ok) {
       // `cancelled`, not `failed` — hitting your own cap is the system working.
-      // Filing it as a failure would make the run history read like the hunt
-      // is broken.
       result.budget_stopped = true;
-      result.error = budgetReachedMessage(status);
-      if (result.run_id) {
-        await sb.from("prospect_hunt_runs").update({
-          status: "cancelled", error: result.error, finished_at: new Date().toISOString(),
-        }).eq("id", result.run_id);
-      }
-      return result;
+      await say(budgetReachedMessage(status), "warn");
+      return finish("cancelled", budgetReachedMessage(status));
     }
   }
 
-  if (hunt.centre_lat == null || hunt.centre_lng == null) {
-    return fail("This hunt has no search area. Set a centre point and radius.");
+  const areas = areasFor(hunt);
+  if (!areas.length) {
+    await say("This hunt has no search area.", "error");
+    return finish("failed", hunt.area_mode === "suburbs"
+      ? "No suburbs on this hunt could be located. Add at least one."
+      : "This hunt has no search area. Set a centre point and radius.");
   }
   if (!hunt.queries?.length) {
-    return fail("This hunt has no search terms.");
+    await say("This hunt has no search terms.", "error");
+    return finish("failed", "This hunt has no search terms.");
   }
 
-  const area: SearchArea = {
-    lat: hunt.centre_lat, lng: hunt.centre_lng, radiusM: hunt.radius_m || 25000,
-  };
+  const target = Math.min(Math.max(hunt.target_count || 20, 1), 100);
+  const params = hunt.custom_params ?? [];
+
+  await say(`Hunting for ${target} ${target === 1 ? "prospect" : "prospects"} · `
+    + `${hunt.queries.length} search ${hunt.queries.length === 1 ? "term" : "terms"} · `
+    + `${areas.length} ${areas.length === 1 ? "area" : "areas"}`
+    + (params.length ? ` · ${params.length} named ${params.length === 1 ? "requirement" : "requirements"}` : ""));
+
   const known = await knownContacts(sb, hunt.business_id);
 
   // ── 1. Search ────────────────────────────────────────────────────────────
+  const totalSearches = hunt.queries.length * areas.length;
+  await progress("searching", 0, totalSearches);
+
   const hits = new Map<string, PlaceHit>();
   const searchErrors: string[] = [];
-  for (const query of hunt.queries) {
-    const { hits: batch, error, requests } = await searchPlaces(apiKey, query, area);
-    result.places_requests += requests;
-    if (error) searchErrors.push(error);
-    // Overlapping queries ("roof repair" / "roofing contractor") return the
-    // same businesses; the map means each is judged once, not once per query.
-    for (const h of batch) if (!hits.has(h.place_id)) hits.set(h.place_id, h);
+  let done = 0;
+
+  for (const { label, area } of areas) {
+    for (const query of hunt.queries) {
+      const { hits: batch, error, requests } = await searchPlaces(apiKey, query, area);
+      result.places_requests += requests;
+      done++;
+
+      if (error) {
+        searchErrors.push(error);
+        await say(`"${query}" in ${label} failed — ${error}`, "error");
+      } else {
+        // Overlapping queries return the same businesses; the map means each
+        // is judged once, not once per query.
+        let fresh = 0;
+        for (const h of batch) if (!hits.has(h.place_id)) { hits.set(h.place_id, h); fresh++; }
+        await say(`"${query}" in ${label} — ${batch.length} found, ${fresh} new`);
+      }
+      await progress("searching", done, totalSearches);
+    }
   }
+
   result.places_cost_cents = placesCost(result.places_requests);
   result.cost_cents = result.places_cost_cents;
-  if (!hits.size && searchErrors.length) return fail(searchErrors[0]);
+
+  if (!hits.size) {
+    const why = searchErrors[0]
+      ?? "Google returned nothing for those terms in that area. Try broader terms or a wider radius.";
+    await say(why, "error");
+    return finish(searchErrors.length ? "failed" : "done", why);
+  }
   result.found = hits.size;
+  await say(`${result.found} businesses found`, "success");
 
   // ── 2. Screen ────────────────────────────────────────────────────────────
+  await progress("screening", 0, result.found);
+
   const survivors: PlaceHit[] = [];
   const rejects: { hit: PlaceHit; reason: string; checks: Record<string, unknown> }[] = [];
+  const screenReasons: Record<string, number> = {};
+  let screened = 0;
 
   for (const hit of hits.values()) {
-    if (known.placeIds.has(hit.place_id)) { result.screened_out++; continue; }
+    screened++;
+    if (known.placeIds.has(hit.place_id)) {
+      result.screened_out++;
+      screenReasons["Already seen by an earlier run"] =
+        (screenReasons["Already seen by an earlier run"] ?? 0) + 1;
+      continue;
+    }
     const verdict = screenCandidate(hit, hunt.filters ?? {}, known);
     if (verdict.keep) survivors.push(hit);
     else {
       result.screened_out++;
+      screenReasons[verdict.reason] = (screenReasons[verdict.reason] ?? 0) + 1;
       rejects.push({ hit, reason: verdict.reason, checks: verdict.checks });
     }
   }
+  await progress("screening", screened, result.found);
 
-  // Screened-out rows are still written: they're why the funnel numbers add up,
-  // and they stop the next run re-finding the same rejects.
+  // Screened-out rows are still written: they're why the funnel adds up, and
+  // they stop the next run re-finding the same rejects.
   if (rejects.length) {
     await sb.from("prospect_candidates").upsert(
       rejects.map(({ hit, reason, checks }) => ({
@@ -233,39 +327,59 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
     );
   }
 
-  // ── 3. Verify ────────────────────────────────────────────────────────────
-  const toVerify = survivors.slice(0, VERIFY_CAP);
-  const overflow = survivors.length - toVerify.length;
+  await say(`${survivors.length} past the filters, ${result.screened_out} removed`,
+    survivors.length ? "success" : "warn");
 
-  let budgetStoppedAt = 0;
+  // ── 3. Verify, stopping at the target ────────────────────────────────────
+  const ceiling = Math.min(survivors.length, VERIFY_CEILING);
+  await progress("verifying", 0, Math.min(ceiling, Math.max(target, 1)));
 
-  for (const [i, hit] of toVerify.entries()) {
-    // Re-checked every few candidates, not just once at the top: a run can
-    // spend for minutes, and the whole point of a cap is that it stops the
-    // spending in progress rather than reporting it afterwards.
-    if (platform && i > 0 && i % 10 === 0) {
+  const paramFailures: Record<string, number> = {};
+  const sampleRejections: string[] = [];
+  let judged = 0;
+
+  for (const hit of survivors.slice(0, ceiling)) {
+    if (result.verified >= target) {
+      await say(`Target of ${target} reached — stopping early, ${survivors.length - judged} left unjudged`, "success");
+      break;
+    }
+
+    // Re-checked periodically: a run spends for minutes, and the point of a
+    // cap is that it stops the spending in progress.
+    if (platform && judged > 0 && judged % 10 === 0) {
       const status = await prospectingSpendStatus(sb, hunt.business_id, { usingPlatformKey: true });
-      if (!(status.spentCents + result.cost_cents < status.budgetCents) && status.budgetCents !== 0) {
+      if (status.budgetCents !== 0 && status.spentCents + result.cost_cents >= status.budgetCents) {
         result.budget_stopped = true;
-        budgetStoppedAt = toVerify.length - i;
+        await say(budgetReachedMessage(status), "warn");
         break;
       }
     }
 
     let verdict;
     try {
-      verdict = await verifyCandidate(hit, hunt.criteria);
+      verdict = await verifyCandidate(hit, hunt.criteria, params);
     } catch (e) {
-      // One failed judgement shouldn't lose the rest of the run. It stays
-      // pending so a re-run can pick it up.
+      // One failed judgement shouldn't lose the rest of the run.
       verdict = {
-        fit: false, score: 0, cost_cents: 0,
+        fit: false, score: 0, cost_cents: 0, params: [],
         reasoning: e instanceof Error ? e.message : "Verification failed",
       };
     }
+    judged++;
+
     result.model_cost_cents = Number((result.model_cost_cents + verdict.cost_cents).toFixed(3));
     result.cost_cents = Number((result.places_cost_cents + result.model_cost_cents).toFixed(3));
-    if (verdict.fit) result.verified++; else result.rejected++;
+
+    if (verdict.fit) {
+      result.verified++;
+      await say(`${hit.name} — ${verdict.score}% · ${verdict.reasoning}`, "success");
+    } else {
+      result.rejected++;
+      if (sampleRejections.length < 8) sampleRejections.push(`${hit.name}: ${verdict.reasoning}`);
+      for (const p of verdict.params) {
+        if (!p.pass) paramFailures[p.label] = (paramFailures[p.label] ?? 0) + 1;
+      }
+    }
 
     await sb.from("prospect_candidates").upsert({
       ...candidateRow(hunt, result.run_id, hit),
@@ -273,31 +387,54 @@ export async function runHunt(sb: SB, hunt: HuntRow): Promise<RunResult> {
       score: verdict.score,
       reasoning: verdict.reasoning,
       checks: { screened: "passed" },
+      param_results: verdict.params,
     }, { onConflict: "business_id,place_id", ignoreDuplicates: true });
+
+    await progress("verifying", result.verified, target);
   }
+
+  // ── 4. Audit the run itself ──────────────────────────────────────────────
+  await progress("auditing", 0, 1);
+  await say("Reviewing how the run went…");
+
+  const auditInput: AuditInput = {
+    criteria: hunt.criteria,
+    params,
+    queries: hunt.queries,
+    areaLabel: areas.map((a) => a.label).join(", "),
+    filters: (hunt.filters ?? {}) as Record<string, unknown>,
+    target,
+    found: result.found,
+    screenedOut: result.screened_out,
+    verified: result.verified,
+    rejected: result.rejected,
+    screenReasons,
+    paramFailures,
+    sampleRejections,
+  };
+
+  const audit = await auditRun(auditInput);
+  result.model_cost_cents = Number((result.model_cost_cents + audit.cost_cents).toFixed(3));
+  result.cost_cents = Number((result.places_cost_cents + result.model_cost_cents).toFixed(3));
 
   if (result.run_id) {
     await sb.from("prospect_hunt_runs").update({
-      status: "done",
-      found: result.found,
-      screened_out: result.screened_out,
-      verified: result.verified,
-      rejected: result.rejected,
-      cost_cents: result.cost_cents,
-      places_requests: result.places_requests,
-      places_cost_cents: result.places_cost_cents,
-      model_cost_cents: result.model_cost_cents,
-      // Never silently drop coverage: if either cap bit, say so on the run.
-      error: result.budget_stopped
-        ? `Stopped on the monthly budget with ${budgetStoppedAt} left to check. Raise the budget to finish.`
-        : overflow > 0
-          ? `${overflow} more matched the filters but weren't verified this run (cap ${VERIFY_CAP}). Run again to continue.`
-          : searchErrors[0] ?? null,
-      finished_at: new Date().toISOString(),
+      audit: { summary: audit.summary, problems: audit.problems },
     }).eq("id", result.run_id);
   }
+  for (const p of audit.problems) {
+    await say(`${p.title} — ${p.fix}`, p.severity === "high" ? "warn" : "info");
+  }
 
-  return result;
+  const shortfall = result.verified < target;
+  await say(
+    `Done — ${result.verified} to review (asked for ${target}), $${(result.cost_cents / 100).toFixed(2)} spent`,
+    shortfall ? "warn" : "success",
+  );
+
+  return finish("done", result.budget_stopped
+    ? "Stopped on the monthly budget before reaching the target. Raise it to continue."
+    : searchErrors[0] ?? null);
 }
 
 function candidateRow(hunt: HuntRow, runId: string | null, hit: PlaceHit) {

--- a/src/lib/prospecting/verify.ts
+++ b/src/lib/prospecting/verify.ts
@@ -6,26 +6,35 @@
  * the "contractor" category; whether that's a sole-trader sparky or a
  * 200-person facilities firm is a reading task.
  *
- * Deliberately narrow: it gets the listing and the criteria, and returns a
- * fit/no-fit with a score and a sentence of reasoning. It does NOT decide
- * whether to add anyone — that's the operator's call in the review queue.
+ * Named params are judged ONE BY ONE and reported that way. With a single
+ * paragraph of criteria a rejection can only say "not a fit", which tells you
+ * nothing about what to change. With named requirements it says which one
+ * failed, and the auditor can then count failures per requirement and point at
+ * the one that's killing the run.
  *
  * Cheap model on purpose. This runs per candidate and a hunt can return
- * hundreds; the reasoning required is "does this description match those
- * words", which does not need the expensive tier. The cost model is the whole
- * reason screening runs first.
+ * hundreds; the cost model is the whole reason screening runs first.
  */
 
 import Anthropic from "@anthropic-ai/sdk";
 import { AI_MODELS } from "@/lib/ai/models";
 import type { PlaceHit } from "./places";
+import type { ProspectHuntParam } from "@/types/database";
 
 const anthropic = new Anthropic();
+
+export interface ParamResult {
+  id: string;
+  label: string;
+  pass: boolean;
+  note: string;
+}
 
 export interface Verdict {
   fit: boolean;
   score: number;        // 0-100
   reasoning: string;
+  params: ParamResult[];
   cost_cents: number;
 }
 
@@ -38,20 +47,26 @@ function costOf(u: { input_tokens: number; output_tokens: number }): number {
 
 const SYSTEM = `You screen business listings against a prospecting brief.
 
-You will be given one business listing and the operator's criteria. Decide
-whether this business matches the criteria.
+You are given one business listing, the operator's overall criteria, and
+possibly a list of named requirements. Decide whether this business matches.
 
 Rules:
 - Judge ONLY from the listing. Do not speculate about what the business might
-  also do. If the listing is too thin to tell, that is a low score, not a guess.
+  also do. If the listing is too thin to tell, that is a fail with a low score,
+  not a guess.
 - "No website" has already been verified in code before you see this. Never
   contradict it, and never treat a Facebook or directory page as a website.
+- Judge each named requirement separately and say why for each. A requirement
+  marked required:true that fails means the business is NOT a fit, whatever
+  the others say.
 - Be decisive. A score of 50 helps nobody — commit to a judgement.
-- Reasoning is ONE sentence, written for the operator, naming the specific
-  thing that decided it. Not "appears to match the criteria".
+- Reasoning is ONE sentence for the operator, naming the specific thing that
+  decided it. Never "appears to match the criteria".
 
 Respond with JSON only:
-{"fit": boolean, "score": 0-100, "reasoning": "one sentence"}`;
+{"fit": boolean, "score": 0-100, "reasoning": "one sentence",
+ "params": [{"id": "the id given", "pass": boolean, "note": "few words"}]}
+If there are no named requirements, return an empty params array.`;
 
 function listingText(hit: PlaceHit): string {
   return [
@@ -64,16 +79,23 @@ function listingText(hit: PlaceHit): string {
   ].filter(Boolean).join("\n");
 }
 
+function paramsText(params: ProspectHuntParam[]): string {
+  if (!params.length) return "";
+  return "\n\nNAMED REQUIREMENTS:\n" + params.map((p) =>
+    `- id=${p.id} | ${p.label}${p.required ? " (REQUIRED)" : ""}: ${p.requirement}`,
+  ).join("\n");
+}
+
 export async function verifyCandidate(
-  hit: PlaceHit, criteria: string,
+  hit: PlaceHit, criteria: string, params: ProspectHuntParam[] = [],
 ): Promise<Verdict> {
   const res = await anthropic.messages.create({
     model: AI_MODELS.balanced,
-    max_tokens: 300,
+    max_tokens: 700,
     system: SYSTEM,
     messages: [{
       role: "user",
-      content: `CRITERIA:\n${criteria}\n\nLISTING:\n${listingText(hit)}`,
+      content: `CRITERIA:\n${criteria}${paramsText(params)}\n\nLISTING:\n${listingText(hit)}`,
     }],
   });
 
@@ -85,18 +107,42 @@ export async function verifyCandidate(
   // the first object rather than failing the whole candidate over formatting.
   const match = raw.match(/\{[\s\S]*\}/);
   if (!match) {
-    return { fit: false, score: 0, reasoning: "Could not read the verdict.", cost_cents: cost };
+    return { fit: false, score: 0, reasoning: "Could not read the verdict.", params: [], cost_cents: cost };
   }
+
   try {
     const v = JSON.parse(match[0]);
     const score = Math.max(0, Math.min(100, Number(v.score) || 0));
+
+    // Re-attach labels from the hunt rather than trusting the model to echo
+    // them back — the id is the only thing it needs to get right.
+    const byId = new Map(params.map((p) => [p.id, p]));
+    const results: ParamResult[] = Array.isArray(v.params)
+      ? v.params.flatMap((r: { id?: string; pass?: unknown; note?: unknown }) => {
+          const def = r.id ? byId.get(String(r.id)) : undefined;
+          if (!def) return [];
+          return [{
+            id: def.id,
+            label: def.label,
+            pass: Boolean(r.pass),
+            note: String(r.note ?? "").slice(0, 200),
+          }];
+        })
+      : [];
+
+    // A required param that failed overrules a cheerful `fit: true`. The
+    // operator marked it required; the model doesn't get a veto on that.
+    const failedRequired = results.some((r) => !r.pass && byId.get(r.id)?.required);
+    const fit = Boolean(v.fit) && !failedRequired;
+
     return {
-      fit: Boolean(v.fit),
-      score,
+      fit,
+      score: failedRequired ? Math.min(score, 40) : score,
       reasoning: String(v.reasoning ?? "").slice(0, 500) || "No reason given.",
+      params: results,
       cost_cents: cost,
     };
   } catch {
-    return { fit: false, score: 0, reasoning: "Verdict was not valid JSON.", cost_cents: cost };
+    return { fit: false, score: 0, reasoning: "Verdict was not valid JSON.", params: [], cost_cents: cost };
   }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -762,6 +762,26 @@ export interface ProspectHuntFilters {
   require_phone?: boolean;
 }
 
+/** One named requirement, judged and reported on its own. */
+export interface ProspectHuntParam {
+  id: string;
+  label: string;
+  /** What the agent should check, in plain words. */
+  requirement: string;
+  /** A failure here disqualifies the business outright. */
+  required: boolean;
+}
+
+/** A named area in `suburbs` mode — each is searched in its own right. */
+export interface ProspectHuntSuburb {
+  label: string;
+  lat: number | null;
+  lng: number | null;
+  radius_m: number;
+}
+
+export type ProspectHuntAreaMode = 'radius' | 'suburbs';
+
 export interface ProspectHunt {
   id: string;
   business_id: string;
@@ -774,6 +794,11 @@ export interface ProspectHunt {
   /** Free text handed to the verifying agent verbatim. Deliberately not an enum. */
   criteria: string;
   filters: ProspectHuntFilters;
+  /** How many verified prospects this run should aim for (1-100). */
+  target_count: number;
+  area_mode: ProspectHuntAreaMode;
+  suburbs: ProspectHuntSuburb[];
+  custom_params: ProspectHuntParam[];
   active: boolean;
   created_by: string | null;
   created_at: string;
@@ -781,6 +806,29 @@ export interface ProspectHunt {
 }
 
 export type ProspectHuntRunStatus = 'running' | 'done' | 'failed' | 'cancelled';
+export type ProspectHuntStage =
+  'queued' | 'searching' | 'screening' | 'verifying' | 'auditing' | 'finished';
+
+export interface ProspectAuditProblem {
+  severity: 'high' | 'medium' | 'low';
+  title: string;
+  detail: string;
+  fix: string;
+}
+export interface ProspectAudit {
+  summary: string;
+  problems: ProspectAuditProblem[];
+}
+
+export interface ProspectHuntEvent {
+  id: string;
+  business_id: string;
+  hunt_id: string | null;
+  run_id: string | null;
+  level: 'info' | 'success' | 'warn' | 'error';
+  message: string;
+  created_at: string;
+}
 export interface ProspectHuntRun {
   id: string;
   business_id: string;
@@ -795,6 +843,11 @@ export interface ProspectHuntRun {
   places_requests: number;
   places_cost_cents: number;
   model_cost_cents: number;
+  stage: ProspectHuntStage;
+  /** Progress within the current stage, for the bar. */
+  processed: number;
+  total: number;
+  audit: ProspectAudit | null;
   error: string | null;
   started_at: string;
   finished_at: string | null;
@@ -822,6 +875,8 @@ export interface ProspectCandidate {
   score: number | null;
   reasoning: string | null;
   checks: Record<string, unknown>;
+  /** Per-named-requirement verdicts: which one it met, which it missed. */
+  param_results: { id: string; label: string; pass: boolean; note: string }[];
   prospect_id: string | null;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20260811180000_prospecting_v2.sql
+++ b/supabase/migrations/20260811180000_prospecting_v2.sql
@@ -1,0 +1,89 @@
+-- Prospecting v2: a target, named criteria, real areas, live progress, and an
+-- auditor that tells you why a run went badly.
+--
+-- v1 could only answer "here's what I found". The gaps that made it feel thin:
+-- you couldn't say how many you wanted, every criterion was buried in one
+-- paragraph so a rejection never told you WHICH requirement failed, an area
+-- was a single circle, a run was a black box for minutes, and a hunt that
+-- returned nothing left you guessing whether the terms, the filters, or the
+-- criteria were at fault.
+
+-- ── Hunts: what you're asking for ──────────────────────────────────────────
+ALTER TABLE public.prospect_hunts
+  -- How many verified prospects you actually want. The run stops when it has
+  -- them rather than judging everything Google returned — the cost of a run
+  -- should follow the size of the ask, not the size of the suburb.
+  ADD COLUMN IF NOT EXISTS target_count INTEGER NOT NULL DEFAULT 20
+    CONSTRAINT prospect_hunts_target_range CHECK (target_count BETWEEN 1 AND 100),
+
+  -- 'radius' = one circle. 'suburbs' = a named list, each searched in its own
+  -- right. A service area is usually "these six suburbs", not a circle that
+  -- happens to cover them plus a harbour.
+  ADD COLUMN IF NOT EXISTS area_mode TEXT NOT NULL DEFAULT 'radius'
+    CONSTRAINT prospect_hunts_area_mode CHECK (area_mode IN ('radius', 'suburbs')),
+  ADD COLUMN IF NOT EXISTS suburbs JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Named requirements, judged and reported one by one:
+  --   [{ id, label, requirement, required }]
+  -- The point is the reporting. With one blob of criteria a rejection says
+  -- "not a fit"; with named params it says WHICH one failed, which is the
+  -- difference between fixing the hunt and guessing at it.
+  ADD COLUMN IF NOT EXISTS custom_params JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.prospect_hunts.suburbs IS
+  'When area_mode = suburbs: [{label, lat, lng, radius_m}]. Each is searched separately.';
+COMMENT ON COLUMN public.prospect_hunts.custom_params IS
+  'Named requirements: [{id, label, requirement, required}]. Judged individually so failures name themselves.';
+
+-- ── Runs: progress you can watch, and a verdict on the run itself ──────────
+ALTER TABLE public.prospect_hunt_runs
+  ADD COLUMN IF NOT EXISTS stage TEXT NOT NULL DEFAULT 'queued'
+    CONSTRAINT prospect_hunt_runs_stage CHECK (
+      stage IN ('queued', 'searching', 'screening', 'verifying', 'auditing', 'finished')),
+  -- Progress is processed/total within the current stage, so a bar can move
+  -- during the slow part instead of sitting at 0 for two minutes.
+  ADD COLUMN IF NOT EXISTS processed INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS total INTEGER NOT NULL DEFAULT 0,
+  -- The auditor's findings: { summary, problems: [{severity, title, detail, fix}] }
+  ADD COLUMN IF NOT EXISTS audit JSONB;
+
+COMMENT ON COLUMN public.prospect_hunt_runs.audit IS
+  'The audit agent on the run itself — why it under-delivered and what to change.';
+
+-- ── The live feed ─────────────────────────────────────────────────────────
+-- Same shape as seo_job_events, for the same reason: a multi-minute agent run
+-- with no output reads as a hang.
+CREATE TABLE IF NOT EXISTS public.prospect_hunt_events (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id UUID NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  hunt_id     UUID REFERENCES public.prospect_hunts(id) ON DELETE CASCADE,
+  run_id      UUID REFERENCES public.prospect_hunt_runs(id) ON DELETE CASCADE,
+  level       TEXT NOT NULL DEFAULT 'info'
+    CHECK (level IN ('info', 'success', 'warn', 'error')),
+  message     TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_prospect_hunt_events_run
+  ON public.prospect_hunt_events (run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_prospect_hunt_events_business
+  ON public.prospect_hunt_events (business_id, created_at DESC);
+
+ALTER TABLE public.prospect_hunt_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS prospect_hunt_events_read ON public.prospect_hunt_events;
+CREATE POLICY prospect_hunt_events_read ON public.prospect_hunt_events FOR SELECT USING (
+  business_id IN (
+    SELECT id FROM public.businesses WHERE user_id = auth.uid()
+    UNION SELECT business_id FROM public.business_members
+      WHERE user_id = auth.uid() AND status = 'active'
+  ) AND NOT public.is_business_worker(business_id)
+);
+
+-- Candidates gain the per-param breakdown, so the review queue can show which
+-- requirement each business met and which it missed.
+ALTER TABLE public.prospect_candidates
+  ADD COLUMN IF NOT EXISTS param_results JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.prospect_candidates.param_results IS
+  'Per-custom-param verdicts: [{id, label, pass, note}].';


### PR DESCRIPTION
Everything asked for, plus the auditor. Each item below is a place v1 made you guess.

## How many — 1 to 100

`target_count` on a slider. The run **stops when it has them** rather than judging everything Google returned. Asking for 10 and paying to read 200 listings is the failure mode that makes an agent expensive for no benefit.

## Custom params — named requirements

Criteria used to be one paragraph, so a rejection could only say "not a fit". Now each requirement is its own row (name + what to check + optional *must pass*), judged separately, with its own verdict stored on the candidate.

A `required` requirement that fails **overrules** a cheerful `fit: true` from the model — you marked it required, the model doesn't get a veto on that.

This is also what makes the auditor possible: it can count failures per requirement and point at the one killing the run.

## Area — radius **or** suburb list

A service area is usually "these six suburbs", not a circle that happens to cover them plus a harbour. Each suburb is searched in its own right, and geocoded **once at save time** — doing it per run would bill a Places request per suburb for an answer that never changes.

## Search terms as ± chips

Add and remove one at a time, with a live count. A textarea of commas hides the cost model: you can't see that `roof repair, roofing` is two searches and therefore twice the spend. Enter adds a chip and deliberately does **not** submit the dialog.

## Progress bar + live log

Runs moved to `POST /api/prospecting/run` + `after()`: the request returns a run id immediately and the work continues server-side. The page polls stage, `processed/total`, and an append-only event feed.

You watch it search, filter, and judge — and the log names each business as it's accepted (`Ace Plumbing — 82% · sole trader, no website`), so you can tell early whether it's finding the right *sort* of business while there's still time to stop it.

- A run in flight is **rejoined on reload** rather than orphaned.
- **One run per hunt at a time** — two would double-spend and race each other on the same `place_id` upserts.

## The auditor

A second agent reads the run's own evidence — where candidates were lost, which requirement failed most often, what the rejections actually said — and names the problem with a concrete fix:

> **Drop the "no website" filter** — it removed 22 of the 30 businesses found, before anything was judged.

It is **diagnostic only** and never edits the hunt. An agent that silently rewrote your criteria would make the next run's results unexplainable.

## Also

Hunts are now editable (the builder is shared between create and edit), and legacy hunts saved before this open with sane defaults rather than blank.

## Verification

`npx tsc --noEmit` clean · `npm test` 377 passed, **15 new** covering draft validation, both area modes' different required fields, and the legacy-hunt round-trip · `npm run build` clean · migration applied and recorded on the remote (verified: `hunt_cols 4, run_cols 4, events_tbl 1, events_policies 1, param_col 1`).

**Not visually verified** — the pages are auth-gated and I have no signed-in session. The build compiles and the builder's logic is unit-tested, but nobody has clicked through it.

**Also still blocked:** the Places key is returning `403 PERMISSION_DENIED` since the Cloud console changes, so a run will fail at the search step until that's sorted regardless of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)