### PR TITLE
feat(plugins): a search box, and stop calling things agents that aren't

### DIFF
--- a/src/components/agents/agents-store.tsx
+++ b/src/components/agents/agents-store.tsx
@@ -11,9 +11,10 @@ import {
   Zap, Newspaper, MailCheck, UserRoundCheck, FileClock, CheckCircle, Star, ClipboardList, ListChecks,
   LayoutDashboard, Users, Columns3, Users2, UserPlus, FileCheck, FileText, Repeat, FileStack,
   Wrench, CalendarDays, Package, MessageSquare, TrendingUp, Sparkles, Receipt, Boxes, Clock, Hammer, Target, DollarSign,
-  Megaphone,
+  Megaphone, Search, X,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -136,6 +137,7 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
   const { refresh } = useTrackedRefresh();
   const [installs, setInstalls] = useState<AgentInstall[]>(initialInstalls);
   const [activeCategory, setActiveCategory] = useState<AgentCategory | "all">("all");
+  const [search, setSearch] = useState("");
   const [uninstallTarget, setUninstallTarget] = useState<AgentDefinition | null>(null);
   const [modules, setModules] = useState<Record<string, boolean>>(pluginEnabled);
   const [presetTarget, setPresetTarget] = useState<IndustryPreset | null>(null);
@@ -174,10 +176,25 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
 
   const installMap = new Map(installs.map((i) => [i.agent_id, i]));
 
-  const filtered =
-    activeCategory === "all"
-      ? AGENT_CATALOG
-      : AGENT_CATALOG.filter((a) => a.category === activeCategory);
+  // One search across BOTH catalogues. Someone hunting for "invoice" does not
+  // know or care whether the thing they want is filed as a module or an agent —
+  // asking them to guess which of two lists to look in is the search box's job
+  // to make unnecessary.
+  const query = search.trim().toLowerCase();
+  const matches = (name: string, description: string) =>
+    !query || `${name} ${description}`.toLowerCase().includes(query);
+
+  const filtered = AGENT_CATALOG
+    .filter((a) => activeCategory === "all" || a.category === activeCategory)
+    .filter((a) => matches(a.name, a.description));
+
+  // Groups whose modules all filtered out are dropped, so a search never leaves
+  // a heading standing over nothing.
+  const visibleGroups = MODULE_GROUPS
+    .map((g) => ({ ...g, modules: g.modules.filter((m) => matches(m.name, m.description)) }))
+    .filter((g) => g.modules.length > 0);
+
+  const hitCount = filtered.length + visibleGroups.reduce((n, g) => n + g.modules.length, 0);
 
   // ── Actions ────────────────────────────────────────────────────────────────
 
@@ -274,8 +291,37 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
           )}
         </div>
 
-        {/* Category filter */}
-        <div className="mt-5 flex flex-wrap gap-2">
+        {/* Search — spans modules and agents alike */}
+        <div className="mt-5 relative max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search modules and agents…"
+            className="pl-9 pr-9"
+            aria-label="Search modules and agents"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        {query && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {hitCount === 0
+              ? `Nothing matches "${search.trim()}"`
+              : `${hitCount} ${hitCount === 1 ? "match" : "matches"} for "${search.trim()}"`}
+          </p>
+        )}
+
+        {/* Category filter — agents only, so it is hidden while searching */}
+        <div className={cn("mt-5 flex flex-wrap gap-2", query && "hidden")}>
           {ALL_CATEGORIES.map((cat) => (
             <button
               key={cat}
@@ -293,8 +339,9 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
         </div>
       </div>
 
-      {/* Industry presets — one click to shape the whole app for a business type */}
-      <div className="mb-10">
+      {/* Industry presets — one click to shape the whole app for a business type.
+          Hidden mid-search: they are not things you search FOR. */}
+      <div className={cn("mb-10", query && "hidden")}>
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Industry preset</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {INDUSTRY_PRESETS.map((preset) => {
@@ -336,9 +383,9 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
 
       {/* Modules — grouped by the job they do, not by where they live in the
           code. A flat wall of thirty toggles told nobody what to turn on. */}
-      <div className="mb-10">
+      <div className={cn("mb-10", visibleGroups.length === 0 && "hidden")}>
         <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Modules</h2>
-        {MODULE_GROUPS.map((group) => (
+        {visibleGroups.map((group) => (
         <div key={group.id} className="mb-6">
         <div className="mb-2.5">
           <p className="text-sm font-semibold">{group.label}</p>
@@ -377,13 +424,15 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
         <p className="text-[11px] text-muted-foreground mt-2">Turning a module off only hides it — nothing is deleted, and re-enabling brings everything back.</p>
       </div>
 
-      <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">AI Agents</h2>
+      <h2 className={cn(
+        "text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3",
+        filtered.length === 0 && "hidden",
+      )}>AI Agents</h2>
       {/* Grid */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {filtered.map((agent, i) => {
           const install = installMap.get(agent.id);
           const isInstalled = !!install;
-          const isComingSoon = agent.badge === "coming-soon";
 
           return (
             <motion.div
@@ -396,7 +445,6 @@ export function AgentsStore({ installs: initialInstalls, pluginEnabled, activePr
                 agent={agent}
                 install={install}
                 isInstalled={isInstalled}
-                isComingSoon={isComingSoon}
                 isPending={isPending}
                 onInstall={() => handleInstall(agent)}
                 onUninstall={() => setUninstallTarget(agent)}
@@ -482,7 +530,6 @@ interface AgentCardProps {
   agent: AgentDefinition;
   install: AgentInstall | undefined;
   isInstalled: boolean;
-  isComingSoon: boolean;
   isPending: boolean;
   onInstall: () => void;
   onUninstall: () => void;
@@ -494,7 +541,6 @@ function AgentCard({
   agent,
   install,
   isInstalled,
-  isComingSoon,
   isPending,
   onInstall,
   onUninstall,
@@ -507,8 +553,7 @@ function AgentCard({
     <div
       className={cn(
         "relative flex flex-col rounded-xl border bg-card p-5 gap-4 transition-shadow",
-        isComingSoon && "opacity-60",
-        isInstalled && !isComingSoon && "border-primary/30 shadow-sm"
+        isInstalled && "border-primary/30 shadow-sm"
       )}
     >
       {/* Status dot for installed agents */}
@@ -537,14 +582,9 @@ function AgentCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="font-semibold text-sm">{agent.name}</span>
-            {agent.badge && agent.badge !== "coming-soon" && (
+            {agent.badge && (
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
                 {BADGE_LABELS[agent.badge]}
-              </Badge>
-            )}
-            {isComingSoon && (
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">
-                Coming Soon
               </Badge>
             )}
           </div>
@@ -561,9 +601,7 @@ function AgentCard({
 
       {/* Footer actions */}
       <div className="flex items-center justify-between gap-2 pt-1 border-t border-border/60">
-        {isComingSoon ? (
-          <span className="text-xs text-muted-foreground">Available soon</span>
-        ) : isInstalled ? (
+        {isInstalled ? (
           <>
             {/* Enable / disable toggle */}
             <div className="flex items-center gap-2">

--- a/src/lib/agents-catalog.ts
+++ b/src/lib/agents-catalog.ts
@@ -1,5 +1,5 @@
 export type AgentCategory = "productivity" | "leads" | "integrations" | "billing" | "communication";
-export type AgentBadge = "new" | "beta" | "coming-soon";
+export type AgentBadge = "new" | "beta";
 
 /**
  * configType controls what happens when a user clicks "Configure":
@@ -24,6 +24,19 @@ export interface AgentDefinition {
   badge?: AgentBadge;
 }
 
+/**
+ * What belongs in here: things that DO WORK ON THEIR OWN — on a schedule, or off
+ * a trigger, without anyone opening a page. A cron that emails overdue invoices
+ * is an agent. A form builder is not; that's a module you use, and it lives in
+ * the plugin registry.
+ *
+ * Two rules learned the hard way:
+ *   - Nothing ships here without an implementation. Four entries once sat in
+ *     production badged "coming soon" with not one line of code behind them.
+ *   - Nothing appears here AND in src/lib/plugins/registry.ts. Client
+ *     Onboarding and Form Builder were in both, so the same feature showed up
+ *     twice with two different mental models attached.
+ */
 export const AGENT_CATALOG: AgentDefinition[] = [
   // ── Productivity ────────────────────────────────────────────────────────────
   {
@@ -35,30 +48,6 @@ export const AGENT_CATALOG: AgentDefinition[] = [
     icon: "bot",
     category: "productivity",
     configType: "none",
-    badge: "new",
-  },
-  {
-    id: "client-onboarding",
-    name: "Client Onboarding",
-    description: "Build custom intake forms and send them to customers to complete.",
-    longDescription:
-      "Design your own onboarding form with a drag-and-drop builder — ABN, social accounts, opening hours, brand images, even securely-encrypted credentials — then send customers a link to fill it in. Answers are stored on the customer's profile. Enabling adds an Onboarding tab under Contacts.",
-    icon: "clipboard-list",
-    category: "productivity",
-    configType: "inline",
-    configPath: "/onboarding-forms",
-    badge: "new",
-  },
-  {
-    id: "form-builder",
-    name: "Form Builder",
-    description: "Build public lead-capture forms to share or embed on your website.",
-    longDescription:
-      "Design public forms with the drag-and-drop builder and share them via a link or embed them on any website with an iframe snippet. Every submission is captured, and can automatically create a lead in your sales pipeline. Enabling adds a Forms tab under Sales.",
-    icon: "list-checks",
-    category: "leads",
-    configType: "inline",
-    configPath: "/forms",
     badge: "new",
   },
   {
@@ -84,30 +73,6 @@ export const AGENT_CATALOG: AgentDefinition[] = [
     configType: "email-config",
     configPath: "/settings?tab=email",
   },
-  {
-    id: "lead-auto-response",
-    name: "Lead Auto-Response",
-    description: "Instantly reply to new leads with a personalised acknowledgement email.",
-    longDescription:
-      "When a new lead is created, automatically send them a warm acknowledgement email so they know you received their enquiry — reducing no-shows and building trust from the first contact.",
-    icon: "mail-check",
-    category: "leads",
-    configType: "inline",
-    badge: "coming-soon",
-  },
-  {
-    id: "customer-reengagement",
-    name: "Customer Re-engagement",
-    description: "Automatically reach out to customers who haven't booked in a while.",
-    longDescription:
-      "Identify dormant customers and send a personalised re-engagement email to bring them back. Configure how long since their last invoice before the agent triggers.",
-    icon: "user-round-check",
-    category: "leads",
-    configType: "inline",
-    badge: "coming-soon",
-  },
-
-  // ── Billing ─────────────────────────────────────────────────────────────────
   {
     id: "invoice-reminders",
     name: "Invoice Reminder Agent",
@@ -141,30 +106,6 @@ export const AGENT_CATALOG: AgentDefinition[] = [
     configType: "none",
   },
   {
-    id: "review-request",
-    name: "Review Request Agent",
-    description: "Ask customers for a review a few days after a job is completed.",
-    longDescription:
-      "Automatically send a review request email to customers 3–5 days after their work order is marked complete. Helps build your online reputation on autopilot.",
-    icon: "star",
-    category: "communication",
-    configType: "inline",
-    badge: "coming-soon",
-  },
-  {
-    id: "telegram-bot",
-    name: "Telegram Bot",
-    description: "Receive lead notifications and manage your business via Telegram.",
-    longDescription:
-      "Connect a Telegram bot to get instant lead alerts and send commands to your business AI directly from the Telegram app.",
-    icon: "send",
-    category: "communication",
-    configType: "inline",
-    badge: "coming-soon",
-  },
-
-  // ── Integrations ────────────────────────────────────────────────────────────
-  {
     id: "api-agent",
     name: "External API Agent",
     description: "Expose your business AI via API for Telegram, SMS, and third-party apps.",
@@ -188,5 +129,4 @@ export const CATEGORY_LABELS: Record<AgentCategory, string> = {
 export const BADGE_LABELS: Record<AgentBadge, string> = {
   new: "New",
   beta: "Beta",
-  "coming-soon": "Coming Soon",
 };


### PR DESCRIPTION
The immediate fixes from your list. The **full rehaul waits for the audit** — a fleet of 10 agents is working through every plugin and agent right now, and re-laying the IA before their verdicts land would mean doing it twice.

## Search

One box across **both** catalogues. Someone hunting for "invoice" doesn't know whether what they want is filed as a module or an agent, and shouldn't have to guess which list to read.

Groups whose contents all filter out are dropped, so a search never leaves a heading standing over nothing. Presets and the category chips hide while searching — they aren't things you search *for*.

## Four agents that didn't exist

`lead-auto-response`, `customer-reengagement`, `review-request`, `telegram-bot` — all badged **"coming soon"** in a production UI. I grepped for implementations:

```
lead-auto-response    → 0 files outside the catalog
customer-reengagement → 0 files outside the catalog
review-request        → 0 files outside the catalog
telegram-bot          → 0 files outside the catalog
```

Nothing. Not a cron, not a table, not a stub. Promising four features nobody has started is worse than shipping six that work — so they're gone, along with the `coming-soon` badge and every dead branch that handled it. The typechecker found all five of those once the union shrank.

## Two things that aren't agents

You were right about the forms. **Client Onboarding** and **Form Builder** are builders — you open them and use them; they don't do anything while you sleep. They were also *already* in `src/lib/plugins/registry.ts` **with settings tables**, so the same feature appeared in two places under two different mental models.

Removing them from the agent catalog surfaces them under Modules automatically (the store already filters registry entries that have agent cards), and `setPluginEnabled` writes their settings tables via `syncPluginSideEffects` — identical enable path, one place in the UI.

## The rule, written down

Now at the top of `agents-catalog.ts`, where the next person will look:

> An agent does work on a schedule or a trigger, without anyone opening a page. Everything else is a module. Nothing ships in the catalog without an implementation, and nothing lives in both lists.

**7 agents left, all of them real:** AI Assistant, Daily Digest, Email Lead Scanner, Invoice Reminders, Quote Follow-up, Job Completion Notifier, External API Agent. Whether all seven *should* be agents is a question for the audit — `ai-chat` is arguably core and `api-agent` arguably a setting.

## Verification

`npx tsc --noEmit` clean · `npm test` 377 passed · `npm run build` clean.

**Not visually verified** — the page is auth-gated and I have no signed-in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)