### PR TITLE
fix(forms): escape public input in notification emails; submissions get their own tab

### DIFF
--- a/src/app/(dashboard)/forms/page.tsx
+++ b/src/app/(dashboard)/forms/page.tsx
@@ -1,21 +1,48 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
-import { getFormBuilderSettings, getPublicForms } from "@/lib/actions/forms";
+import { getUser } from "@/lib/auth";
+import { getFormBuilderSettings, getPublicForms, listAllFormSubmissions } from "@/lib/actions/forms";
 import { appUrl } from "@/lib/app-url";
 import { FormsListClient } from "@/components/forms/forms-list-client";
 
-export default async function FormsPage() {
+export default async function FormsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string; form?: string }>;
+}) {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/auth/login");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await getActiveBizId(supabase as any, user.id);
+  try {
+    const user = await getUser();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await getActiveBizId(supabase as any, user.id);
+  } catch {
+    redirect("/auth/login");
+  }
 
   const settings = await getFormBuilderSettings();
   if (!settings.enabled) {
     return <FormsListClient enabled={false} forms={[]} baseUrl={appUrl()} />;
   }
-  const forms = await getPublicForms();
-  return <FormsListClient enabled forms={forms} baseUrl={appUrl()} />;
+
+  const { tab, form } = await searchParams;
+  const onSubmissions = tab === "submissions";
+
+  // Only pay for submissions when that tab is actually open — the forms list
+  // already carries the counts the tab label needs.
+  const [forms, submissions] = await Promise.all([
+    getPublicForms(),
+    onSubmissions ? listAllFormSubmissions(form) : Promise.resolve([]),
+  ]);
+
+  return (
+    <FormsListClient
+      enabled
+      forms={forms}
+      baseUrl={appUrl()}
+      submissions={submissions}
+      tab={onSubmissions ? "submissions" : "forms"}
+      activeFormId={form}
+    />
+  );
 }

--- a/src/app/api/f/[slug]/submit/route.ts
+++ b/src/app/api/f/[slug]/submit/route.ts
@@ -3,6 +3,7 @@ import { emitAutomationEvent } from "@/lib/automations/emit";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { processAnswersForStorage, missingRequiredFields, invalidAnswerFields } from "@/lib/onboarding/answers";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { esc } from "@/lib/outreach/render";
 import { rateLimit, clientIp } from "@/lib/booking/public";
 import { resolveInvite } from "@/lib/forms/invite";
 import type { OnboardingField, PublicFormSettings } from "@/types/database";
@@ -139,13 +140,24 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
   if (notify.length > 0) {
     try {
       const { data: biz } = await tbl(sb, "businesses").select("name, email").eq("id", form.business_id).single();
+
+      // ESCAPE EVERYTHING. `answers` is whatever an anonymous stranger typed
+      // into a public form; interpolated raw it lands as live HTML in the
+      // owner's inbox, in an email they trust because it came from their own
+      // form. A link reading "view invoice" pointing anywhere is enough.
+      // `f.label` and `form.name` are business-authored and lower risk, but
+      // there is no reason for any of it to be raw.
       const rows = schema.filter((f) => !["heading", "divider", "instructions"].includes(f.type))
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map((f) => `<tr><td style="padding:4px 10px;color:#666">${f.label}</td><td style="padding:4px 10px"><strong>${fmt((answers as any)[f.id])}</strong></td></tr>`).join("");
-      const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px"><div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:24px"><h1 style="font-size:18px;margin:0 0 12px">New submission: ${form.name}</h1><table style="width:100%;border-collapse:collapse;font-size:14px">${rows}</table>${leadId ? '<p style="font-size:12px;color:#2f6f73;margin-top:12px">✓ A lead was created in your pipeline.</p>' : ""}</div></body></html>`;
+        .map((f) => `<tr><td style="padding:4px 10px;color:#666">${esc(f.label ?? "")}</td><td style="padding:4px 10px"><strong>${esc(fmt((answers as any)[f.id]))}</strong></td></tr>`).join("");
+      const formName = esc(form.name ?? "");
+      const html = `<!doctype html><html><body style="font-family:Arial,Helvetica,sans-serif;background:#f6f6f4;padding:24px"><div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;border:1px solid #e5e3d9;padding:24px"><h1 style="font-size:18px;margin:0 0 12px">New submission: ${formName}</h1><table style="width:100%;border-collapse:collapse;font-size:14px">${rows}</table>${leadId ? '<p style="font-size:12px;color:#2f6f73;margin-top:12px">✓ A lead was created in your pipeline.</p>' : ""}</div></body></html>`;
       await sendEmail({
         to: notify, subject: `New form submission — ${form.name}`, html,
-        from: buildBusinessFrom({ name: biz?.name ?? "Kirei", slug: biz?.slug, localPart: "forms" }),
+        // No `slug` here: `businesses` has no such column (only `audit_slug`),
+        // the select above doesn't ask for one, and `tbl()` returns `any` so
+        // TypeScript never flagged the undefined it was quietly passing.
+        from: buildBusinessFrom({ name: biz?.name ?? "Kirei", localPart: "forms" }),
         replyTo: biz?.email ?? undefined,
         tags: { business_id: form.business_id, doc_type: "custom", doc_id: form.id },
       });

--- a/src/components/forms/forms-builder-client.tsx
+++ b/src/components/forms/forms-builder-client.tsx
@@ -13,8 +13,7 @@ import Link from "next/link";
 import { Reorder } from "framer-motion";
 import { toast } from "sonner";
 import {
-  ArrowLeft, Plus, Trash2, Save, Loader2, Eye, Pencil, GripVertical, Copy, ExternalLink, CodeIcon,
-} from "@/components/ui/icons";
+  ArrowLeft, Plus, Trash2, Save, Loader2, Eye, Pencil, GripVertical, Copy, ExternalLink, CodeIcon, ListChecks } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -172,11 +171,20 @@ export function FormsBuilderClient({ form, submissions, baseUrl }: Props) {
       )}
 
       <Tabs defaultValue="build">
-        <TabsList>
-          <TabsTrigger value="build">Build</TabsTrigger>
-          <TabsTrigger value="settings">Settings</TabsTrigger>
-          <TabsTrigger value="submissions">Submissions ({submissions.length})</TabsTrigger>
-        </TabsList>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <TabsList>
+            <TabsTrigger value="build">Build</TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+          </TabsList>
+          {/* Replies live on their own tab now, not inside the editor. The
+              link keeps the per-form path a click away. */}
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/forms?tab=submissions&form=${form.id}`}>
+              <ListChecks className="w-3.5 h-3.5 mr-1.5" />
+              Submissions ({submissions.length})
+            </Link>
+          </Button>
+        </div>
 
         {/* ── BUILD ── */}
         <TabsContent value="build" className="mt-4">
@@ -357,35 +365,6 @@ export function FormsBuilderClient({ form, submissions, baseUrl }: Props) {
           </div>
         </TabsContent>
 
-        {/* ── SUBMISSIONS ── */}
-        <TabsContent value="submissions" className="mt-4">
-          {submissions.length === 0 ? (
-            <Card><CardContent className="py-12 text-center text-muted-foreground text-sm">No submissions yet.</CardContent></Card>
-          ) : (
-            <div className="space-y-2">
-              {submissions.map((s) => (
-                <Card key={s.id}><CardContent className="p-4 space-y-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-xs text-muted-foreground">{formatDate(s.created_at)}
-                      {s.leads?.name ? <> · lead: <Link href={`/leads/${s.lead_id}`} className="underline hover:text-foreground">{s.leads.name}</Link></> : ""}</p>
-                    <button className="text-muted-foreground hover:text-destructive"
-                      onClick={async () => { if (!confirm("Delete this submission?")) return; try { await deleteFormSubmission(s.id); refresh(); } catch { toast.error("Delete failed"); } }}>
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
-                  </div>
-                  <dl className="grid gap-x-6 gap-y-1 sm:grid-cols-2">
-                    {(form.schema ?? []).filter((f) => !["heading", "divider", "instructions"].includes(f.type)).map((f) => (
-                      <div key={f.id} className="min-w-0">
-                        <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{f.label}</dt>
-                        <dd className="text-sm break-words">{fmtAnswer(s.answers?.[f.id])}</dd>
-                      </div>
-                    ))}
-                  </dl>
-                </CardContent></Card>
-              ))}
-            </div>
-          )}
-        </TabsContent>
       </Tabs>
     </div>
   );

--- a/src/components/forms/forms-list-client.tsx
+++ b/src/components/forms/forms-list-client.tsx
@@ -16,9 +16,11 @@ import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { setFormBuilderEnabled, createPublicForm, deletePublicForm } from "@/lib/actions/forms";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { embedSnippet } from "@/lib/forms/embed";
+import { SubmissionsView } from "@/components/forms/submissions-view";
 import type { PublicForm } from "@/types/database";
+import type { SubmissionWithForm } from "@/lib/actions/forms";
 
 const STATUS_TONES: Record<string, string> = {
   draft: "bg-muted text-muted-foreground",
@@ -30,9 +32,16 @@ interface Props {
   enabled: boolean;
   forms: (PublicForm & { submission_count: number })[];
   baseUrl: string;
+  submissions?: SubmissionWithForm[];
+  /** Which tab the URL asked for. */
+  tab?: "forms" | "submissions";
+  /** ?form= — the builder deep-links here filtered to one form. */
+  activeFormId?: string;
 }
 
-export function FormsListClient({ enabled, forms, baseUrl }: Props) {
+export function FormsListClient({
+  enabled, forms, baseUrl, submissions = [], tab = "forms", activeFormId,
+}: Props) {
   const router = useRouter();
   // The scrim has to outlast the refresh: a local `finally { setBusy(false) }`
   // fires when refresh() is CALLED, not when the server output arrives.
@@ -85,6 +94,11 @@ export function FormsListClient({ enabled, forms, baseUrl }: Props) {
     finally { setBusy(false); }
   };
 
+  // The tab count comes from the forms list, not the loaded page of
+  // submissions — the Forms tab must show the true total even when the
+  // Submissions tab hasn't been opened and `submissions` is empty.
+  const totalSubmissions = forms.reduce((n, f) => n + (f.submission_count ?? 0), 0);
+
   const publicUrl = (slug: string) => `${baseUrl}/f/${slug}`;
   const copy = (text: string, msg: string) => navigator.clipboard.writeText(text).then(() => toast.success(msg), () => toast.error("Copy failed"));
 
@@ -109,7 +123,36 @@ export function FormsListClient({ enabled, forms, baseUrl }: Props) {
         }
       />
 
-      {forms.length === 0 ? (
+      {/* Reading replies and editing the form are different jobs. Submissions
+          used to sit INSIDE the builder, so checking what someone sent meant
+          opening the editor for a live form. Two tabs, one nav entry. */}
+      <div className="mb-5 flex gap-2 border-b border-border">
+        {([
+          { id: "forms", label: `Forms (${forms.length})`, href: "/forms" },
+          { id: "submissions", label: `Submissions (${totalSubmissions})`, href: "/forms?tab=submissions" },
+        ] as const).map((t) => (
+          <Link
+            key={t.id}
+            href={t.href}
+            className={cn(
+              "-mb-px border-b-2 px-1 pb-2 text-sm font-medium transition-colors",
+              tab === t.id
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t.label}
+          </Link>
+        ))}
+      </div>
+
+      {tab === "submissions" ? (
+        <SubmissionsView
+          submissions={submissions}
+          forms={forms.map((f) => ({ id: f.id, name: f.name }))}
+          activeFormId={activeFormId}
+        />
+      ) : forms.length === 0 ? (
         <Card><CardContent className="py-12 text-center text-muted-foreground">
           <ListChecks className="w-8 h-8 mx-auto mb-3 opacity-40" />
           <p className="font-medium">No forms yet</p>

--- a/src/components/forms/submissions-view.tsx
+++ b/src/components/forms/submissions-view.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+/**
+ * Reading what people sent you.
+ *
+ * This used to live inside the form BUILDER, so checking replies meant opening
+ * the editor for the live form you were collecting them with — the routine job
+ * guarded by the dangerous one. It's its own tab now, across every form, with
+ * a filter when you want one form's replies.
+ */
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useMutation } from "@/components/layout/use-mutation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Trash2, Search, X, ListChecks } from "@/components/ui/icons";
+import { cn, formatDate } from "@/lib/utils";
+import { deleteFormSubmission, type SubmissionWithForm } from "@/lib/actions/forms";
+import type { OnboardingField, PublicForm } from "@/types/database";
+
+const LAYOUT_ONLY = ["heading", "divider", "instructions"];
+
+/** Answers are keyed by field id, so a label needs the form's schema. */
+function answerRows(schema: OnboardingField[] | undefined, answers: Record<string, unknown> | null) {
+  return (schema ?? [])
+    .filter((f) => !LAYOUT_ONLY.includes(f.type))
+    .map((f) => ({ id: f.id, label: f.label, value: fmtAnswer(answers?.[f.id]) }));
+}
+
+function fmtAnswer(v: unknown): string {
+  if (v == null || v === "") return "—";
+  if (Array.isArray(v)) return v.join(", ");
+  if (typeof v === "object" && (v as { name?: string }).name) return `📎 ${(v as { name: string }).name}`;
+  if (v === true) return "Yes";
+  if (v === false) return "No";
+  return String(v);
+}
+
+interface Props {
+  submissions: SubmissionWithForm[];
+  forms: Pick<PublicForm, "id" | "name">[];
+  /** Pre-selected form filter, from ?form= — how the builder deep-links here. */
+  activeFormId?: string;
+}
+
+export function SubmissionsView({ submissions, forms, activeFormId }: Props) {
+  const router = useRouter();
+  const { run, pending } = useMutation();
+  const [formFilter, setFormFilter] = useState(activeFormId ?? "");
+  const [search, setSearch] = useState("");
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return submissions.filter((s) => {
+      if (formFilter && s.form_id !== formFilter) return false;
+      if (!q) return true;
+      // Search the answers themselves — you remember what someone wrote, not
+      // which field they wrote it in.
+      const hay = [
+        s.public_forms?.name,
+        s.leads?.name,
+        ...Object.values(s.answers ?? {}).map((v) => fmtAnswer(v)),
+      ].filter(Boolean).join(" ").toLowerCase();
+      return hay.includes(q);
+    });
+  }, [submissions, formFilter, search]);
+
+  function handleDelete(id: string) {
+    if (!confirm("Delete this submission? This can't be undone.")) return;
+    void run(() => deleteFormSubmission(id), {
+      busy: "Deleting…", success: "Submission deleted", error: "Couldn't delete",
+    });
+  }
+
+  function setFilter(id: string) {
+    setFormFilter(id);
+    // Keep the URL honest so a refresh or a shared link lands in the same place.
+    const url = id ? `/forms?tab=submissions&form=${id}` : "/forms?tab=submissions";
+    router.replace(url, { scroll: false });
+  }
+
+  if (submissions.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-14 text-center">
+          <ListChecks className="w-8 h-8 mx-auto mb-3 text-muted-foreground" />
+          <p className="font-medium">No submissions yet</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Share a form&apos;s link or embed it on your site — replies land here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search answers, names…"
+            className="pl-9 pr-9"
+            aria-label="Search submissions"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        {forms.length > 1 && (
+          <div className="flex flex-wrap gap-1.5">
+            <button
+              onClick={() => setFilter("")}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                !formFilter ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground hover:bg-muted/80",
+              )}
+            >
+              All forms
+            </button>
+            {forms.map((f) => (
+              <button
+                key={f.id}
+                onClick={() => setFilter(f.id)}
+                className={cn(
+                  "rounded-full px-3 py-1 text-xs font-medium transition-colors max-w-[14rem] truncate",
+                  formFilter === f.id ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground hover:bg-muted/80",
+                )}
+              >
+                {f.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {visible.length} of {submissions.length} {submissions.length === 1 ? "submission" : "submissions"}
+      </p>
+
+      {visible.length === 0 ? (
+        <Card><CardContent className="py-10 text-center text-sm text-muted-foreground">
+          Nothing matches that.
+        </CardContent></Card>
+      ) : (
+        <div className="space-y-2">
+          {visible.map((s) => {
+            const rows = answerRows(s.public_forms?.schema, s.answers as Record<string, unknown> | null);
+            return (
+              <Card key={s.id}>
+                <CardContent className="p-4 space-y-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex flex-wrap items-center gap-2 min-w-0">
+                      {s.public_forms?.name && (
+                        <Badge variant="secondary" className="text-[10px]">{s.public_forms.name}</Badge>
+                      )}
+                      <span className="text-xs text-muted-foreground">{formatDate(s.created_at)}</span>
+                      {s.leads?.name && (
+                        <span className="text-xs text-muted-foreground">
+                          · lead:{" "}
+                          <Link href={`/leads/${s.lead_id}`} className="underline hover:text-foreground">
+                            {s.leads.name}
+                          </Link>
+                        </span>
+                      )}
+                    </div>
+                    <Button
+                      variant="ghost" size="sm" disabled={pending}
+                      onClick={() => handleDelete(s.id)}
+                      className="text-muted-foreground hover:text-destructive shrink-0"
+                      aria-label="Delete submission"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  </div>
+
+                  {rows.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      The form&apos;s fields have changed since this was sent, so there are no
+                      labels to show it against.
+                    </p>
+                  ) : (
+                    <dl className="grid gap-x-6 gap-y-1 sm:grid-cols-2">
+                      {rows.map((r) => (
+                        <div key={r.id} className="min-w-0">
+                          <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{r.label}</dt>
+                          <dd className="text-sm break-words">{r.value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/actions/forms.ts
+++ b/src/lib/actions/forms.ts
@@ -164,12 +164,44 @@ export async function getFormSubmissions(formId: string): Promise<SubmissionRow[
   return (data ?? []) as SubmissionRow[];
 }
 
+/** A submission plus the form it came from — enough to render it standalone. */
+export interface SubmissionWithForm extends SubmissionRow {
+  public_forms?: { id: string; name: string; schema: OnboardingField[] } | null;
+}
+
+/**
+ * Every form's submissions in one list, newest first.
+ *
+ * The per-form view required opening the form's BUILDER to read replies, which
+ * put "read what someone sent me" behind "edit my form" — two different jobs,
+ * and the dangerous one guarding the routine one. This is the routine one.
+ *
+ * The form's schema rides along because answers are keyed by field id and
+ * there is no schema snapshot on `public_form_submissions`; labels have to
+ * come from the form as it stands today.
+ */
+export async function listAllFormSubmissions(formId?: string): Promise<SubmissionWithForm[]> {
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  let q = tbl(supabase, "public_form_submissions")
+    .select("*, leads(id, name), public_forms(id, name, schema)")
+    .eq("business_id", businessId);
+  if (formId) q = q.eq("form_id", formId);
+
+  const { data, error } = await q.order("created_at", { ascending: false }).limit(500);
+  if (error) throw error;
+  return (data ?? []) as SubmissionWithForm[];
+}
+
 export async function deleteFormSubmission(id: string): Promise<void> {
   const supabase = await createClient();
   const user = await getUser();
   const businessId = await getActiveBizId(supabase, user.id);
   const { error } = await tbl(supabase, "public_form_submissions").delete().eq("id", id).eq("business_id", businessId);
   if (error) throw error;
+  revalidatePath("/forms");
 }
 
 /** Signed URL for a submission's uploaded file/image (private bucket). */

--- a/src/lib/booking/notify.ts
+++ b/src/lib/booking/notify.ts
@@ -4,6 +4,7 @@
  * relies on session-scoped helpers. Fire-and-forget: never throws to callers.
  */
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
+import { esc } from "@/lib/outreach/render";
 import { clickSendSend, deriveSenderId } from "@/lib/sms";
 import { dispatchWebhook } from "@/lib/webhooks";
 import { bookingEmailHtml, type BookingEmailKind } from "@/lib/emails/booking";
@@ -120,12 +121,15 @@ export async function notifyBookingCreated(sb: Sb, businessId: string, settings:
         subject: `New booking: ${appt.customer_name} — ${when}`,
         from, replyTo: appt.customer_email ?? undefined,
         tags: { business_id: businessId, doc_type: "custom" },
+        // Every field here was typed by an anonymous member of the public on
+        // the booking page. Raw, `notes` alone is enough to put a live link
+        // into the owner's inbox inside an email they trust.
         html: `<div style="font-family:system-ui,sans-serif">
           <h3>New online booking</h3>
-          <p><strong>${appt.customer_name}</strong><br>${when}</p>
-          <p>${appt.customer_phone ?? ""} ${appt.customer_email ? `· ${appt.customer_email}` : ""}</p>
-          ${appt.customer_address ? `<p>${appt.customer_address}</p>` : ""}
-          ${appt.notes ? `<p>Notes: ${appt.notes}</p>` : ""}
+          <p><strong>${esc(appt.customer_name ?? "")}</strong><br>${when}</p>
+          <p>${esc(appt.customer_phone ?? "")} ${appt.customer_email ? `· ${esc(appt.customer_email)}` : ""}</p>
+          ${appt.customer_address ? `<p>${esc(appt.customer_address)}</p>` : ""}
+          ${appt.notes ? `<p>Notes: ${esc(appt.notes)}</p>` : ""}
         </div>`,
       }).catch(() => undefined);
     }

--- a/src/lib/outreach/__tests__/esc.test.ts
+++ b/src/lib/outreach/__tests__/esc.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { esc } from "../render";
+
+/**
+ * `esc` is now a security control in three places — outreach email bodies, the
+ * public form-submission notification, and the booking notification — and had
+ * no test of its own. Two of those take input from anonymous members of the
+ * public and mail the result to the business owner, so a regression here puts
+ * live HTML into an inbox that trusts it.
+ */
+describe("esc", () => {
+  it("neutralises a tag", () => {
+    expect(esc("<script>alert(1)</script>"))
+      .toBe("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  // The realistic attack on a form notification isn't a script tag — mail
+  // clients strip those. It's a plausible link in an email the owner trusts.
+  it("neutralises a link, which is the attack that actually works in email", () => {
+    const out = esc('<a href="https://evil.example">View invoice</a>');
+    expect(out).not.toContain("<a ");
+    expect(out).toContain("&lt;a href=");
+  });
+
+  it("escapes the ampersand FIRST, so escapes aren't double-escaped", () => {
+    // If & were escaped after < , "&lt;" would become "&amp;lt;" and render
+    // as literal "&lt;" instead of "<". Order is load-bearing.
+    expect(esc("a < b & c > d")).toBe("a &lt; b &amp; c &gt; d");
+    expect(esc("&")).toBe("&amp;");
+    expect(esc("&amp;")).toBe("&amp;amp;");
+  });
+
+  it("leaves ordinary copy alone", () => {
+    expect(esc("Smith & Sons — roof repair, 3pm")).toBe("Smith &amp; Sons — roof repair, 3pm");
+    expect(esc("")).toBe("");
+  });
+
+  it("handles every occurrence, not just the first", () => {
+    expect(esc("<b><i>x</i></b>")).toBe("&lt;b&gt;&lt;i&gt;x&lt;/i&gt;&lt;/b&gt;");
+  });
+
+  /**
+   * Documented limitation, asserted so nobody assumes otherwise: esc() does
+   * NOT escape quotes. That is fine for text between tags — which is every
+   * current call site — and NOT fine inside an attribute value. If you ever
+   * interpolate user input into an attribute, this is not the function.
+   */
+  it("does not escape quotes — text-content only, never attributes", () => {
+    expect(esc('say "hi"')).toBe('say "hi"');
+  });
+});


### PR DESCRIPTION
Plugin 1 of the audit: **Form Builder**. Two commits — the security fix first, so it can be reviewed on its own.

## 1. A stranger could put live HTML in your inbox

`src/app/api/f/[slug]/submit/route.ts:144` interpolated every answer raw into the notification email:

```
`<td><strong>${fmt(answers[f.id])}</strong></td>`
```

Public forms take submissions from anyone, no auth. Someone types `<a href="https://evil">View invoice</a>` into a text field and it arrives as a working link — in an email you trust, because it came from your own form. Script tags are the obvious version and the one mail clients strip; a plausible link is the one that actually works.

**Sweeping the siblings found the same bug a second time, in booking** (`src/lib/booking/notify.ts:120-128`) — `customer_name`, phone, email, address *and* free-text `notes`, all raw into the team notification, all typed by an anonymous member of the public. **The audit only flagged the forms one.**

Both now go through `esc()` from `src/lib/outreach/render.ts`, which already existed for outreach bodies and escapes `& < >` — correct for text between tags, which is every call site here.

### The audit was wrong about one thing

It said `esc()` was "already regression-tested there". It wasn't — no test existed. So it has one now, covering tag neutralisation, the link case that actually works in email, ampersand ordering (escape `&` *last* and `&lt;` becomes `&amp;lt;` and renders as a literal `<`), and an **asserted limitation**: it does not escape quotes, so it is text-content only and must never go inside an attribute value.

Also removed `biz?.slug` from the From address — `businesses` has no `slug` column (only `audit_slug`), the query doesn't select one, and `tbl()` returns `any`, so TypeScript never saw the `undefined` being passed.

## 2. Submissions are their own tab

Reading a reply and editing the form are different jobs, and the routine one was locked behind the dangerous one: to check what someone sent, you opened the **builder** for a live published form you were actively collecting on.

`/forms` now has **Forms** and **Submissions** tabs. Submissions shows every form's replies in one list, newest first, form name on each card, chips to filter to one form, and a search that looks *inside the answers* — you remember what someone wrote, not which field they wrote it in.

Deep-linkable at `/forms?tab=submissions&form=<id>`, which is how the builder reaches it — it keeps a **Submissions (n)** button beside its tabs, so the per-form path is still one click; it just isn't inside the editor any more.

Two things I was deliberate about:
- The tab count comes from the **forms list**, not the loaded submissions, so it's true before the tab has ever been opened.
- The submissions query **only runs when that tab is open** — the Forms tab already has the counts it needs and shouldn't fetch 500 rows to render a number.

Answers are keyed by field id and `public_form_submissions` has no schema snapshot, so labels come from the form as it stands today. A submission whose fields have since been deleted says so plainly rather than rendering an empty card.

## Verification

`npx tsc --noEmit` clean · `npm test` 383 passed (6 new) · `npm run build` clean.

**Not visually verified** — auth-gated, no signed-in session here. The security fix is logic and is covered by tests; the tab layout is the part nobody has clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)