### PR TITLE
fix(ui): look at the app in the theme it actually ships in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,17 +129,19 @@ Conventions:
 - `src/components/layout/dashboard-shell.tsx` — single `<main>` wrapper at `w-full p-6` with **no max-width cap** (the prototype is 240px sidebar + 1fr content). Pages should NOT add their own `max-w-*` outer wrappers — only narrow forms (e.g. `/customers/new` at `max-w-2xl`) keep their own caps for readability.
 - The shell `<div key={business.id}>`-keys content so switching businesses fully remounts the tree (works around `useState(initial)` not syncing on prop changes — see Known traps).
 
-### Theme — Connected Hub design system
+### Theme — five palettes, and the default is DARK
 
-The active theme is set via `<html data-theme="console">` in `src/app/layout.tsx`. The Connected Hub palette in `src/app/globals.css` under `[data-theme="console"]`:
+**🔴 The app ships `<html data-theme="Midnight">` (`src/app/layout.tsx`), and `Midnight` is dark.** This section used to claim the default was `console` with a warm off-white canvas. It wasn't, and hadn't been for a while — `console` isn't in `UI_THEMES`, so no code path can select it and its CSS block is unreachable. That stale line caused a whole class of bug: components were written and reviewed against a white card nobody was looking at, so the KPI icon chips, the status pills and the Site Reports table were all painted in light-mode literals that vanished or glared on the theme users actually had.
 
-- Canvas: warm off-white `#fafaf7` · cards: pure white · borders: warm-grey `#e5e3d9`
-- Primary/accent: deep teal (`oklch(0.55 0.08 195)` ≈ `hsl(191 38% 36%)`)
-- `--radius: 0.625rem` (10px) so `rounded-md/lg/xl` resolve to **8 / 10 / 14 px** matching the prototype's `--r-md / --r-lg / --r-xl`
-- Card defaults to `rounded-xl + border-border + shadow-sm`
-- Button defaults to `rounded-md` (NOT pill — that was the earlier flux pass)
-- Default sidebar theme is `light`; default accent is `teal`
-- `data-accent`, `data-sidebar-theme`, `data-pattern` overrides in globals.css drive Settings → Appearance customisation
+The live palettes are in `src/lib/ui-themes.ts` and defined in `globals.css`: **Midnight** (default, dark), **Daylight** (light), **Azure**, **Orchid**, **Studio**. Settings → Appearance switches them; `layout.tsx` pre-paints the stored choice so a cold load doesn't flash.
+
+**Never author a colour at a call site.** Every palette defines the full token set — `--primary`, `--ok`, `--warn`, `--bad`, `--accent-2`, `--lime`, `--muted` — and they're registered as Tailwind colours in the `@theme` block, so `bg-ok/15`, `text-warn`, `bg-accent-2` all work. A literal hex or a raw Tailwind palette class (`bg-green-100`, `text-slate-700`) is a bug: it can only ever be right on one theme.
+
+- `--radius: 0.875rem` on the v2 palettes; the scale must stay **monotonic** (`sm < md < lg < xl < 2xl < 3xl`). It wasn't once — `xl` was 18px while `2xl` was 16px, so every Card inside a panel had a rounder inner corner than its outer one.
+- Card defaults to `rounded-xl + border-border + shadow-sm`; Button to `rounded-md`
+- `data-accent`, `data-sidebar-theme`, `data-pattern` overrides drive Settings → Appearance
+
+**🔴 Customer-facing pages do NOT inherit the operator's theme.** `src/app/{portal,f,book,embed}/layout.tsx` each wrap their tree in `<CustomerSurface>`, which pins `Daylight` and strips `.dark`. Without it a homeowner opening an invoice link gets a dark navy SaaS panel — the software's identity instead of the business's. Any new customer-facing route group needs the same layout.
 
 **Connected Hub utility classes** at the bottom of `globals.css` (prefix `.ch-*`) are the prototype's design vocabulary. List pages compose with them rather than ad-hoc Tailwind:
 

--- a/src/app/book/[slug]/booking-widget.tsx
+++ b/src/app/book/[slug]/booking-widget.tsx
@@ -29,7 +29,6 @@ interface Slot { start: string; end: string; resource_id: string; resource_name:
 type Step = "type" | "worker" | "time" | "details" | "done";
 
 const API = (slug: string, path: string) => `/api/public/v1/biz/${encodeURIComponent(slug)}${path}`;
-const KIREI_LOGO = "/kirei-logo.png"; // fallback when the business has no logo
 
 function addDays(key: string, n: number) {
   const [y, m, d] = key.split("-").map(Number);
@@ -44,6 +43,13 @@ function shade(hex: string, pct: number) {
   const adj = (c: number) => Math.max(0, Math.min(255, Math.round(c + 255 * pct)));
   const [r, g, b] = [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)];
   return `#${[adj(r), adj(g), adj(b)].map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+}
+
+/** First letters of the first two words — "Crown Roofers" reads as CR. */
+function initialsOf(name: string | null | undefined): string {
+  const words = (name ?? "").trim().split(/\s+/).filter(Boolean);
+  if (!words.length) return "•";
+  return words.slice(0, 2).map((w) => w[0]!.toUpperCase()).join("");
 }
 
 export function BookingWidget({ slug }: { slug: string }) {
@@ -205,9 +211,20 @@ export function BookingWidget({ slug }: { slug: string }) {
           <div style={{ display: "flex", alignItems: "center", gap: 14, position: "relative" }}>
             <motion.div initial={{ scale: 0.6, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} transition={{ delay: 0.1, type: "spring", stiffness: 200 }}
               style={{ width: 56, height: 56, borderRadius: 16, background: "rgba(255,255,255,0.2)", border: "2px solid rgba(255,255,255,0.4)", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", flexShrink: 0 }}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img loading="lazy" decoding="async" src={config.branding.logo_url || KIREI_LOGO} alt={config.business_name || "Kirei"}
-                style={{ width: "100%", height: "100%", objectFit: "contain", background: config.branding.logo_url ? "transparent" : "#fff", padding: config.branding.logo_url ? 0 : 4 }} />
+              {/* No vendor logo fallback. A business that hasn't uploaded one
+                  used to get KIREI's mark here — actively telling the customer
+                  they're booking with a company they've never heard of, on the
+                  one page that is supposed to be the tradie's shopfront.
+                  Initials belong to the business; our logo doesn't. */}
+              {config.branding.logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img loading="lazy" decoding="async" src={config.branding.logo_url} alt={config.business_name || "Logo"}
+                  style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+              ) : (
+                <span style={{ fontSize: 22, fontWeight: 800, letterSpacing: "0.02em" }}>
+                  {initialsOf(config.business_name)}
+                </span>
+              )}
             </motion.div>
             <div style={{ minWidth: 0 }}>
               <div style={{ fontSize: "clamp(18px, 5vw, 21px)", fontWeight: 800, lineHeight: 1.15 }}>{config.business_name || "Book an appointment"}</div>

--- a/src/app/book/layout.tsx
+++ b/src/app/book/layout.tsx
@@ -1,0 +1,6 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/** Customer-facing: pinned light, never the operator's dashboard theme. */
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <CustomerSurface>{children}</CustomerSurface>;
+}

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -1,0 +1,6 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/** Customer-facing: pinned light, never the operator's dashboard theme. */
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <CustomerSurface>{children}</CustomerSurface>;
+}

--- a/src/app/embed/not-found.tsx
+++ b/src/app/embed/not-found.tsx
@@ -1,0 +1,27 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/**
+ * A dead customer link — expired token, deleted form, renamed slug.
+ *
+ * It wraps itself in CustomerSurface rather than relying on the segment
+ * layout: verified in dev, a `notFound()` boundary does NOT inherit the
+ * segment's layout here, so without this the root theme (Midnight, dark)
+ * catches it and someone whose link expired gets a dark navy page from a
+ * vendor they've never heard of. Expired tokens are the normal end of a portal
+ * link's life, not an edge case — real people see this page.
+ */
+export default function NotFound() {
+  return (
+    <CustomerSurface>
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 text-center shadow-sm">
+          <h1 className="text-lg font-semibold">This link isn&apos;t available</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            It may have expired, or been replaced by a newer one. Ask whoever
+            sent it to share it again.
+          </p>
+        </div>
+      </div>
+    </CustomerSurface>
+  );
+}

--- a/src/app/f/layout.tsx
+++ b/src/app/f/layout.tsx
@@ -1,0 +1,6 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/** Customer-facing: pinned light, never the operator's dashboard theme. */
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <CustomerSurface>{children}</CustomerSurface>;
+}

--- a/src/app/f/not-found.tsx
+++ b/src/app/f/not-found.tsx
@@ -1,0 +1,27 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/**
+ * A dead customer link — expired token, deleted form, renamed slug.
+ *
+ * It wraps itself in CustomerSurface rather than relying on the segment
+ * layout: verified in dev, a `notFound()` boundary does NOT inherit the
+ * segment's layout here, so without this the root theme (Midnight, dark)
+ * catches it and someone whose link expired gets a dark navy page from a
+ * vendor they've never heard of. Expired tokens are the normal end of a portal
+ * link's life, not an edge case — real people see this page.
+ */
+export default function NotFound() {
+  return (
+    <CustomerSurface>
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 text-center shadow-sm">
+          <h1 className="text-lg font-semibold">This link isn&apos;t available</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            It may have expired, or been replaced by a newer one. Ask whoever
+            sent it to share it again.
+          </p>
+        </div>
+      </div>
+    </CustomerSurface>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,8 +58,12 @@
   /* 2xl/3xl were never defined, so `rounded-2xl` and `rounded-3xl` silently
      produced no radius at all wherever they were used. The v2 design needs
      both (16px controls, 22px cards), so they are defined off the same
-     --radius the rest of the scale uses. */
-  --radius-2xl: calc(var(--radius) + 2px);
+     --radius the rest of the scale uses.
+     2xl was +2px, i.e. SMALLER than xl's +4px — a non-monotonic scale, so
+     every Card (rounded-xl) sitting inside a rounded-2xl panel had a rounder
+     inner corner than its outer one and read as a rendering fault. The scale
+     must only ever increase. */
+  --radius-2xl: calc(var(--radius) + 6px);
   --radius-3xl: calc(var(--radius) + 8px);
 }
 
@@ -656,8 +660,8 @@
   gap: 6px;
 }
 .ch-stat-delta { font-weight: 600; font-variant-numeric: tabular-nums; }
-.ch-stat-delta.up   { color: hsl(150 60% 38%); }
-.ch-stat-delta.down { color: hsl(0 70% 50%); }
+.ch-stat-delta.up   { color: hsl(var(--ok)); }
+.ch-stat-delta.down { color: hsl(var(--bad)); }
 
 /* Tables */
 .ch-table-wrap {
@@ -718,26 +722,41 @@
   background: currentColor;
 }
 .ch-pill.no-dot::before { display: none; }
+
+/* Status colours resolve from the theme, they are not authored here.
+ *
+ * These were 16 literal light pastels — `background: hsl(150 50% 95%)` — with
+ * no dark override anywhere. The app ships `data-theme="Midnight"` by default,
+ * where a 95%-lightness chip on a #1a2333 card measures 14.7:1 the WRONG way:
+ * a near-white sticker, the brightest thing on the screen, attached to the
+ * least important information on it. That is what a roofer saw when he checked
+ * a job status on his phone.
+ *
+ * `.sent` and `.new` already read from --primary and were the only two that
+ * survived the dark default. Every other status now follows that pattern
+ * against --ok / --warn / --bad / --primary / --accent-2, which all five live
+ * palettes define. One tint alpha throughout, so the row of pills in a list
+ * reads as one family. */
 .ch-pill.paid,
 .ch-pill.completed,
-.ch-pill.accepted   { background: hsl(150 50% 95%); color: hsl(150 60% 32%); }
+.ch-pill.accepted,
+.ch-pill.won,
+.ch-pill.active     { background: hsl(var(--ok) / 0.15);       color: hsl(var(--ok)); }
 .ch-pill.pending,
-.ch-pill.in-progress { background: hsl(40 80% 95%); color: hsl(35 75% 38%); }
+.ch-pill.in-progress,
+.ch-pill.partial    { background: hsl(var(--warn) / 0.15);     color: hsl(var(--warn)); }
 .ch-pill.overdue,
-.ch-pill.cancelled  { background: hsl(0 70% 96%); color: hsl(0 70% 45%); }
-.ch-pill.draft      { background: hsl(220 14% 95%); color: hsl(220 10% 40%); }
-.ch-pill.scheduled  { background: hsl(280 40% 96%); color: hsl(280 40% 40%); }
-.ch-pill.sent       { background: hsl(var(--primary) / 0.12); color: hsl(var(--primary)); }
-.ch-pill.partial    { background: hsl(40 80% 95%); color: hsl(35 75% 38%); }
+.ch-pill.cancelled,
+.ch-pill.lost       { background: hsl(var(--bad) / 0.15);      color: hsl(var(--bad)); }
+.ch-pill.sent,
+.ch-pill.new,
+.ch-pill.contacted  { background: hsl(var(--primary) / 0.15);  color: hsl(var(--primary)); }
+.ch-pill.scheduled,
+.ch-pill.quoted     { background: hsl(var(--accent-2) / 0.15); color: hsl(var(--accent-2)); }
+.ch-pill.draft,
 .ch-pill.declined,
-.ch-pill.rejected   { background: hsl(220 14% 95%); color: hsl(220 10% 40%); }
-.ch-pill.new        { background: hsl(var(--primary) / 0.12); color: hsl(var(--primary)); }
-.ch-pill.contacted  { background: hsl(220 80% 95%); color: hsl(220 70% 45%); }
-.ch-pill.quoted     { background: hsl(280 40% 96%); color: hsl(280 40% 40%); }
-.ch-pill.won        { background: hsl(150 50% 95%); color: hsl(150 60% 32%); }
-.ch-pill.lost       { background: hsl(0 70% 96%); color: hsl(0 70% 45%); }
-.ch-pill.active     { background: hsl(150 50% 95%); color: hsl(150 60% 32%); }
-.ch-pill.archived   { background: hsl(220 14% 95%); color: hsl(220 10% 40%); }
+.ch-pill.rejected,
+.ch-pill.archived   { background: hsl(var(--muted));           color: hsl(var(--muted-foreground)); }
 
 /* Tabs */
 .ch-tabs {

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,0 +1,6 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/** Customer-facing: pinned light, never the operator's dashboard theme. */
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <CustomerSurface>{children}</CustomerSurface>;
+}

--- a/src/app/portal/not-found.tsx
+++ b/src/app/portal/not-found.tsx
@@ -1,0 +1,27 @@
+import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/**
+ * A dead customer link — expired token, deleted form, renamed slug.
+ *
+ * It wraps itself in CustomerSurface rather than relying on the segment
+ * layout: verified in dev, a `notFound()` boundary does NOT inherit the
+ * segment's layout here, so without this the root theme (Midnight, dark)
+ * catches it and someone whose link expired gets a dark navy page from a
+ * vendor they've never heard of. Expired tokens are the normal end of a portal
+ * link's life, not an edge case — real people see this page.
+ */
+export default function NotFound() {
+  return (
+    <CustomerSurface>
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 text-center shadow-sm">
+          <h1 className="text-lg font-semibold">This link isn&apos;t available</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            It may have expired, or been replaced by a newer one. Ask whoever
+            sent it to share it again.
+          </p>
+        </div>
+      </div>
+    </CustomerSurface>
+  );
+}

--- a/src/components/customer-portal/sign-contract.tsx
+++ b/src/components/customer-portal/sign-contract.tsx
@@ -94,7 +94,14 @@ export function SignContract({ token, contractId }: { token: string; contractId:
         <div>
           <canvas ref={canvasRef} width={500} height={160}
             onPointerDown={down} onPointerMove={move} onPointerUp={up} onPointerLeave={up}
-            className="w-full rounded-lg border border-border bg-background touch-none cursor-crosshair" />
+            // Paper, not a theme surface. `bg-background` made the canvas
+            // #111a29 under the dark default while the ink stayed #0f172a —
+            // two near-identical near-blacks, so a customer dragged a finger
+            // across the signature box and nothing appeared, at the exact
+            // moment the product most needs to feel deliberate. A signature is
+            // ink on paper in every theme.
+            style={{ background: "#ffffff" }}
+            className="w-full rounded-lg border border-border touch-none cursor-crosshair" />
           <button onClick={clear} className="mt-1 text-xs text-muted-foreground hover:text-foreground">Clear</button>
         </div>
       )}

--- a/src/components/customers/customer-detail-client.tsx
+++ b/src/components/customers/customer-detail-client.tsx
@@ -632,12 +632,12 @@ export function CustomerDetailClient({
             {/* Stat tiles */}
             <FadeIn delay={60}>
               <div className="grid grid-cols-2 gap-2">
-                <StatTile gradient="softTeal"   toneColor="#1f4f4a" icon={<DollarSign  className="w-3 h-3" />} label="Total spent" value={formatCurrency(totalSpent, currency)} />
-                <StatTile gradient="softAmber"  toneColor="#78350f" icon={<DollarSign  className="w-3 h-3" />} label="Outstanding" value={formatCurrency(outstanding, currency)} />
-                <StatTile gradient="softBlue"   toneColor="#1e3a8a" icon={<Wrench      className="w-3 h-3" />} label="Work orders" value={String(initialWorkOrders.length)} />
-                <StatTile gradient="softTeal"   toneColor="#064e3b" icon={<FileText    className="w-3 h-3" />} label="Invoices"    value={String(invoices.length)} />
-                <StatTile gradient="softViolet" toneColor="#3b1d6b" icon={<FileCheck   className="w-3 h-3" />} label="Quotes"      value={String(quotes.length)} />
-                <StatTile gradient="softRose"   toneColor="#9f1239" icon={<Home        className="w-3 h-3" />} label="Properties"  value={String(properties.length)} />
+                <StatTile gradient="softTeal"   tone="info" icon={<DollarSign  className="w-3 h-3" />} label="Total spent" value={formatCurrency(totalSpent, currency)} />
+                <StatTile gradient="softAmber"  tone="warn" icon={<DollarSign  className="w-3 h-3" />} label="Outstanding" value={formatCurrency(outstanding, currency)} />
+                <StatTile gradient="softBlue"   tone="info" icon={<Wrench      className="w-3 h-3" />} label="Work orders" value={String(initialWorkOrders.length)} />
+                <StatTile gradient="softTeal"   tone="ok" icon={<FileText    className="w-3 h-3" />} label="Invoices"    value={String(invoices.length)} />
+                <StatTile gradient="softViolet" tone="accent" icon={<FileCheck   className="w-3 h-3" />} label="Quotes"      value={String(quotes.length)} />
+                <StatTile gradient="softRose"   tone="bad" icon={<Home        className="w-3 h-3" />} label="Properties"  value={String(properties.length)} />
               </div>
             </FadeIn>
 

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -115,16 +115,16 @@ export function CustomersClient({
       {/* KPI tiles */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <FadeIn delay={60}>
-          <StatTile gradient="softTeal"   toneColor="#1f4f4a" icon={<Users      className="w-3.5 h-3.5" />} label="Total"      value={String(counts.all)}        sub={`${counts.active} active`} />
+          <StatTile gradient="softTeal"   tone="info" icon={<Users      className="w-3.5 h-3.5" />} label="Total"      value={String(counts.all)}        sub={`${counts.active} active`} />
         </FadeIn>
         <FadeIn delay={110}>
-          <StatTile gradient="softBlue"   toneColor="#1e3a8a" icon={<Mail       className="w-3.5 h-3.5" />} label="With email" value={String(counts.withEmail)}  sub="reachable" />
+          <StatTile gradient="softBlue"   tone="info" icon={<Mail       className="w-3.5 h-3.5" />} label="With email" value={String(counts.withEmail)}  sub="reachable" />
         </FadeIn>
         <FadeIn delay={160}>
-          <StatTile gradient="softViolet" toneColor="#3b1d6b" icon={<Building2  className="w-3.5 h-3.5" />} label="Companies"  value={String(counts.withCompany)} sub="B2B accounts" />
+          <StatTile gradient="softViolet" tone="accent" icon={<Building2  className="w-3.5 h-3.5" />} label="Companies"  value={String(counts.withCompany)} sub="B2B accounts" />
         </FadeIn>
         <FadeIn delay={210}>
-          <StatTile gradient="softAmber"  toneColor="#78350f" icon={<Archive    className="w-3.5 h-3.5" />} label="Archived"   value={String(counts.archived)}   sub="hidden by default" />
+          <StatTile gradient="softAmber"  tone="neutral" icon={<Archive    className="w-3.5 h-3.5" />} label="Archived"   value={String(counts.archived)}   sub="hidden by default" />
         </FadeIn>
       </div>
 

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -135,16 +135,16 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
       {/* KPI strip */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <FadeIn delay={60}>
-          <StatTile gradient="softTeal"  toneColor="#1f4f4a" icon={<FileText      className="w-3.5 h-3.5" />} label="Total"       value={String(invoices.length)} sub="all time" />
+          <StatTile gradient="softTeal"  tone="info" icon={<FileText      className="w-3.5 h-3.5" />} label="Total"       value={String(invoices.length)} sub="all time" />
         </FadeIn>
         <FadeIn delay={110}>
-          <StatTile gradient="softBlue"  toneColor="#1e3a8a" icon={<Clock         className="w-3.5 h-3.5" />} label="Outstanding" value={formatCurrency(totalOutstanding, currency)} sub="awaiting payment" />
+          <StatTile gradient="softBlue"  tone="warn" icon={<Clock         className="w-3.5 h-3.5" />} label="Outstanding" value={formatCurrency(totalOutstanding, currency)} sub="awaiting payment" />
         </FadeIn>
         <FadeIn delay={160}>
-          <StatTile gradient="softTeal"  toneColor="#064e3b" icon={<DollarSign    className="w-3.5 h-3.5" />} label="Paid"        value={formatCurrency(totalPaid, currency)} sub="all time" />
+          <StatTile gradient="softTeal"  tone="ok" icon={<DollarSign    className="w-3.5 h-3.5" />} label="Paid"        value={formatCurrency(totalPaid, currency)} sub="all time" />
         </FadeIn>
         <FadeIn delay={210}>
-          <StatTile gradient="softRose"  toneColor="#9f1239" icon={<AlertTriangle className="w-3.5 h-3.5" />} label="Overdue"     value={String(counts.overdue ?? 0)} sub="need follow-up" />
+          <StatTile gradient="softRose"  tone="bad" icon={<AlertTriangle className="w-3.5 h-3.5" />} label="Overdue"     value={String(counts.overdue ?? 0)} sub="need follow-up" />
         </FadeIn>
       </div>
 

--- a/src/components/layout/customer-surface.tsx
+++ b/src/components/layout/customer-surface.tsx
@@ -1,0 +1,44 @@
+/**
+ * Everything a CUSTOMER sees, pinned to a light theme.
+ *
+ * The root layout ships `data-theme="Midnight"` and a boot script that reads
+ * the operator's own theme out of localStorage. That is right for the
+ * dashboard and wrong for every page a customer opens: there was no layout
+ * under portal/, f/, book/ or embed/, so a homeowner who tapped "view your
+ * invoice" in a text message got a dark navy SaaS panel — the software's
+ * identity, not the roofer's.
+ *
+ * Two things have to move together, which is why this is one component:
+ *
+ *   1. The TOKENS. `[data-theme="Daylight"]` is a plain attribute selector, so
+ *      a wrapper element re-declares the whole palette for its subtree. That
+ *      part is server-rendered and needs no JavaScript.
+ *
+ *   2. The `.dark` CLASS on <html>, which Tailwind's `dark:` variants key off.
+ *      Leave it and you get the worst of both: dark tokens with `dark:`
+ *      utilities resolving light, which is how the portal ended up rendering
+ *      dark green text on dark navy. A nested layout can't change <html>
+ *      server-side, so a pre-paint script does it — before first paint, so
+ *      there is no flash.
+ *
+ * The customer's own device preference is deliberately ignored. This is a
+ * document from a business, not an app the customer configured; it should look
+ * the same in their hand as it does in the tradie's.
+ */
+
+const PIN_LIGHT = `(function(){try{
+  var d=document.documentElement;
+  d.dataset.theme='Daylight';
+  d.classList.remove('dark');
+}catch(e){}})();`;
+
+export function CustomerSurface({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: PIN_LIGHT }} />
+      <div data-theme="Daylight" className="min-h-screen bg-background text-foreground">
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/components/leads/leads-client.tsx
+++ b/src/components/leads/leads-client.tsx
@@ -266,15 +266,15 @@ export function LeadsClient({ leads: initial, tagPresets: initialPresets = [] }:
       {/* Four KPIs — the numbers the board columns and list tabs don't repeat. */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         {[
-          { icon: <Users className="w-3.5 h-3.5" />, label: "Total leads", value: String(stats.total), sub: "all time", gradient: "softBlue" as const, tone: "#1e3a8a" },
-          { icon: <Sparkles className="w-3.5 h-3.5" />, label: "New", value: String(stats.new), sub: "need first contact", gradient: "softAmber" as const, tone: "#78350f" },
-          { icon: <CheckCircle className="w-3.5 h-3.5" />, label: "Won", value: String(stats.won), sub: "converted", gradient: "softTeal" as const, tone: "#064e3b" },
-          { icon: <TrendingUp className="w-3.5 h-3.5" />, label: "Conv. rate", value: `${stats.conversion}%`, sub: "won / total", gradient: "softViolet" as const, tone: "#3b1d6b" },
+          { icon: <Users className="w-3.5 h-3.5" />, label: "Total leads", value: String(stats.total), sub: "all time", gradient: "softBlue" as const, tone: "info" as const },
+          { icon: <Sparkles className="w-3.5 h-3.5" />, label: "New", value: String(stats.new), sub: "need first contact", gradient: "softAmber" as const, tone: "warn" as const },
+          { icon: <CheckCircle className="w-3.5 h-3.5" />, label: "Won", value: String(stats.won), sub: "converted", gradient: "softTeal" as const, tone: "ok" as const },
+          { icon: <TrendingUp className="w-3.5 h-3.5" />, label: "Conv. rate", value: `${stats.conversion}%`, sub: "won / total", gradient: "softViolet" as const, tone: "accent" as const },
         ].map((k, i) => (
           <FadeIn key={k.label} delay={60 + i * 40}>
             <StatTile
               gradient={k.gradient}
-              toneColor={k.tone}
+              tone={k.tone}
               icon={k.icon}
               label={k.label}
               value={k.value}

--- a/src/components/materials/materials-client.tsx
+++ b/src/components/materials/materials-client.tsx
@@ -140,9 +140,9 @@ export function MaterialsClient({ materials: initial, currency = "GBP" }: { mate
       />
 
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
-        <FadeIn delay={60}><StatTile gradient="softAmber" toneColor="#78350f" icon={<Package     className="w-3.5 h-3.5" />} label="Total items"  value={String(materials.length)}                  sub="in catalog" /></FadeIn>
-        <FadeIn delay={110}><StatTile gradient="softAmber" toneColor="#78350f" icon={<DollarSign  className="w-3.5 h-3.5" />} label="Total cost"   value={formatCurrency(totalCatalogCost, currency)} sub="sum of cost prices" /></FadeIn>
-        <FadeIn delay={160}><StatTile gradient="softTeal"  toneColor="#064e3b" icon={<CheckCircle className="w-3.5 h-3.5" />} label="Active"       value={String(activeCount)}                        sub="materials on file" /></FadeIn>
+        <FadeIn delay={60}><StatTile gradient="softAmber" tone="warn" icon={<Package     className="w-3.5 h-3.5" />} label="Total items"  value={String(materials.length)}                  sub="in catalog" /></FadeIn>
+        <FadeIn delay={110}><StatTile gradient="softAmber" tone="warn" icon={<DollarSign  className="w-3.5 h-3.5" />} label="Total cost"   value={formatCurrency(totalCatalogCost, currency)} sub="sum of cost prices" /></FadeIn>
+        <FadeIn delay={160}><StatTile gradient="softTeal"  tone="ok" icon={<CheckCircle className="w-3.5 h-3.5" />} label="Active"       value={String(activeCount)}                        sub="materials on file" /></FadeIn>
       </div>
 
       <div className="flex items-center gap-3 flex-wrap">

--- a/src/components/outreach/outreach-client.tsx
+++ b/src/components/outreach/outreach-client.tsx
@@ -176,13 +176,13 @@ export function OutreachClient({
       {tab === "overview" && (
         <div className="space-y-5">
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <StatTile toneColor="#1f4f4a" icon={<Send className="h-4 w-4" />} label="Sent" value={String(stats.sent)}
+            <StatTile tone="info" icon={<Send className="h-4 w-4" />} label="Sent" value={String(stats.sent)}
               sub={`${stats.delivered} delivered`} />
-            <StatTile toneColor="#2563eb" icon={<MailCheck className="h-4 w-4" />} label="Opened" value={String(stats.opened)}
+            <StatTile tone="info" icon={<MailCheck className="h-4 w-4" />} label="Opened" value={String(stats.opened)}
               sub={`${pct(stats.opened, stats.sent)} of sent`} />
-            <StatTile toneColor="#7c3aed" icon={<MousePointer2 className="h-4 w-4" />} label="Clicked" value={String(stats.clicked)}
+            <StatTile tone="accent" icon={<MousePointer2 className="h-4 w-4" />} label="Clicked" value={String(stats.clicked)}
               sub={`${pct(stats.clicked, stats.sent)} of sent`} />
-            <StatTile toneColor="#dc2626" icon={<AlertCircle className="h-4 w-4" />} label="Bounced" value={String(stats.bounced)}
+            <StatTile tone="bad" icon={<AlertCircle className="h-4 w-4" />} label="Bounced" value={String(stats.bounced)}
               sub={`${pct(stats.bounced, stats.sent)} — keep under 2%`} />
           </div>
 

--- a/src/components/products/products-client.tsx
+++ b/src/components/products/products-client.tsx
@@ -133,9 +133,9 @@ export function ProductsClient({ products: initial, currency = "GBP" }: { produc
       />
 
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
-        <FadeIn delay={60}><StatTile gradient="softTeal"  toneColor="#1f4f4a" icon={<Package      className="w-3.5 h-3.5" />} label="Total items"   value={String(products.length)}                  sub="in catalog" /></FadeIn>
-        <FadeIn delay={110}><StatTile gradient="softAmber" toneColor="#78350f" icon={<DollarSign   className="w-3.5 h-3.5" />} label="Catalog value" value={formatCurrency(totalCatalogValue, currency)} sub="sum of unit prices" /></FadeIn>
-        <FadeIn delay={160}><StatTile gradient="softTeal"  toneColor="#064e3b" icon={<CheckCircle  className="w-3.5 h-3.5" />} label="Active"        value={String(activeCount)}                       sub="available to invoice" /></FadeIn>
+        <FadeIn delay={60}><StatTile gradient="softTeal"  tone="info" icon={<Package      className="w-3.5 h-3.5" />} label="Total items"   value={String(products.length)}                  sub="in catalog" /></FadeIn>
+        <FadeIn delay={110}><StatTile gradient="softAmber" tone="warn" icon={<DollarSign   className="w-3.5 h-3.5" />} label="Catalog value" value={formatCurrency(totalCatalogValue, currency)} sub="sum of unit prices" /></FadeIn>
+        <FadeIn delay={160}><StatTile gradient="softTeal"  tone="ok" icon={<CheckCircle  className="w-3.5 h-3.5" />} label="Active"        value={String(activeCount)}                       sub="available to invoice" /></FadeIn>
       </div>
 
       <div className="flex items-center gap-3 flex-wrap">

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -119,16 +119,16 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <FadeIn delay={60}>
-          <StatTile gradient="softTeal"   toneColor="#1f4f4a" icon={<FileCheck  className="w-3.5 h-3.5" />} label="Total"          value={String(quotes.length)}            sub="all time" />
+          <StatTile gradient="softTeal"   tone="info" icon={<FileCheck  className="w-3.5 h-3.5" />} label="Total"          value={String(quotes.length)}            sub="all time" />
         </FadeIn>
         <FadeIn delay={110}>
-          <StatTile gradient="softBlue"   toneColor="#1e3a8a" icon={<Briefcase  className="w-3.5 h-3.5" />} label="Open pipeline"  value={formatCurrency(totalPipeline, currency)} sub="awaiting decision" />
+          <StatTile gradient="softBlue"   tone="warn" icon={<Briefcase  className="w-3.5 h-3.5" />} label="Open pipeline"  value={formatCurrency(totalPipeline, currency)} sub="awaiting decision" />
         </FadeIn>
         <FadeIn delay={160}>
-          <StatTile gradient="softTeal"   toneColor="#064e3b" icon={<CheckCircle className="w-3.5 h-3.5" />} label="Accepted"      value={formatCurrency(totalAccepted, currency)} sub="won deals" />
+          <StatTile gradient="softTeal"   tone="ok" icon={<CheckCircle className="w-3.5 h-3.5" />} label="Accepted"      value={formatCurrency(totalAccepted, currency)} sub="won deals" />
         </FadeIn>
         <FadeIn delay={210}>
-          <StatTile gradient="softViolet" toneColor="#3b1d6b" icon={<TrendingUp  className="w-3.5 h-3.5" />} label="Acceptance"    value={`${acceptanceRate}%`}              sub="of decided quotes" />
+          <StatTile gradient="softViolet" tone="accent" icon={<TrendingUp  className="w-3.5 h-3.5" />} label="Acceptance"    value={`${acceptanceRate}%`}              sub="of decided quotes" />
         </FadeIn>
       </div>
 

--- a/src/components/sites/site-detail-client.tsx
+++ b/src/components/sites/site-detail-client.tsx
@@ -105,10 +105,10 @@ export function SiteDetailClient({
             {/* Stat tiles */}
             <FadeIn delay={60}>
               <div className="grid grid-cols-2 gap-2">
-                <StatTile gradient="softTeal"   toneColor="#1f4f4a" icon={<Wrench   className="w-3 h-3" />} label="Total jobs" value={String(jobs.length)} />
-                <StatTile gradient="softAmber"  toneColor="#78350f" icon={<Wrench   className="w-3 h-3" />} label="Open"       value={String(jobs.filter((j) => !["completed", "cancelled"].includes(j.status)).length)} />
-                <StatTile gradient="softBlue"   toneColor="#1e3a8a" icon={<Boxes    className="w-3 h-3" />} label="Assets"     value={String(assets.length)} />
-                <StatTile gradient="softViolet" toneColor="#3b1d6b" icon={<Users    className="w-3 h-3" />} label="Contacts"   value={String(siteContacts.length)} />
+                <StatTile gradient="softTeal"   tone="info" icon={<Wrench   className="w-3 h-3" />} label="Total jobs" value={String(jobs.length)} />
+                <StatTile gradient="softAmber"  tone="warn" icon={<Wrench   className="w-3 h-3" />} label="Open"       value={String(jobs.filter((j) => !["completed", "cancelled"].includes(j.status)).length)} />
+                <StatTile gradient="softBlue"   tone="info" icon={<Boxes    className="w-3 h-3" />} label="Assets"     value={String(assets.length)} />
+                <StatTile gradient="softViolet" tone="accent" icon={<Users    className="w-3 h-3" />} label="Contacts"   value={String(siteContacts.length)} />
               </div>
             </FadeIn>
 

--- a/src/components/telephony/calls-client.tsx
+++ b/src/components/telephony/calls-client.tsx
@@ -171,12 +171,12 @@ export function CallsClient({
       {tab !== "setup" && (
         <>
           <div className="mb-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <StatTile toneColor="#1f4f4a" icon={<Phone className="h-4 w-4" />} label="Calls" value={String(stats.total)}
+            <StatTile tone="info" icon={<Phone className="h-4 w-4" />} label="Calls" value={String(stats.total)}
               sub={`${stats.inbound} in · ${stats.outbound} out`} />
-            <StatTile toneColor="#dc2626" icon={<PhoneOff className="h-4 w-4" />} label="Missed" value={String(stats.missed)}
+            <StatTile tone="bad" icon={<PhoneOff className="h-4 w-4" />} label="Missed" value={String(stats.missed)}
               sub="each one is a possible lost job" />
-            <StatTile toneColor="#b45309" icon={<AlertCircle className="h-4 w-4" />} label="Voicemail" value={String(stats.voicemail)} />
-            <StatTile toneColor="#64748b" icon={<Phone className="h-4 w-4" />} label="Unknown numbers" value={String(stats.unmatched)}
+            <StatTile tone="info" icon={<AlertCircle className="h-4 w-4" />} label="Voicemail" value={String(stats.voicemail)} />
+            <StatTile tone="info" icon={<Phone className="h-4 w-4" />} label="Unknown numbers" value={String(stats.unmatched)}
               sub="not on file yet" />
           </div>
 

--- a/src/components/ui/kirei/stat-tile.tsx
+++ b/src/components/ui/kirei/stat-tile.tsx
@@ -1,18 +1,41 @@
 "use client";
 
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 import type { GradientName } from "./gradient-tokens";
 
 /**
- * Stat tile — a clean white card with a big value and a small tinted icon chip.
- * (The vibrant gradient background was dropped for the calmer MYOB/Linear look;
- * `gradient` is kept for API compatibility. `toneColor` still tints the icon
- * chip so KPIs stay lightly colour-coded without the loud fill.)
+ * Stat tile — a card with a big value and a small tinted icon chip.
+ *
+ * The chip used to be painted from a `toneColor` hex prop, and every call site
+ * passed a 900-level colour picked against a white card: #1f4f4a, #1e3a8a,
+ * #064e3b, #9f1239. The app ships `data-theme="Midnight"` by default, whose
+ * card is roughly #1a2333 — a #1e3a8a glyph on that is about 1.2:1, which is
+ * to say invisible. This is the KPI strip on Invoices, Quotes, Leads,
+ * Customers, Work Orders and every customer detail page, so it was the first
+ * thing both businesses saw on almost every screen, and it only ever looked
+ * right on the one light theme nobody was using.
+ *
+ * So the tone is now a name, not a colour, and the colour comes from the
+ * theme. No hex survives in this file — that is the point of it.
  */
+
+export type StatTone = "neutral" | "ok" | "warn" | "bad" | "info" | "accent";
+
+const TONES: Record<StatTone, string> = {
+  neutral: "bg-muted text-muted-foreground",
+  ok: "bg-ok/15 text-ok",
+  warn: "bg-warn/15 text-warn",
+  bad: "bg-bad/15 text-bad",
+  info: "bg-primary/15 text-primary",
+  accent: "bg-accent-2/15 text-accent-2",
+};
+
 interface StatTileProps {
+  /** Retained for API compatibility; the vibrant fill was dropped long ago. */
   gradient?: GradientName;
-  /** Hex colour (e.g. "#1f4f4a") used to tint the small icon chip. */
-  toneColor: string;
+  /** What the number MEANS, not what colour to paint it. */
+  tone?: StatTone;
   icon: React.ReactNode;
   label: string;
   value: string;
@@ -20,14 +43,11 @@ interface StatTileProps {
   href?: string;
 }
 
-export function StatTile({ toneColor, icon, label, value, sub, href }: StatTileProps) {
+export function StatTile({ tone = "info", icon, label, value, sub, href }: StatTileProps) {
   const card = (
     <div className="h-full rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/30">
       <div className="flex items-center gap-2">
-        <div
-          className="flex h-7 w-7 items-center justify-center rounded-md"
-          style={{ backgroundColor: `${toneColor}1a`, color: toneColor }}
-        >
+        <div className={cn("flex h-7 w-7 items-center justify-center rounded-md", TONES[tone])}>
           {icon}
         </div>
         <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</p>

--- a/src/components/work-orders/work-orders-client.tsx
+++ b/src/components/work-orders/work-orders-client.tsx
@@ -161,10 +161,10 @@ export function WorkOrdersClient({ workOrders, userRole }: WorkOrdersClientProps
       />
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <FadeIn delay={60}><StatTile gradient="softAmber" toneColor="#78350f" icon={<Calendar className="w-3.5 h-3.5" />} label="Today"        value={String(stats.todayCount)}  sub={stats.todayCount === 1 ? "scheduled job" : "scheduled jobs"} /></FadeIn>
-        <FadeIn delay={110}><StatTile gradient="softBlue"  toneColor="#1e3a8a" icon={<Wrench   className="w-3.5 h-3.5" />} label="On site now"  value={String(stats.onSite)}      sub="in progress" /></FadeIn>
-        <FadeIn delay={160}><StatTile gradient="softViolet"toneColor="#3b1d6b" icon={<Wrench   className="w-3.5 h-3.5" />} label="Needs review" value={String(stats.needsReview)} sub="submitted by workers" /></FadeIn>
-        <FadeIn delay={210}><StatTile gradient="softTeal"  toneColor="#064e3b" icon={<Wrench   className="w-3.5 h-3.5" />} label="Completed"    value={String(stats.completed)}   sub="all time" /></FadeIn>
+        <FadeIn delay={60}><StatTile gradient="softAmber" tone="warn" icon={<Calendar className="w-3.5 h-3.5" />} label="Today"        value={String(stats.todayCount)}  sub={stats.todayCount === 1 ? "scheduled job" : "scheduled jobs"} /></FadeIn>
+        <FadeIn delay={110}><StatTile gradient="softBlue"  tone="info" icon={<Wrench   className="w-3.5 h-3.5" />} label="On site now"  value={String(stats.onSite)}      sub="in progress" /></FadeIn>
+        <FadeIn delay={160}><StatTile gradient="softViolet"tone="accent" icon={<Wrench   className="w-3.5 h-3.5" />} label="Needs review" value={String(stats.needsReview)} sub="submitted by workers" /></FadeIn>
+        <FadeIn delay={210}><StatTile gradient="softTeal"  tone="ok" icon={<Wrench   className="w-3.5 h-3.5" />} label="Completed"    value={String(stats.completed)}   sub="all time" /></FadeIn>
       </div>
 
       <KireiTabs


### PR DESCRIPTION
The first and largest item from the UX audit. Everything here is **one bug with many exits**: colour was *authored* at the call site instead of *resolved* from the theme.

## The root cause

CLAUDE.md said the default theme was `console`, a warm off-white. It isn't — `layout.tsx:60` ships `data-theme="Midnight"`, which is **dark**, and `console` isn't in `UI_THEMES` at all, so no code path can select it and its CSS block is unreachable.

Components were written and reviewed against a white card nobody was looking at. **CLAUDE.md is corrected in the same commit**, because the stale line is what caused all of this.

## What was broken on the default theme

**Status pills** — 16 of 18 `.ch-pill` rules were literal light pastels (`hsl(150 50% 95%)`) with no dark override anywhere. On Midnight's `#1a2333` card that measures **14.7:1 the wrong way**: a near-white sticker, the brightest thing on the screen, attached to the least important information on it. That's what a roofer saw checking a job status on his phone. `.sent` and `.new` already read from `--primary` — they were the pattern; now all of them follow it.

**KPI tiles** — `StatTile` painted its icon chip from a `toneColor` hex prop, and all **41 call sites** passed a 900-level colour picked for a white card. `#1e3a8a` on `#1a2333` is ~1.2:1 — invisible. That's the strip on Invoices, Quotes, Leads, Customers, Work Orders and every customer detail page.

The prop is now a **tone name**, mapped semantically rather than mechanically: `Outstanding` → warn, `Overdue` → bad, `Paid`/`Accepted`/`Active` → ok, `Archived` → neutral. No hex survives in that file.

**Radius** — `--radius-xl` was +4px and `--radius-2xl` was +2px. A scale that runs backwards, so every `Card` inside a panel had a **rounder inner corner than its outer one** and read as a rendering fault.

## Customer-facing — the ones that cost money

**There was no layout under `portal/`, `f/`, `book/` or `embed/`.** A homeowner tapping "view your invoice" in a text got the operator's dark dashboard: the software's identity instead of the tradie's. Each now wraps in `<CustomerSurface>`, which pins Daylight **and** strips `.dark` before paint — both are needed, because dark tokens with `dark:` utilities resolving light is exactly how the portal ended up rendering dark green on dark navy.

Their `not-found` pages wrap themselves too. I verified in dev that a `notFound()` boundary renders in Next's `__next_error__` shell and does **not** inherit the segment layout — and an expired token is the normal end of a portal link's life, not an edge case.

**The signature canvas** was `bg-background` (`#111a29` under Midnight) with `#0f172a` ink. Two near-identical near-blacks: a customer dragged a finger across the signature box and **nothing appeared**, at the moment the product most needs to feel deliberate. It's paper now, in every theme.

**The booking page** showed *Kirei's* logo when a business hadn't uploaded one — actively telling the customer they were booking with a company they've never heard of, on the page that's meant to be the tradie's shopfront. Initials on the business's own colour instead.

## Verification

`npx tsc --noEmit` clean · `npm test` 377 passed · `npm run build` clean.

**Visually verified** what I could without a session: `/book/[slug]` renders light through the new wrapper (screenshot taken via headless Edge — white card on the teal gradient, not dark navy), and the customer 404s resolve light. The authed dashboard pages are still unverified by eye; the pill and StatTile changes are token substitutions with no logic, and both are covered by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)