### PR TITLE
fix(prospects): every hunt result was being thrown away

### DIFF
--- a/src/lib/prospecting/__tests__/run-writes.test.ts
+++ b/src/lib/prospecting/__tests__/run-writes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { runHunt, type HuntRow } from "../run";
+
+/**
+ * The bug this exists to catch, because nothing else did:
+ *
+ * every candidate write went through `.upsert(...)` with the error ignored.
+ * The conflict target was a PARTIAL unique index, which Postgres refuses as an
+ * ON CONFLICT arbiter, so every write raised 42P10 — and the run reported
+ * "5 to review", billed 45 cents, and stored nothing. tsc was clean, the unit
+ * tests were green, and the feature had never once persisted a row.
+ *
+ * A run that cannot save its results must FAIL, loudly. It must never report
+ * a count it didn't write.
+ */
+
+const HUNT: HuntRow = {
+  id: "h1", business_id: "b1", name: "Test hunt",
+  queries: ["plumber"], centre_label: "Parramatta", centre_lat: -33.8, centre_lng: 151.0,
+  radius_m: 10000, criteria: "anyone", filters: {},
+  target_count: 5, area_mode: "radius", suburbs: [], custom_params: [],
+};
+
+/**
+ * Minimal Supabase double. `candidateError` simulates the upsert rejecting —
+ * exactly what the partial index did in production.
+ */
+function fakeSb(opts: { candidateError?: string } = {}) {
+  const runRow = { id: "run1" };
+  const updates: Record<string, unknown>[] = [];
+
+  const chain = (table: string) => {
+    const api: Record<string, unknown> = {};
+    const self = () => api;
+    Object.assign(api, {
+      select: self, eq: self, gte: self, in: self, limit: self, order: self,
+      maybeSingle: async () => ({ data: table === "outreach_settings" ? null : null }),
+      single: async () => ({ data: runRow, error: null }),
+      insert: () => ({ select: () => ({ single: async () => ({ data: runRow, error: null }) }) }),
+      update: (patch: Record<string, unknown>) => {
+        if (table === "prospect_hunt_runs") updates.push(patch);
+        return api;
+      },
+      upsert: async () => ({
+        error: table === "prospect_candidates" && opts.candidateError
+          ? { message: opts.candidateError } : null,
+      }),
+      then: undefined,
+    });
+    return api;
+  };
+
+  return { from: (t: string) => chain(t), __updates: updates };
+}
+
+describe("runHunt — a run that can't save must not claim success", () => {
+  it("fails the run when candidate writes are rejected", async () => {
+    process.env.GOOGLE_PLACES_API_KEY = "test-key";
+
+    // One real-looking Places hit, so screening has something to reject or keep.
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        places: [{
+          id: "place-1",
+          displayName: { text: "Ace Plumbing" },
+          formattedAddress: "1 Test St",
+          nationalPhoneNumber: "02 9000 0000",
+          location: { latitude: -33.8, longitude: 151.0 },
+        }],
+      }),
+    })));
+
+    const sb = fakeSb({ candidateError: "there is no unique or exclusion constraint matching the ON CONFLICT specification" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await runHunt(sb as any, { ...HUNT, filters: { no_website: false } });
+
+    expect(result.error).toBeTruthy();
+    expect(result.error).toMatch(/couldn't save/i);
+
+    // And the run row must say failed — not "done" with a count nobody stored.
+    const finalStatus = (sb.__updates as Record<string, unknown>[])
+      .map((u) => u.status).filter(Boolean).pop();
+    expect(finalStatus).toBe("failed");
+  }, 30_000);
+});

--- a/src/lib/prospecting/run.ts
+++ b/src/lib/prospecting/run.ts
@@ -157,6 +157,26 @@ function areasFor(hunt: HuntRow): { label: string; area: SearchArea }[] {
   }];
 }
 
+/**
+ * Write candidates, and NOTICE when it fails.
+ *
+ * The original code called `.upsert(...)` and never looked at `error`. The
+ * conflict target was a partial unique index, which Postgres refuses to use as
+ * an ON CONFLICT arbiter, so every single write raised 42P10 — and a hunt
+ * searched Google, screened 93 businesses, paid to judge 5 of them, reported
+ * "5 to review" and stored nothing. CLAUDE.md already says to check `error`,
+ * not just `data`; this is that rule costing money.
+ *
+ * Returns the error message so the run can report it rather than claim a
+ * success it didn't have.
+ */
+async function writeCandidates(sb: SB, rows: Record<string, unknown>[]): Promise<string | null> {
+  if (!rows.length) return null;
+  const { error } = await sb.from("prospect_candidates")
+    .upsert(rows, { onConflict: "business_id,place_id", ignoreDuplicates: true });
+  return error ? (error.message ?? "Couldn't save candidates") : null;
+}
+
 export async function runHunt(sb: SB, hunt: HuntRow, existingRunId?: string): Promise<RunResult> {
   const result: RunResult = {
     run_id: existingRunId ?? null, found: 0, screened_out: 0, verified: 0, rejected: 0,
@@ -317,14 +337,13 @@ export async function runHunt(sb: SB, hunt: HuntRow, existingRunId?: string): Pr
 
   // Screened-out rows are still written: they're why the funnel adds up, and
   // they stop the next run re-finding the same rejects.
-  if (rejects.length) {
-    await sb.from("prospect_candidates").upsert(
-      rejects.map(({ hit, reason, checks }) => ({
-        ...candidateRow(hunt, result.run_id, hit),
-        status: "screened_out", reasoning: reason, checks,
-      })),
-      { onConflict: "business_id,place_id", ignoreDuplicates: true },
-    );
+  const screenWriteError = await writeCandidates(sb, rejects.map(({ hit, reason, checks }) => ({
+    ...candidateRow(hunt, result.run_id, hit),
+    status: "screened_out", reasoning: reason, checks,
+  })));
+  if (screenWriteError) {
+    await say(`Couldn't save screened-out businesses — ${screenWriteError}`, "error");
+    return finish("failed", `Couldn't save results: ${screenWriteError}`);
   }
 
   await say(`${survivors.length} past the filters, ${result.screened_out} removed`,
@@ -381,14 +400,20 @@ export async function runHunt(sb: SB, hunt: HuntRow, existingRunId?: string): Pr
       }
     }
 
-    await sb.from("prospect_candidates").upsert({
+    // Written one at a time so a judgement is never paid for twice: if this
+    // throws we stop here rather than carrying on spending.
+    const writeError = await writeCandidates(sb, [{
       ...candidateRow(hunt, result.run_id, hit),
       status: verdict.fit ? "verified" : "rejected",
       score: verdict.score,
       reasoning: verdict.reasoning,
       checks: { screened: "passed" },
       param_results: verdict.params,
-    }, { onConflict: "business_id,place_id", ignoreDuplicates: true });
+    }]);
+    if (writeError) {
+      await say(`Couldn't save "${hit.name}" — ${writeError}`, "error");
+      return finish("failed", `Couldn't save results: ${writeError}`);
+    }
 
     await progress("verifying", result.verified, target);
   }

--- a/supabase/migrations/20260812200000_prospect_candidates_conflict_target.sql
+++ b/supabase/migrations/20260812200000_prospect_candidates_conflict_target.sql
@@ -1,0 +1,28 @@
+-- Every hunt result was being thrown away.
+--
+-- `uq_prospect_candidates_place` was a PARTIAL unique index
+-- (`... WHERE place_id IS NOT NULL`). Postgres will not use a partial index as
+-- an ON CONFLICT arbiter unless the statement repeats the index predicate, and
+-- PostgREST doesn't emit one — so every upsert from the runner raised
+--
+--     there is no unique or exclusion constraint matching the ON CONFLICT
+--     specification                                                (SQLSTATE 42P10)
+--
+-- Verified against this database on a temp table carrying each index shape:
+-- partial → rejected, total → accepted.
+--
+-- The runner didn't check the error, so a hunt searched Google, screened 93
+-- businesses, paid an agent to judge 5 of them, reported "5 to review", billed
+-- 45 cents — and persisted nothing. prospect_candidates had zero rows.
+--
+-- A plain unique index is inferable and keeps the semantics: in Postgres NULLs
+-- are distinct by default, so rows with no place_id still don't collide, which
+-- is the only thing the WHERE clause was buying.
+
+DROP INDEX IF EXISTS public.uq_prospect_candidates_place;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_prospect_candidates_place
+  ON public.prospect_candidates (business_id, place_id);
+
+COMMENT ON INDEX public.uq_prospect_candidates_place IS
+  'One row per business per place. Deliberately NOT partial: a partial index cannot be an ON CONFLICT arbiter, and the upsert in lib/prospecting/run.ts depends on it.';


### PR DESCRIPTION
You ran the Chipping Norton hunt and couldn't find the results. They were never saved.

The run searched Google, found **93** businesses, screened **78** out, paid an agent to judge the rest, reported **"5 to review"**, billed **45 cents** — and wrote nothing. `prospect_candidates` had **zero rows in it, ever.**

## Two faults, and the second hid the first

**1. The conflict target was a partial index.** `uq_prospect_candidates_place` was declared `... WHERE place_id IS NOT NULL`. Postgres won't use a partial index as an `ON CONFLICT` arbiter unless the statement repeats the index predicate, and PostgREST doesn't emit one — so every upsert raised:

```
42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

Proven against this database on a temp table carrying each index shape — **partial rejected, total accepted.** The index is now plain. NULLs are distinct in Postgres by default, so rows without a `place_id` still don't collide, which is all the `WHERE` clause was buying.

**2. The runner never checked `error`.** CLAUDE.md has said *"always check `error`, not just `data`"* since PR #398 cost a duplicate customer. Same rule, and this time it meant a feature that had **never once persisted a row** reported success on every run, with counters incremented in memory and a cost recorded for work that was discarded.

Candidate writes now go through one checked helper, and a run that can't save its results **fails** instead of claiming a count it didn't write.

## The test

It asserts the honest behaviour rather than the mechanism: a run whose writes are rejected must return an error and mark the run `failed`.

I checked it actually catches the bug — reverted `run.ts` to the broken version and confirmed it fails (`expected null to be truthy`), then restored. A regression test that passes on the bug is worth nothing.

## What this doesn't recover

The 45 cents and the five judgements from that run are gone; nothing was stored to recover. **Re-run the hunt after this merges** and the same businesses will come back — the dedupe reads `prospect_candidates`, which is empty, so nothing is suppressed.

Migration applied and recorded. `npx tsc --noEmit` clean · `npm test` 378 passed (1 new) · `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)