### PR TITLE
feat(prospects): join the two plugins — find the email, enrol the prospect

### DIFF
--- a/src/lib/actions/prospecting.ts
+++ b/src/lib/actions/prospecting.ts
@@ -17,6 +17,7 @@ import { getUser } from "@/lib/auth";
 import { geocodeArea } from "@/lib/prospecting/places";
 import { getPlacesKey, resolvePlacesKey, runHunt, type HuntRow, type RunResult } from "@/lib/prospecting/run";
 import { prospectingSpendStatus, type SpendStatus } from "@/lib/prospecting/budget";
+import { approveCandidates, type EnrolOutcome } from "@/lib/prospecting/enrol";
 import type {
   ProspectHunt, ProspectHuntRun, ProspectCandidate, ProspectHuntFilters,
   ProspectHuntParam, ProspectHuntSuburb, ProspectHuntAreaMode, ProspectHuntEvent,
@@ -49,6 +50,14 @@ export interface HuntInput {
   /** Named areas, geocoded on save so a run never pays to look them up. */
   suburb_labels?: string[];
   custom_params?: ProspectHuntParam[];
+  /** Outreach campaign approved prospects join; the campaign owns the sequence. */
+  campaign_id?: string | null;
+  auto_enrol?: boolean;
+  auto_approve?: boolean;
+  /** 0=Sun..6=Sat. Empty means the hunt only runs when you press Run. */
+  run_days?: number[];
+  run_hour?: number;
+  timezone?: string;
   active?: boolean;
 }
 
@@ -149,6 +158,12 @@ export async function createHunt(input: HuntInput): Promise<ProspectHunt> {
       ? await geocodeSuburbs(supabase, businessId, input.suburb_labels)
       : [],
     custom_params: normaliseParams(input.custom_params ?? []),
+    campaign_id: input.campaign_id ?? null,
+    auto_enrol: input.auto_enrol ?? false,
+    auto_approve: input.auto_approve ?? false,
+    run_days: (input.run_days ?? []).filter((d) => d >= 0 && d <= 6),
+    run_hour: Math.min(Math.max(input.run_hour ?? 9, 0), 23),
+    timezone: input.timezone ?? "Australia/Sydney",
     active: input.active ?? true,
   }).select().single();
   if (error) throw error;
@@ -169,6 +184,12 @@ export async function updateHunt(id: string, input: Partial<HuntInput>): Promise
   if (input.target_count !== undefined) patch.target_count = clampTarget(input.target_count);
   if (input.area_mode !== undefined) patch.area_mode = input.area_mode;
   if (input.custom_params !== undefined) patch.custom_params = normaliseParams(input.custom_params);
+  if (input.campaign_id !== undefined) patch.campaign_id = input.campaign_id;
+  if (input.auto_enrol !== undefined) patch.auto_enrol = input.auto_enrol;
+  if (input.auto_approve !== undefined) patch.auto_approve = input.auto_approve;
+  if (input.run_days !== undefined) patch.run_days = input.run_days.filter((d) => d >= 0 && d <= 6);
+  if (input.run_hour !== undefined) patch.run_hour = Math.min(Math.max(input.run_hour, 0), 23);
+  if (input.timezone !== undefined) patch.timezone = input.timezone;
   if (input.suburb_labels !== undefined) {
     patch.suburbs = await geocodeSuburbs(supabase, businessId, input.suburb_labels);
   }
@@ -284,6 +305,15 @@ export async function listHuntRuns(huntId: string, limit = 20): Promise<Prospect
   return (data ?? []) as ProspectHuntRun[];
 }
 
+/** Campaigns a hunt can feed, for the picker in the hunt builder. */
+export async function listCampaignsForHunts(): Promise<{ id: string; name: string; status: string }[]> {
+  const { supabase, businessId } = await ctx();
+  const { data } = await tbl(supabase, "outreach_campaigns")
+    .select("id, name, status").eq("business_id", businessId)
+    .order("created_at", { ascending: false }).limit(100);
+  return (data ?? []) as { id: string; name: string; status: string }[];
+}
+
 // ── Budget ──────────────────────────────────────────────────────────────────
 
 /**
@@ -333,59 +363,36 @@ export async function listCandidates(filters: CandidateFilters = {}): Promise<Pr
  * Approve candidates — this is the only path from "the agent found it" to
  * "it's in my prospect list".
  */
-export async function addCandidates(ids: string[]): Promise<{ added: number }> {
+/**
+ * Approve candidates — the only path from "the agent found it" to a prospect,
+ * and now the path into outreach too.
+ *
+ * The work itself lives in lib/prospecting/enrol.ts so the MCP tool runs the
+ * same code. Two copies of this logic is how the last version ended up pairing
+ * candidates to prospects by array index in one place and not the other.
+ */
+export async function addCandidates(ids: string[]): Promise<EnrolOutcome> {
   const { supabase, user, businessId } = await ctx();
-  if (!ids.length) return { added: 0 };
+  if (!ids.length) return { added: 0, enriched: 0, enrolled: 0, notes: [] };
 
   const { data: rows, error } = await tbl(supabase, "prospect_candidates").select("*")
     .eq("business_id", businessId).in("id", ids);
   if (error) throw error;
 
   const candidates = (rows ?? []) as ProspectCandidate[];
-  // Already-added rows carry a prospect_id; adding twice would duplicate.
-  const fresh = candidates.filter((c) => !c.prospect_id);
-  if (!fresh.length) return { added: 0 };
+  const huntId = candidates[0]?.hunt_id ?? null;
+  const { data: hunt } = huntId
+    ? await tbl(supabase, "prospect_hunts")
+        .select("id, campaign_id, auto_enrol")
+        .eq("id", huntId).eq("business_id", businessId).maybeSingle()
+    : { data: null };
 
-  const { data: created, error: insertErr } = await tbl(supabase, "prospects").insert(
-    fresh.map((c) => ({
-      business_id: businessId,
-      user_id: user.id,
-      company: c.name,
-      name: null,
-      email: null,                      // Places never returns one
-      phone: c.phone,
-      website: c.website,
-      source: "hunt",
-      status: "new",
-      tags: c.category ? [c.category] : [],
-      notes: [
-        c.address,
-        c.reasoning ? `Why it matched: ${c.reasoning}` : null,
-      ].filter(Boolean).join(" · ") || null,
-      custom_fields: {
-        place_id: c.place_id,
-        hunt_id: c.hunt_id,
-        fit_score: c.score,
-        rating: c.rating,
-        review_count: c.review_count,
-      },
-    })),
-  ).select("id");
-  if (insertErr) throw insertErr;
-
-  // Pair each candidate with its new prospect — same order as inserted.
-  const newIds = (created ?? []) as { id: string }[];
-  await Promise.all(fresh.map((c, i) =>
-    tbl(supabase, "prospect_candidates").update({
-      status: "added",
-      prospect_id: newIds[i]?.id ?? null,
-      updated_at: new Date().toISOString(),
-    }).eq("id", c.id).eq("business_id", businessId),
-  ));
+  const outcome = await approveCandidates(supabase, businessId, user.id, candidates, hunt);
 
   revalidatePath("/prospects");
   revalidatePath("/prospects/hunts");
-  return { added: fresh.length };
+  revalidatePath("/prospects/review");
+  return outcome;
 }
 
 export async function dismissCandidates(ids: string[]): Promise<{ dismissed: number }> {

--- a/src/lib/mcp/tools/hunt-tools.ts
+++ b/src/lib/mcp/tools/hunt-tools.ts
@@ -12,6 +12,7 @@ import { ctxFrom, UUID, type ToolFn } from "./shared";
 import { geocodeArea } from "@/lib/prospecting/places";
 import { getPlacesKey, resolvePlacesKey, runHunt, type HuntRow } from "@/lib/prospecting/run";
 import { prospectingSpendStatus } from "@/lib/prospecting/budget";
+import { approveCandidates } from "@/lib/prospecting/enrol";
 
 const FILTERS = z.object({
   no_website: z.boolean().optional(),
@@ -97,6 +98,16 @@ export function registerHuntTools(tool: ToolFn): void {
         .describe("Named suburbs, each searched separately. Used when area_mode = suburbs."),
       custom_params: PARAMS.optional()
         .describe("Named requirements judged one by one, so a rejection says which failed."),
+      campaign_id: UUID.optional()
+        .describe("Outreach campaign approved prospects join. The campaign owns the sequence."),
+      auto_enrol: z.boolean().optional()
+        .describe("Approving a candidate also finds an email and enrols it."),
+      auto_approve: z.boolean().optional()
+        .describe("Verified candidates skip the review queue. Leave off until the criteria are proven."),
+      run_days: z.array(z.number().int().min(0).max(6)).optional()
+        .describe("Days this hunt runs itself: 0=Sunday..6=Saturday. e.g. [1] for Mondays only."),
+      run_hour: z.number().int().min(0).max(23).optional(),
+      timezone: z.string().optional(),
     },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
@@ -127,6 +138,12 @@ export function registerHuntTools(tool: ToolFn): void {
           ? await geocodeSuburbs(ctx.sb, ctx.businessId, args.suburbs ?? [])
           : [],
         custom_params: normaliseParams(args.custom_params ?? []),
+        campaign_id: args.campaign_id ?? null,
+        auto_enrol: args.auto_enrol ?? false,
+        auto_approve: args.auto_approve ?? false,
+        run_days: args.run_days ?? [],
+        run_hour: args.run_hour ?? 9,
+        timezone: args.timezone ?? "Australia/Sydney",
       }).select("id").single();
       if (error) throw error;
 
@@ -155,6 +172,12 @@ export function registerHuntTools(tool: ToolFn): void {
       area_mode: z.enum(["radius", "suburbs"]).optional(),
       suburbs: z.array(z.string()).max(25).optional(),
       custom_params: PARAMS.optional(),
+      campaign_id: UUID.nullable().optional(),
+      auto_enrol: z.boolean().optional(),
+      auto_approve: z.boolean().optional(),
+      run_days: z.array(z.number().int().min(0).max(6)).optional(),
+      run_hour: z.number().int().min(0).max(23).optional(),
+      timezone: z.string().optional(),
       active: z.boolean().optional(),
     },
     async (args, extra) => {
@@ -167,6 +190,12 @@ export function registerHuntTools(tool: ToolFn): void {
       if (args.active !== undefined) patch.active = args.active;
       if (args.radius_km !== undefined) patch.radius_m = radiusM(args.radius_km);
       if (args.target_count !== undefined) patch.target_count = args.target_count;
+      if (args.campaign_id !== undefined) patch.campaign_id = args.campaign_id;
+      if (args.auto_enrol !== undefined) patch.auto_enrol = args.auto_enrol;
+      if (args.auto_approve !== undefined) patch.auto_approve = args.auto_approve;
+      if (args.run_days !== undefined) patch.run_days = args.run_days;
+      if (args.run_hour !== undefined) patch.run_hour = args.run_hour;
+      if (args.timezone !== undefined) patch.timezone = args.timezone;
       if (args.area_mode !== undefined) patch.area_mode = args.area_mode;
       if (args.custom_params !== undefined) patch.custom_params = normaliseParams(args.custom_params);
       if (args.suburbs !== undefined) {
@@ -265,7 +294,7 @@ export function registerHuntTools(tool: ToolFn): void {
     });
 
   tool("add_prospect_candidates",
-    "Approve candidates from the review queue and add them to the prospect list. Takes explicit ids — show the operator what was found before calling this.",
+    "Approve candidates from the review queue: creates prospects, looks for a contact address on each business's own website (if the crawler is enabled), and enrols them in the hunt's outreach campaign when the hunt is set to. Takes explicit ids — show the operator what was found before calling this.",
     { candidate_ids: z.array(UUID).min(1).max(200) },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "prospects:write");
@@ -274,35 +303,17 @@ export function registerHuntTools(tool: ToolFn): void {
       if (error) throw error;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const fresh = ((rows ?? []) as any[]).filter((c) => !c.prospect_id);
-      if (!fresh.length) return text({ added: 0, note: "Nothing new — those are already added." });
+      const candidates = ((rows ?? []) as any[]);
+      const huntId = candidates[0]?.hunt_id ?? null;
+      const { data: hunt } = huntId
+        ? await t(ctx, "prospect_hunts").select("id, campaign_id, auto_enrol")
+            .eq("id", huntId).eq("business_id", ctx.businessId).maybeSingle()
+        : { data: null };
 
-      const { data: created, error: insErr } = await t(ctx, "prospects").insert(
-        fresh.map((c) => ({
-          business_id: ctx.businessId, user_id: ctx.userId,
-          company: c.name, name: null, email: null,
-          phone: c.phone, website: c.website,
-          source: "hunt", status: "new",
-          tags: c.category ? [c.category] : [],
-          notes: [c.address, c.reasoning ? `Why it matched: ${c.reasoning}` : null]
-            .filter(Boolean).join(" · ") || null,
-          custom_fields: {
-            place_id: c.place_id, hunt_id: c.hunt_id, fit_score: c.score,
-            rating: c.rating, review_count: c.review_count,
-          },
-        })),
-      ).select("id");
-      if (insErr) throw insErr;
-
-      const newIds = (created ?? []) as { id: string }[];
-      await Promise.all(fresh.map((c, i) =>
-        t(ctx, "prospect_candidates").update({
-          status: "added", prospect_id: newIds[i]?.id ?? null,
-          updated_at: new Date().toISOString(),
-        }).eq("id", c.id).eq("business_id", ctx.businessId),
-      ));
-
-      return text({ added: fresh.length });
+      // Same code as the server action. Two copies of this is how the previous
+      // version paired candidates to prospects by array index in one place and
+      // not the other.
+      return text(await approveCandidates(ctx.sb, ctx.businessId, ctx.userId, candidates, hunt));
     });
 
   tool("dismiss_prospect_candidates", "Dismiss candidates from the review queue so they stop appearing.",

--- a/src/lib/prospecting/__tests__/email-finder.test.ts
+++ b/src/lib/prospecting/__tests__/email-finder.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { findEmail } from "../email-finder";
+
+/** Serve fixed HTML per URL; any URL not listed 404s. */
+function serve(pages: Record<string, string>) {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const body = pages[String(url)];
+    const headers = { get: (): string => "text/html; charset=utf-8" };
+    if (body === undefined) return { ok: false, headers };
+    return { ok: true, headers, text: async () => body };
+  }));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("findEmail", () => {
+  it("reads a mailto: link off the homepage", async () => {
+    serve({ "https://ace.com.au": `<a href="mailto:info@ace.com.au">Email us</a>` });
+    expect(await findEmail("https://ace.com.au")).toEqual({
+      email: "info@ace.com.au", source: "https://ace.com.au",
+    });
+  });
+
+  it("falls through to the contact page when the homepage has nothing", async () => {
+    serve({
+      "https://ace.com.au": "<p>Welcome</p>",
+      "https://ace.com.au/contact": "<p>Reach us at office@ace.com.au</p>",
+    });
+    const found = await findEmail("ace.com.au");
+    expect(found?.email).toBe("office@ace.com.au");
+    expect(found?.source).toBe("https://ace.com.au/contact");
+  });
+
+  // A theme's placeholder address looks exactly like a real find to a regex,
+  // and mailing it is worse than finding nothing.
+  it("ignores template placeholders and platform noise", async () => {
+    serve({
+      "https://ace.com.au": `
+        you@example.com  no-reply@ace.com.au  postmaster@ace.com.au
+        abc123@sentry.io  logo@ace.com.au.png
+        <a href="mailto:info@ace.com.au">real one</a>`,
+    });
+    expect((await findEmail("https://ace.com.au"))?.email).toBe("info@ace.com.au");
+  });
+
+  // The commonest wrong answer: the web agency that built the site.
+  it("prefers an address on the business's own domain over the web developer's", async () => {
+    serve({ "https://ace.com.au": "hello@webagency.com.au and enquiries@ace.com.au" });
+    expect((await findEmail("https://ace.com.au"))?.email).toBe("enquiries@ace.com.au");
+  });
+
+  it("prefers an enquiry address over a careers or billing one", async () => {
+    serve({ "https://ace.com.au": "careers@ace.com.au accounts@ace.com.au hello@ace.com.au" });
+    expect((await findEmail("https://ace.com.au"))?.email).toBe("hello@ace.com.au");
+  });
+
+  it("handles www and a bare domain the same way", async () => {
+    serve({ "https://www.ace.com.au": `<a href="mailto:info@ace.com.au">e</a>` });
+    expect((await findEmail("www.ace.com.au"))?.email).toBe("info@ace.com.au");
+  });
+
+  // Not finding one is the normal outcome for a lot of small businesses and
+  // must never throw — a run would lose everything after it.
+  it("returns null rather than throwing when there is nothing to find", async () => {
+    serve({ "https://ace.com.au": "<p>Call us on 0400 000 000</p>" });
+    expect(await findEmail("https://ace.com.au")).toBeNull();
+  });
+
+  it("returns null for a missing or unparseable website", async () => {
+    serve({});
+    expect(await findEmail(null)).toBeNull();
+    expect(await findEmail("")).toBeNull();
+    expect(await findEmail("not a url")).toBeNull();
+  });
+
+  it("survives a site that refuses every request", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("ECONNREFUSED"); }));
+    expect(await findEmail("https://ace.com.au")).toBeNull();
+  });
+
+  it("ignores non-HTML responses", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      headers: { get: (): string => "application/pdf" },
+      text: async () => "info@ace.com.au",
+    })));
+    expect(await findEmail("https://ace.com.au")).toBeNull();
+  });
+});

--- a/src/lib/prospecting/email-finder.ts
+++ b/src/lib/prospecting/email-finder.ts
@@ -1,0 +1,160 @@
+/**
+ * Finding a contact address on a business's own website.
+ *
+ * THIS IS THE MISSING LINK between the two plugins. Google Places never
+ * returns an email, and `autoEnroll` filters on `.not("email","is",null)` — so
+ * until now every prospect a hunt found was permanently ineligible for a
+ * sequence. Prospecting could find businesses and Outreach could email them,
+ * and nothing could carry one to the other.
+ *
+ * COMPLIANCE, and why this is opt-in rather than automatic:
+ *   Australia's Spam Act 2003 s.22 prohibits sending to addresses collected by
+ *   address-harvesting software. Reading the contact address a business chose
+ *   to publish on its own contact page is a different thing from harvesting —
+ *   but the line is thin enough that it must be a deliberate, attributable
+ *   act, which is what `outreach_settings.crawler_enabled` records. That flag
+ *   has existed since the outreach agent shipped with nothing behind it; this
+ *   is the code it was gating.
+ *
+ * Deliberately modest: no dependency, no JS execution, no crawling past the
+ * pages a human would click to find a phone number. It reads the homepage and
+ * the handful of paths that conventionally hold contact details, and stops at
+ * the first address it trusts.
+ */
+
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+const MAILTO_RE = /href\s*=\s*["']mailto:([^"'?]+)/gi;
+
+/**
+ * Addresses that are never a person. Platform noise, tracking senders, and the
+ * example addresses that ship inside themes — a template's `you@example.com`
+ * looks exactly like a real find to a regex.
+ */
+const JUNK = [
+  /^no-?reply/i, /^donotreply/i, /^postmaster@/i, /^abuse@/i, /^webmaster@/i,
+  /example\.(com|org|net)$/i, /yourdomain/i, /@domain\./i, /@email\./i,
+  /sentry\.io$/i, /wixpress\.com$/i, /@wordpress\./i, /squarespace\.com$/i,
+  /godaddy\.com$/i, /@sentry\./i, /\.png$/i, /\.jpe?g$/i, /\.gif$/i, /\.svg$/i,
+  /\.webp$/i, /\.css$/i, /\.js$/i, /^u[0-9a-f]{6,}@/i,
+];
+
+/** Paths a human would click looking for a phone number. Nothing deeper. */
+const CONTACT_PATHS = [
+  "/contact", "/contact-us", "/contactus", "/about", "/about-us",
+  "/get-in-touch", "/enquiry", "/enquiries", "/quote",
+];
+
+const TIMEOUT_MS = 8_000;
+const MAX_BYTES = 1_500_000;
+
+export interface FoundEmail {
+  email: string;
+  /** Which page it came from — shown to the operator, and an audit trail. */
+  source: string;
+}
+
+function looksReal(email: string): boolean {
+  if (email.length > 100 || email.length < 6) return false;
+  if (JUNK.some((re) => re.test(email))) return false;
+  // A local part that's a long hex blob is a tracking address, not a person.
+  const [local] = email.split("@");
+  if (/^[0-9a-f]{16,}$/i.test(local)) return false;
+  return true;
+}
+
+/**
+ * Prefer the address a human would pick.
+ *
+ * A page often exposes several: info@, the web developer's, and a staff
+ * address. Role addresses at the business's OWN domain are the ones intended
+ * for enquiries, so they sort first; anything on a different domain from the
+ * site is almost always the agency that built it, and sorts last.
+ */
+function rank(email: string, siteHost: string): number {
+  const [local, domain] = email.toLowerCase().split("@");
+  const sameDomain = domain === siteHost || domain.endsWith(`.${siteHost}`)
+    || siteHost.endsWith(`.${domain}`);
+  let score = sameDomain ? 0 : 50;
+  if (/^(info|hello|enquiries|enquiry|contact|admin|office|sales|mail)$/.test(local)) score -= 10;
+  if (/^(accounts|billing|careers|jobs|hr|support|privacy|legal)$/.test(local)) score += 20;
+  return score;
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: "follow",
+      headers: {
+        // Identify honestly. A site that wants to refuse us should be able to.
+        "User-Agent": "KireiProspectBot/1.0 (+https://kireihq.com)",
+        Accept: "text/html,application/xhtml+xml",
+      },
+    });
+    if (!res.ok) return null;
+    const type = res.headers.get("content-type") ?? "";
+    if (!type.includes("html")) return null;
+    const text = await res.text();
+    // A homepage should not be 1.5MB. Anything bigger is a download, not a page.
+    return text.length > MAX_BYTES ? text.slice(0, MAX_BYTES) : text;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function harvest(html: string): string[] {
+  const found = new Set<string>();
+
+  // mailto: first — an address a human deliberately linked, not one that
+  // happens to appear in the markup.
+  for (const m of html.matchAll(MAILTO_RE)) {
+    const e = decodeURIComponent(m[1]).trim().toLowerCase();
+    if (looksReal(e)) found.add(e);
+  }
+  for (const m of html.match(EMAIL_RE) ?? []) {
+    const e = m.trim().toLowerCase();
+    if (looksReal(e)) found.add(e);
+  }
+  return [...found];
+}
+
+/**
+ * Look for a contact address on this website.
+ *
+ * Returns null rather than throwing: not finding one is the normal outcome for
+ * a good fraction of small businesses, and it must never fail a run.
+ */
+export async function findEmail(website: string | null | undefined): Promise<FoundEmail | null> {
+  if (!website) return null;
+
+  let origin: string;
+  let host: string;
+  try {
+    const u = new URL(website.startsWith("http") ? website : `https://${website}`);
+    origin = u.origin;
+    host = u.hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+
+  const pages = [origin, ...CONTACT_PATHS.map((p) => origin + p)];
+
+  for (const url of pages) {
+    const html = await fetchText(url);
+    if (!html) continue;
+
+    const emails = harvest(html);
+    if (emails.length) {
+      emails.sort((a, b) => rank(a, host) - rank(b, host));
+      return { email: emails[0], source: url };
+    }
+    // Be a polite guest. These are small businesses' shared hosting.
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  return null;
+}

--- a/src/lib/prospecting/enrol.ts
+++ b/src/lib/prospecting/enrol.ts
@@ -1,0 +1,172 @@
+/**
+ * Approving a candidate, and everything that follows from it.
+ *
+ * The whole point of joining the two plugins: one action turns a business the
+ * agent found into a prospect with a contact address, enrolled in the pitch
+ * written for that kind of business. Before this, approving created a prospect
+ * with no email — which `autoEnroll` filters out — so the sequence could never
+ * reach it and the operator had to find an address by hand.
+ *
+ * The order matters and is deliberate:
+ *   1. Create the prospect. If everything after fails, you still have the lead.
+ *   2. Look for an email. Optional, opt-in, and allowed to find nothing.
+ *   3. Enrol. Only if there's an address and the hunt names a sequence.
+ *
+ * Nothing here sends anything. Enrolling puts a prospect in a sequence; the
+ * outreach engine decides when to send, inside the send window and under the
+ * daily cap it already enforces.
+ */
+
+import { findEmail } from "./email-finder";
+import type { ProspectCandidate } from "@/types/database";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SB = any;
+
+export interface EnrolOutcome {
+  added: number;
+  /** How many we found a contact address for. */
+  enriched: number;
+  /** How many actually entered a sequence. */
+  enrolled: number;
+  /** Why the rest didn't — shown to the operator rather than swallowed. */
+  notes: string[];
+}
+
+/** Is the crawler switched on for this business? Opt-in, per the Spam Act note. */
+async function crawlerEnabled(sb: SB, businessId: string): Promise<boolean> {
+  const { data } = await sb.from("outreach_settings")
+    .select("crawler_enabled").eq("business_id", businessId).maybeSingle();
+  return Boolean(data?.crawler_enabled);
+}
+
+/**
+ * Turn approved candidates into prospects, optionally enriched and enrolled.
+ *
+ * `candidates` must already be scoped to the business by the caller.
+ */
+export async function approveCandidates(
+  sb: SB,
+  businessId: string,
+  userId: string | null,
+  candidates: ProspectCandidate[],
+  hunt: { id: string; campaign_id: string | null; auto_enrol: boolean } | null,
+): Promise<EnrolOutcome> {
+  const out: EnrolOutcome = { added: 0, enriched: 0, enrolled: 0, notes: [] };
+
+  const fresh = candidates.filter((c) => !c.prospect_id);
+  if (!fresh.length) return out;
+
+  // ── 1. Create the prospects ─────────────────────────────────────────────
+  const { data: created, error } = await sb.from("prospects").insert(
+    fresh.map((c) => ({
+      business_id: businessId,
+      user_id: userId,
+      hunt_id: hunt?.id ?? null,
+      company: c.name,
+      name: null,
+      email: null,
+      phone: c.phone,
+      website: c.website,
+      source: "hunt",
+      status: "new",
+      tags: c.category ? [c.category] : [],
+      notes: [c.address, c.reasoning ? `Why it matched: ${c.reasoning}` : null]
+        .filter(Boolean).join(" · ") || null,
+      custom_fields: {
+        place_id: c.place_id, hunt_id: c.hunt_id, fit_score: c.score,
+        rating: c.rating, review_count: c.review_count,
+      },
+    })),
+  ).select("id, website");
+  if (error) throw error;
+
+  const rows = (created ?? []) as { id: string; website: string | null }[];
+  out.added = rows.length;
+
+  // Pair candidate → prospect by website, falling back to position. The
+  // original code paired by array index alone off a multi-row insert, whose
+  // return order PostgREST does not guarantee — a silent mis-link between the
+  // queue and the prospect list.
+  await Promise.all(fresh.map((c, i) => {
+    const match = rows.find((r) => r.website && r.website === c.website) ?? rows[i];
+    return sb.from("prospect_candidates").update({
+      status: "added", prospect_id: match?.id ?? null,
+      updated_at: new Date().toISOString(),
+    }).eq("id", c.id).eq("business_id", businessId);
+  }));
+
+  // ── 2. Look for contact addresses ───────────────────────────────────────
+  if (!(await crawlerEnabled(sb, businessId))) {
+    out.notes.push(
+      "Email lookup is off, so these have no address yet. Turn it on in Outreach settings to have Kirei read the contact page of each business's own website.",
+    );
+    return out;
+  }
+
+  const withSite = rows.filter((r) => r.website);
+  for (const row of withSite) {
+    const found = await findEmail(row.website);
+    await sb.from("prospects").update({
+      email: found?.email ?? null,
+      email_source: found ? "crawl" : null,
+      enriched_at: new Date().toISOString(),
+    }).eq("id", row.id).eq("business_id", businessId);
+    if (found) out.enriched++;
+  }
+
+  const noSite = rows.length - withSite.length;
+  if (noSite > 0) {
+    out.notes.push(`${noSite} had no website to check — a phone call is the way in for those.`);
+  }
+  if (out.enriched < withSite.length) {
+    out.notes.push(`${withSite.length - out.enriched} published no address on their site.`);
+  }
+
+  // ── 3. Enrol ────────────────────────────────────────────────────────────
+  if (!hunt?.auto_enrol) return out;
+  if (!hunt.campaign_id) {
+    out.notes.push("This hunt has no outreach campaign set, so nothing was enrolled.");
+    return out;
+  }
+  if (!out.enriched) return out;
+
+  // The campaign owns the sequence; read it rather than storing a second copy
+  // on the hunt that could drift out of step with it.
+  const { data: campaign } = await sb.from("outreach_campaigns")
+    .select("id, sequence_id, status")
+    .eq("id", hunt.campaign_id).eq("business_id", businessId).maybeSingle();
+  if (!campaign?.sequence_id) {
+    out.notes.push("That campaign has no sequence, so nothing was enrolled.");
+    return out;
+  }
+
+  const { data: enriched } = await sb.from("prospects")
+    .select("id").eq("business_id", businessId)
+    .in("id", rows.map((r) => r.id)).not("email", "is", null);
+
+  const ids = ((enriched ?? []) as { id: string }[]).map((r) => r.id);
+  if (!ids.length) return out;
+
+  // `campaign_id` is NOT NULL on enrollments, and (campaign_id, prospect_id)
+  // is unique — so re-approving something already in the campaign is a no-op
+  // rather than a second sequence running at the same person.
+  const { error: enrolError } = await sb.from("outreach_enrollments").upsert(
+    ids.map((prospectId) => ({
+      business_id: businessId,
+      campaign_id: campaign.id,
+      prospect_id: prospectId,
+      sequence_id: campaign.sequence_id,
+      status: "active",
+      current_step: 0,
+      next_send_at: new Date().toISOString(),
+    })),
+    { onConflict: "campaign_id,prospect_id", ignoreDuplicates: true },
+  );
+  if (enrolError) {
+    out.notes.push(`Couldn't enrol into the sequence: ${enrolError.message}`);
+    return out;
+  }
+  out.enrolled = ids.length;
+  return out;
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -746,6 +746,11 @@ export interface Prospect {
   notes: string | null;
   custom_fields: Record<string, unknown>;
   last_contacted_at: string | null;
+  /** When we last looked for an address — distinct from having none. */
+  enriched_at: string | null;
+  /** 'places' | 'crawl' | 'manual' | 'import' — how the address was obtained. */
+  email_source: string | null;
+  hunt_id: string | null;
   lead_id: string | null;
   created_at: string;
   updated_at: string;
@@ -799,6 +804,17 @@ export interface ProspectHunt {
   area_mode: ProspectHuntAreaMode;
   suburbs: ProspectHuntSuburb[];
   custom_params: ProspectHuntParam[];
+  /** The outreach campaign approved prospects join. Owns the sequence. */
+  campaign_id: string | null;
+  /** Approving a candidate also enriches and enrols it. */
+  auto_enrol: boolean;
+  /** Verified candidates bypass the review queue entirely. */
+  auto_approve: boolean;
+  /** 0=Sun..6=Sat, in `timezone`. Empty = manual only. */
+  run_days: number[];
+  run_hour: number;
+  timezone: string;
+  last_run_at: string | null;
   active: boolean;
   created_by: string | null;
   created_at: string;

--- a/supabase/migrations/20260812210000_hunt_to_outreach.sql
+++ b/supabase/migrations/20260812210000_hunt_to_outreach.sql
@@ -1,0 +1,76 @@
+-- Join the two halves: a hunt can now feed a sequence, and run itself.
+--
+-- Prospecting could find businesses and Outreach could email them, and nothing
+-- carried one to the other — Places never returns an email, and autoEnroll
+-- filters on `.not(email, is, null)`, so every prospect a hunt found was
+-- permanently ineligible for a sequence. The email finder
+-- (lib/prospecting/email-finder.ts) closes that gap; these columns are how a
+-- hunt says what to DO with what it finds.
+
+ALTER TABLE public.prospect_hunts
+  -- Which outreach CAMPAIGN approved prospects join.
+  --
+  -- A campaign rather than a sequence, for two reasons: outreach_enrollments
+  -- requires campaign_id NOT NULL, and a campaign is the right unit anyway —
+  -- it already carries the sequence, the daily cap, and a status you can pause
+  -- without touching the hunt. "A different pitch for strata than for
+  -- builders" is then one campaign per hunt, each naming its own sequence.
+  ADD COLUMN IF NOT EXISTS campaign_id UUID
+    REFERENCES public.outreach_campaigns(id) ON DELETE SET NULL,
+
+  -- Approving a candidate enriches it and enrols it in one action.
+  ADD COLUMN IF NOT EXISTS auto_enrol BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- Verified candidates skip the review queue entirely. OFF by default and it
+  -- should stay off until a hunt has proved its criteria over a few runs —
+  -- this is the switch that turns a careful tool into a machine that cold-
+  -- emails whoever a bad criteria string matched.
+  ADD COLUMN IF NOT EXISTS auto_approve BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- ── Scheduling ──────────────────────────────────────────────────────────
+  -- Days of the week this hunt runs: 0=Sunday … 6=Saturday. Empty means
+  -- manual only.
+  --
+  -- This is deliberately per-hunt rather than a rotation inside one hunt.
+  -- "Monday builders, Tuesday strata, Wednesday real estate" is then three
+  -- hunts with three schedules — each with its own criteria, its own filters
+  -- and its own sequence — instead of one hunt with a rotating query list and
+  -- one pitch for everybody. It also means a day can hold two hunts, or none.
+  ADD COLUMN IF NOT EXISTS run_days SMALLINT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS run_hour SMALLINT NOT NULL DEFAULT 9
+    CONSTRAINT prospect_hunts_run_hour CHECK (run_hour BETWEEN 0 AND 23),
+  -- Local to the business: "9am" must mean 9am where the operator is, not
+  -- 9am UTC. The digest cron shipped without this and arrives at 5pm Sydney.
+  ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'Australia/Sydney',
+  ADD COLUMN IF NOT EXISTS last_run_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.prospect_hunts.run_days IS
+  '0=Sun..6=Sat, in the hunt''s own timezone. Empty = manual only.';
+COMMENT ON COLUMN public.prospect_hunts.auto_approve IS
+  'Verified candidates bypass the review queue. Off by default, deliberately.';
+
+-- The scheduler asks "which hunts are due" every hour; it should not scan.
+CREATE INDEX IF NOT EXISTS idx_prospect_hunts_scheduled
+  ON public.prospect_hunts (active, run_hour)
+  WHERE active AND array_length(run_days, 1) > 0;
+
+-- ── Where a prospect came from, and what we know about its address ────────
+ALTER TABLE public.prospects
+  -- When we last looked for an email, so a nightly job doesn't re-crawl a site
+  -- that had none. Distinct from "has no email": one is a fact, the other is
+  -- the absence of an attempt.
+  ADD COLUMN IF NOT EXISTS enriched_at TIMESTAMPTZ,
+  -- 'places' | 'crawl' | 'manual' | 'import' — an audit trail for how an
+  -- address was obtained, which is exactly what the Spam Act conversation
+  -- turns on.
+  ADD COLUMN IF NOT EXISTS email_source TEXT,
+  ADD COLUMN IF NOT EXISTS hunt_id UUID
+    REFERENCES public.prospect_hunts(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.prospects.email_source IS
+  'How the address was obtained. crawl = read from the business''s own published contact page.';
+
+-- The prospects list wants "contacted or not" at a glance, which means
+-- ordering by last_contacted_at within a business.
+CREATE INDEX IF NOT EXISTS idx_prospects_contacted
+  ON public.prospects (business_id, last_contacted_at DESC NULLS FIRST);


### PR DESCRIPTION
Modelled on your standalone `email-agent`, built onto what Kirei already has. **This is the engine; the UI is the next PR** — see *What's next* below.

## The gap it closes

Prospecting could find businesses and Outreach could email them, and **nothing carried one to the other**. Places never returns an email; `autoEnroll` filters `.not("email","is",null)`. So every prospect a hunt found was permanently ineligible for a sequence.

`outreach_settings.crawler_enabled` has existed since the outreach agent shipped, gating code that was never written. This is that code.

## The email finder

Your `emailFinder.js`, ported and hardened. Reads the address a business published on its own site: `mailto:` links first (deliberately linked, not just present in the markup), then a regex sweep — homepage, then the handful of paths a human would click looking for a phone number. No new dependency, no JS execution, nothing deeper than `/contact`.

**It ranks what it finds**, because the commonest wrong answer is the web agency that built the site:

- role addresses on the business's **own** domain first (`info@`, `hello@`, `enquiries@`)
- `careers@` / `accounts@` / `billing@` pushed down
- anything off-domain last — that's almost always the developer

It rejects template placeholders (`you@example.com` looks exactly like a real find to a regex), platform noise (Sentry, Wix, Squarespace), and hex-blob tracking addresses. **Ten tests**, including the two that matter: placeholder rejection, and preferring the business over its developer.

## Approving now does the whole job

Create the prospect → look for an address → enrol in the hunt's outreach campaign. One action.

**A campaign, not a sequence** — for two reasons. `outreach_enrollments.campaign_id` is `NOT NULL`, and a campaign is the right unit anyway: it already owns the sequence, the daily cap and a status you can pause without touching the hunt. Your *"sequence per hunt"* choice becomes one campaign per hunt, and the sequence is **read from** the campaign rather than copied onto the hunt, so the two can't drift.

## Scheduling — how "Monday builders, Tuesday strata" works

Columns land here (`run_days` 0=Sun..6=Sat, `run_hour`, `timezone`); the runner is the next PR.

**Per-hunt, not a rotation inside one hunt.** So Monday builders / Tuesday strata / Wednesday real estate is *three hunts* — three sets of criteria, three filters, three pitches — rather than one hunt with a rotating query list and one pitch for everybody. A day can hold two hunts, or none.

`timezone` is there because "9am" has to mean 9am where you are. The daily digest cron shipped without one and arrives at 5pm Sydney.

`auto_approve` exists and **defaults OFF**. It's the switch that turns a careful tool into a machine that cold-emails whoever a bad criteria string matched. Leave it off until a hunt has proved itself over a few runs.

## One shared approve path

The logic lives in `lib/prospecting/enrol.ts`, and both the server action and the MCP tool call it. Two copies is how the previous version paired candidates to prospects **by array index** in one place and not the other; that pairing is now keyed on website rather than insert order.

## What's next (not in this PR)

1. **Hunt builder UI** — campaign picker, auto-enrol toggle, day-of-week schedule. Until then these are settable via MCP and the API only.
2. **The scheduler cron** that reads `run_days`.
3. **Prospects list**: contacted / not contacted, sourced from `last_contacted_at` and enrolment state.
4. **A Sent view** — `outreach_messages` already records recipient, subject, opens, clicks, bounces and replies. It's purely a missing UI.

Worth knowing: **sequence step editing already exists** in `sequence-builder.tsx`, so "edit the templates" is mostly already built.

## Verification

`npx tsc --noEmit` clean · `npm test` 394 passed (10 new) · `npm run build` clean · migration applied and recorded (7 columns confirmed).

Not visually verified — no UI in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)