### PR TITLE
feat(nav): breadcrumbs, so a deep page has a way back out

### DIFF
--- a/src/app/(dashboard)/prospects/review/page.tsx
+++ b/src/app/(dashboard)/prospects/review/page.tsx
@@ -1,7 +1,4 @@
-import Link from "next/link";
 import { PageHeader } from "@/components/layout/page-header";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "@/components/ui/icons";
 import { CandidateQueue } from "@/components/prospects/candidate-queue";
 import { listCandidates, listHunts } from "@/lib/actions/prospecting";
 
@@ -18,11 +15,10 @@ export default async function ReviewPage() {
       <PageHeader
         title="Review"
         subtitle="Businesses your hunts found and verified. Add the good ones to your prospect list."
-        actions={
-          <Button variant="outline" asChild>
-            <Link href="/prospects/hunts"><ArrowLeft className="w-4 h-4 mr-1.5" /> Hunts</Link>
-          </Button>
-        }
+        trail={[
+          { label: "Prospects", href: "/prospects" },
+          { label: "Prospecting", href: "/prospects/hunts" },
+        ]}
       />
       <CandidateQueue
         candidates={candidates}

--- a/src/components/layout/breadcrumbs.tsx
+++ b/src/components/layout/breadcrumbs.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { ChevronRight, ArrowLeft } from "@/components/ui/icons";
+
+/**
+ * Where you are, and how to get back out.
+ *
+ * Kirei goes three levels deep in several places — /prospects → hunts → a hunt
+ * → its review queue — and had no consistent way back. Twenty-six files
+ * hand-rolled their own ArrowLeft link, each deciding for itself what "back"
+ * meant, and several deep pages had none at all: the only way out was the
+ * browser button or the sidebar, which drops you at the top of a section
+ * rather than where you were.
+ *
+ * The trail is passed explicitly rather than derived from the URL. A derived
+ * one would render "/prospects/hunts/3ce6b0ba-8039-…" — the segment a route
+ * needs is not the word a person recognises, and the page is the only thing
+ * that knows a hunt is called "Chipping Norton — no website".
+ *
+ * On a phone it collapses to the immediate parent with a back arrow. A
+ * three-level trail wraps to two lines on a 375px screen and stops being
+ * navigation; one clear way back is worth more than a complete map.
+ */
+
+export interface Crumb {
+  label: string;
+  href: string;
+}
+
+export function Breadcrumbs({ trail }: { trail: Crumb[] }) {
+  if (!trail.length) return null;
+  const parent = trail[trail.length - 1];
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-2 min-w-0">
+      {/* Phone: one unambiguous way back. */}
+      <Link
+        href={parent.href}
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground sm:hidden"
+      >
+        <ArrowLeft className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">{parent.label}</span>
+      </Link>
+
+      {/* Wider: the whole path, so you can jump two levels in one click. */}
+      <ol className="hidden flex-wrap items-center gap-1 text-sm text-muted-foreground sm:flex">
+        {trail.map((crumb, i) => (
+          <li key={crumb.href} className="flex items-center gap-1 min-w-0">
+            <Link
+              href={crumb.href}
+              className="truncate transition-colors hover:text-foreground hover:underline"
+            >
+              {crumb.label}
+            </Link>
+            {i < trail.length - 1 && (
+              <ChevronRight className="h-3.5 w-3.5 shrink-0 opacity-50" aria-hidden />
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumbs, type Crumb } from "@/components/layout/breadcrumbs";
 /**
  * Standard page header used across list / detail pages — Kirei design.
  *
@@ -12,6 +13,12 @@ interface Props {
   title: React.ReactNode;
   subtitle?: React.ReactNode;
   actions?: React.ReactNode;
+  /**
+   * Ancestors of this page, nearest last. The page's own title is not a crumb.
+   * Passed explicitly because a URL segment is not the word a person
+   * recognises — a hunt's crumb is its name, not its uuid.
+   */
+  trail?: Crumb[];
 }
 
 /**
@@ -27,10 +34,12 @@ interface Props {
  * If per-section colour is ever genuinely wanted, it comes back as a token
  * enum resolved here — never as a string passed in from the page.
  */
-export function PageHeader({ title, subtitle, actions }: Props) {
+export function PageHeader({ title, subtitle, actions, trail }: Props) {
   const accentBg = "linear-gradient(180deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.6) 100%)";
   return (
-    <div className="flex items-end justify-between gap-3 flex-wrap mb-6">
+    <div className="mb-6">
+      {trail?.length ? <Breadcrumbs trail={trail} /> : null}
+      <div className="flex items-end justify-between gap-3 flex-wrap">
       <div className="flex items-stretch gap-3 min-w-0">
         <div
           className="w-1 rounded-full shrink-0"
@@ -38,15 +47,16 @@ export function PageHeader({ title, subtitle, actions }: Props) {
           aria-hidden
         />
         <div className="min-w-0">
-          <h1 className="text-3xl font-bold tracking-tight truncate">{title}</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-balance break-words">{title}</h1>
           {subtitle && (
             <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
           )}
         </div>
       </div>
-      {actions && (
-        <div className="flex items-center gap-2 flex-wrap">{actions}</div>
-      )}
+        {actions && (
+          <div className="flex items-center gap-2 flex-wrap">{actions}</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/prospects/hunt-detail.tsx
+++ b/src/components/prospects/hunt-detail.tsx
@@ -10,7 +10,6 @@
  */
 
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation } from "@/components/layout/use-mutation";
 import { PageHeader } from "@/components/layout/page-header";
@@ -20,7 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 import {
-  Play, MapPin, ArrowLeft, Trash2, Edit, Target, AlertTriangle, CheckCircle,
+  Play, MapPin, Trash2, Edit, Target, AlertTriangle, CheckCircle,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import { CandidateQueue } from "@/components/prospects/candidate-queue";
@@ -130,11 +129,12 @@ export function HuntDetail({ hunt, runs, candidates, activeRunId }: Props) {
       <PageHeader
         title={hunt.name}
         subtitle={hunt.criteria}
+        trail={[
+          { label: "Prospects", href: "/prospects" },
+          { label: "Prospecting", href: "/prospects/hunts" },
+        ]}
         actions={
           <>
-            <Button variant="outline" asChild>
-              <Link href="/prospects/hunts"><ArrowLeft className="w-4 h-4 mr-1.5" /> All hunts</Link>
-            </Button>
             <Button variant="outline" onClick={() => { setDraft(draftFrom(hunt)); setEditing(true); }}>
               <Edit className="w-4 h-4 mr-1.5" /> Edit
             </Button>

--- a/src/components/prospects/hunts-view.tsx
+++ b/src/components/prospects/hunts-view.tsx
@@ -142,6 +142,7 @@ export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
     <>
       <PageHeader
         title="Prospecting"
+        trail={[{ label: "Prospects", href: "/prospects" }]}
         subtitle="Describe who you want to find. The agent searches your area, checks each business, and queues the matches for you."
         actions={
           <Button onClick={() => setOpen(true)} disabled={pending}>


### PR DESCRIPTION
You went into a hunt and there was no way back to Prospects. You're right that it needs breadcrumbs — the UX audit's IA agent flagged the same thing ("after you drill three levels in, how do you get back where you were?").

## What was actually wrong

Kirei goes three levels deep in several places — Prospects → Prospecting → a hunt → its review queue — and had no consistent way out. **Twenty-six files hand-roll their own `ArrowLeft` link**, each deciding for itself what "back" means, and several deep pages had none at all. The only exit was the browser button or the sidebar, which drops you at the *top* of a section rather than where you were.

## The fix

`PageHeader` takes a `trail` now, so the answer lives in the one component every page already uses instead of in twenty-six separate opinions.

```tsx
<PageHeader
  title={hunt.name}
  trail={[
    { label: "Prospects", href: "/prospects" },
    { label: "Prospecting", href: "/prospects/hunts" },
  ]}
/>
```

**Passed explicitly, not derived from the URL.** A derived trail would render `/prospects/hunts/3ce6b0ba-8039-4166` — the segment a route needs is not the word a person recognises, and only the page knows the hunt is called "Chipping Norton — no website".

**On a phone it collapses** to the immediate parent with a back arrow. A three-level trail wraps onto two lines at 375px and stops being navigation; one unambiguous way back beats a complete map you can't read. The full path shows from `sm` up so you can jump two levels in one click.

## Applied where you hit it

The three prospecting pages. The hunt page's "All hunts" button and the review page's "Hunts" button are **removed** — they're exactly what the trail replaces, and leaving both would be two answers to one question.

## One thing I fixed while in there

The page title was `truncate`, so "Chipping Norton — no website" lost its tail. Now `break-words` + `text-balance`. You've asked for wrapping over clipping more than once and this was a live instance of it.

## Not done

**25 files still carry a hand-rolled back link.** They want the same treatment, but each needs a judgement about what its parent is *called* — that's a deliberate sweep, not a regex, and it belongs with the audit's navigation work rather than bolted onto this.

## Verification

`npx tsc --noEmit` clean · `npm test` 384 passed · `npm run build` clean. Not visually verified — auth-gated, no session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)