### PR TITLE
fix(leads): a quoted lead was indistinguishable from a paying client

### DIFF
--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -194,7 +194,17 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-xs text-muted-foreground">{invoice.number}</span>
                   </div>
-                  <div className="text-sm font-semibold break-words">{invoice.customers?.name ?? "No client"}</div>
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="text-sm font-semibold break-words">{invoice.customers?.name ?? "No contact yet"}</span>
+                    {invoice.customers?.lifecycle_stage === "lead" && (
+                      /* They've been quoted but haven't bought yet. Without this
+                         a quoted lead is indistinguishable from a paying client
+                         the moment you quote them. */
+                      <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                        Lead
+                      </span>
+                    )}
+                  </div>
                 </div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(invoice.issue_date)}</div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(invoice.due_date)}</div>

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -174,7 +174,17 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
                 </GradientTile>
                 <div className="flex-1 min-w-[140px] basis-0">
                   <div className="font-mono text-xs text-muted-foreground">{quote.number}</div>
-                  <div className="text-sm font-semibold break-words">{quote.customers?.name ?? "No client"}</div>
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="text-sm font-semibold break-words">{quote.customers?.name ?? "No contact yet"}</span>
+                    {quote.customers?.lifecycle_stage === "lead" && (
+                      /* They've been quoted but haven't bought yet. Without this
+                         a quoted lead is indistinguishable from a paying client
+                         the moment you quote them. */
+                      <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                        Lead
+                      </span>
+                    )}
+                  </div>
                 </div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(quote.issue_date)}</div>
                 <div className="hidden md:block w-32 text-xs text-muted-foreground">{formatDate(quote.expiry_date)}</div>

--- a/src/lib/actions/customers.ts
+++ b/src/lib/actions/customers.ts
@@ -64,9 +64,15 @@ export async function getCustomer(id: string): Promise<Customer> {
   return data as Customer;
 }
 
+/**
+ * `lifecycle_stage` is part of the input on purpose.
+ *
+ * The column defaults to 'client', and the one caller that must NOT take that
+ * default — quoting a lead — was silently getting it. See ensureCustomerForLead.
+ */
 type CreateCustomerInput =
-  Omit<Customer, "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods" | "stripe_customer_id" | "stripe_payment_method_id" | "stripe_pm_brand" | "stripe_pm_last4" | "stripe_pm_exp" | "autopay_enabled">
-  & Partial<Pick<Customer, "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods">>;
+  Omit<Customer, "lifecycle_stage" | "id" | "created_at" | "updated_at" | "user_id" | "business_id" | "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods" | "stripe_customer_id" | "stripe_payment_method_id" | "stripe_pm_brand" | "stripe_pm_last4" | "stripe_pm_exp" | "autopay_enabled">
+  & Partial<Pick<Customer, "account_type" | "website" | "secondary_phone" | "contact_role" | "preferred_contact" | "state" | "allowed_payment_methods" | "lifecycle_stage">>;
 
 export async function createCustomer(payload: CreateCustomerInput): Promise<Customer> {
   const supabase = await createClient();

--- a/src/lib/actions/invoices.ts
+++ b/src/lib/actions/invoices.ts
@@ -32,7 +32,7 @@ export async function getInvoices(filters?: { status?: string; customer_id?: str
       id, user_id, number, status, customer_id,
       issue_date, due_date, total, amount_paid,
       parent_invoice_id, created_at, updated_at,
-      customers(id, name, email, company)
+      customers(id, name, email, company, lifecycle_stage)
     `)
     .eq("business_id", businessId)
     .order("created_at", { ascending: false })

--- a/src/lib/actions/leads.ts
+++ b/src/lib/actions/leads.ts
@@ -261,9 +261,21 @@ export async function deleteLeadNote(noteId: string): Promise<void> {
 
 // ── Pipeline conversions ────────────────────────────────────────────────────
 
+/**
+ * The contact row behind a quoted lead.
+ *
+ * `lifecycle_stage: "lead"` is the whole point and was missing. The column
+ * defaults to 'client', so every lead you quoted became indistinguishable from
+ * a real customer the moment you quoted them — 9 out of 9 rows in production
+ * were mislabelled. The lead-lifecycle migration's stated design is "a lead
+ * gets a real contact row the moment you first quote them, and that row is
+ * marked as still being a lead"; the marking was never wired up, so the Lead
+ * tag it exists to drive could never appear anywhere.
+ */
 async function ensureCustomerForLead(lead: Lead): Promise<string> {
   if (lead.customer_id) return lead.customer_id;
   const customer = await createCustomer({
+    lifecycle_stage: "lead",
     name: lead.name,
     email: lead.email ?? null,
     phone: lead.phone ?? null,

--- a/src/lib/actions/quotes.ts
+++ b/src/lib/actions/quotes.ts
@@ -28,7 +28,7 @@ export async function getQuotes(filters?: { status?: string; customer_id?: strin
       id, user_id, number, status, customer_id,
       issue_date, expiry_date, total, invoice_id,
       created_at, updated_at,
-      customers(id, name, email, company)
+      customers(id, name, email, company, lifecycle_stage)
     `)
     .eq("business_id", businessId)
     .order("created_at", { ascending: false })

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -93,6 +93,13 @@ export interface Business {
 }
 
 export interface Customer {
+  /**
+   * 'lead' until they become a real client. The migration that added this
+   * column never added it to THIS type, so nothing could set it and every
+   * lead-created contact silently took the 'client' default — which is why
+   * the Lead tag never appeared anywhere.
+   */
+  lifecycle_stage: LifecycleStage;
   id: string;
   user_id: string;
   business_id: string;
@@ -303,8 +310,8 @@ export interface LineItem {
   total: number;
 }
 
-export type InvoiceWithCustomer = Invoice & { customers: Pick<Customer, "id" | "name" | "email" | "company"> | null };
-export type QuoteWithCustomer = Quote & { customers: Pick<Customer, "id" | "name" | "email" | "company"> | null };
+export type InvoiceWithCustomer = Invoice & { customers: Pick<Customer, "id" | "name" | "email" | "company" | "lifecycle_stage"> | null };
+export type QuoteWithCustomer = Quote & { customers: Pick<Customer, "id" | "name" | "email" | "company" | "lifecycle_stage"> | null };
 
 // ----------------------------------------------------------------
 // REPORTS
@@ -364,7 +371,7 @@ export interface Report {
 }
 
 export type ReportWithCustomer = Report & {
-  customers: Pick<Customer, "id" | "name" | "email" | "company"> | null;
+  customers: Pick<Customer, "id" | "name" | "email" | "company" | "lifecycle_stage"> | null;
 };
 
 // ----------------------------------------------------------------

--- a/supabase/migrations/20260812230000_backfill_lead_lifecycle.sql
+++ b/supabase/migrations/20260812230000_backfill_lead_lifecycle.sql
@@ -1,0 +1,21 @@
+-- Nine contacts created by quoting a lead were all labelled 'client'.
+--
+-- The lead-lifecycle migration's design was "a lead gets a real contact row
+-- the moment you first quote them, and that row is marked as still being a
+-- lead". The marking was never wired: `customers.lifecycle_stage` was added to
+-- the database and to the TypeScript `Contact` type, but NOT to `Customer` —
+-- so no code could set it, TypeScript couldn't flag its absence, and every row
+-- silently took the 'client' default. 9 of 9 in production were wrong, and the
+-- Lead tag the column exists to drive could never appear anywhere.
+--
+-- Only rows a lead actually points at are touched. A contact somebody typed in
+-- by hand is a client and stays one.
+UPDATE public.customers c
+SET lifecycle_stage = 'lead'
+WHERE c.lifecycle_stage = 'client'
+  AND EXISTS (SELECT 1 FROM public.leads l WHERE l.customer_id = c.id)
+  -- Someone who has paid you is not a lead any more, whatever they started as.
+  AND NOT EXISTS (
+    SELECT 1 FROM public.invoices i
+    WHERE i.customer_id = c.id AND i.status IN ('paid', 'partial')
+  );


### PR DESCRIPTION
You quoted a lead and the quote didn't show them as one. **Nine out of nine** contacts in production created by quoting a lead were labelled `client`.

## Root cause

The lead-lifecycle migration added `customers.lifecycle_stage` to the **database** and to the TypeScript **`Contact`** type — but **not to `Customer`**.

So no code could set it, TypeScript couldn't flag its absence, and every row silently took the `'client'` default. The migration's own header states the intended design:

> a lead gets a real contact row the moment you first quote them, and that row is marked as still being a lead

The marking was never wired up, so the tag it exists to drive could never appear anywhere.

## The fix

- `lifecycle_stage` is on the `Customer` type now, **optional on create** so a contact you type in by hand still defaults to `client`.
- `ensureCustomerForLead` passes `"lead"` explicitly.
- Quote and invoice lists show a **Lead** pill beside the name. `lifecycle_stage` rides along on the list getters — one extra column on a join that was already happening.

## The backfill

Nine rows corrected, with two deliberate exclusions:

- **only rows a lead actually points at** — a contact someone typed in by hand is a client and stays one
- **not anyone who has already paid an invoice** — someone who has paid you isn't a lead any more, whatever they started as

Verified after: `lifecycle_stage = lead → 9`.

## One thing that is *not* what you hit

Three quotes and three invoices genuinely have **no customer attached** — Crown Roofers, April and May, all expired or rejected. They pre-date the lead flow and aren't related to it. I replaced the literal `"No client"` with `"No contact yet"`, because "No client" reads like an error where "No contact yet" reads like a state.

**If the quote you saw was recent, that's a different bug from this one** — tell me the quote number and I'll trace it. What I've fixed here is provable: the lifecycle flag was never set, on any row, ever.

## On the bigger question you raised

You asked whether leads should get a separate quotes page. I'd argue not, and the migration agrees: giving documents a `lead_id` means a second branch in the PDF, the email, the portal token, the Stripe customer, deposits, autopay and dunning — and the likely outcome is being able to quote a lead but not take their deposit. One document pipeline, with the contact marked as a lead, keeps all of that working. The tag is the honest version of the distinction.

`npx tsc --noEmit` clean · `npm test` 394 passed · `npm run build` clean · migration applied and recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)