### PR TITLE
feat(prospects,outreach): the rest of the loop — schedule, enrol, and see what went out

### DIFF
--- a/src/app/(dashboard)/outreach/sent/page.tsx
+++ b/src/app/(dashboard)/outreach/sent/page.tsx
@@ -1,0 +1,18 @@
+import { PageHeader } from "@/components/layout/page-header";
+import { listSentMessages } from "@/lib/actions/outreach";
+import { SentView } from "@/components/outreach/sent-view";
+
+/** Everything the outreach agent has sent, and what came of it. */
+export default async function SentPage() {
+  const messages = await listSentMessages();
+  return (
+    <>
+      <PageHeader
+        title="Sent"
+        subtitle="Every email the outreach agent has sent, and whether it landed"
+        trail={[{ label: "Outreach", href: "/outreach" }]}
+      />
+      <SentView messages={messages} />
+    </>
+  );
+}

--- a/src/app/(dashboard)/prospects/hunts/[id]/page.tsx
+++ b/src/app/(dashboard)/prospects/hunts/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getHunt, listHuntRuns, listCandidates } from "@/lib/actions/prospecting";
+import { getHunt, listHuntRuns, listCandidates, listCampaignsForHunts } from "@/lib/actions/prospecting";
 import { HuntDetail } from "@/components/prospects/hunt-detail";
 
 export default async function HuntPage({ params }: { params: Promise<{ id: string }> }) {
@@ -8,9 +8,10 @@ export default async function HuntPage({ params }: { params: Promise<{ id: strin
   const hunt = await getHunt(id);
   if (!hunt) notFound();
 
-  const [runs, candidates] = await Promise.all([
+  const [runs, candidates, campaigns] = await Promise.all([
     listHuntRuns(id),
     listCandidates({ hunt_id: id, status: "verified" }),
+    listCampaignsForHunts(),
   ]);
 
   // A run started in another tab (or before a reload) is rejoined rather than
@@ -24,6 +25,7 @@ export default async function HuntPage({ params }: { params: Promise<{ id: strin
       runs={runs}
       candidates={candidates}
       activeRunId={active?.id ?? null}
+      campaigns={campaigns}
     />
   );
 }

--- a/src/app/(dashboard)/prospects/hunts/page.tsx
+++ b/src/app/(dashboard)/prospects/hunts/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveBizId } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
-import { listHunts, getProspectingBudget } from "@/lib/actions/prospecting";
+import { listHunts, getProspectingBudget, listCampaignsForHunts } from "@/lib/actions/prospecting";
 import { resolvePlacesKey } from "@/lib/prospecting/run";
 import { HuntsView } from "@/components/prospects/hunts-view";
 
@@ -17,13 +17,14 @@ export default async function HuntsPage() {
     redirect("/auth/login");
   }
 
-  const [hunts, review, budget, places] = await Promise.all([
+  const [hunts, review, budget, places, campaigns] = await Promise.all([
     listHunts(),
     supabase.from("prospect_candidates")
       .select("id", { count: "exact", head: true })
       .eq("business_id", businessId).eq("status", "verified"),
     getProspectingBudget(),
     resolvePlacesKey(supabase, businessId),
+    listCampaignsForHunts(),
   ]);
 
   return (
@@ -33,6 +34,7 @@ export default async function HuntsPage() {
       budget={budget}
       // Only whether a key exists crosses to the client — never the key.
       canHunt={Boolean(places.key)}
+      campaigns={campaigns}
     />
   );
 }

--- a/src/app/api/cron/prospect-hunts/route.ts
+++ b/src/app/api/cron/prospect-hunts/route.ts
@@ -1,0 +1,109 @@
+/**
+ * Hunts that run themselves.
+ *
+ * Fires hourly. Each hunt names the weekdays it runs on and the local hour it
+ * runs at, so "builders on Monday, strata on Tuesday" is three hunts with
+ * three schedules — each with its own criteria, filters and campaign — rather
+ * than one hunt rotating a query list and sending everybody the same pitch.
+ *
+ * Two things this deliberately does NOT do:
+ *
+ *   - It never sends anything. A run fills the review queue; the outreach
+ *     engine decides what leaves the building, inside the send window and
+ *     under the daily cap it already enforces.
+ *   - It never runs a hunt whose budget is spent. runHunt checks that itself,
+ *     but the scheduler also skips inactive hunts and ones already running, so
+ *     a slow run can't be started twice by two ticks of the cron.
+ */
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { runHunt, type HuntRow } from "@/lib/prospecting/run";
+
+export const maxDuration = 300;
+
+/** The weekday (0=Sun) and hour it is right now in a given timezone. */
+function localNow(timezone: string): { day: number; hour: number } {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone, weekday: "short", hour: "numeric", hour12: false,
+    }).formatToParts(new Date());
+    const weekday = parts.find((p) => p.type === "weekday")?.value ?? "Sun";
+    const hour = Number(parts.find((p) => p.type === "hour")?.value ?? "0");
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    return { day: Math.max(0, days.indexOf(weekday)), hour: hour % 24 };
+  } catch {
+    // An unknown timezone must not wedge the whole cron for every business.
+    const d = new Date();
+    return { day: d.getUTCDay(), hour: d.getUTCHours() };
+  }
+}
+
+/** Has this hunt already run today, in its own timezone? */
+function ranToday(lastRunAt: string | null, timezone: string): boolean {
+  if (!lastRunAt) return false;
+  try {
+    const fmt = new Intl.DateTimeFormat("en-CA", { timeZone: timezone });
+    return fmt.format(new Date(lastRunAt)) === fmt.format(new Date());
+  } catch {
+    return new Date(lastRunAt).toISOString().slice(0, 10)
+      === new Date().toISOString().slice(0, 10);
+  }
+}
+
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = createAdminClient() as any;
+
+  const { data: hunts, error } = await sb.from("prospect_hunts")
+    .select("*").eq("active", true).not("run_days", "eq", "{}");
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const results: Record<string, unknown>[] = [];
+
+  for (const hunt of (hunts ?? []) as HuntRow[] & Record<string, unknown>[]) {
+    const h = hunt as unknown as HuntRow & {
+      run_days: number[]; run_hour: number; timezone: string; last_run_at: string | null;
+    };
+
+    const { day, hour } = localNow(h.timezone || "Australia/Sydney");
+    if (!h.run_days?.includes(day)) continue;
+    if (hour !== h.run_hour) continue;
+    // The cron fires hourly and a run can outlive its slot; without this a
+    // retry an hour later would run the same hunt twice in a day.
+    if (ranToday(h.last_run_at, h.timezone || "Australia/Sydney")) continue;
+
+    // One run per hunt at a time — two concurrent runs would double-spend and
+    // race each other on the same place_id upserts.
+    const { data: active } = await sb.from("prospect_hunt_runs")
+      .select("id").eq("hunt_id", h.id).eq("status", "running").limit(1).maybeSingle();
+    if (active) {
+      results.push({ hunt: h.name, skipped: "already running" });
+      continue;
+    }
+
+    // Stamp BEFORE running, not after. A run takes minutes; stamping after
+    // would let the next hourly tick start it again while it's still going.
+    await sb.from("prospect_hunts")
+      .update({ last_run_at: new Date().toISOString() }).eq("id", h.id);
+
+    try {
+      const result = await runHunt(sb, h);
+      results.push({
+        hunt: h.name, verified: result.verified, found: result.found,
+        cost_cents: result.cost_cents, error: result.error,
+      });
+    } catch (e) {
+      results.push({ hunt: h.name, error: e instanceof Error ? e.message : "failed" });
+    }
+  }
+
+  return NextResponse.json({ checked: hunts?.length ?? 0, ran: results.length, results });
+}

--- a/src/components/outreach/outreach-client.tsx
+++ b/src/components/outreach/outreach-client.tsx
@@ -126,6 +126,11 @@ export function OutreachClient({
         subtitle="Multi-step cold email over your prospect list — sequences, campaigns and delivery tracking."
         actions={
           <>
+            {/* The record of what actually went out. It was being written all
+                along and had nowhere to be read. */}
+            <Button variant="outline" asChild>
+              <Link href="/outreach/sent"><MailCheck className="mr-1.5 h-4 w-4" /> Sent</Link>
+            </Button>
             <Button variant="outline" onClick={sendNow} disabled={running || !settings.enabled}>
               {running ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Send className="mr-1.5 h-4 w-4" />}
               Send due now

--- a/src/components/outreach/sent-view.tsx
+++ b/src/components/outreach/sent-view.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * What the outreach agent actually sent.
+ *
+ * Every one of these facts was already being recorded — recipient, subject,
+ * which step, opens, clicks, bounces, replies — and none of it was visible
+ * anywhere in the app. An agent that emails people on your behalf and can't
+ * show you what it sent is asking to be trusted on nothing.
+ */
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Search, X, MailCheck, MousePointer2, AlertCircle, Send } from "@/components/ui/icons";
+import { cn, formatDate } from "@/lib/utils";
+import type { SentMessage } from "@/lib/actions/outreach";
+
+/**
+ * The furthest state a message reached, and how it reads.
+ *
+ * Deliberately ordered by what the operator cares about rather than by what
+ * happened last: a reply is the point of the whole exercise, so it wins over
+ * a click, which wins over an open.
+ */
+function outcome(m: SentMessage): { label: string; tone: string; icon: typeof Send } {
+  if (m.replied_at) return { label: "Replied", tone: "bg-ok/15 text-ok", icon: MailCheck };
+  if (m.bounced_at || m.status === "bounced") return { label: "Bounced", tone: "bg-bad/15 text-bad", icon: AlertCircle };
+  if (m.status === "failed") return { label: "Failed", tone: "bg-bad/15 text-bad", icon: AlertCircle };
+  if (m.clicked_at) return { label: "Clicked", tone: "bg-primary/15 text-primary", icon: MousePointer2 };
+  if (m.opened_at) return { label: "Opened", tone: "bg-accent-2/15 text-accent-2", icon: MailCheck };
+  return { label: "Sent", tone: "bg-muted text-muted-foreground", icon: Send };
+}
+
+const FILTERS = [
+  { key: "", label: "Everything" },
+  { key: "replied", label: "Replied" },
+  { key: "clicked", label: "Clicked" },
+  { key: "opened", label: "Opened" },
+  { key: "problem", label: "Bounced or failed" },
+] as const;
+
+export function SentView({ messages }: { messages: SentMessage[] }) {
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<string>("");
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return messages.filter((m) => {
+      if (filter === "replied" && !m.replied_at) return false;
+      if (filter === "clicked" && !m.clicked_at) return false;
+      if (filter === "opened" && !m.opened_at) return false;
+      if (filter === "problem" && !(m.bounced_at || m.status === "bounced" || m.status === "failed")) return false;
+      if (!q) return true;
+      return [m.recipient, m.subject, m.prospects?.name, m.prospects?.company, m.outreach_campaigns?.name]
+        .filter(Boolean).join(" ").toLowerCase().includes(q);
+    });
+  }, [messages, search, filter]);
+
+  // Counted from everything, not the filtered view — a rate that changes when
+  // you filter is a rate nobody can trust.
+  const stats = useMemo(() => ({
+    sent: messages.length,
+    opened: messages.filter((m) => m.opened_at).length,
+    clicked: messages.filter((m) => m.clicked_at).length,
+    replied: messages.filter((m) => m.replied_at).length,
+  }), [messages]);
+
+  if (messages.length === 0) {
+    return (
+      <Card><CardContent className="py-14 text-center">
+        <Send className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+        <p className="font-medium">Nothing sent yet</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Once a campaign is running, every email it sends shows up here — with whether it
+          was opened, clicked or replied to.
+        </p>
+      </CardContent></Card>
+    );
+  }
+
+  const pct = (n: number) => (stats.sent ? Math.round((n / stats.sent) * 100) : 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="ch-stat-grid">
+        <div className="ch-stat"><span>Sent</span><strong>{stats.sent}</strong></div>
+        <div className="ch-stat"><span>Opened</span><strong>{stats.opened} <span className="text-sm font-normal text-muted-foreground">({pct(stats.opened)}%)</span></strong></div>
+        <div className="ch-stat"><span>Clicked</span><strong>{stats.clicked} <span className="text-sm font-normal text-muted-foreground">({pct(stats.clicked)}%)</span></strong></div>
+        <div className="ch-stat"><span>Replied</span><strong>{stats.replied} <span className="text-sm font-normal text-muted-foreground">({pct(stats.replied)}%)</span></strong></div>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search} onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search recipient, subject, company…" className="pl-9 pr-9"
+            aria-label="Search sent emails"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Clear search"
+            ><X className="h-3.5 w-3.5" /></button>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setFilter(f.key)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                filter === f.key
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80",
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {visible.length} of {messages.length}
+      </p>
+
+      <div className="space-y-2">
+        {visible.map((m) => {
+          const o = outcome(m);
+          const Icon = o.icon;
+          return (
+            <Card key={m.id}>
+              <CardContent className="flex flex-wrap items-start justify-between gap-3 p-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={cn("inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium", o.tone)}>
+                      <Icon className="h-3 w-3" /> {o.label}
+                    </span>
+                    {m.prospects?.name || m.prospects?.company ? (
+                      <Link href={`/prospects/${m.prospects.id}`} className="text-sm font-medium hover:underline break-words">
+                        {m.prospects.company || m.prospects.name}
+                      </Link>
+                    ) : (
+                      <span className="text-sm font-medium break-all">{m.recipient}</span>
+                    )}
+                    {m.step_order != null && (
+                      <span className="text-[11px] text-muted-foreground">step {m.step_order}</span>
+                    )}
+                  </div>
+                  {m.subject && <p className="mt-1 text-sm break-words">{m.subject}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground break-all">
+                    {m.recipient}
+                    {m.outreach_campaigns?.name ? ` · ${m.outreach_campaigns.name}` : ""}
+                  </p>
+                  {m.error && <p className="mt-1 text-xs text-destructive break-words">{m.error}</p>}
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">{formatDate(m.sent_at)}</span>
+              </CardContent>
+            </Card>
+          );
+        })}
+        {visible.length === 0 && (
+          <Card><CardContent className="py-10 text-center text-sm text-muted-foreground">
+            Nothing matches that.
+          </CardContent></Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/prospects/hunt-builder.tsx
+++ b/src/components/prospects/hunt-builder.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Plus, X, Trash2, MapPin, Search, Target } from "@/components/ui/icons";
+import { Plus, X, Trash2, MapPin, Search, Target, Calendar, Send } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import type {
   ProspectHunt, ProspectHuntParam, ProspectHuntAreaMode, ProspectHuntFilters,
@@ -36,13 +36,24 @@ export interface HuntDraft {
   suburb_labels: string[];
   custom_params: ProspectHuntParam[];
   filters: ProspectHuntFilters;
+  /** Outreach campaign approved prospects join. The campaign owns the sequence. */
+  campaign_id: string | null;
+  auto_enrol: boolean;
+  auto_approve: boolean;
+  /** 0=Sun..6=Sat. Empty means it only runs when you press Run. */
+  run_days: number[];
+  run_hour: number;
 }
+
+export interface CampaignOption { id: string; name: string; status: string }
 
 export function emptyDraft(): HuntDraft {
   return {
     name: "", queries: [], criteria: "", target_count: 20,
     area_mode: "radius", area: "", radius_km: 25, suburb_labels: [],
     custom_params: [], filters: { require_phone: true },
+    campaign_id: null, auto_enrol: false, auto_approve: false,
+    run_days: [], run_hour: 9,
   };
 }
 
@@ -58,6 +69,11 @@ export function draftFrom(h: ProspectHunt): HuntDraft {
     suburb_labels: (h.suburbs ?? []).map((s) => s.label),
     custom_params: h.custom_params ?? [],
     filters: h.filters ?? {},
+    campaign_id: h.campaign_id ?? null,
+    auto_enrol: h.auto_enrol ?? false,
+    auto_approve: h.auto_approve ?? false,
+    run_days: h.run_days ?? [],
+    run_hour: h.run_hour ?? 9,
   };
 }
 
@@ -211,9 +227,17 @@ function ParamEditor({ params, onChange }: {
   );
 }
 
-export function HuntBuilder({ draft, onChange }: {
+const DAYS = [
+  { n: 1, label: "Mon" }, { n: 2, label: "Tue" }, { n: 3, label: "Wed" },
+  { n: 4, label: "Thu" }, { n: 5, label: "Fri" }, { n: 6, label: "Sat" },
+  { n: 0, label: "Sun" },
+];
+
+export function HuntBuilder({ draft, onChange, campaigns = [] }: {
   draft: HuntDraft;
   onChange: (next: HuntDraft) => void;
+  /** Campaigns this hunt can feed. Empty until one exists in Outreach. */
+  campaigns?: CampaignOption[];
 }) {
   const set = <K extends keyof HuntDraft>(key: K, value: HuntDraft[K]) =>
     onChange({ ...draft, [key]: value });
@@ -320,6 +344,119 @@ export function HuntBuilder({ draft, onChange }: {
         params={draft.custom_params}
         onChange={(next) => set("custom_params", next)}
       />
+
+      {/* ── When it runs ─────────────────────────────────────────────── */}
+      <div>
+        <Label className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /> Run it automatically</Label>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Pick the days this hunt goes looking on its own. One hunt per weekday is how you
+          get builders on Monday and strata on Tuesday — each with its own criteria and its
+          own pitch, rather than one hunt sending everybody the same email.
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {DAYS.map((d) => {
+            const on = draft.run_days.includes(d.n);
+            return (
+              <button
+                key={d.n}
+                type="button"
+                onClick={() => set("run_days", on
+                  ? draft.run_days.filter((x) => x !== d.n)
+                  : [...draft.run_days, d.n])}
+                className={cn(
+                  "h-9 w-12 rounded-md border text-xs font-medium transition-colors",
+                  on
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-input text-muted-foreground hover:text-foreground",
+                )}
+                aria-pressed={on}
+              >
+                {d.label}
+              </button>
+            );
+          })}
+        </div>
+        {draft.run_days.length > 0 && (
+          <label className="mt-2 flex items-center gap-2 text-sm">
+            at
+            <Input
+              type="number" min={0} max={23} className="h-8 w-20"
+              value={draft.run_hour}
+              onChange={(e) => set("run_hour", Number(e.target.value))}
+            />
+            <span className="text-xs text-muted-foreground">
+              :00, your local time
+            </span>
+          </label>
+        )}
+        {draft.run_days.length === 0 && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No days picked — this hunt only runs when you press Run.
+          </p>
+        )}
+      </div>
+
+      {/* ── What happens to what it finds ────────────────────────────── */}
+      <div className="space-y-3 rounded-lg border border-border p-3">
+        <div>
+          <Label className="flex items-center gap-1.5"><Send className="w-3.5 h-3.5" /> Outreach</Label>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Approving a prospect can hand it straight to a campaign — Kirei looks for a
+            contact address on the business&apos;s own website and enrols them.
+          </p>
+        </div>
+
+        {campaigns.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+            No outreach campaigns yet. Create one under Outreach and it&apos;ll appear here.
+          </p>
+        ) : (
+          <select
+            value={draft.campaign_id ?? ""}
+            onChange={(e) => set("campaign_id", e.target.value || null)}
+            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+            aria-label="Outreach campaign"
+          >
+            <option value="">No campaign — just add to prospects</option>
+            {campaigns.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}{c.status !== "active" ? ` (${c.status})` : ""}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox" className="mt-0.5"
+            checked={draft.auto_enrol}
+            disabled={!draft.campaign_id}
+            onChange={(e) => set("auto_enrol", e.target.checked)}
+          />
+          <span>
+            Find an email and enrol on approval
+            <span className="block text-xs text-muted-foreground">
+              Needs email lookup switched on in Outreach settings.
+            </span>
+          </span>
+        </label>
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox" className="mt-0.5"
+            checked={draft.auto_approve}
+            onChange={(e) => set("auto_approve", e.target.checked)}
+          />
+          <span>
+            Skip the review queue
+            <span className="block text-xs text-muted-foreground">
+              Verified businesses are approved without you seeing them first. Leave this off
+              until a few runs have shown the criteria pick the right people — it is the
+              difference between a tool and a machine that emails whoever it matched.
+            </span>
+          </span>
+        </label>
+      </div>
 
       {/* ── Hard filters ─────────────────────────────────────────────── */}
       <div className="space-y-2 rounded-lg border border-border p-3">

--- a/src/components/prospects/hunt-detail.tsx
+++ b/src/components/prospects/hunt-detail.tsx
@@ -24,7 +24,9 @@ import {
 import { cn } from "@/lib/utils";
 import { CandidateQueue } from "@/components/prospects/candidate-queue";
 import { HuntProgress, startHunt } from "@/components/prospects/hunt-progress";
-import { HuntBuilder, draftFrom, validateDraft, type HuntDraft } from "@/components/prospects/hunt-builder";
+import {
+  HuntBuilder, draftFrom, validateDraft, type HuntDraft, type CampaignOption,
+} from "@/components/prospects/hunt-builder";
 import { deleteHunt, updateHunt } from "@/lib/actions/prospecting";
 import type {
   ProspectHunt, ProspectHuntRun, ProspectCandidate, ProspectAudit,
@@ -36,6 +38,7 @@ interface Props {
   candidates: ProspectCandidate[];
   /** A run already in flight when the page loaded, so reopening rejoins it. */
   activeRunId: string | null;
+  campaigns: CampaignOption[];
 }
 
 const SEVERITY: Record<string, string> = {
@@ -77,7 +80,7 @@ function AuditPanel({ audit, shortfall }: { audit: ProspectAudit; shortfall: boo
   );
 }
 
-export function HuntDetail({ hunt, runs, candidates, activeRunId }: Props) {
+export function HuntDetail({ hunt, runs, candidates, activeRunId, campaigns }: Props) {
   const router = useRouter();
   const { run: mutate, pending } = useMutation();
   const [runId, setRunId] = useState<string | null>(activeRunId);
@@ -108,6 +111,11 @@ export function HuntDetail({ hunt, runs, candidates, activeRunId }: Props) {
         suburb_labels: draft.suburb_labels,
         custom_params: draft.custom_params,
         filters: draft.filters,
+        campaign_id: draft.campaign_id,
+        auto_enrol: draft.auto_enrol,
+        auto_approve: draft.auto_approve,
+        run_days: draft.run_days,
+        run_hour: draft.run_hour,
       });
       setEditing(false);
     }, { busy: "Saving hunt…", success: "Hunt updated", error: "Couldn't save" });
@@ -194,7 +202,7 @@ export function HuntDetail({ hunt, runs, candidates, activeRunId }: Props) {
       <Dialog open={editing} onOpenChange={setEditing}>
         <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
           <DialogHeader><DialogTitle>Edit hunt</DialogTitle></DialogHeader>
-          <HuntBuilder draft={draft} onChange={setDraft} />
+          <HuntBuilder draft={draft} onChange={setDraft} campaigns={campaigns} />
           <DialogFooter>
             <Button variant="outline" onClick={() => setEditing(false)} disabled={pending}>Cancel</Button>
             <Button onClick={handleSave} disabled={pending}>Save</Button>

--- a/src/components/prospects/hunts-view.tsx
+++ b/src/components/prospects/hunts-view.tsx
@@ -24,7 +24,7 @@ import {
 import { Target, Plus, MapPin, Search, Globe, Star } from "@/components/ui/icons";
 import { createHunt, setProspectingBudget } from "@/lib/actions/prospecting";
 import {
-  HuntBuilder, emptyDraft, validateDraft, type HuntDraft,
+  HuntBuilder, emptyDraft, validateDraft, type HuntDraft, type CampaignOption,
 } from "@/components/prospects/hunt-builder";
 import type { SpendStatus } from "@/lib/prospecting/budget";
 import type { ProspectHunt } from "@/types/database";
@@ -35,6 +35,7 @@ interface Props {
   budget: SpendStatus;
   /** A Places key is available — the business's own, or Kirei's. */
   canHunt: boolean;
+  campaigns: CampaignOption[];
 }
 
 const money = (cents: number) => `$${(cents / 100).toFixed(2)}`;
@@ -110,7 +111,7 @@ function BudgetCard({ budget }: { budget: SpendStatus }) {
   );
 }
 
-export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
+export function HuntsView({ hunts, pendingReview, budget, canHunt, campaigns }: Props) {
   const { run, pending } = useMutation();
   const [open, setOpen] = useState(false);
 
@@ -132,6 +133,11 @@ export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
         suburb_labels: draft.suburb_labels,
         custom_params: draft.custom_params,
         filters: draft.filters,
+        campaign_id: draft.campaign_id,
+        auto_enrol: draft.auto_enrol,
+        auto_approve: draft.auto_approve,
+        run_days: draft.run_days,
+        run_hour: draft.run_hour,
       });
       setOpen(false);
       setDraft(emptyDraft());
@@ -226,7 +232,7 @@ export function HuntsView({ hunts, pendingReview, budget, canHunt }: Props) {
             </DialogDescription>
           </DialogHeader>
 
-          <HuntBuilder draft={draft} onChange={setDraft} />
+          <HuntBuilder draft={draft} onChange={setDraft} campaigns={campaigns} />
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)} disabled={pending}>Cancel</Button>

--- a/src/components/prospects/prospects-view.tsx
+++ b/src/components/prospects/prospects-view.tsx
@@ -11,7 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/layout/page-header";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { Send } from "@/components/ui/icons";
 import { createProspect, bulkUpdateProspects, bulkDeleteProspects } from "@/lib/actions/prospects";
 import { ProspectsImport } from "@/components/prospects/prospects-import";
@@ -37,6 +37,7 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
   const [emailOpen, setEmailOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<ProspectStatus | "">("");
+  const [contactFilter, setContactFilter] = useState<"" | "yes" | "no">("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkStatus, setBulkStatus] = useState<ProspectStatus | "">("");
   const [bulkTag, setBulkTag] = useState("");
@@ -57,10 +58,12 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
     const s = search.trim().toLowerCase();
     return prospects.filter((p) => {
       if (statusFilter && p.status !== statusFilter) return false;
+      if (contactFilter === "yes" && !p.last_contacted_at) return false;
+      if (contactFilter === "no" && p.last_contacted_at) return false;
       if (s && !`${p.name ?? ""} ${p.email ?? ""} ${p.company ?? ""}`.toLowerCase().includes(s)) return false;
       return true;
     });
-  }, [prospects, search, statusFilter]);
+  }, [prospects, search, statusFilter, contactFilter]);
 
   function handleAdd() {
     if (!name.trim() && !email.trim()) { toast.error("Enter a name or email"); return; }
@@ -94,6 +97,18 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
           <option value="">All statuses</option>
           {STATUSES.map((s) => <option key={s} value={s} className="capitalize">{s}</option>)}
         </select>
+        {/* "Who haven't I reached out to yet" is the question this list exists
+            to answer, and it needed opening every row to find out. */}
+        <select
+          className={selectCls}
+          value={contactFilter}
+          onChange={(e) => setContactFilter(e.target.value as "" | "yes" | "no")}
+          aria-label="Filter by whether they've been contacted"
+        >
+          <option value="">Contacted or not</option>
+          <option value="no">Not contacted yet</option>
+          <option value="yes">Already contacted</option>
+        </select>
       </div>
 
       {prospects.length === 0 ? (
@@ -125,7 +140,7 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
             <table className="ch-table w-full">
               <thead><tr>
                 <th className="w-8"><input type="checkbox" checked={filtered.length > 0 && filtered.every((p) => selected.has(p.id))} onChange={(e) => setSelected(e.target.checked ? new Set(filtered.map((p) => p.id)) : new Set())} /></th>
-                <th>Name</th><th>Company</th><th>Email</th><th>Source</th><th>Status</th>
+                <th>Name</th><th>Company</th><th>Email</th><th>Source</th><th>Contacted</th><th>Status</th>
               </tr></thead>
               <tbody>
                 {filtered.map((p) => (
@@ -134,11 +149,25 @@ export function ProspectsView({ prospects }: { prospects: Prospect[] }) {
                     <td className="font-medium cursor-pointer" onClick={() => router.push(`/prospects/${p.id}`)}>{p.name || "—"}</td>
                     <td className="cursor-pointer" onClick={() => router.push(`/prospects/${p.id}`)}>{p.company || "—"}</td>
                     <td className="break-words cursor-pointer" onClick={() => router.push(`/prospects/${p.id}`)}>{p.email || "—"}</td>
+                    {/* Whether anyone has actually reached out. Without this
+                        the only way to know was to open each prospect, and a
+                        list you can't triage is a list you re-work. */}
                     <td>{p.source || "—"}</td>
+                    <td>
+                      {p.last_contacted_at ? (
+                        <span className="text-[11px] text-muted-foreground">
+                          {formatDate(p.last_contacted_at)}
+                        </span>
+                      ) : (
+                        <span className="text-[11px] font-medium rounded-full px-2 py-0.5 bg-muted text-muted-foreground">
+                          Not yet
+                        </span>
+                      )}
+                    </td>
                     <td><span className={cn("text-[11px] font-medium rounded-full px-2 py-0.5 capitalize", TONE[p.status])}>{p.status}</span></td>
                   </tr>
                 ))}
-                {filtered.length === 0 && <tr><td colSpan={6} className="text-center text-muted-foreground py-6">No prospects match.</td></tr>}
+                {filtered.length === 0 && <tr><td colSpan={7} className="text-center text-muted-foreground py-6">No prospects match.</td></tr>}
               </tbody>
             </table>
           </div>

--- a/src/lib/actions/outreach.ts
+++ b/src/lib/actions/outreach.ts
@@ -313,3 +313,49 @@ export async function runOutreachNow(limit = 25): Promise<{ sent: number; skippe
   revalidatePath("/outreach");
   return { sent: res.sent, skipped: res.skipped, failed: res.failed };
 }
+
+
+// ── What actually went out ───────────────────────────────────────────────────
+
+export interface SentMessage {
+  id: string;
+  recipient: string;
+  subject: string | null;
+  status: string;
+  step_order: number | null;
+  sent_at: string;
+  opened_at: string | null;
+  clicked_at: string | null;
+  replied_at: string | null;
+  bounced_at: string | null;
+  error: string | null;
+  prospects?: { id: string; name: string | null; company: string | null } | null;
+  outreach_campaigns?: { id: string; name: string } | null;
+}
+
+/**
+ * Every email the outreach agent has sent, newest first.
+ *
+ * All of this was already recorded — recipient, subject, opens, clicks,
+ * bounces, replies — and none of it was visible anywhere. An agent that sends
+ * on your behalf and can't show you what it sent is asking to be trusted on
+ * nothing, and it's how the mobile toggle that silently did nothing survived
+ * as long as it did.
+ */
+export async function listSentMessages(filters?: {
+  campaign_id?: string;
+  status?: string;
+  limit?: number;
+}): Promise<SentMessage[]> {
+  const { supabase, businessId } = await ctx();
+  let q = tbl(supabase, "outreach_messages")
+    .select("id, recipient, subject, status, step_order, sent_at, opened_at, clicked_at, replied_at, bounced_at, error, prospects(id, name, company), outreach_campaigns(id, name)")
+    .eq("business_id", businessId);
+  if (filters?.campaign_id) q = q.eq("campaign_id", filters.campaign_id);
+  if (filters?.status) q = q.eq("status", filters.status);
+  const { data, error } = await q
+    .order("sent_at", { ascending: false })
+    .limit(filters?.limit ?? 300);
+  if (error) throw error;
+  return (data ?? []) as SentMessage[];
+}

--- a/src/lib/mcp/tools/outreach-tools.ts
+++ b/src/lib/mcp/tools/outreach-tools.ts
@@ -352,4 +352,23 @@ export function registerOutreachTools(tool: ToolFn): void {
       if (res.errors.length && !res.created) return errorText(res.errors[0]);
       return text(res);
     });
+
+  tool("list_sent_emails",
+    "Every email the outreach agent has actually sent, newest first — recipient, subject, which sequence step, and whether it was delivered, opened, clicked, replied to or bounced. Use this to answer 'what did we send this person' and 'is the campaign working'.",
+    {
+      campaign_id: UUID.optional(),
+      status: z.enum(["sent", "delivered", "opened", "clicked", "bounced", "complained", "failed"]).optional(),
+      limit: z.number().int().min(1).max(500).optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
+      let q = t(ctx, "outreach_messages")
+        .select("id, recipient, subject, status, step_order, sent_at, opened_at, clicked_at, replied_at, bounced_at, error, prospects(id, name, company), outreach_campaigns(id, name)")
+        .eq("business_id", ctx.businessId);
+      if (args.campaign_id) q = q.eq("campaign_id", args.campaign_id);
+      if (args.status) q = q.eq("status", args.status);
+      const { data, error } = await q.order("sent_at", { ascending: false }).limit(args.limit ?? 100);
+      if (error) throw error;
+      return text(data);
+    });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -78,6 +78,10 @@
     {
       "path": "/api/cron/recurring-expenses",
       "schedule": "0 19 * * *"
+    },
+    {
+      "path": "/api/cron/prospect-hunts",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
The four things I said were missing after [#503](https://github.com/maltamimi96/invoicer/pull/503). Everything you asked for is now reachable by clicking.

## 1. The hunt builder

- **Campaign picker** — approving a prospect hands it to an outreach campaign
- **Day-of-week strip** — this is the "builders Monday, strata Tuesday" ask
- **Find-an-email-and-enrol** toggle
- **Skip-the-review-queue** toggle

Per-hunt scheduling rather than a rotation inside one hunt, so each weekday carries its own criteria, its own filters and its own pitch — instead of one hunt rotating queries and sending everybody the same email. A day can hold two hunts, or none.

Skip-the-queue is written to be read twice before it's used, and says in the UI that it's the difference between a tool and a machine that emails whoever it matched. Off by default.

## 2. The scheduler

Hourly cron. Each hunt decides whether it's due **in its own timezone** — the daily digest shipped without one and arrives at 5pm Sydney.

Three separate guards against running a hunt twice, because each was reachable:

- `last_run_at` is stamped **before** the run, not after. A run takes minutes; stamping after lets the next hourly tick start it again mid-flight.
- an already-running check, for a run that outlives its slot
- a ran-today check in local time, so an hour-later retry doesn't repeat it

**The cron never sends anything.** It fills the review queue; the outreach engine decides what leaves the building, inside the send window and daily cap it already enforces.

## 3. Prospects say whether they've been contacted

`last_contacted_at` was already stamped by both send paths and shown nowhere — so *"who haven't I contacted yet"*, the question the list exists to answer, meant opening every row. Column plus a filter.

## 4. A Sent view — `/outreach/sent`

Recipient, subject, which sequence step, and whether it was delivered, opened, clicked, replied to or bounced. **Every one of those facts was already in `outreach_messages` and none of it was visible anywhere.** An agent that emails people on your behalf and can't show you what it sent is asking to be trusted on nothing.

Two details worth keeping:
- The outcome shown is the **furthest state** a message reached, ordered by what you care about rather than what happened last — a reply beats a click, a click beats an open.
- Rates are counted from **everything**, not the filtered view. A rate that moves when you filter is a rate nobody can trust.

`list_sent_emails` over MCP too, per the standing rule.

## Verification

`npx tsc --noEmit` clean · `npm test` 394 passed · `npm run build` clean, `/outreach/sent` and `/api/cron/prospect-hunts` both in the route list.

Not visually verified — auth-gated, no session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)