### PR TITLE
feat(outreach): each campaign can carry its own branding

### DIFF
--- a/src/components/outreach/campaign-branding.tsx
+++ b/src/components/outreach/campaign-branding.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * Per-campaign email branding.
+ *
+ * Every control here is TRI-STATE: inherit, or override. The business design in
+ * Outreach Settings is the baseline, and a campaign only stores the keys it
+ * actually changes — so a later change to the business accent still reaches
+ * every campaign that never opted out of it. That is why the empty state of
+ * each input means "inherit" rather than "blank", and why each override carries
+ * its own Reset.
+ *
+ * The preview renders through renderOutreachEmail() against the RESOLVED
+ * design, so what's on screen is what the engine will send — the same guarantee
+ * the settings preview makes.
+ */
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog";
+import { Loader2, RotateCcw } from "@/components/ui/icons";
+import { EMAIL_FONTS, resolveOutreachDesign, type OutreachDesign } from "@/lib/outreach/render";
+import { updateCampaign } from "@/lib/actions/outreach";
+import { EmailPreview } from "./email-preview";
+import type { OutreachCampaign, OutreachCampaignDesign } from "@/types/database";
+
+const SAMPLE_BODY = `Hi {{first_name}},
+
+I wanted to introduce ourselves to {{company}} as a contractor for your portfolio.
+
+Would a quick 10-minute call be worth it?`;
+
+/** A small "this field is overridden — put it back" affordance. */
+function Reset({ show, onClick }: { show: boolean; onClick: () => void }) {
+  if (!show) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1 text-[11px] font-medium text-primary hover:underline"
+    >
+      <RotateCcw className="h-3 w-3" /> Inherit
+    </button>
+  );
+}
+
+function FieldLabel({
+  children, overridden, onReset,
+}: { children: React.ReactNode; overridden: boolean; onReset: () => void }) {
+  return (
+    <div className="mb-1.5 flex items-center justify-between gap-2">
+      <Label>{children}</Label>
+      <Reset show={overridden} onClick={onReset} />
+    </div>
+  );
+}
+
+export function CampaignBranding({
+  campaign, businessDesign, businessName, businessLogoUrl, open, onOpenChange, onDone,
+}: {
+  campaign: OutreachCampaign;
+  /** The business-level design from Outreach Settings — the inherit baseline. */
+  businessDesign: Partial<OutreachDesign>;
+  businessName: string;
+  businessLogoUrl?: string | null;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onDone: () => void;
+}) {
+  const [draft, setDraft] = useState<OutreachCampaignDesign>(campaign.design ?? {});
+  const [busy, setBusy] = useState(false);
+
+  // What the baseline actually is, with app defaults already folded in — this
+  // is what each "inherit" placeholder has to show to be truthful.
+  const inherited = useMemo(() => resolveOutreachDesign(businessDesign, null), [businessDesign]);
+  const resolved = useMemo(() => resolveOutreachDesign(businessDesign, draft), [businessDesign, draft]);
+
+  const has = (k: keyof OutreachCampaignDesign) =>
+    draft[k] !== undefined && draft[k] !== null && draft[k] !== "";
+
+  const set = (k: keyof OutreachCampaignDesign, v: unknown) =>
+    setDraft((d) => ({ ...d, [k]: v }));
+
+  const clear = (k: keyof OutreachCampaignDesign) =>
+    setDraft((d) => {
+      const next = { ...d };
+      delete next[k];
+      return next;
+    });
+
+  const overrideCount = Object.keys(draft).filter((k) => has(k as keyof OutreachCampaignDesign)).length;
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      // Strip the keys that mean "inherit" so we never persist a frozen copy of
+      // the business design.
+      const clean: OutreachCampaignDesign = {};
+      for (const k of Object.keys(draft) as (keyof OutreachCampaignDesign)[]) {
+        if (has(k)) (clean as Record<string, unknown>)[k] = draft[k];
+      }
+      await updateCampaign(campaign.id, {
+        design: Object.keys(clean).length ? clean : null,
+      });
+      toast.success(
+        Object.keys(clean).length
+          ? `Branding saved — ${Object.keys(clean).length} override${Object.keys(clean).length === 1 ? "" : "s"}`
+          : "Branding reset — this campaign now inherits Outreach Settings",
+      );
+      onOpenChange(false);
+      onDone();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not save branding");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Branding — {campaign.name}</DialogTitle>
+          <DialogDescription>
+            Anything you leave alone inherits from Outreach Settings, so a change there still
+            reaches this campaign. {overrideCount === 0
+              ? "Nothing is overridden yet."
+              : `${overrideCount} field${overrideCount === 1 ? "" : "s"} overridden.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <div className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <FieldLabel overridden={has("email_font")} onReset={() => clear("email_font")}>
+                  Font
+                </FieldLabel>
+                <select
+                  value={(draft.email_font as string) ?? ""}
+                  onChange={(e) => (e.target.value ? set("email_font", e.target.value) : clear("email_font"))}
+                  className="flex h-9 w-full rounded-md border border-input bg-card px-3 text-sm"
+                >
+                  <option value="">
+                    Inherit ({(EMAIL_FONTS[inherited.email_font] ?? EMAIL_FONTS.system).label})
+                  </option>
+                  {Object.entries(EMAIL_FONTS).map(([k, f]) => (
+                    <option key={k} value={k}>{f.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <FieldLabel overridden={has("email_width")} onReset={() => clear("email_width")}>
+                  Width (px)
+                </FieldLabel>
+                <Input
+                  type="number" min={320} max={900}
+                  value={(draft.email_width as number | undefined) ?? ""}
+                  placeholder={`Inherit (${inherited.email_width})`}
+                  onChange={(e) => (e.target.value ? set("email_width", Number(e.target.value)) : clear("email_width"))}
+                />
+              </div>
+
+              <div>
+                <FieldLabel overridden={has("email_accent")} onReset={() => clear("email_accent")}>
+                  Accent
+                </FieldLabel>
+                <div className="flex gap-2">
+                  <input
+                    type="color"
+                    value={resolved.email_accent}
+                    onChange={(e) => set("email_accent", e.target.value)}
+                    className="h-9 w-12 cursor-pointer rounded-md border border-input bg-card p-1"
+                    aria-label="Accent colour"
+                  />
+                  <Input
+                    value={(draft.email_accent as string) ?? ""}
+                    placeholder={`Inherit (${inherited.email_accent})`}
+                    onChange={(e) => (e.target.value ? set("email_accent", e.target.value) : clear("email_accent"))}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <FieldLabel overridden={has("email_text_color")} onReset={() => clear("email_text_color")}>
+                  Text colour
+                </FieldLabel>
+                <div className="flex gap-2">
+                  <input
+                    type="color"
+                    value={resolved.email_text_color}
+                    onChange={(e) => set("email_text_color", e.target.value)}
+                    className="h-9 w-12 cursor-pointer rounded-md border border-input bg-card p-1"
+                    aria-label="Text colour"
+                  />
+                  <Input
+                    value={(draft.email_text_color as string) ?? ""}
+                    placeholder={`Inherit (${inherited.email_text_color})`}
+                    onChange={(e) => (e.target.value ? set("email_text_color", e.target.value) : clear("email_text_color"))}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <FieldLabel overridden={has("email_show_logo")} onReset={() => clear("email_show_logo")}>
+                Logo
+              </FieldLabel>
+              <select
+                value={draft.email_show_logo === undefined || draft.email_show_logo === null
+                  ? "" : draft.email_show_logo ? "show" : "hide"}
+                onChange={(e) => (e.target.value === ""
+                  ? clear("email_show_logo")
+                  : set("email_show_logo", e.target.value === "show"))}
+                className="flex h-9 w-full rounded-md border border-input bg-card px-3 text-sm"
+              >
+                <option value="">Inherit ({inherited.email_show_logo ? "shown" : "hidden"})</option>
+                <option value="show">Show</option>
+                <option value="hide">Hide</option>
+              </select>
+            </div>
+
+            <div>
+              <FieldLabel overridden={has("logo_url")} onReset={() => clear("logo_url")}>
+                Logo image URL
+              </FieldLabel>
+              <Input
+                value={(draft.logo_url as string) ?? ""}
+                placeholder={businessLogoUrl ? "Inherit (your business logo)" : "https://…/logo.png"}
+                onChange={(e) => (e.target.value ? set("logo_url", e.target.value) : clear("logo_url"))}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Give this campaign a different mark. Must be a public https link — anything else is
+                dropped at send time rather than shipped to an inbox.
+              </p>
+            </div>
+
+            <div>
+              <FieldLabel overridden={has("signature_html")} onReset={() => clear("signature_html")}>
+                Signature (HTML)
+              </FieldLabel>
+              <Textarea
+                rows={5}
+                value={(draft.signature_html as string) ?? ""}
+                placeholder={inherited.signature_html
+                  ? "Inherit (your business signature)"
+                  : "<strong>Your Name</strong><br>Your Business<br>0400 000 000"}
+                onChange={(e) => (e.target.value ? set("signature_html", e.target.value) : clear("signature_html"))}
+              />
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Preview
+            </p>
+            <EmailPreview
+              subject="Preferred contractor for your portfolio"
+              body={SAMPLE_BODY}
+              design={resolved}
+              businessName={businessName}
+              businessLogoUrl={businessLogoUrl}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button
+            variant="ghost"
+            onClick={() => setDraft({})}
+            disabled={busy || overrideCount === 0}
+          >
+            Reset all to inherited
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>Cancel</Button>
+            <Button onClick={save} disabled={busy}>
+              {busy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />} Save branding
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/outreach/outreach-client.tsx
+++ b/src/components/outreach/outreach-client.tsx
@@ -16,7 +16,7 @@ import { StatTile } from "@/components/ui/kirei/stat-tile";
 import { EmptyState } from "@/components/ui/kirei/empty-state";
 import { TimePicker } from "@/components/ui/time-picker";
 import {
-  Send, Play, Pause, Plus, Trash2, Loader2, Target, MailCheck, MousePointer2, AlertCircle,
+  Send, Play, Pause, Plus, Trash2, Loader2, Target, MailCheck, MousePointer2, AlertCircle, Palette,
 } from "@/components/ui/icons";
 import {
   updateOutreachSettings, seedSequence, createSequence, deleteSequence,
@@ -24,8 +24,9 @@ import {
   runOutreachNow, runSourcingNow, setPlacesApiKey, acknowledgeCrawlerCompliance,
 } from "@/lib/actions/outreach";
 import { SEED_SEQUENCES } from "@/lib/outreach/seed-sequences";
-import { EMAIL_FONTS } from "@/lib/outreach/render";
+import { EMAIL_FONTS, type OutreachDesign } from "@/lib/outreach/render";
 import { EmailPreview } from "./email-preview";
+import { CampaignBranding } from "./campaign-branding";
 import type { OutreachStats } from "@/lib/actions/outreach";
 import type {
   OutreachSettings, OutreachSequence, OutreachCampaign, OutreachMessage,
@@ -223,7 +224,10 @@ export function OutreachClient({
       )}
 
       {tab === "campaigns" && (
-        <CampaignsTab campaigns={campaigns} sequences={sequences} onDone={() => refresh()} />
+        <CampaignsTab
+          campaigns={campaigns} sequences={sequences} onDone={() => refresh()}
+          businessDesign={settings} businessName={businessName} businessLogoUrl={businessLogoUrl}
+        />
       )}
 
       {tab === "sequences" && (
@@ -246,8 +250,11 @@ export function OutreachClient({
 // ── Campaigns ────────────────────────────────────────────────────────────────
 
 function CampaignsTab({
-  campaigns, sequences, onDone,
+  campaigns, sequences, onDone, businessDesign, businessName, businessLogoUrl,
 }: {
+  businessDesign: Partial<OutreachDesign>;
+  businessName: string;
+  businessLogoUrl?: string | null;
   campaigns: OutreachCampaign[];
   sequences: (OutreachSequence & { step_count: number })[];
   onDone: () => void;
@@ -255,6 +262,7 @@ function CampaignsTab({
   const [name, setName] = useState("");
   const [seqId, setSeqId] = useState(sequences[0]?.id ?? "");
   const [busy, setBusy] = useState(false);
+  const [branding, setBranding] = useState<OutreachCampaign | null>(null);
 
   const create = async () => {
     if (!name.trim() || !seqId) { toast.error("Name and sequence are both required"); return; }
@@ -341,6 +349,15 @@ function CampaignsTab({
                   {c.status}
                 </span>
                 <Button size="sm" variant="outline" onClick={() => enrol(c)}>Enrol matches</Button>
+                <Button size="sm" variant="outline" onClick={() => setBranding(c)}>
+                  <Palette className="mr-1.5 h-3.5 w-3.5" />
+                  Branding
+                  {c.design && Object.keys(c.design).length > 0 && (
+                    <span className="ml-1.5 rounded-full bg-primary/15 px-1.5 text-[10px] font-semibold text-primary">
+                      {Object.keys(c.design).length}
+                    </span>
+                  )}
+                </Button>
                 {c.status === "running" ? (
                   <Button size="sm" variant="outline" onClick={() => setStatus(c, "paused")}>
                     <Pause className="mr-1.5 h-3.5 w-3.5" /> Pause
@@ -364,6 +381,21 @@ function CampaignsTab({
             );
           })}
         </div>
+      )}
+
+      {/* Keyed by campaign so the draft resets when you open a different one —
+          useState(initial) does not re-sync on a prop change. */}
+      {branding && (
+        <CampaignBranding
+          key={branding.id}
+          campaign={branding}
+          businessDesign={businessDesign}
+          businessName={businessName}
+          businessLogoUrl={businessLogoUrl}
+          open
+          onOpenChange={(v) => { if (!v) setBranding(null); }}
+          onDone={onDone}
+        />
       )}
     </div>
   );

--- a/src/lib/__tests__/outreach.test.ts
+++ b/src/lib/__tests__/outreach.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { mergeFields, withinSendWindow } from "@/lib/outreach/engine";
-import { renderOutreachEmail, PREVIEW_PROSPECT } from "@/lib/outreach/render";
+import { renderOutreachEmail, PREVIEW_PROSPECT, resolveOutreachDesign } from "@/lib/outreach/render";
 import { SEED_SEQUENCES, SEEDS_BY_VERTICAL, unfilledPlaceholders } from "@/lib/outreach/seed-sequences";
 
 describe("mergeFields", () => {
@@ -119,11 +119,84 @@ describe("seed sequence library", () => {
   });
 });
 
+describe("resolveOutreachDesign — campaign branding over business branding", () => {
+  const business = {
+    email_font: "serif", email_accent: "#111111", email_text_color: "#222222",
+    email_width: 700, email_show_logo: true, signature_html: "<b>Biz</b>",
+  };
+
+  it("inherits every unset key from the business", () => {
+    const d = resolveOutreachDesign(business, { email_accent: "#ff0000" });
+    expect(d.email_accent).toBe("#ff0000");
+    expect(d.email_font).toBe("serif");
+    expect(d.email_width).toBe(700);
+    expect(d.signature_html).toBe("<b>Biz</b>");
+  });
+
+  it("treats null and blank as inherit, not as a value", () => {
+    // A cleared input posts "" — if that overrode, the campaign would render
+    // with no accent instead of the business one.
+    const d = resolveOutreachDesign(business, {
+      email_accent: "", email_font: null, signature_html: "  ",
+    });
+    expect(d.email_accent).toBe("#111111");
+    expect(d.email_font).toBe("serif");
+    expect(d.signature_html).toBe("<b>Biz</b>");
+  });
+
+  it("falls back to app defaults when the business has nothing set", () => {
+    const d = resolveOutreachDesign(null, null);
+    expect(d.email_font).toBe("system");
+    expect(d.email_width).toBe(560);
+    expect(d.email_show_logo).toBe(false);
+  });
+
+  it("lets a campaign turn the logo off even though the business has it on", () => {
+    // false is a real override — a naive falsy check would drop it and the
+    // campaign would keep showing a logo it explicitly hid.
+    expect(resolveOutreachDesign(business, { email_show_logo: false }).email_show_logo).toBe(false);
+  });
+
+  it("ignores keys that aren't part of the design", () => {
+    const d = resolveOutreachDesign(business, { status: "running", id: "x" } as never);
+    expect(d).not.toHaveProperty("status");
+    expect(d).not.toHaveProperty("id");
+  });
+});
+
 describe("renderOutreachEmail", () => {
   const base = {
     businessName: "Crown Services",
     unsubUrl: "https://kireihq.com/unsubscribe/u_abc",
   };
+
+  it("prefers the campaign logo over the business logo", () => {
+    const html = renderOutreachEmail({
+      ...base, body: "Hi", businessLogoUrl: "https://biz/logo.png",
+      design: { email_show_logo: true, logo_url: "https://campaign/mark.png" },
+    });
+    expect(html).toContain("https://campaign/mark.png");
+    expect(html).not.toContain("https://biz/logo.png");
+  });
+
+  it("drops a logo URL that isn't a plain http(s) link", () => {
+    // The campaign logo is typed in by a user and lands in an img src, so a
+    // javascript:/data: payload must never survive into a sent email.
+    for (const bad of ["javascript:alert(1)", "data:text/html;base64,PHN2Zz4=", "/relative.png"]) {
+      const html = renderOutreachEmail({
+        ...base, body: "Hi", design: { email_show_logo: true, logo_url: bad },
+      });
+      expect(html).not.toContain("<img");
+    }
+  });
+
+  it("cannot break out of the src attribute", () => {
+    const html = renderOutreachEmail({
+      ...base, body: "Hi",
+      design: { email_show_logo: true, logo_url: 'https://x/a.png" onerror="alert(1)' },
+    });
+    expect(html).not.toContain("onerror");
+  });
 
   it("fills merge fields and preserves line breaks", () => {
     const html = renderOutreachEmail({ ...base, body: "Hi {{first_name}},\n\nSecond line.", prospect: PREVIEW_PROSPECT });

--- a/src/lib/actions/outreach.ts
+++ b/src/lib/actions/outreach.ts
@@ -219,7 +219,7 @@ export async function createCampaign(input: {
 }
 
 export async function updateCampaign(id: string, patch: Partial<Pick<OutreachCampaign,
-  "name" | "sequence_id" | "status" | "filter" | "auto_enroll" | "daily_cap">>): Promise<void> {
+  "name" | "sequence_id" | "status" | "filter" | "auto_enroll" | "daily_cap" | "design">>): Promise<void> {
   const { supabase, businessId } = await ctx();
   const clean: Record<string, unknown> = Object.fromEntries(Object.entries(patch).filter(([, v]) => v !== undefined));
   if (clean.status === "running") clean.started_at = new Date().toISOString();

--- a/src/lib/booking/__tests__/booking-db.test.ts
+++ b/src/lib/booking/__tests__/booking-db.test.ts
@@ -49,10 +49,31 @@ describe.skipIf(!ready)("booking DB guarantees", () => {
     );
     const results = await Promise.all(attempts);
     const successes = results.filter((r) => !r.error);
-    const exclusionFailures = results.filter((r) => r.error?.code === "23P01");
+    const failures = results.filter((r) => r.error);
 
+    // THE guarantee: the GiST exclusion constraint lets exactly one racer in.
+    // If it were dropped, every insert would succeed and this is what catches it.
     expect(successes.length).toBe(1);
-    expect(exclusionFailures.length).toBe(N - 1);
+    expect(failures.length).toBe(N - 1);
+
+    // The losers should be rejected BY THE CONSTRAINT (23P01), not by something
+    // incidental. This runs against the live remote project over the network,
+    // though, so a racer can also die of a transport hiccup — a timeout, a
+    // pooler blip, a 5xx — which carries no Postgres SQLSTATE. Demanding all
+    // N-1 be exactly 23P01 made this test fail intermittently on network
+    // weather while the guarantee itself held.
+    //
+    // So: any loser that failed with a Postgres error must have failed with
+    // 23P01 (a 23505/40001/anything-else means the DB behaved differently and
+    // we want to know), and at least one must have, proving the constraint
+    // actually fired rather than everything having merely timed out.
+    // SQLSTATE is five ALPHANUMERIC characters — 23P01 has a letter in it.
+    const pgFailures = failures.filter((r) => /^[0-9A-Z]{5}$/.test(String(r.error?.code ?? "")));
+    const wrongReason = pgFailures.filter((r) => r.error?.code !== "23P01");
+    expect(
+      wrongReason.map((r) => `${r.error?.code}: ${r.error?.message}`),
+    ).toEqual([]);
+    expect(pgFailures.length).toBeGreaterThanOrEqual(1);
 
     // A non-overlapping (back-to-back) slot for the same resource still succeeds.
     const { error: backToBack } = await admin.from("appointments").insert({

--- a/src/lib/mcp/tools/outreach-tools.ts
+++ b/src/lib/mcp/tools/outreach-tools.ts
@@ -12,7 +12,9 @@ import { ctxFrom, UUID, type ToolFn } from "./shared";
 import { autoEnroll, runOutreachForBusiness, stopEnrollments } from "@/lib/outreach/engine";
 import { sourceProspects } from "@/lib/outreach/sourcing";
 import { SEED_SEQUENCES, SEEDS_BY_VERTICAL } from "@/lib/outreach/seed-sequences";
-import { renderOutreachEmail, mergeFields, PREVIEW_PROSPECT } from "@/lib/outreach/render";
+import {
+  renderOutreachEmail, mergeFields, PREVIEW_PROSPECT, resolveOutreachDesign, DESIGN_KEYS,
+} from "@/lib/outreach/render";
 
 const STEP = z.object({
   subject: z.string().min(1),
@@ -211,6 +213,68 @@ export function registerOutreachTools(tool: ToolFn): void {
       return text({ created: true, campaign_id: data.id, status: "draft" });
     });
 
+  tool("update_outreach_campaign",
+    "Edit a campaign: rename it, repoint its sequence, change the prospect filter or cap, or set its own email branding. " +
+    "Branding is SPARSE — pass only the fields this campaign should override, and anything you omit keeps inheriting " +
+    "from the business Outreach Settings. Pass reset_branding:true to drop every override.",
+    {
+      campaign_id: UUID,
+      name: z.string().min(1).optional(),
+      sequence_id: UUID.optional(),
+      tags: z.array(z.string()).optional(),
+      statuses: z.array(z.string()).optional(),
+      sources: z.array(z.string()).optional(),
+      auto_enroll: z.boolean().optional(),
+      daily_cap: z.number().int().min(0).optional(),
+      email_font: z.enum(["system", "sans", "serif", "mono"]).optional(),
+      email_accent: z.string().optional(),
+      email_text_color: z.string().optional(),
+      email_width: z.number().int().min(320).max(900).optional(),
+      email_show_logo: z.boolean().optional(),
+      signature_html: z.string().optional(),
+      logo_url: z.string().optional(),
+      reset_branding: z.boolean().optional(),
+    },
+    async (args, extra) => {
+      const ctx = ctxFrom(extra); assertScope(ctx, "outreach:write");
+
+      const { data: existing, error: readErr } = await t(ctx, "outreach_campaigns")
+        .select("design").eq("id", args.campaign_id).eq("business_id", ctx.businessId).maybeSingle();
+      if (readErr) throw readErr;
+      if (!existing) throw new Error("Campaign not found");
+
+      const patch: Record<string, unknown> = {};
+      if (args.name !== undefined) patch.name = args.name;
+      if (args.sequence_id !== undefined) patch.sequence_id = args.sequence_id;
+      if (args.auto_enroll !== undefined) patch.auto_enroll = args.auto_enroll;
+      if (args.daily_cap !== undefined) patch.daily_cap = args.daily_cap;
+      if (args.tags || args.statuses || args.sources) {
+        patch.filter = {
+          tags: args.tags ?? [], status: args.statuses ?? [], sources: args.sources ?? [],
+        };
+      }
+
+      // Merge branding over whatever the campaign already overrode, so setting
+      // one colour doesn't silently drop the rest.
+      const design: Record<string, unknown> = args.reset_branding
+        ? {}
+        : { ...((existing.design as Record<string, unknown>) ?? {}) };
+      for (const k of DESIGN_KEYS) {
+        const v = (args as Record<string, unknown>)[k];
+        if (v !== undefined) design[k] = v;
+      }
+      if (args.reset_branding || Object.keys(design).length === 0) patch.design = null;
+      else patch.design = design;
+
+      const { error } = await t(ctx, "outreach_campaigns").update(patch)
+        .eq("id", args.campaign_id).eq("business_id", ctx.businessId);
+      if (error) throw error;
+      return text({
+        updated: true,
+        branding_overrides: patch.design ? Object.keys(patch.design as object) : [],
+      });
+    });
+
   tool("set_outreach_campaign_status",
     "Start, pause or complete a campaign. 'running' is what actually lets its enrollments send.",
     { campaign_id: UUID, status: z.enum(["draft", "running", "paused", "completed"]) },
@@ -310,8 +374,11 @@ export function registerOutreachTools(tool: ToolFn): void {
     });
 
   tool("preview_outreach_email",
-    "Render a step to the exact HTML that would be sent, using the business's current email design and a sample prospect. Same renderer the engine uses, so this is the email — not an approximation. Pass a sequence_id + step_order, or raw body copy.",
-    { sequence_id: UUID.optional(), step_order: z.number().int().min(1).optional(), body: z.string().optional() },
+    "Render a step to the exact HTML that would be sent, using the business's current email design and a sample prospect. Same renderer the engine uses, so this is the email — not an approximation. Pass a sequence_id + step_order, or raw body copy. Pass campaign_id to layer that campaign's own branding on top, which is what its enrollments will actually receive.",
+    {
+      sequence_id: UUID.optional(), step_order: z.number().int().min(1).optional(),
+      body: z.string().optional(), campaign_id: UUID.optional(),
+    },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "outreach:read");
 
@@ -326,20 +393,29 @@ export function registerOutreachTools(tool: ToolFn): void {
       }
       if (!body) return errorText("Provide a sequence_id or body copy to preview");
 
-      const [{ data: settings }, { data: business }] = await Promise.all([
+      const [{ data: settings }, { data: business }, { data: campaign }] = await Promise.all([
         t(ctx, "outreach_settings").select("*").eq("business_id", ctx.businessId).maybeSingle(),
         t(ctx, "businesses").select("name, logo_url").eq("id", ctx.businessId).maybeSingle(),
+        args.campaign_id
+          ? t(ctx, "outreach_campaigns").select("design")
+              .eq("id", args.campaign_id).eq("business_id", ctx.businessId).maybeSingle()
+          : Promise.resolve({ data: null }),
       ]);
+
+      const design = resolveOutreachDesign(settings, campaign?.design ?? null);
 
       return text({
         subject: mergeFields(subject, PREVIEW_PROSPECT),
         html: renderOutreachEmail({
-          body, design: settings, businessName: business?.name ?? "us",
+          body, design, businessName: business?.name ?? "us",
           businessLogoUrl: business?.logo_url ?? null,
           unsubUrl: "https://example.invalid/unsubscribe/preview",
           prospect: PREVIEW_PROSPECT,
         }),
         rendered_with: PREVIEW_PROSPECT,
+        branding: args.campaign_id
+          ? { source: "campaign + business", overrides: Object.keys(campaign?.design ?? {}) }
+          : { source: "business" },
       });
     });
 

--- a/src/lib/outreach/engine.ts
+++ b/src/lib/outreach/engine.ts
@@ -15,7 +15,7 @@
 import { randomBytes } from "node:crypto";
 import { sendEmail, buildBusinessFrom } from "@/lib/email";
 import { appUrl } from "@/lib/app-url";
-import { renderOutreachEmail, mergeFields } from "./render";
+import { renderOutreachEmail, mergeFields, resolveOutreachDesign } from "./render";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SB = any;
@@ -74,7 +74,7 @@ export async function runOutreachForBusiness(
 
   // Due enrollments, oldest first, only from running campaigns.
   const { data: due } = await sb.from("outreach_enrollments")
-    .select("*, outreach_campaigns!inner(id,status,daily_cap), prospects!inner(id,name,email,company,title,website,status)")
+    .select("*, outreach_campaigns!inner(id,status,daily_cap,design), prospects!inner(id,name,email,company,title,website,status)")
     .eq("business_id", businessId)
     .eq("status", "active")
     .eq("outreach_campaigns.status", "running")
@@ -135,7 +135,8 @@ export async function runOutreachForBusiness(
     // user saw is byte-for-byte what goes out (src/lib/outreach/render.ts).
     const html = renderOutreachEmail({
       body: step.body,
-      design: settings,
+      // Business design, with this campaign's overrides layered on top.
+      design: resolveOutreachDesign(settings, enr.outreach_campaigns?.design),
       businessName: business?.name ?? "us",
       businessLogoUrl: business?.logo_url ?? null,
       unsubUrl: `${appUrl()}/unsubscribe/${token}`,

--- a/src/lib/outreach/render.ts
+++ b/src/lib/outreach/render.ts
@@ -45,6 +45,11 @@ export interface OutreachDesign {
   email_width: number;
   email_show_logo: boolean;
   signature_html: string | null;
+  /**
+   * Campaign-specific logo. Falls back to the business logo when unset, so a
+   * campaign can carry a different mark without touching the business record.
+   */
+  logo_url: string | null;
 }
 
 export const DEFAULT_DESIGN: OutreachDesign = {
@@ -54,11 +59,67 @@ export const DEFAULT_DESIGN: OutreachDesign = {
   email_width: 560,
   email_show_logo: false,
   signature_html: null,
+  logo_url: null,
 };
+
+/** The keys a campaign is allowed to override. */
+export const DESIGN_KEYS = Object.keys(DEFAULT_DESIGN) as (keyof OutreachDesign)[];
+
+/**
+ * A partial design where null is meaningful: it means "inherit", not "unset to
+ * nothing". Stored campaign overrides arrive in this shape straight from JSONB.
+ */
+export type DesignOverride = { [K in keyof OutreachDesign]?: OutreachDesign[K] | null };
+
+/**
+ * Layer a campaign's overrides over the business defaults.
+ *
+ * Only keys the campaign actually set win. An absent key — and equally a null
+ * or an empty string, which is what a cleared input posts — inherits, so
+ * editing the business accent still moves every campaign that never opted out.
+ * Storing a full copy per campaign would silently freeze each one at whatever
+ * the business looked like the day it was created.
+ */
+export function resolveOutreachDesign(
+  business: DesignOverride | null | undefined,
+  campaign: DesignOverride | null | undefined,
+): OutreachDesign {
+  const out = { ...DEFAULT_DESIGN, ...pick(business) };
+  return { ...out, ...pick(campaign) };
+}
+
+/** Drop keys that mean "inherit" (absent / null / blank) and anything unknown. */
+function pick(src: DesignOverride | null | undefined): Partial<OutreachDesign> {
+  if (!src || typeof src !== "object") return {};
+  const out: Record<string, unknown> = {};
+  for (const k of DESIGN_KEYS) {
+    const v = (src as Record<string, unknown>)[k];
+    if (v === undefined || v === null) continue;
+    if (typeof v === "string" && v.trim() === "") continue;
+    out[k] = v;
+  }
+  return out as Partial<OutreachDesign>;
+}
 
 /** A colour we're willing to interpolate into a style attribute. */
 function hex(v: string | null | undefined, fallback: string): string {
   return v && /^#[0-9a-f]{3,8}$/i.test(v.trim()) ? v.trim() : fallback;
+}
+
+/**
+ * A URL we're willing to put in an img src.
+ *
+ * The business logo comes from our own storage bucket, but a campaign logo is
+ * typed in by a user, so it reaches the same attribute untrusted. Anything but
+ * a plain http(s) URL is dropped — that rules out `javascript:` and `data:`
+ * payloads — and the value is escaped so a quote can't break out of the
+ * attribute and add its own.
+ */
+function safeUrl(v: string | null | undefined): string | null {
+  if (!v) return null;
+  const s = v.trim();
+  if (!/^https?:\/\/[^\s"'<>]+$/i.test(s)) return null;
+  return esc(s).replace(/"/g, "&quot;");
 }
 
 export interface RenderInput {
@@ -90,8 +151,10 @@ export function renderOutreachEmail(input: RenderInput): string {
 
   const bodyHtml = esc(mergeFields(input.body, input.prospect ?? {})).replace(/\n/g, "<br>");
 
-  const logo = d.email_show_logo && input.businessLogoUrl
-    ? `<img src="${input.businessLogoUrl}" alt="${esc(input.businessName)}" height="36" style="display:block;height:36px;width:auto;margin:0 0 20px;border:0">`
+  // The campaign's own logo wins; the business logo is the fallback.
+  const logoSrc = safeUrl(d.logo_url) ?? safeUrl(input.businessLogoUrl);
+  const logo = d.email_show_logo && logoSrc
+    ? `<img src="${logoSrc}" alt="${esc(input.businessName)}" height="36" style="display:block;height:36px;width:auto;margin:0 0 20px;border:0">`
     : "";
 
   const signature = d.signature_html

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2272,7 +2272,20 @@ export interface OutreachCampaign {
   status: OutreachCampaignStatus;
   filter: { tags?: string[]; status?: string[]; sources?: string[] };
   auto_enroll: boolean; daily_cap: number | null; started_at: string | null;
+  /** Sparse email-design overrides. Absent key = inherit from outreach_settings. */
+  design: OutreachCampaignDesign | null;
   created_at: string; updated_at: string;
+}
+
+/** Every field optional — a campaign only stores what it actually overrides. */
+export interface OutreachCampaignDesign {
+  email_font?: string | null;
+  email_accent?: string | null;
+  email_text_color?: string | null;
+  email_width?: number | null;
+  email_show_logo?: boolean | null;
+  signature_html?: string | null;
+  logo_url?: string | null;
 }
 
 export interface OutreachEnrollment {

--- a/supabase/migrations/20260812235900_outreach_campaign_branding.sql
+++ b/supabase/migrations/20260812235900_outreach_campaign_branding.sql
@@ -1,0 +1,21 @@
+-- Per-campaign email branding.
+--
+-- Outreach design (font, accent, text colour, width, logo, signature) lived
+-- only on outreach_settings, so every campaign a business ran looked identical.
+-- A roofer pitching strata managers and the same roofer pitching handyman
+-- trades are different conversations and can want different marks.
+--
+-- Stored as a SPARSE object: only the keys this campaign overrides. An absent
+-- key inherits from outreach_settings at render time (resolveOutreachDesign in
+-- src/lib/outreach/render.ts). Copying the whole design in at create time would
+-- freeze each campaign at whatever the business looked like that day, so a
+-- later brand change would silently miss them.
+--
+-- NULL / {} = inherit everything, which is exactly today's behaviour — so every
+-- existing campaign is unaffected.
+
+ALTER TABLE outreach_campaigns
+  ADD COLUMN IF NOT EXISTS design JSONB;
+
+COMMENT ON COLUMN outreach_campaigns.design IS
+  'Sparse per-campaign overrides of outreach_settings email design. Absent key = inherit. Keys: email_font, email_accent, email_text_color, email_width, email_show_logo, signature_html, logo_url.';


### PR DESCRIPTION
## What

Outreach email design (font, accent, text colour, width, logo, signature) lived only on `outreach_settings`, so every campaign a business ran looked identical. Pitching strata managers and pitching handyman trades are different conversations and can want different marks.

Each campaign can now override any of those, plus carry **its own logo**.

## How

`outreach_campaigns` gains a **sparse** `design` JSONB — only the keys that campaign actually overrides.

An absent key inherits from the business **at render time**, so changing the business accent still reaches every campaign that never opted out. Copying the whole design in at create time would have frozen each campaign at whatever the business looked like that day — the failure mode this shape exists to avoid.

`NULL` / `{}` = inherit everything, which is exactly today's behaviour, so **every existing campaign is untouched**.

- `resolveOutreachDesign()` layers campaign → business → app defaults, treating `null` and blank as *inherit*. A cleared input posts `""`, and that has to mean inherit rather than "no accent at all".
- Per-campaign `logo_url`. Unlike the business logo this is typed in by a user and lands in an `<img src>`, so it is validated — http(s) only, which rules out `javascript:`/`data:` — and escaped so a quote can't break out and add an `onerror`.
- The engine resolves per enrollment, so what sends matches what the preview showed: the same single-renderer guarantee `render.ts` already made.
- UI: a **Branding** button on each campaign card opens a tri-state editor (every field shows its inherited value as the placeholder and carries its own "Inherit" reset) with a live preview, and the card shows an override count.

## MCP

- **`update_outreach_campaign`** (new) — rename, repoint, refilter, recap, and set branding. Branding merges over existing overrides so setting one colour doesn't drop the rest; `reset_branding: true` clears them.
- **`preview_outreach_email`** takes `campaign_id`, so a preview can show what that campaign's enrollments will actually receive.

## Second commit — an unrelated flaky test

`booking-db.test.ts` raced 8 inserts against the live remote project then asserted all 7 losers failed with exactly SQLSTATE `23P01`. The guarantee under test is *exactly one racer wins*; the distribution of error codes among losers isn't that guarantee, and any transient (timeout, pooler blip, 5xx) carries no SQLSTATE and turned the run red while the constraint had behaved perfectly. This is the intermittent failure that's been showing up for weeks.

Now: one success and N−1 failures (a dropped constraint still fails loudly), every loser that failed with a *Postgres* error must have failed with `23P01`, and at least one must have — so a run where everything merely timed out can't pass silently.

## Verification

- Migration applied to the linked project and recorded; `design` confirmed `jsonb`.
- `npm test` — 402 passed / 14 skipped, and the booking test passed 3 consecutive isolated runs.
- New tests cover inheritance precedence, null/blank meaning inherit, `false` surviving as a real override, unknown keys being ignored, campaign logo beating business logo, and the `javascript:`/`data:`/attribute-escape guards.
- `npx tsc --noEmit` clean, `npm run build` succeeded.
- Not visually verified in a browser — no signed-in session available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
