### PR TITLE
fix: the three blockers from the feature audit

### DIFF
--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -22,7 +22,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { getActiveBizId } from "@/lib/active-business";
+import { getActiveBizId, userBelongsToBusiness } from "@/lib/active-business";
 import { getUser } from "@/lib/auth";
 import { getMyRoleCached } from "@/lib/role";
 import { ANTHROPIC_TOOLS } from "@/lib/mcp/anthropic-tools";
@@ -163,6 +163,16 @@ export async function POST(request: NextRequest) {
   }
 
   const businessId = await getActiveBizId(supabase, user.id);
+
+  // That business id came from a cookie, and on this route the tools run as
+  // service-role — so RLS, which everywhere else makes a tampered cookie
+  // harmless, is not going to catch it. Without this check any signed-in user
+  // could point active_business_id at another tenant's UUID, resolve to a role
+  // (see the fail-closed fallback in lib/role.ts), and have the tools read that
+  // tenant's customers, invoices and leads straight past RLS.
+  if (!(await userBelongsToBusiness(supabase, user.id, businessId))) {
+    return Response.json({ error: "Business not found" }, { status: 403 });
+  }
 
   // The tools run as service-role, bypassing RLS — so the caller's role, not
   // the database, decides what they can reach here. See lib/assistant/scopes.

--- a/src/lib/__tests__/business-access.test.ts
+++ b/src/lib/__tests__/business-access.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The gate that stands between a cookie and the service-role client.
+ *
+ * getActiveBizId trusts the active_business_id cookie, which is safe wherever
+ * RLS re-checks the query. On the assistant route it isn't: the tools run as
+ * service-role. userBelongsToBusiness is what makes the cookie trustworthy
+ * there, so its failure modes are worth pinning down.
+ */
+import { describe, it, expect } from "vitest";
+import { userBelongsToBusiness } from "@/lib/active-business";
+
+type Row = { data: unknown; error: unknown };
+
+/**
+ * Minimal stand-in for the PostgREST builder chain: every filter returns this,
+ * and maybeSingle() resolves whatever the table was seeded with.
+ */
+function fakeClient(tables: Record<string, Row>) {
+  const builder = (table: string) => {
+    const chain: Record<string, unknown> = {};
+    for (const m of ["select", "eq"]) chain[m] = () => chain;
+    chain.maybeSingle = async () => tables[table] ?? { data: null, error: null };
+    return chain;
+  };
+  return { from: (table: string) => builder(table) };
+}
+
+const OWNED = { data: { id: "biz-1" }, error: null };
+const NOT_FOUND = { data: null, error: null };
+const MEMBER = { data: { business_id: "biz-1" }, error: null };
+
+describe("userBelongsToBusiness", () => {
+  it("accepts the owner", async () => {
+    const sb = fakeClient({ businesses: OWNED, business_members: NOT_FOUND });
+    expect(await userBelongsToBusiness(sb, "user-1", "biz-1")).toBe(true);
+  });
+
+  it("accepts an active member who is not the owner", async () => {
+    const sb = fakeClient({ businesses: NOT_FOUND, business_members: MEMBER });
+    expect(await userBelongsToBusiness(sb, "user-1", "biz-1")).toBe(true);
+  });
+
+  it("rejects a stranger — the cross-tenant case", async () => {
+    // What a forged active_business_id cookie looks like: RLS returns nothing
+    // for both lookups, and that has to be a refusal rather than a shrug.
+    const sb = fakeClient({ businesses: NOT_FOUND, business_members: NOT_FOUND });
+    expect(await userBelongsToBusiness(sb, "attacker", "someone-elses-biz")).toBe(false);
+  });
+
+  it("fails closed when a lookup errors", async () => {
+    // A transient error must not read as "no objection".
+    const boom = { data: null, error: { message: "connection reset" } };
+    expect(await userBelongsToBusiness(fakeClient({ businesses: boom, business_members: NOT_FOUND }), "u", "b"))
+      .toBe(false);
+    expect(await userBelongsToBusiness(fakeClient({ businesses: NOT_FOUND, business_members: boom }), "u", "b"))
+      .toBe(false);
+  });
+
+  it("fails closed even when the other lookup would have said yes", async () => {
+    // Belt and braces: an error anywhere means we don't know, and not knowing
+    // is a no. Otherwise an attacker who can induce one error gets a bypass.
+    const boom = { data: null, error: { message: "timeout" } };
+    expect(await userBelongsToBusiness(fakeClient({ businesses: OWNED, business_members: boom }), "u", "b"))
+      .toBe(false);
+  });
+});

--- a/src/lib/active-business.ts
+++ b/src/lib/active-business.ts
@@ -47,3 +47,32 @@ export const getActiveBizId = cache(async (supabase: AnySupabase, userId: string
 
   throw new Error("No business found. Please complete onboarding.");
 });
+
+/**
+ * Does this user actually belong to this business?
+ *
+ * getActiveBizId trusts the cookie, and everywhere it's used that is fine —
+ * RLS re-checks access on every query, so a tampered cookie just yields empty
+ * results. The exception is any path that goes on to use the SERVICE-ROLE
+ * client, which bypasses RLS entirely: there the cookie is the only thing
+ * naming the tenant, and trusting it is a cross-tenant read.
+ *
+ * Call this before handing a cookie-derived business id to an admin client.
+ *
+ * The lookups run on the caller's own RLS-scoped client, so a business the user
+ * has no claim to simply returns no row — the check can't be talked out of it
+ * by a forged id. Errors fail closed.
+ */
+export async function userBelongsToBusiness(
+  supabase: AnySupabase,
+  userId: string,
+  businessId: string,
+): Promise<boolean> {
+  const [owned, member] = await Promise.all([
+    supabase.from("businesses").select("id").eq("id", businessId).eq("user_id", userId).maybeSingle(),
+    supabase.from("business_members").select("business_id")
+      .eq("business_id", businessId).eq("user_id", userId).eq("status", "active").maybeSingle(),
+  ]);
+  if (owned.error || member.error) return false;
+  return Boolean(owned.data) || Boolean(member.data);
+}

--- a/src/lib/role.ts
+++ b/src/lib/role.ts
@@ -22,7 +22,7 @@ export const getMyRoleCached = cache(async (): Promise<Role> => {
   const businessId = await getActiveBizId(supabase, user.id);
 
   // Owner check and member lookup are independent — run them in parallel.
-  const [{ data: biz }, { data: member }] = await Promise.all([
+  const [{ data: biz }, { data: member, error: memberError }] = await Promise.all([
     tbl(supabase, "businesses").select("user_id").eq("id", businessId).single(),
     tbl(supabase, "business_members")
       .select("role")
@@ -33,5 +33,19 @@ export const getMyRoleCached = cache(async (): Promise<Role> => {
   ]);
 
   if (biz?.user_id === user.id) return "owner";
-  return (member?.role ?? "viewer") as Role;
+
+  /**
+   * No membership row — or a lookup that failed — means we do not know who this
+   * is, and the answer to that must be the LEAST privilege, not a middling one.
+   *
+   * This used to return "viewer", which is a real role carrying every read
+   * scope. Combined with the active_business_id cookie being trusted, that
+   * handed a stranger read access to a business they'd merely named. Worker is
+   * the hard-isolation role, and it's what mobile already falls back to.
+   *
+   * A legitimate user is always either the owner (returned above) or holds an
+   * active member row, so this branch only fires on the anomaly it guards.
+   */
+  if (memberError || !member?.role) return "worker";
+  return member.role as Role;
 });

--- a/src/lib/stripe-charge.ts
+++ b/src/lib/stripe-charge.ts
@@ -55,6 +55,20 @@ export async function chargeInvoiceToSavedCard(
   if (!customerAllowsCard(customer.allowed_payment_methods)) {
     return { ok: false, reason: "not_eligible", message: "Card payment is disabled for this customer" };
   }
+  // The customer's standing consent to be charged off-session. This gate used
+  // to live only on the send-invoice path, so the recurring cron happily kept
+  // billing saved cards that the customer had switched autopay OFF on — the
+  // manual path honoured the flag and the automated one didn't, which is the
+  // shape of bug that never shows up in testing.
+  //
+  // It belongs here rather than at each caller because EVERY route through this
+  // function charges off_session, and an off-session merchant-initiated charge
+  // is exactly what withdrawn consent forbids. That deliberately covers the
+  // "Charge saved card" button too: the operator gets told why, and can send a
+  // pay link instead. Fails closed — only an explicit true is consent.
+  if (customer.autopay_enabled !== true) {
+    return { ok: false, reason: "not_eligible", message: "Customer has autopay disabled" };
+  }
 
   const currency = (biz.currency || "GBP").toLowerCase();
   const surcharge = computeSurcharge(balance, {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -12,6 +12,22 @@ export async function updateSession(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isAuthRoute = pathname.startsWith("/auth");
 
+  /**
+   * The one auth route a signed-in user must be allowed to stay on.
+   *
+   * A password reset link lands on /auth/callback, which exchanges the code for
+   * a REAL session before forwarding here. So the recovery visit always arrives
+   * holding a session, and the "signed in? go to /dashboard" bounce fired every
+   * single time: the reset page was unreachable, and the emailed link silently
+   * behaved as a passwordless sign-in that left the forgotten — or compromised
+   * — password still live.
+   *
+   * Only the signed-in bounce is exempted, not the signed-out one: someone
+   * arriving with an expired link and no session should still reach the page
+   * that tells them so, rather than a login screen that explains nothing.
+   */
+  const isPasswordReset = pathname === "/auth/reset-password";
+
   // Endpoints that authenticate themselves via an Authorization: Bearer
   // header (mobile clients) — let the route handler do its own auth check
   // instead of cookie-redirecting them to the login page (which produces
@@ -125,7 +141,7 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  if (claims && isAuthRoute) {
+  if (claims && isAuthRoute && !isPasswordReset) {
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";
     return NextResponse.redirect(url);


### PR DESCRIPTION
The audit confirmed 241 findings across 25 features, three of them rated **blocker**. This is all three. Nothing here is from the cut list — these are fixes to features that stay.

Each is its own commit, so any one can be reverted alone.

---

### 1. Saved cards charged after the customer turned autopay off — `fix(payments)`

`chargeInvoiceToSavedCard` selected `autopay_enabled` and then never looked at it. The send-invoice path checked the flag itself before calling in, so the **manual** route behaved correctly — and the **recurring cron**, which gates only on the schedule's own `auto_charge`, kept billing customers every cycle after they'd switched autopay off. One path honouring consent and the other ignoring it is the shape of bug that never surfaces in testing.

The gate belongs in the charge function rather than at each caller: every route through it charges `off_session`, and an off-session merchant-initiated charge is precisely what withdrawn consent forbids. That deliberately covers the "Charge saved card" button and the MCP tool too — the operator is told why and can send a pay link instead.

Fails closed; only an explicit `true` counts as consent. The column is `NOT NULL DEFAULT false`, so no existing row changes meaning. **No live customer currently has a saved card, so the blast radius today is zero** — it matters going forward.

### 2. Password reset was impossible — `fix(auth)`

A reset link lands on `/auth/callback`, which exchanges the code for a **real session** before forwarding to `/auth/reset-password`. Middleware bounced any signed-in visitor on an `/auth` route to `/dashboard`, so that redirect fired every single time. The reset page was unreachable, and the emailed link quietly behaved as a passwordless sign-in that left the forgotten — or compromised — password live.

Exempts only the signed-**in** bounce, not the signed-out one, so someone arriving with an expired link and no session still reaches the page that explains it rather than a login screen that doesn't.

### 3. Cross-tenant read through the assistant's service-role tools — `fix(assistant)`

Two fail-open steps lined up:

- `getActiveBizId` returns the `active_business_id` cookie on trust, documented as safe because *"RLS enforces actual access at the query level"*. True everywhere it's used **except** `/api/assistant`, whose tools run on the service-role client and bypass RLS — there the cookie is the only thing naming the tenant.
- `getMyRoleCached` fell back to `"viewer"` when no membership row came back. That isn't a null result; it's a real role carrying every read scope.

So any signed-in user could point the cookie at another business's UUID, resolve to viewer, and have the tools read that business's customers, invoices, quotes and leads straight past RLS.

- New `userBelongsToBusiness()`, checked before the business id reaches the admin client. The lookups run on the caller's own RLS-scoped client, so a forged id simply returns no row. Errors fail closed — including when the other lookup would have said yes.
- `role.ts` now returns `"worker"` (the hard-isolation role, and what mobile already falls back to) when the member lookup is empty **or** errors. A legitimate user is either the owner or holds an active member row, so this branch only fires on the anomaly it guards.

**Deliberately not changed:** the same viewer fallback in the dashboard layout and `stripe.ts`. Both sit behind RLS, where a wrongly-viewer user still cannot read another tenant, so they're UX-level rather than a privilege boundary. Changing them would alter what the 3 pending members see, which isn't this PR's job.

---

## Verification

- 5 new tests on the access gate: owner, active member, stranger (the cross-tenant case), and fail-closed on error from either lookup — including when the other would have passed, so an attacker who can induce one error gets no bypass.
- `npm test` — 407 passed / 14 skipped.
- `npx tsc --noEmit` clean; `npm run build` succeeded.
- Not verified in a browser: no signed-in session. The reset-password path in particular is worth one manual run — request a reset and confirm the page renders instead of bouncing to /dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
