### PR TITLE
fix(booking): validate slots, fix timezones, stop losing appointment history

### DIFF
--- a/src/app/api/public/v1/biz/[slug]/bookings/route.ts
+++ b/src/app/api/public/v1/biz/[slug]/bookings/route.ts
@@ -10,6 +10,7 @@
  * manage_token for self-serve reschedule/cancel.
  */
 import { NextRequest } from "next/server";
+import { isSlotBookable, workOrderTimesFor } from "@/lib/booking/validate";
 import { emitAutomationEvent } from "@/lib/automations/emit";
 import {
   resolveTenant, json, publicError, preflight, rateLimit, clientIp,
@@ -85,6 +86,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
     start = new Date(startIso);
     if (isNaN(start.getTime())) return publicError("Invalid start", 400);
     end = new Date(start.getTime() + type.duration_minutes * 60_000);
+
+    // Without this, `start` was whatever the caller sent: 4am, a blackout day,
+    // last Tuesday, or a year past max_advance_days. The exclusion constraint
+    // only ever stopped two bookings colliding — it never had an opinion about
+    // whether the business was open. A hold took the same path through
+    // isSlotBookable when it was created, so it isn't re-checked here.
+    const check = await isSlotBookable(sb, settings, typeId, resourceId, start);
+    if (!check.ok) return publicError(check.reason, 409);
   }
 
   // Insert — the exclusion constraint guards concurrency. 23P01 = overlap.
@@ -155,6 +164,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
       if (leadId) await emitAutomationEvent(sb, businessId, "lead.created", "lead", leadId);
     }
     if (settings.create_work_order && ownerId) {
+      const { data: bs } = await sb.from("booking_settings")
+        .select("timezone").eq("business_id", businessId).maybeSingle();
+      const bookingTz: string = bs?.timezone || "UTC";
       const next = biz?.work_order_next_number ?? 1;
       const number = `${biz?.work_order_prefix ?? "WO"}-${String(next).padStart(4, "0")}`;
       await sb.from("businesses").update({ work_order_next_number: next + 1 }).eq("id", businessId);
@@ -166,9 +178,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
         business_id: businessId, user_id: ownerId, number,
         title: `Booking: ${customerName}`,
         status: profileId ? "assigned" : "draft",
-        scheduled_date: start.toISOString().slice(0, 10),
-        start_time: start.toISOString().slice(11, 16),
-        end_time: end.toISOString().slice(11, 16),
+        // Local wall-clock, not UTC — work_orders stores a naive date+time that
+        // booking_busy_intervals reads back AT TIME ZONE the business's own.
+        ...workOrderTimesFor(start, end, bookingTz),
       };
       if (profileId) woInsert.assigned_to_profile_id = profileId;
       if (customerId) woInsert.customer_id = customerId;

--- a/src/app/api/public/v1/biz/[slug]/holds/route.ts
+++ b/src/app/api/public/v1/biz/[slug]/holds/route.ts
@@ -5,6 +5,7 @@
  * while the customer fills the form. Returns { hold_token, expires_at }.
  */
 import { NextRequest } from "next/server";
+import { isSlotBookable } from "@/lib/booking/validate";
 import {
   resolveTenant, json, publicError, preflight, rateLimit, clientIp, honeypotTripped,
 } from "@/lib/booking/public";
@@ -20,7 +21,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
 
   const tenant = await resolveTenant(slug);
   if (!tenant) return publicError("Booking not available", 404);
-  const { businessId, sb } = tenant;
+  const { businessId, sb, settings } = tenant;
 
   let body: Record<string, unknown>;
   try { body = await req.json(); } catch { return publicError("Invalid JSON", 400); }
@@ -46,6 +47,15 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
   if (!resource || !resource.active) return publicError("Resource not found", 404);
 
   const end = new Date(start.getTime() + type.duration_minutes * 60_000);
+
+  // A hold is later trusted by the booking route, which reads its stored
+  // start/end verbatim — so if a bogus time can be held, it can be booked.
+  // This checks the same thing the booking route does: that the time is one
+  // the business actually offered, honouring working hours, blackouts,
+  // max_advance_days, and the form's own type/resource restriction (which the
+  // per-tenant lookups above don't cover).
+  const check = await isSlotBookable(sb, settings, typeId, resourceId, start);
+  if (!check.ok) return publicError(check.reason, 409);
 
   // Re-check the slot is actually free for this resource (appointments + holds + jobs).
   const { data: busy } = await sb.rpc("booking_busy_intervals", {

--- a/src/app/api/public/v1/bookings/[manage_token]/route.ts
+++ b/src/app/api/public/v1/bookings/[manage_token]/route.ts
@@ -8,7 +8,8 @@
 import { NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { json, publicError, preflight, rateLimit, clientIp } from "@/lib/booking/public";
-import { fireBookingWebhook, notifyBookingCancelled } from "@/lib/booking/notify";
+import { fireBookingWebhook, notifyBookingCancelled, notifyBookingRescheduled } from "@/lib/booking/notify";
+import { isSlotBookable, workOrderTimesFor } from "@/lib/booking/validate";
 import type { Appointment, BookingSettings } from "@/types/database";
 
 export const dynamic = "force-dynamic";
@@ -79,9 +80,41 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ ma
   const newStart = new Date(startIso);
   if (isNaN(newStart.getTime())) return publicError("Invalid start", 400);
 
+  // The cancellation window applies to moving a booking too. It only guarded
+  // DELETE, so a customer blocked from cancelling two hours out could simply
+  // reschedule to next month instead — same outcome for the crew, window
+  // defeated.
+  const hoursUntil = (new Date(appt.starts_at).getTime() - Date.now()) / 3_600_000;
+  if (hoursUntil < settings.cancellation_window_hours) {
+    return publicError(`Changes require at least ${settings.cancellation_window_hours}h notice`, 409);
+  }
+
   const durationMs = new Date(appt.ends_at).getTime() - new Date(appt.starts_at).getTime();
   const newEnd = new Date(newStart.getTime() + durationMs);
   const resourceId = String(body.resource_id ?? appt.resource_id);
+
+  // resource_id came straight from the request body and went into the update
+  // unchecked — a customer could move their job onto any resource id at all,
+  // including another business's, orphaning it from the calendar it belonged to.
+  if (resourceId !== appt.resource_id) {
+    const { data: res } = await sb.from("booking_resources")
+      .select("id, active").eq("id", resourceId).eq("business_id", appt.business_id).maybeSingle();
+    if (!res || !res.active) return publicError("That resource isn't available", 400);
+  }
+
+  // Validate against real availability, not just "does something else overlap".
+  // Without it a customer could move their booking to 4am. Appointments made
+  // outside a form (admin-created) have no form to validate against; those keep
+  // the overlap-only check below rather than becoming unreschedulable.
+  const typeId = appt.appointment_type_id;
+  if (appt.form_id && typeId) {
+    const { data: form } = await sb.from("booking_forms")
+      .select("*").eq("id", appt.form_id).eq("business_id", appt.business_id).maybeSingle();
+    if (form) {
+      const check = await isSlotBookable(sb, form, typeId, resourceId, newStart);
+      if (!check.ok) return publicError(check.reason, 409);
+    }
+  }
 
   // Free up the old slot first by marking this row rescheduled-exempt: we update
   // in place — the exclusion constraint ignores the row's own prior range since
@@ -106,10 +139,21 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ ma
     return publicError("Could not reschedule", 500);
   }
 
+  // Move the generated job with the booking. It used to stay at the old time,
+  // so the crew's schedule still showed the original slot — and the stale row
+  // kept blocking that window in booking_busy_intervals.
+  if (appt.work_order_id) {
+    await sb.from("work_orders")
+      .update(workOrderTimesFor(newStart, newEnd, settings.timezone))
+      .eq("id", appt.work_order_id).eq("business_id", appt.business_id);
+  }
+
   await sb.from("booking_audit_log").insert({
     business_id: appt.business_id, appointment_id: appt.id, event: "rescheduled", actor: "customer",
     detail: { from: appt.starts_at, to: newStart.toISOString() },
   });
+  await notifyBookingRescheduled(sb, appt.business_id, settings, updated as Appointment, appt.starts_at)
+    .catch(() => undefined);
   await fireBookingWebhook(appt.business_id, settings, "booking.rescheduled", {
     id: appt.id, from: appt.starts_at, to: newStart.toISOString(), resource_id: resourceId,
   });
@@ -136,6 +180,13 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ m
     status: "cancelled", cancelled_at: new Date().toISOString(),
   }).eq("id", appt.id).select("*").single();
   if (error) return publicError("Could not cancel", 500);
+
+  // Cancel the generated job too. Leaving it live meant a cancelled booking
+  // still sat on the crew's schedule and somebody turned up.
+  if (appt.work_order_id) {
+    await sb.from("work_orders").update({ status: "cancelled" })
+      .eq("id", appt.work_order_id).eq("business_id", appt.business_id);
+  }
 
   await sb.from("booking_audit_log").insert({
     business_id: appt.business_id, appointment_id: appt.id, event: "cancelled", actor: "customer",

--- a/src/components/booking/booking-admin-client.tsx
+++ b/src/components/booking/booking-admin-client.tsx
@@ -172,19 +172,27 @@ export function BookingAdminClient({
             <ResourceRow key={r.id} resource={r} teamMembers={teamMembers}
               onLink={(memberId) => start(async () => { await updateResource(r.id, { member_profile_id: memberId }); setResources((arr) => arr.map((x) => x.id === r.id ? { ...x, member_profile_id: memberId } : x)); })}
               onDelete={async () => {
-                // appointments.resource_id REFERENCES booking_resources
-                // ON DELETE CASCADE — so this does not just remove the
-                // resource, it permanently deletes every appointment ever
-                // booked against it. That has to be said out loud.
+                // The FK is ON DELETE RESTRICT now and the action retires a
+                // resource that has any appointments rather than deleting it,
+                // so the old "this wipes every appointment" warning would be
+                // untrue — and scaring an owner off a safe action is its own
+                // kind of bug.
                 if (!(await confirm({
-                  title: `Delete "${r.display_name}"?`,
-                  body: "Every appointment ever booked against this resource will be permanently deleted too, including past bookings. This cannot be undone.",
-                  confirmLabel: "Delete resource and its appointments",
+                  title: `Remove "${r.display_name}"?`,
+                  body: "It stops being offered for new bookings. If anything has ever been booked with it, the resource is kept so that history and the calendar still make sense.",
+                  confirmLabel: "Remove resource",
                 }))) return;
                 start(async () => {
-                  await deleteResource(r.id);
-                  setResources((arr) => arr.filter((x) => x.id !== r.id));
-                  toast.success("Resource deleted");
+                  const res = await deleteResource(r.id);
+                  if (res.deleted) {
+                    setResources((arr) => arr.filter((x) => x.id !== r.id));
+                    toast.success("Resource deleted");
+                  } else {
+                    setResources((arr) => arr.map((x) => x.id === r.id ? { ...x, active: false } : x));
+                    toast.success(
+                      `Resource retired — ${res.appointments} appointment${res.appointments === 1 ? "" : "s"} kept`,
+                    );
+                  }
                 });
               }} />
           ))}

--- a/src/lib/__tests__/booking-validate.test.ts
+++ b/src/lib/__tests__/booking-validate.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The work-order times a booking generates.
+ *
+ * work_orders stores a NAIVE local date and time, and booking_busy_intervals
+ * reads them back as `(scheduled_date + start_time) AT TIME ZONE
+ * bs.timezone`. The booking route was writing `start.toISOString()` slices —
+ * UTC — so for a Sydney business a 09:00 booking became a job dated the
+ * previous day at 22:00 or 23:00. The crew's schedule was wrong, and the bad
+ * row then blocked a 22:00 window in busy-intervals that nobody wanted.
+ */
+import { describe, it, expect } from "vitest";
+import { workOrderTimesFor } from "@/lib/booking/validate";
+
+describe("workOrderTimesFor", () => {
+  it("keeps a Sydney morning booking on the same local day", () => {
+    // 2026-03-02T09:00 Sydney (AEDT, UTC+11) === 2026-03-01T22:00Z.
+    // The naive UTC slice would have said 2026-03-01 at 22:00 — a day early.
+    const start = new Date("2026-03-01T22:00:00.000Z");
+    const end = new Date("2026-03-01T23:00:00.000Z");
+    const wo = workOrderTimesFor(start, end, "Australia/Sydney");
+    expect(wo.scheduled_date).toBe("2026-03-02");
+    expect(wo.start_time).toBe("09:00");
+    expect(wo.end_time).toBe("10:00");
+  });
+
+  it("differs from the naive UTC slice exactly where the old bug was", () => {
+    const start = new Date("2026-03-01T22:00:00.000Z");
+    expect(workOrderTimesFor(start, start, "Australia/Sydney").scheduled_date)
+      .not.toBe(start.toISOString().slice(0, 10));
+  });
+
+  it("handles a booking that crosses local midnight", () => {
+    // 2026-06-30T23:30 Sydney (AEST, UTC+10) === 2026-06-30T13:30Z.
+    const start = new Date("2026-06-30T13:30:00.000Z");
+    const end = new Date("2026-06-30T14:30:00.000Z"); // 00:30 next local day
+    const wo = workOrderTimesFor(start, end, "Australia/Sydney");
+    expect(wo.scheduled_date).toBe("2026-06-30");
+    expect(wo.start_time).toBe("23:30");
+    expect(wo.end_time).toBe("00:30");
+  });
+
+  it("respects a non-Australian zone", () => {
+    // 2026-01-15T08:00 London (GMT) === 08:00Z.
+    const start = new Date("2026-01-15T08:00:00.000Z");
+    const end = new Date("2026-01-15T09:30:00.000Z");
+    const wo = workOrderTimesFor(start, end, "Europe/London");
+    expect(wo.scheduled_date).toBe("2026-01-15");
+    expect(wo.start_time).toBe("08:00");
+    expect(wo.end_time).toBe("09:30");
+  });
+
+  it("pads single-digit months, days, hours and minutes", () => {
+    const start = new Date("2026-02-03T04:05:00.000Z");
+    const wo = workOrderTimesFor(start, start, "UTC");
+    expect(wo.scheduled_date).toBe("2026-02-03");
+    expect(wo.start_time).toBe("04:05");
+  });
+
+  it("falls back to UTC rather than throwing on an empty timezone", () => {
+    const start = new Date("2026-05-05T10:00:00.000Z");
+    expect(workOrderTimesFor(start, start, "").scheduled_date).toBe("2026-05-05");
+  });
+});

--- a/src/lib/actions/booking.ts
+++ b/src/lib/actions/booking.ts
@@ -240,10 +240,42 @@ export async function updateResource(id: string, patch: Partial<{
   revalidate();
 }
 
-export async function deleteResource(id: string): Promise<void> {
+/**
+ * Remove a resource — or, if anything was ever booked with it, retire it.
+ *
+ * This used to be an unconditional delete behind a bare trash icon, and the FK
+ * was ON DELETE CASCADE: tidying up after a worker left took that worker's
+ * entire appointment history with them, past and future, with no undo.
+ *
+ * The `active` flag already existed for exactly this. A retired resource stops
+ * being offered for new bookings and everything already booked with it survives,
+ * so the calendar and the audit log still make sense. Only a resource with no
+ * appointments at all is actually deleted.
+ *
+ * Returns what happened so the UI can say so rather than claiming it deleted
+ * something it retired.
+ */
+export async function deleteResource(id: string): Promise<{ deleted: boolean; appointments: number }> {
   const { supabase, businessId } = await ctx();
-  await tbl(supabase, "booking_resources").delete().eq("id", id).eq("business_id", businessId);
+
+  const { count } = await tbl(supabase, "appointments")
+    .select("id", { count: "exact", head: true })
+    .eq("business_id", businessId).eq("resource_id", id);
+  const appointments = count ?? 0;
+
+  if (appointments > 0) {
+    const { error } = await tbl(supabase, "booking_resources")
+      .update({ active: false }).eq("id", id).eq("business_id", businessId);
+    if (error) throw new Error(error.message);
+    revalidate();
+    return { deleted: false, appointments };
+  }
+
+  const { error } = await tbl(supabase, "booking_resources")
+    .delete().eq("id", id).eq("business_id", businessId);
+  if (error) throw new Error(error.message);
   revalidate();
+  return { deleted: true, appointments: 0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -354,5 +386,16 @@ export async function setAppointmentStatus(id: string, status: Appointment["stat
   if (status === "cancelled") patch.cancelled_at = new Date().toISOString();
   const { error } = await tbl(supabase, "appointments").update(patch).eq("id", id).eq("business_id", businessId);
   if (error) throw new Error(error.message);
+
+  // Same as the customer-facing cancel: take the generated job down with the
+  // booking, or the crew keeps a cancelled visit on their schedule.
+  if (status === "cancelled") {
+    const { data: appt } = await tbl(supabase, "appointments")
+      .select("work_order_id").eq("id", id).eq("business_id", businessId).maybeSingle();
+    if (appt?.work_order_id) {
+      await tbl(supabase, "work_orders").update({ status: "cancelled" })
+        .eq("id", appt.work_order_id).eq("business_id", businessId);
+    }
+  }
   revalidatePath("/settings/booking");
 }

--- a/src/lib/booking/notify.ts
+++ b/src/lib/booking/notify.ts
@@ -159,6 +159,47 @@ export async function notifyBookingReminder(sb: Sb, businessId: string, settings
   }
 }
 
+/**
+ * Reschedule notice (customer + team).
+ *
+ * A customer could move their own appointment and NOBODY was told — not the
+ * crew who'd turn up at the old time, not the customer who got no confirmation
+ * that it took. Cancellation notified both; reschedule notified neither.
+ *
+ * Reuses the "confirmed" email body deliberately: it already renders the new
+ * time and the manage link, which is precisely what a reschedule confirmation
+ * needs to say. Only the subject differs, so nobody mistakes it for a new
+ * booking.
+ */
+export async function notifyBookingRescheduled(
+  sb: Sb, businessId: string, settings: BookingSettings, appt: Appointment, previousStart: string,
+): Promise<void> {
+  const biz = await getBiz(sb, businessId);
+  if (!biz) return;
+  const when = fmtLocal(appt.starts_at, settings.timezone);
+  const wasWhen = fmtLocal(previousStart, settings.timezone);
+  const from = buildBusinessFrom({ name: biz.name, localPart: "bookings" });
+  const manageUrl = `${APP_URL}/booking/${appt.manage_token}`;
+
+  if (settings.notify_customer_email && appt.customer_email) {
+    await sendEmail({
+      to: appt.customer_email, subject: `Booking moved to ${when} — ${biz.name}`,
+      from, replyTo: biz.email ?? undefined,
+      tags: { business_id: businessId, doc_type: "custom" },
+      html: await bookingEmail(sb, biz, settings, appt, "confirmed", manageUrl),
+    }).catch(() => undefined);
+  }
+  if (settings.notify_team_email) {
+    const teamTo = settings.team_notify_email || biz.email;
+    if (teamTo) await sendEmail({
+      to: teamTo, subject: `Booking moved: ${appt.customer_name} — ${when}`, from,
+      tags: { business_id: businessId, doc_type: "custom" },
+      html: `<div style="font-family:system-ui,sans-serif"><p><strong>${appt.customer_name}</strong> moved their booking.</p>`
+        + `<p>Was: ${wasWhen}<br>Now: <strong>${when}</strong></p></div>`,
+    }).catch(() => undefined);
+  }
+}
+
 /** Cancellation notice (customer + team). */
 export async function notifyBookingCancelled(sb: Sb, businessId: string, settings: BookingSettings, appt: Appointment): Promise<void> {
   const biz = await getBiz(sb, businessId);

--- a/src/lib/booking/validate.ts
+++ b/src/lib/booking/validate.ts
@@ -1,0 +1,96 @@
+/**
+ * Is this actually a slot the business offered?
+ *
+ * The public booking endpoints used to take `start` from the request body,
+ * derive `end` from the appointment type's duration, and insert. The exclusion
+ * constraint stopped double-booking and nothing else — so a crafted POST could
+ * put a job at 4am, on a blackout day, in the past, or months past
+ * max_advance_days, and the owner found it on the calendar.
+ *
+ * This validates by re-running the SAME availability engine that produced the
+ * slots the customer was offered and checking the requested instant is one of
+ * them. Re-deriving the rules here would be a second implementation free to
+ * drift from the one the widget renders, which is how the gap opened in the
+ * first place: getAvailability had exactly one caller, the availability
+ * endpoint.
+ *
+ * It also inherits the form's appointment_type_ids / resource_ids restriction
+ * for free, because loadAvailabilityData applies it and returns null when the
+ * type isn't one this form may book.
+ */
+
+import { getAvailability } from "./availability";
+import { zonedDateKey, utcToZonedParts } from "./time";
+import type { BookingForm } from "@/types/database";
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * The scheduled_date / start_time / end_time a work order should carry for a
+ * booking, in the business's own wall-clock.
+ *
+ * work_orders stores a naive local date and time — the booking_busy_intervals
+ * SQL reads them back as `(scheduled_date + start_time) AT TIME ZONE
+ * bs.timezone`. The booking route was writing `start.toISOString()` slices,
+ * i.e. UTC, so for a Sydney business a 09:00 booking became a job dated the
+ * PREVIOUS day at 22:00 or 23:00. The crew's schedule was wrong, and the bad
+ * row fed back into busy-intervals to block a 22:00 window nobody wanted.
+ */
+export function workOrderTimesFor(start: Date, end: Date, timezone: string): {
+  scheduled_date: string; start_time: string; end_time: string;
+} {
+  const tz = timezone || "UTC";
+  const s = utcToZonedParts(start, tz);
+  const e = utcToZonedParts(end, tz);
+  return {
+    scheduled_date: `${s.year}-${pad(s.month)}-${pad(s.day)}`,
+    start_time: `${pad(s.hour)}:${pad(s.minute)}`,
+    end_time: `${pad(e.hour)}:${pad(e.minute)}`,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Sb = any;
+
+export type SlotCheck = { ok: true } | { ok: false; reason: string };
+
+export async function isSlotBookable(
+  sb: Sb,
+  form: BookingForm,
+  typeId: string,
+  resourceId: string,
+  start: Date,
+): Promise<SlotCheck> {
+  if (isNaN(start.getTime())) return { ok: false, reason: "Invalid start time" };
+
+  // A slot in the past is never bookable, whatever the calendar says. Checked
+  // before the engine so an empty result for a past day reads correctly.
+  if (start.getTime() <= Date.now()) {
+    return { ok: false, reason: "That time is in the past" };
+  }
+
+  let avail: Awaited<ReturnType<typeof getAvailability>>;
+  try {
+    // The business's own timezone decides which local day this instant is on —
+    // getting that wrong would ask for the wrong day's slots and reject a
+    // perfectly good booking near midnight.
+    const { data: bs } = await sb.from("booking_settings")
+      .select("timezone").eq("business_id", form.business_id).maybeSingle();
+    const dayKey = zonedDateKey(start, bs?.timezone || "UTC");
+    // A single local day. getAvailability pads its own query window, so
+    // timezone and buffer edges are already handled inside it.
+    avail = await getAvailability(sb, form, typeId, dayKey, dayKey, resourceId);
+  } catch {
+    // Never fail open: if availability can't be computed we don't know that
+    // this slot is legitimate, and guessing yes is what created the hole.
+    return { ok: false, reason: "Could not verify that time" };
+  }
+
+  if (!avail) return { ok: false, reason: "That appointment type isn't available on this form" };
+
+  const wanted = start.getTime();
+  const match = avail.slots.some(
+    (s) => s.resource_id === resourceId && new Date(s.start).getTime() === wanted,
+  );
+  return match ? { ok: true } : { ok: false, reason: "That time is no longer available" };
+}

--- a/supabase/migrations/20260813100000_booking_resource_restrict.sql
+++ b/supabase/migrations/20260813100000_booking_resource_restrict.sql
@@ -1,0 +1,23 @@
+-- Deleting a booking resource must not delete its appointments.
+--
+-- appointments.resource_id was ON DELETE CASCADE, and deleteResource() removed
+-- the row unconditionally from a bare trash icon with no confirmation. An owner
+-- tidying up after a worker left destroyed that worker's ENTIRE appointment
+-- history -- past and future -- with no undo. booking_audit_log.appointment_id
+-- is ON DELETE SET NULL, so even the audit trail lost its anchor.
+--
+-- RESTRICT makes the database refuse. The application soft-deletes instead
+-- (booking_resources.active = false), which is what the `active` column was
+-- always for: an inactive resource stops being offered for new bookings while
+-- everything already booked with it stays intact.
+
+ALTER TABLE public.appointments
+  DROP CONSTRAINT IF EXISTS appointments_resource_id_fkey;
+
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_resource_id_fkey
+  FOREIGN KEY (resource_id) REFERENCES public.booking_resources(id)
+  ON DELETE RESTRICT;
+
+COMMENT ON CONSTRAINT appointments_resource_id_fkey ON public.appointments IS
+  'RESTRICT, not CASCADE: deleting a resource must never wipe its appointment history. Deactivate the resource instead (booking_resources.active = false).';


### PR DESCRIPTION
All five high findings the audit raised against **Online booking** — the worst plugin cluster, and the only one that's public-facing and unauthenticated. Each was confirmed in current code before I changed anything.

## 1. Nothing validated the slot

The public endpoints took `start` from the request body, derived `end` from the appointment type's duration, and inserted. The exclusion constraint stopped two bookings colliding and had **no opinion about whether the business was open** — so a crafted POST could put a job at 4am, on a blackout day, in the past, or a year past `max_advance_days`.

New `isSlotBookable()` re-runs the **same availability engine** that produced the slots the customer was offered and checks the requested instant is one of them. Re-deriving the rules would be a second implementation free to drift from what the widget renders — which is exactly how the gap opened: `getAvailability` had precisely one caller, the availability endpoint. It fails closed, and inherits the form's type/resource restriction for free because `loadAvailabilityData` already applies it.

Wired into the booking route, the manage PATCH, **and holds** — a hold's stored times are later trusted verbatim by the booking route, so a bogus time that could be *held* could be *booked*.

## 2. Deleting a resource wiped that worker's entire appointment history

`appointments.resource_id` was `ON DELETE CASCADE`, behind a bare trash icon. Tidying up after a worker left destroyed every appointment ever booked with them, past and future, with no undo — and `booking_audit_log.appointment_id` is `ON DELETE SET NULL`, so even the audit trail lost its anchor.

Now `ON DELETE RESTRICT` (migration), and `deleteResource()` **retires** the resource via the `active` flag — what that column was always for — when any appointment references it, hard-deleting only a resource nobody ever booked. Confirmed zero orphan rows before swapping the constraint.

The confirmation dialog's copy promised the old destructive behaviour, which would now be untrue; scaring an owner off a safe action is its own kind of bug, so it says what actually happens and the action reports which path it took.

## 3. Work orders landed on the wrong day

`work_orders` stores a **naive local** date+time that `booking_busy_intervals` reads back as `AT TIME ZONE bs.timezone`. The route wrote `start.toISOString()` slices — UTC. For a Sydney business a **09:00 booking became a job dated the previous day at 22:00**. The crew's schedule was wrong, and the bad row fed back into busy-intervals to block a 22:00 window nobody wanted.

Shared `workOrderTimesFor()` converts properly. Six tests pin it, including one asserting the result *differs* from the old naive slice precisely where the bug was.

## 4. Reschedule was the hole in every rule

- It **bypassed the cancellation window** — only `DELETE` checked it, so a customer blocked from cancelling two hours out could just move the booking to next month. Same window now applies to both.
- It took `resource_id` **straight from the body** into the update, so a customer could move their job onto any resource id at all, including another business's. Now verified as belonging to the business and active.

## 5. Cancel/reschedule left the generated job behind

A cancelled booking kept a **live job on the crew's schedule** and somebody turned up; a rescheduled one left the job at the old time. Both now move or cancel it, and `setAppointmentStatus` does the same so the dashboard behaves like the customer portal.

## Plus: a reschedule told nobody

Not the crew who'd attend the old time, not the customer confirming it took. Cancellation notified both; reschedule notified neither. `notifyBookingRescheduled` covers both, reusing the confirmation body — which already renders the new time and manage link, precisely what a reschedule confirmation needs — with its own subject so it isn't mistaken for a new booking.

## Verification

- 6 new tests on the timezone conversion (Sydney AEDT/AEST, local-midnight crossing, London, zero-padding, empty-timezone fallback).
- `npm test` — 422 passed / 14 skipped; `npx tsc --noEmit` clean; `npm run build` succeeded.
- Migration applied to the linked project and recorded; `delete_rule` confirmed `RESTRICT` afterwards.
- Not verified in a browser: no signed-in session. A live booking through the public widget is the check worth doing by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
