### PR TITLE
fix(plugins): remaining audit findings — reports, public forms, onboarding

### DIFF
--- a/src/app/api/f/[slug]/submit/route.ts
+++ b/src/app/api/f/[slug]/submit/route.ts
@@ -72,6 +72,33 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
     const email = val(emailFieldId);
     const phone = val(phoneFieldId);
 
+    // Everything the visitor actually told us used to stop here. The lead got a
+    // name, an email and a phone number; address, roof type, urgency and the
+    // message they wrote went only to public_form_submissions, so the
+    // salesperson had to open /forms/[id] → Submissions and match by timestamp.
+    // A lead you have to go and look up somewhere else is half a lead.
+    const addressFieldId = settings.lead_map?.address ?? firstOfType(["address"]);
+    const addressValue = val(addressFieldId);
+
+    // Everything answered, in the form's own field order, minus the display-only
+    // furniture and the three fields already promoted to lead columns.
+    const promoted = new Set([nameFieldId, emailFieldId, phoneFieldId, addressFieldId].filter(Boolean));
+    const detailLines = schema
+      .filter((f) => !["heading", "divider", "instructions"].includes(f.type))
+      .filter((f) => !promoted.has(f.id))
+      .map((f) => {
+        const raw = answers[f.id];
+        const text = Array.isArray(raw)
+          ? raw.join(", ")
+          : raw && typeof raw === "object" && "name" in (raw as Record<string, unknown>)
+            ? String((raw as { name?: string }).name ?? "")
+            : raw === true ? "Yes" : raw === false ? "No" : String(raw ?? "");
+        return text.trim() ? `${f.label}: ${text.trim()}` : "";
+      })
+      .filter(Boolean);
+
+    const leadNotes = [`Submitted via form "${form.name}"`, ...detailLines].join("\n");
+
     if (name || email || phone) {
       const { data: biz } = await tbl(sb, "businesses").select("user_id, name, email").eq("id", form.business_id).single();
       const leadName = name || email || phone || "Website enquiry";
@@ -85,9 +112,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
           p_name: leadName,
           p_email: email || null,
           p_phone: phone || null,
-          p_address: null, p_suburb: null, p_service: null,
+          p_address: addressValue || null, p_suburb: null, p_service: null,
           p_property_type: null, p_timing: null,
-          p_notes: `Submitted via form "${form.name}"`,
+          p_notes: leadNotes,
           p_source: "form",
           p_source_ref: slug,
         }).single();
@@ -100,7 +127,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ slu
             const { data: ins, error: insErr } = await tbl(sb, "leads").insert({
               business_id: form.business_id, user_id: ownerId, name: leadName,
               email: email || null, phone: phone || null, status: "new",
-              source: "form", notes: `Submitted via form "${form.name}" (${slug})`,
+              source: "form", notes: leadNotes, address: addressValue || null,
             }).select("id").single();
             if (insErr) console.error("[form-submit] lead insert fallback failed:", insErr.message);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/pdf/report/[id]/route.ts
+++ b/src/app/api/pdf/report/[id]/route.ts
@@ -60,6 +60,28 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       } catch { /* fall back to nothing — header renders the business name */ }
     }
 
+    // Photos need exactly the same treatment as the logo, and never got it:
+    // they were handed to <Image src={photo.url}> as raw remote URLs, so ONE
+    // unreachable photo rejected the whole render and the customer opening the
+    // link got a JSON error blob instead of their report.
+    //
+    // Fetched in parallel with a timeout — a slow host used to stall every PDF,
+    // since nothing bounded these — and a failure drops that single photo
+    // rather than the document.
+    const photoDataUrls: Record<string, string> = {};
+    await Promise.all((reportData.photos ?? []).map(async (photo) => {
+      if (!photo?.url) return;
+      try {
+        const res = await fetch(photo.url, { signal: AbortSignal.timeout(8000) });
+        if (!res.ok) return;
+        const buf = Buffer.from(await res.arrayBuffer());
+        const ct = res.headers.get("content-type") ?? "image/jpeg";
+        photoDataUrls[photo.id] = `data:${ct};base64,${buf.toString("base64")}`;
+      } catch {
+        // Skip this photo; the report is still worth producing without it.
+      }
+    }));
+
     const { renderToStream } = await import("@react-pdf/renderer");
     const { ReportPdfDocument } = await import("@/components/reports/report-pdf-document");
     const React = await import("react");
@@ -68,6 +90,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       report: reportData,
       business,
       logoDataUrl,
+      photoDataUrls,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,6 +113,16 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[Report PDF]", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    // This URL is always opened in a browser tab — a customer or an inspector
+    // clicking "Download PDF". Returning JSON meant they saw a raw error blob
+    // with a stack-ish message in it and no idea what to do next.
+    return new NextResponse(
+      `<!doctype html><meta charset="utf-8"><title>Report unavailable</title>` +
+      `<div style="font-family:system-ui,sans-serif;max-width:34rem;margin:12vh auto;padding:0 1.5rem;line-height:1.6">` +
+      `<h1 style="font-size:1.25rem;margin:0 0 .5rem">This report couldn't be generated</h1>` +
+      `<p style="color:#555;margin:0">Please try again in a moment. If it keeps happening, contact the business that sent you this link.</p>` +
+      `</div>`,
+      { status: 500, headers: { "Content-Type": "text/html; charset=utf-8" } },
+    );
   }
 }

--- a/src/components/forms/form-upload-answer.tsx
+++ b/src/components/forms/form-upload-answer.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+/**
+ * An uploaded file on a public-form submission, as something you can actually
+ * open.
+ *
+ * The bucket is private, and getFormUploadUrl — which mints the signed URL —
+ * had exactly one reference in the whole repo: its own definition. The
+ * Submissions tab rendered uploads as the dead string "📎 filename.jpg", so
+ * "upload a photo of the damage", the highest-value question a trades business
+ * can ask, produced a file only reachable by hand-crafting a signed URL.
+ *
+ * Images resolve a thumbnail on mount; everything else stays a click-to-open
+ * button, so a submission full of attachments doesn't fire a signed-URL request
+ * per row on render.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, Paperclip, ImageIcon } from "@/components/ui/icons";
+import { getFormUploadUrl } from "@/lib/actions/forms";
+
+export interface UploadAnswer {
+  path: string;
+  name?: string | null;
+  type?: string | null;
+}
+
+const isImage = (u: UploadAnswer) =>
+  (u.type ?? "").startsWith("image/") || /\.(png|jpe?g|gif|webp|avif|heic)$/i.test(u.name ?? "");
+
+export function FormUploadAnswer({ upload }: { upload: UploadAnswer }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const image = isImage(upload);
+
+  useEffect(() => {
+    if (!image) return;
+    let alive = true;
+    getFormUploadUrl(upload.path)
+      .then((u) => { if (alive) { if (u) setUrl(u); else setFailed(true); } })
+      .catch(() => { if (alive) setFailed(true); });
+    return () => { alive = false; };
+  }, [image, upload.path]);
+
+  const open = async () => {
+    if (url) { window.open(url, "_blank", "noopener,noreferrer"); return; }
+    setBusy(true);
+    try {
+      const u = await getFormUploadUrl(upload.path);
+      if (u) { setUrl(u); window.open(u, "_blank", "noopener,noreferrer"); }
+      else setFailed(true);
+    } catch {
+      setFailed(true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const label = upload.name || "Attachment";
+
+  if (failed) {
+    return <span className="text-sm text-muted-foreground">{label} — unavailable</span>;
+  }
+
+  if (image) {
+    return (
+      <button
+        type="button" onClick={open}
+        className="group mt-1 block overflow-hidden rounded-lg border border-border bg-muted/40"
+        title={`Open ${label}`}
+      >
+        {url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={url} alt={label} loading="lazy" decoding="async"
+            className="h-28 w-28 object-cover transition-transform group-hover:scale-105"
+          />
+        ) : (
+          <span className="flex h-28 w-28 items-center justify-center text-muted-foreground">
+            <ImageIcon className="h-5 w-5" />
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button" onClick={open} disabled={busy}
+      className="mt-0.5 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline disabled:opacity-60"
+    >
+      {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Paperclip className="h-3.5 w-3.5" />}
+      <span className="break-all">{label}</span>
+    </button>
+  );
+}

--- a/src/components/forms/submissions-view.tsx
+++ b/src/components/forms/submissions-view.tsx
@@ -21,15 +21,29 @@ import { Badge } from "@/components/ui/badge";
 import { Trash2, Search, X, ListChecks } from "@/components/ui/icons";
 import { cn, formatDate } from "@/lib/utils";
 import { deleteFormSubmission, type SubmissionWithForm } from "@/lib/actions/forms";
+import { FormUploadAnswer, type UploadAnswer } from "./form-upload-answer";
 import type { OnboardingField, PublicForm } from "@/types/database";
 
 const LAYOUT_ONLY = ["heading", "divider", "instructions"];
+
+/** An upload answer carries a storage path; anything else is display text. */
+function asUpload(v: unknown): UploadAnswer | null {
+  if (!v || typeof v !== "object") return null;
+  const o = v as Record<string, unknown>;
+  return typeof o.path === "string" && o.path
+    ? { path: o.path, name: typeof o.name === "string" ? o.name : null, type: typeof o.type === "string" ? o.type : null }
+    : null;
+}
 
 /** Answers are keyed by field id, so a label needs the form's schema. */
 function answerRows(schema: OnboardingField[] | undefined, answers: Record<string, unknown> | null) {
   return (schema ?? [])
     .filter((f) => !LAYOUT_ONLY.includes(f.type))
-    .map((f) => ({ id: f.id, label: f.label, value: fmtAnswer(answers?.[f.id]) }));
+    .map((f) => ({
+      id: f.id, label: f.label,
+      upload: asUpload(answers?.[f.id]),
+      value: fmtAnswer(answers?.[f.id]),
+    }));
 }
 
 function fmtAnswer(v: unknown): string {
@@ -198,7 +212,9 @@ export function SubmissionsView({ submissions, forms, activeFormId }: Props) {
                       {rows.map((r) => (
                         <div key={r.id} className="min-w-0">
                           <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{r.label}</dt>
-                          <dd className="text-sm break-words">{r.value}</dd>
+                          <dd className="text-sm break-words">
+                            {r.upload ? <FormUploadAnswer upload={r.upload} /> : r.value}
+                          </dd>
                         </div>
                       ))}
                     </dl>

--- a/src/components/onboarding/form-builder-client.tsx
+++ b/src/components/onboarding/form-builder-client.tsx
@@ -105,6 +105,8 @@ export function FormBuilderClient({ form, secureAvailable, startInPreview = fals
   const [name, setName] = useState(form.name);
   const [description, setDescription] = useState(form.description ?? "");
   const [status, setStatus] = useState(form.status);
+  const [thankYou, setThankYou] = useState(form.settings?.thank_you_message ?? "");
+  const [allowEdit, setAllowEdit] = useState(Boolean(form.settings?.allow_edit_after_submit));
   const [fields, setFields] = useState<OnboardingField[]>(form.schema ?? []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [preview, setPreview] = useState(startInPreview);
@@ -147,6 +149,15 @@ export function FormBuilderClient({ form, secureAvailable, startInPreview = fals
     try {
       await updateOnboardingForm(form.id, {
         name: name.trim(), description: description.trim() || null, status, schema: fields,
+        // The action and the portal both handled settings end-to-end; the
+        // builder just never sent them, so allow_edit_after_submit was
+        // permanently falsy (a client with a typo got a 409 forever and the
+        // request had to be deleted and resent) and the thank-you screen was
+        // the same hardcoded copy for everyone.
+        settings: {
+          thank_you_message: thankYou.trim() || undefined,
+          allow_edit_after_submit: allowEdit,
+        },
       });
       toast.success("Saved");
       refresh();
@@ -173,6 +184,13 @@ export function FormBuilderClient({ form, secureAvailable, startInPreview = fals
             className="text-lg font-semibold h-10" placeholder="Form name" />
           <Input value={description} onChange={(e) => setDescription(e.target.value)}
             className="h-8 text-sm" placeholder="Description shown to the customer (optional)" />
+          <Input value={thankYou} onChange={(e) => setThankYou(e.target.value)}
+            className="h-8 text-sm" placeholder="Thank-you message shown after they submit (optional)" />
+          <label className="flex items-center gap-2 pt-1 text-xs text-muted-foreground">
+            <input type="checkbox" checked={allowEdit} onChange={(e) => setAllowEdit(e.target.checked)}
+              className="size-3.5 accent-[var(--primary)]" />
+            Let them come back and edit after submitting
+          </label>
         </div>
         <div className="flex items-center gap-2">
           <Select value={status} onValueChange={(v) => setStatus(v as typeof status)}>

--- a/src/components/reports/report-pdf-document.tsx
+++ b/src/components/reports/report-pdf-document.tsx
@@ -73,6 +73,10 @@ interface Props {
    *  callers convert the logo to base64 once and pass it in. Falls back to
    *  business.logo_url for client-side rendering. */
   logoDataUrl?: string | null;
+  /** Pre-fetched photos as data URLs, keyed by photo id — same reason as the
+   *  logo. A photo missing from this map failed to fetch and is skipped rather
+   *  than taking the whole render down with it. */
+  photoDataUrls?: Record<string, string>;
 }
 
 function BrandHeader({ business, logoDataUrl }: { business: Business; logoDataUrl?: string | null }) {
@@ -104,7 +108,7 @@ function BrandHeader({ business, logoDataUrl }: { business: Business; logoDataUr
   );
 }
 
-export function ReportPdfDocument({ report, business, logoDataUrl }: Props) {
+export function ReportPdfDocument({ report, business, logoDataUrl, photoDataUrls }: Props) {
   const m = report.meta;
   const sectionMap = Object.fromEntries(report.sections.map((s) => [s.id, s.content]));
   const inspectorLine = m.inspector_name + (m.inspector_license ? `  (Lic. ${m.inspector_license})` : "");
@@ -221,13 +225,20 @@ export function ReportPdfDocument({ report, business, logoDataUrl }: Props) {
             The following {report.photos.length} photograph{report.photos.length !== 1 ? "s" : ""} were captured on-site at {report.property_address} on {report.inspection_date}.
           </Text>
           <View style={styles.photoGrid}>
-            {report.photos.map((photo) => (
-              <View key={photo.id} style={styles.photoItem}>
-                <Image style={styles.photoImage} src={photo.url} />
-                <Text style={styles.photoNumber}>Photo {photo.order} of {report.photos.length}</Text>
-                <Text style={styles.photoCaption}>{photo.caption || "Site photograph"}</Text>
-              </View>
-            ))}
+            {report.photos.map((photo) => {
+              // Server renders pass pre-fetched data URLs; a client-side render
+              // can still use the remote URL directly.
+              const src = photoDataUrls?.[photo.id] ?? (photoDataUrls ? null : photo.url);
+              return (
+                <View key={photo.id} style={styles.photoItem}>
+                  {src
+                    ? <Image style={styles.photoImage} src={src} />
+                    : <Text style={styles.photoCaption}>Photo unavailable</Text>}
+                  <Text style={styles.photoNumber}>Photo {photo.order} of {report.photos.length}</Text>
+                  <Text style={styles.photoCaption}>{photo.caption || "Site photograph"}</Text>
+                </View>
+              );
+            })}
           </View>
           <Text style={styles.businessName}>{business.name}</Text>
           <Text style={styles.pageNumber} render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`} fixed />

--- a/src/lib/actions/reports.ts
+++ b/src/lib/actions/reports.ts
@@ -225,18 +225,41 @@ export async function deleteReport(id: string): Promise<void> {
 
   const businessId = await getActiveBizId(supabase, user.id);
 
-  // Delete storage objects first
-  try {
-    const { data: files } = await supabase.storage
-      .from("report-images")
-      .list(`${user.id}/${id}`);
+  // Delete storage objects first.
+  //
+  // Photos are uploaded under the CREATING user's id (report-generator.tsx:
+  // `${user.id}/${report.id}/…`), but this used the DELETING user's id — so the
+  // normal case on a multi-user account, one person deleting another's report,
+  // listed an empty prefix, removed nothing, and reported success. The
+  // report-images bucket is PUBLIC, so every inspection photo stayed resolvable
+  // by URL forever and storage grew without bound.
+  //
+  // Two changes: key the prefix to the report's own owner, and do the removal
+  // with the admin client — the bucket's DELETE policy is
+  // `auth.uid() = (storage.foldername(name))[1]`, which would refuse anyone but
+  // the original uploader even with the right path.
+  const { data: reportRow } = await tbl(supabase, "reports")
+    .select("user_id").eq("id", id).eq("business_id", businessId).maybeSingle();
+  const ownerId: string | null = reportRow?.user_id ?? null;
 
-    if (files && files.length > 0) {
-      const paths = files.map((f) => `${user.id}/${id}/${f.name}`);
-      await supabase.storage.from("report-images").remove(paths);
+  if (ownerId) {
+    try {
+      const { createAdminClient } = await import("@/lib/supabase/admin");
+      const admin = createAdminClient();
+      const prefix = `${ownerId}/${id}`;
+      const { data: files, error: listErr } = await admin.storage.from("report-images").list(prefix);
+      if (listErr) {
+        console.error("[deleteReport] could not list photos:", listErr.message);
+      } else if (files?.length) {
+        const { error: rmErr } = await admin.storage.from("report-images")
+          .remove(files.map((f) => `${prefix}/${f.name}`));
+        // Don't block the DB delete, but don't pretend it worked either — a
+        // silent catch is how these went unnoticed in a public bucket.
+        if (rmErr) console.error("[deleteReport] could not remove photos:", rmErr.message);
+      }
+    } catch (e) {
+      console.error("[deleteReport] storage cleanup threw:", e instanceof Error ? e.message : e);
     }
-  } catch {
-    // Storage cleanup failure should not block DB delete
   }
 
   const { error } = await tbl(supabase, "reports")

--- a/src/lib/mcp/tools/plugin-form-tools.ts
+++ b/src/lib/mcp/tools/plugin-form-tools.ts
@@ -308,18 +308,37 @@ export function registerPluginFormTools(tool: ToolFn): void {
       return text({ created: true, form: data });
     });
 
-  tool("update_onboarding_form", "Update an onboarding form's name/description/status/fields.",
+  tool("update_onboarding_form",
+    "Update an onboarding form's name/description/status/fields, or its settings — " +
+    "thank_you_message is the copy shown after submitting, and allow_edit_after_submit lets a " +
+    "client come back and correct a typo instead of the request having to be deleted and resent.",
     {
       form_id: UUID, name: z.string().optional(), description: z.string().optional(),
       status: z.enum(["draft", "active", "archived"]).optional(),
       fields: z.array(ONBOARDING_FIELD).optional(),
+      thank_you_message: z.string().optional(),
+      allow_edit_after_submit: z.boolean().optional(),
     },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
-      const { form_id, fields, ...rest } = args;
+      const { form_id, fields, thank_you_message, allow_edit_after_submit, ...rest } = args;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const clean: Record<string, any> = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
       if (fields !== undefined) clean.schema = fields;
+
+      // settings is a single JSONB column, so a partial update has to merge
+      // over what's stored — otherwise setting the thank-you message would
+      // silently clear allow_edit_after_submit.
+      if (thank_you_message !== undefined || allow_edit_after_submit !== undefined) {
+        const { data: existing } = await t(ctx, "onboarding_forms")
+          .select("settings").eq("id", form_id).eq("business_id", ctx.businessId).maybeSingle();
+        clean.settings = {
+          ...((existing?.settings as Record<string, unknown>) ?? {}),
+          ...(thank_you_message !== undefined ? { thank_you_message } : {}),
+          ...(allow_edit_after_submit !== undefined ? { allow_edit_after_submit } : {}),
+        };
+      }
+
       if (Object.keys(clean).length === 0) return errorText("No fields to update.");
       const { error } = await t(ctx, "onboarding_forms").update(clean).eq("id", form_id).eq("business_id", ctx.businessId);
       if (error) throw error;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -624,7 +624,7 @@ export interface PublicFormSettings {
   /** Create a lead in the sales pipeline on submit. */
   create_lead?: boolean;
   /** Which field ids map onto lead name / email / phone. */
-  lead_map?: { name?: string; email?: string; phone?: string };
+  lead_map?: { name?: string; email?: string; phone?: string; address?: string };
   /** Email addresses notified on each submission. */
   notify_emails?: string[];
 }


### PR DESCRIPTION
The rest of the plugin audit backlog, in one pass. Every finding was re-verified against current code first — two turned out to be already fixed, and I've said so rather than pretending to fix them.

## Site reports

**Deleting a report orphaned its photos permanently in a public bucket.** Cleanup listed `${deletingUser.id}/${reportId}`, but photos upload under the **creating** user's id. So the normal case on a multi-user account — one person deleting someone else's report — listed an empty prefix, removed nothing, and reported success. The `report-images` bucket is public, so every inspection photo stayed resolvable by URL forever and storage grew unbounded.

Now keyed to the report's own `user_id` and run through the admin client, because the bucket's DELETE policy is `auth.uid() = (storage.foldername(name))[1]` and would refuse anyone but the original uploader even with the right path. Failures log instead of being swallowed — that silent `catch` is why this went unnoticed.

**One unreachable photo killed the entire PDF.** Photos went to `<Image src>` as raw remote URLs, while the logo four lines away was already pre-fetched as a data URL *for exactly this reason*. Photos now get the same treatment, fetched in parallel with an 8s timeout — nothing bounded these before, so a slow host stalled every report render — and a failed photo drops itself rather than the document. The catch returned JSON to a URL that's always opened in a browser tab; it now returns a page a customer can read.

## Public forms

**Answers never reached the lead.** The pipeline got name/email/phone and `Submitted via form "X"`. Address, roof type, urgency, and the message the visitor actually typed lived only in `public_form_submissions` — so the salesperson had to open Submissions and match by timestamp. A lead you have to go look up elsewhere is half a lead.

Notes now carry every answered field in form order, an address-typed answer routes to `leads.address`, and `lead_map` gains an address slot. Applied to both the RPC path and the fallback insert.

**Uploaded files couldn't be opened.** `getFormUploadUrl` had exactly one reference in the entire repo — its own definition. The Submissions tab rendered uploads as the dead string `📎 photo.jpg`. "Upload a photo of the damage" is the highest-value question a trades business can ask, and the answer was unreachable without hand-crafting a signed URL.

Images now resolve a thumbnail; other files are a click-to-open button, so a submission full of attachments doesn't fire a signed-URL request per row on render.

## Client onboarding

**Form settings couldn't be set by any surface.** The action accepted them and the portal consumed them — the builder's save just never sent them, and the MCP tool had no key for them. So `allow_edit_after_submit` was permanently falsy (a client who submitted a typo got a 409 **forever**, and the request had to be deleted and resent) and every thank-you screen showed the same hardcoded copy.

Added to both write surfaces. The MCP update merges over stored settings rather than replacing them, or setting one would silently clear the other.

## Verified already correct — no change made

- **`/products` "Catalog value" NaN**: `sumMoney` already coerces via `num()`. The audit's line reference is stale.
- **HTML injection into the public-form notification email**: `esc()` is already applied to both labels and answers.

## Not fixed — needs you, not code

`ONBOARDING_SECRET_KEY` is still unset in production, so the encrypted-credential field can't be used. That's a 64-hex env var on Vercel plus a redeploy. **Do not rotate it once set** — existing ciphertext becomes unreadable.

## Verification

- `npm test` — 422 passed / 14 skipped; `npx tsc --noEmit` clean; `npm run build` succeeded; **bundle budget passes**.
- Not verified in a browser: no signed-in session. The upload thumbnails and the onboarding settings controls are the two worth a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
