### PR TITLE
fix(auth): the sign-in and sign-up buttons had no shape

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -12,7 +12,7 @@ import { Eye, EyeOff, Loader2, UserCheck } from "@/components/ui/icons";
 import { createClient } from "@/lib/supabase/client";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { AnimatedPress } from "@/components/ui/kirei";
+import { Button } from "@/components/ui/button";
 
 const schema = z.object({
   email: z.string().email("Enter a valid email"),
@@ -128,13 +128,18 @@ export default function LoginPage() {
           </div>
           {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
         </div>
-        <AnimatedPress
-          onClick={handleSubmit(onSubmit) as unknown as () => void}
-          className={`w-full inline-flex items-center justify-center gap-2  bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer ${isSubmitting ? "opacity-70" : ""}`}
-        >
+        {/* The app's Button, like every other form in the product — including
+            the sibling forgot-password and reset-password pages. This was an
+            AnimatedPress, which is an unstyled motion.div: it carried bg-primary
+            but no radius, height or padding (note the double space where those
+            classes had been removed), so the primary call to action rendered as
+            a 20px-tall square-cornered strip. A div is also not focusable and
+            isn't announced as a button, which is a poor thing for the one
+            control on the sign-in page to be. */}
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
           {isSubmitting && <Loader2 className="w-4 h-4 animate-spin" />}
           Sign in
-        </AnimatedPress>
+        </Button>
       </form>
 
       <p className="text-center text-sm text-muted-foreground mt-6">

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -12,7 +12,7 @@ import { Eye, EyeOff, Loader2, UserCheck } from "@/components/ui/icons";
 import { createClient } from "@/lib/supabase/client";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { AnimatedPress } from "@/components/ui/kirei";
+import { Button } from "@/components/ui/button";
 
 const schema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
@@ -190,13 +190,12 @@ export default function RegisterPage() {
           </div>
           {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
         </div>
-        <AnimatedPress
-          onClick={handleSubmit(onSubmit) as unknown as () => void}
-          className={`w-full inline-flex items-center justify-center gap-2  bg-primary text-primary-foreground text-sm font-semibold shadow-sm cursor-pointer ${isSubmitting ? "opacity-70" : ""}`}
-        >
+        {/* Same as login: this was an unstyled AnimatedPress div carrying
+            bg-primary with no radius, height or padding. */}
+        <Button type="submit" className="w-full" disabled={isSubmitting}>
           {isSubmitting && <Loader2 className="w-4 h-4 animate-spin" />}
           {inviteEmail ? "Join team" : "Create account"}
-        </AnimatedPress>
+        </Button>
       </form>
 
       <p className="text-center text-sm text-muted-foreground mt-6">


### PR DESCRIPTION
## What was wrong

Both auth CTAs were an `AnimatedPress` — an unstyled `motion.div` that supplies the press animation and **no geometry**. Every other call site in the app passes its own padding and radius; these two passed `bg-primary` and nothing else. The class string still had the double space where those classes had been deleted:

```
"w-full inline-flex items-center justify-center gap-2  bg-primary text-primary-foreground …"
                                                     ^^ radius/height/padding used to be here
```

Measured on **production**, before touching anything:

| | before | after |
|---|---|---|
| element | `DIV` | `BUTTON` |
| height | **20px** | 44px |
| border-radius | **0px** | 12px |
| padding | **0 all round** | 16px |
| keyboard focusable | **no** | yes |

So the primary call to action on the sign-in page rendered as a thin, square-cornered strip of colour.

## The fix

They're now the app's `Button` with `type="submit"` — identical to the sibling **forgot-password** and **reset-password** pages, which already did this correctly. Only login and register deviated.

That also makes them real buttons. A `div` isn't keyboard-focusable and isn't announced as a button, which is a poor thing for the only control on the sign-in page to be. Enter-to-submit already worked via the form's `onSubmit` and still does.

## Not changed

**The blue isn't a bug.** `--primary` resolves to `217.2 91.2% 59.8%`, which is Midnight's own primary, and Midnight is the default theme. I checked `globals.css` rather than assume the teal accent applied here. Only the geometry was wrong — so if the colour is what bothered you, that's a theme-level decision and a separate call.

## Verification

Measured live in the browser on both pages after the change — `BUTTON`, 44px, 12px radius, focusable. `npx tsc --noEmit` clean, 422 tests pass, `npm run build` succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
