### PR TITLE
fix(onboarding): one unencryptable secret shouldn't cost the whole submission

### DIFF
--- a/src/app/api/portal/[token]/onboarding/[id]/save/route.ts
+++ b/src/app/api/portal/[token]/onboarding/[id]/save/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { processAnswersForStorage, missingRequiredFields, invalidAnswerFields } from "@/lib/onboarding/answers";
+import { processAnswersForStorageSafe, missingRequiredFields, invalidAnswerFields } from "@/lib/onboarding/answers";
 import type { OnboardingField } from "@/types/database";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,27 +50,35 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tok
     }
   }
 
-  let stored;
-  try {
-    stored = processAnswersForStorage(schema, merged);
-  } catch (e) {
-    // Secure field present but ONBOARDING_SECRET_KEY missing on the server.
-    const msg = e instanceof Error ? e.message : "Could not save secure fields";
-    return NextResponse.json({ error: msg }, { status: 500 });
+  // Encrypt what we can. A secure field that fails (server key missing or
+  // malformed) used to 500 the ENTIRE payload, so a client who filled in twenty
+  // fields and one credential lost all twenty and saw a server error naming an
+  // env var they can't do anything about.
+  const { stored, failed } = processAnswersForStorageSafe(schema, merged);
+
+  // A failed field is never written as plaintext, so re-instate whatever was
+  // already stored for it — otherwise a retry that fails again would also wipe
+  // a value saved successfully on an earlier pass.
+  for (const id of failed) {
+    const prior = (existing?.answers as Record<string, unknown> | undefined)?.[id];
+    if (prior !== undefined) stored[id] = prior as never;
   }
+
+  // Don't call a submission complete when part of it didn't save.
+  const submitting = Boolean(body.submit) && failed.length === 0;
 
   const nowIso = new Date().toISOString();
   const row = {
     business_id: link.business_id, request_id: id, form_id: request.form_id,
     customer_id: link.customer_id, answers: stored, schema_snapshot: schema,
-    draft: !body.submit, ...(body.submit ? { submitted_at: nowIso } : {}),
+    draft: !submitting, ...(submitting ? { submitted_at: nowIso } : {}),
   };
   const { error } = existing
     ? await tbl(sb, "onboarding_responses").update(row).eq("id", existing.id)
     : await tbl(sb, "onboarding_responses").insert(row);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  if (body.submit) {
+  if (submitting) {
     await tbl(sb, "onboarding_requests")
       .update({ status: "completed", completed_at: nowIso }).eq("id", id);
   } else if (request.status === "pending") {
@@ -78,5 +86,16 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tok
       .update({ status: "viewed", viewed_at: nowIso }).eq("id", id);
   }
 
-  return NextResponse.json({ ok: true, submitted: !!body.submit });
+  // Everything else is saved; report the fields that aren't so the client can
+  // highlight them. 422 rather than 500 — the payload was fine, one field
+  // couldn't be secured, and that is a fixable state, not a crash.
+  if (failed.length > 0) {
+    return NextResponse.json({
+      error: "Secure fields couldn't be saved — everything else was. Please re-enter them.",
+      failed,
+      saved: true,
+    }, { status: 422 });
+  }
+
+  return NextResponse.json({ ok: true, submitted: submitting });
 }

--- a/src/lib/__tests__/onboarding-answers.test.ts
+++ b/src/lib/__tests__/onboarding-answers.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Storing onboarding answers when a secure field can't be encrypted.
+ *
+ * The throwing version meant one unencryptable credential 500'd the whole
+ * payload: a client who filled in twenty fields lost all twenty and saw a
+ * server error naming an env var they can't set. The safe version costs them
+ * that one field — and, crucially, never falls back to storing the secret in
+ * the clear, which is the only outcome worse than losing it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OnboardingField } from "@/types/database";
+
+const KEY = "ONBOARDING_SECRET_KEY";
+const VALID = "a".repeat(64); // 64 hex chars
+
+function field(id: string, type: OnboardingField["type"]): OnboardingField {
+  return { id, type, label: id } as OnboardingField;
+}
+
+const SCHEMA: OnboardingField[] = [
+  field("name", "short_text"),
+  field("wifi", "secure"),
+  field("notes", "long_text"),
+];
+
+async function load() {
+  vi.resetModules();
+  return import("@/lib/onboarding/answers");
+}
+
+describe("processAnswersForStorageSafe", () => {
+  const original = process.env[KEY];
+  beforeEach(() => { vi.resetModules(); });
+  afterEach(() => {
+    if (original === undefined) delete process.env[KEY];
+    else process.env[KEY] = original;
+  });
+
+  it("encrypts a secure answer when the key is usable", async () => {
+    process.env[KEY] = VALID;
+    const { processAnswersForStorageSafe } = await load();
+    const { stored, failed } = processAnswersForStorageSafe(SCHEMA, {
+      name: "Sarah", wifi: "hunter2", notes: "gate code out back",
+    });
+    expect(failed).toEqual([]);
+    expect(stored.name).toBe("Sarah");
+    expect(stored.notes).toBe("gate code out back");
+    expect(stored.wifi).toHaveProperty("enc");
+    expect(JSON.stringify(stored.wifi)).not.toContain("hunter2");
+  });
+
+  it("keeps every other answer when a secure field can't be encrypted", async () => {
+    delete process.env[KEY];
+    const { processAnswersForStorageSafe } = await load();
+    const { stored, failed } = processAnswersForStorageSafe(SCHEMA, {
+      name: "Sarah", wifi: "hunter2", notes: "gate code out back",
+    });
+    expect(failed).toEqual(["wifi"]);
+    expect(stored.name).toBe("Sarah");
+    expect(stored.notes).toBe("gate code out back");
+  });
+
+  it("NEVER stores the secret in the clear when encryption fails", async () => {
+    // The whole point. Losing the field is acceptable; leaking it is not.
+    delete process.env[KEY];
+    const { processAnswersForStorageSafe } = await load();
+    const { stored } = processAnswersForStorageSafe(SCHEMA, { wifi: "hunter2" });
+    expect(stored).not.toHaveProperty("wifi");
+    expect(JSON.stringify(stored)).not.toContain("hunter2");
+  });
+
+  it("passes an already-encrypted answer straight through", async () => {
+    // Autosave re-sends the merged draft, so a value encrypted on an earlier
+    // pass must not be double-encrypted — or re-fail once the key is gone.
+    delete process.env[KEY];
+    const { processAnswersForStorageSafe } = await load();
+    const prior = { enc: "v1.aaa.bbb.ccc" };
+    const { stored, failed } = processAnswersForStorageSafe(SCHEMA, { wifi: prior });
+    expect(failed).toEqual([]);
+    expect(stored.wifi).toEqual(prior);
+  });
+
+  it("treats an empty secure answer as nothing to encrypt", async () => {
+    delete process.env[KEY];
+    const { processAnswersForStorageSafe } = await load();
+    const { stored, failed } = processAnswersForStorageSafe(SCHEMA, { wifi: "", name: "Sarah" });
+    expect(failed).toEqual([]);
+    expect(stored.wifi).toBe("");
+  });
+});

--- a/src/lib/mcp/tools/plugin-form-tools.ts
+++ b/src/lib/mcp/tools/plugin-form-tools.ts
@@ -322,6 +322,13 @@ export function registerPluginFormTools(tool: ToolFn): void {
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "onboarding:write");
       const { form_id, fields, thank_you_message, allow_edit_after_submit, ...rest } = args;
+
+      // create_onboarding_form has always checked this; update never did, so a
+      // secure field could be added to an existing form whatever the server key
+      // was doing — producing a form the customer then cannot submit.
+      const blocked = secureFieldsBlocked(fields);
+      if (blocked) return errorText(blocked);
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const clean: Record<string, any> = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
       if (fields !== undefined) clean.schema = fields;

--- a/src/lib/onboarding/answers.ts
+++ b/src/lib/onboarding/answers.ts
@@ -31,6 +31,46 @@ export function processAnswersForStorage(
   return out;
 }
 
+/**
+ * Same as processAnswersForStorage, but a secure field that can't be encrypted
+ * costs you that one field instead of the whole submission.
+ *
+ * The throwing version meant one unencryptable answer 500'd the entire payload:
+ * a client who filled in twenty fields and one credential lost all twenty and
+ * saw a server error naming an env var they can't set.
+ *
+ * A failed field is OMITTED from the result — never stored as plaintext, which
+ * is the one outcome worse than losing it. The caller gets the ids back so it
+ * can tell the client which fields to re-enter, and can decide not to mark a
+ * submission complete.
+ */
+export function processAnswersForStorageSafe(
+  schema: OnboardingField[],
+  answers: OnboardingAnswers,
+): { stored: OnboardingAnswers; failed: string[] } {
+  const secureIds = new Set(schema.filter((f) => f.type === "secure").map((f) => f.id));
+  const stored: OnboardingAnswers = {};
+  const failed: string[] = [];
+
+  for (const [id, value] of Object.entries(answers ?? {})) {
+    if (!secureIds.has(id) || value == null || value === "") {
+      stored[id] = value;
+      continue;
+    }
+    if (isEncryptedAnswer(value)) {
+      // Already encrypted on a previous save — pass through untouched.
+      stored[id] = value;
+      continue;
+    }
+    try {
+      stored[id] = { enc: encryptSecret(String(value)) };
+    } catch {
+      failed.push(id);
+    }
+  }
+  return { stored, failed };
+}
+
 /** Replace secure-field answers with a redaction marker (for lists, MCP, agents). */
 export function redactSecureAnswers(
   schema: OnboardingField[],


### PR DESCRIPTION
Two robustness gaps around secure fields. `ONBOARDING_SECRET_KEY` **is** set in production (Preview + Production, 7 days ago — I checked rather than repeating the audit's stale claim), so neither is currently firing. Both are one malformed key away.

## 1. A failed secret took the whole submission with it

The portal save route called `processAnswersForStorage`, which throws on the first secure field it can't encrypt, and turned that into a **500 for the entire payload**. A client who filled in twenty fields and one credential lost all twenty and saw a server error naming an env var they can't do anything about.

`processAnswersForStorageSafe` encrypts what it can and reports what it couldn't:

- A failed field is **omitted, never stored as plaintext**. Losing the value is acceptable; leaking it is not — and there's a test pinning exactly that.
- The route re-instates any previously stored value for a failed field, so a retry that fails again doesn't *also* wipe something saved successfully on an earlier pass.
- It no longer marks a submission `completed` when part of it didn't save.
- The response is **422 with the failing field ids**, not 500 — the payload was fine, one field couldn't be secured, and that's a fixable state rather than a crash.

## 2. `update_onboarding_form` could add a secure field the server can't honour

`create_onboarding_form` has always refused to author a secure field without a usable key. `update` never checked — so one could be added to an existing form regardless, producing a form the customer then cannot submit. Same guard on both.

## Verification

5 new tests: encrypts when the key is usable; keeps every other answer when it isn't; **never stores the secret in the clear on failure**; passes an already-encrypted answer straight through (autosave re-sends the merged draft, so it must not double-encrypt); treats an empty secure answer as nothing to do.

The failure-path tests assert `failed: ["wifi"]`, which confirms encryption genuinely failed rather than the test passing vacuously.

`npm test` — 427 passed / 14 skipped. `npx tsc --noEmit` clean. `npm run build` succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
