### PR TITLE
feat(ux): finish tier-a — sidebar active state, tap targets, mobile schedule

### DIFF
--- a/src/components/contacts/contacts-client.tsx
+++ b/src/components/contacts/contacts-client.tsx
@@ -266,7 +266,8 @@ export function ContactsClient({ contacts: initial }: { contacts: Contact[] }) {
                 </Button>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon" className="h-8 w-8">
+                    <Button variant="ghost" size="icon" aria-label={`Actions for ${c.name}`}
+                      className="relative h-8 w-8 before:absolute before:-inset-1.5 before:content-['']">
                       <MoreHorizontal className="h-4 w-4" />
                     </Button>
                   </DropdownMenuTrigger>

--- a/src/components/customers/customers-client.tsx
+++ b/src/components/customers/customers-client.tsx
@@ -258,7 +258,9 @@ export function CustomersClient({
                   <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground">
+                        <button
+                        aria-label={`Actions for ${customer.name}`}
+                        className="relative inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground before:absolute before:-inset-2 before:content-['']">
                           <MoreHorizontal className="w-4 h-4" />
                         </button>
                       </DropdownMenuTrigger>

--- a/src/components/invoices/invoices-client.tsx
+++ b/src/components/invoices/invoices-client.tsx
@@ -215,7 +215,9 @@ export function InvoicesClient({ invoices: initial, currency = "GBP" }: Invoices
                 <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground">
+                      <button
+                        aria-label={`Actions for invoice ${invoice.number}`}
+                        className="relative inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground before:absolute before:-inset-2 before:content-['']">
                         <MoreHorizontal className="w-4 h-4" />
                       </button>
                     </DropdownMenuTrigger>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -74,11 +74,41 @@ export function AppSidebar({
     [workerView, features, navConfig],
   );
 
-  const isActive = (href: string) =>
-    href === "/dashboard" ? pathname === "/dashboard" : pathname.startsWith(href);
+  /**
+   * Exactly one row is active, decided once for the whole sidebar.
+   *
+   * This was `pathname.startsWith(href)` per row, which is true for more than
+   * one row at a time in two ways:
+   *
+   *   - no segment boundary, so /recurring-invoices lit up /recurring;
+   *   - nested routes, so /expenses/recurring lit up /expenses AND itself.
+   *
+   * Both are live trades-preset routes. Every active row mounts an <ActiveChip>
+   * carrying the same framer `layoutId`, and two elements claiming one layoutId
+   * is undefined behaviour — the teal rail flickered between them on every
+   * render. Fixing the predicate alone wouldn't have been enough for the nested
+   * case, so the winner is computed here and rows just compare against it:
+   * longest match wins, which is the most specific route.
+   */
+  const activeHref = useMemo(() => {
+    const matches = (href: string) =>
+      href === "/dashboard"
+        ? pathname === "/dashboard"
+        : pathname === href || pathname.startsWith(href + "/");
+
+    let winner: string | null = null;
+    for (const section of sections) {
+      for (const item of section.items) {
+        if (matches(item.href) && (winner === null || item.href.length > winner.length)) {
+          winner = item.href;
+        }
+      }
+    }
+    return winner;
+  }, [pathname, sections]);
 
   const navRow = (item: NavItem) => {
-    const active = isActive(item.href);
+    const active = item.href === activeHref;
     const label = vocab?.[item.href] ?? item.label;
     return (
       <Link
@@ -160,14 +190,16 @@ export function AppSidebar({
         </button>
       </div>
 
-      <nav className="flex-1 overflow-y-auto px-3 py-3">
+      <nav className="ch-scroll flex-1 overflow-y-auto px-3 py-3">
         {sections.map((group, gi) => (
           <div key={group.section} className={cn("flex flex-col gap-1", gi > 0 && "mt-4")}>
             <p className="px-2.5 pb-1.5 pt-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
               {group.section}
             </p>
             {group.items.map((item) => {
-              const active = isActive(item.href);
+              // Same single-winner rule as the desktop rail — the drawer had
+              // its own copy of the startsWith test and lit up two rows too.
+              const active = item.href === activeHref;
               return (
                 <Link
                   key={item.href}

--- a/src/components/layout/dashboard-shell.tsx
+++ b/src/components/layout/dashboard-shell.tsx
@@ -125,7 +125,10 @@ function ShellBody({ business, businesses, user, userRole, features, vocab, navC
           <TabBusinessGuard businessId={business.id} />
           <div
             key={business.id}
-            className="h-full w-full overflow-auto rounded-3xl border border-border bg-card p-5 md:p-7"
+            // ch-scroll: the app's main scroll container was the one place not
+            // using it, so on Windows every page got the default light-grey
+            // browser scrollbar down the side of a Midnight-themed card.
+            className="ch-scroll h-full w-full overflow-auto rounded-3xl border border-border bg-card p-5 md:p-7"
           >
               {children}
             </div>

--- a/src/components/quotes/quotes-client.tsx
+++ b/src/components/quotes/quotes-client.tsx
@@ -195,7 +195,9 @@ export function QuotesClient({ quotes: initial, currency = "GBP" }: { quotes: Qu
                 <div className="w-8 text-right shrink-0" onClick={(e) => e.stopPropagation()}>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground">
+                      <button
+                        aria-label={`Actions for quote ${quote.number}`}
+                        className="relative inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground before:absolute before:-inset-2 before:content-['']">
                         <MoreHorizontal className="w-4 h-4" />
                       </button>
                     </DropdownMenuTrigger>

--- a/src/components/schedule/schedule-client.tsx
+++ b/src/components/schedule/schedule-client.tsx
@@ -234,7 +234,16 @@ export function ScheduleClient({ initialJobs, initialStart, initialEnd, profiles
       </div>
 
       {/* Calendar grid */}
-      <div className={`grid gap-3 flex-1 ${displayDays.length > 1 ? "grid-cols-7" : "grid-cols-1"} min-h-[400px]`}>
+      {/* Seven columns is a week on a desktop and seven crushed slivers on a
+          phone. It stacks below `sm` instead — which is also where the day
+          tabs above appear, so a phone user can either scroll the week or tap
+          a single day.
+
+          Note the day tabs are `sm:hidden` but `selectedDay` is not: it feeds
+          displayDays at every width. Defaulting it to today would have
+          collapsed the DESKTOP week view to one column, so the fix belongs in
+          the grid, not in the state. */}
+      <div className={`grid gap-3 flex-1 ${displayDays.length > 1 ? "grid-cols-1 sm:grid-cols-7" : "grid-cols-1"} min-h-[400px]`}>
         {displayDays.map((dateStr) => {
           const { day, num, today } = formatDateHeader(dateStr);
           const dayJobs = jobsForDay(dateStr);


### PR DESCRIPTION
The rest of the interface audit's tier (a). **Three of the nine remaining items were already done** — `.ch-pill` colour tokens, `StatTile`'s `tone` enum, and `PageHeader`'s `accent` prop removal. Verified in current code rather than re-fixed.

## The sidebar could light up two rows at once

`pathname.startsWith(href)`, evaluated per row, is true for more than one row in two separate ways:

- **no segment boundary** — `/recurring-invoices` lit up `/recurring`
- **nesting** — `/expenses/recurring` lit up `/expenses` *and* itself

Both are live trades-preset routes. Every active row mounts an `<ActiveChip>` carrying the same framer `layoutId`, and two elements claiming one `layoutId` is undefined behaviour — that's the teal rail flickering between them.

Fixing the predicate alone wouldn't have covered the nested case, so the winner is now computed **once for the whole sidebar** (longest match = most specific route) and rows just compare against it. Exactly one chip can mount, by construction. The mobile drawer had its own copy of the same test and now reads the same value.

## Kebab menus were unlabelled 28px squares

On invoices, quotes, customers and contacts a screen reader read "button" and a thumb missed. They now name their record — `Actions for invoice INV-0042` — and carry a **44px hit area** via a `::before` inset, so the target grows without disturbing a layout built on a `w-8` column. (`leads` already had a label.)

## The schedule's 7-column grid on a phone

Now stacks below `sm`.

**The audit asked for something different here and it would have been wrong.** It said default `selectedDay` to today. But the day tabs are `sm:hidden` while `selectedDay` feeds `displayDays` at *every* width — so defaulting it would have collapsed the **desktop** week view to a single column. The fix belongs in the grid, not the state.

## Also

`.ch-scroll` on the main content scroller and the mobile drawer. The app's primary scroll container was the one place not using it, so Windows drew a light-grey scrollbar down the side of a Midnight-themed card.

## Verification

`npx tsc --noEmit` clean · 432 tests pass · `npm run build` succeeded · bundle budget passes.

Not clicked through: no signed-in session. The sidebar rail behaviour is the one worth eyeballing — navigate to `/expenses/recurring` and confirm a single row highlights with no flicker.

## Tier (a) is now complete

Next up is tier (b), whose headline item is the customer-facing block: a shared `PortalShell`, portal 404s that say the link expired, `noindex` on portal routes, and line-item tables that currently put 288px of fixed columns into ~263px on a phone — so a customer can't read what they're being charged for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
