### PR TITLE
fix(portal): the customer-facing surfaces — indexing, mobile tables, contract text

### DIFF
--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -1,4 +1,17 @@
+import type { Metadata } from "next";
 import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/**
+ * An embed is an iframe target, not a destination.
+ *
+ * If it gets indexed, a searcher lands on a chrome-less form floating on a
+ * blank page with no idea whose business it belongs to. The hosted version at
+ * /f/[slug] is the page meant to be found, and it stays indexable.
+ */
+export const metadata: Metadata = {
+  robots: { index: false, follow: false, nocache: true,
+            googleBot: { index: false, follow: false } },
+};
 
 /** Customer-facing: pinned light, never the operator's dashboard theme. */
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1056,3 +1056,65 @@
     scroll-behavior: auto !important;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Contract body.
+ *
+ * The signing page marked this block `prose prose-sm`, but
+ * @tailwindcss/typography is not installed — those classes match nothing, so a
+ * contract rendered as bare unstyled HTML: headings the same size as body text,
+ * no paragraph spacing, list markers missing. That is the document a customer
+ * reads before typing their legal name under it.
+ *
+ * Scoped rather than a dependency: the allowed tag set is fixed by
+ * sanitizeContractHtml, so this only has to style what can actually appear.
+ * ------------------------------------------------------------------------- */
+.contract-body { line-height: 1.65; }
+.contract-body > :first-child { margin-top: 0; }
+.contract-body p { margin: 0 0 0.85em; }
+.contract-body h1,
+.contract-body h2,
+.contract-body h3,
+.contract-body h4,
+.contract-body h5,
+.contract-body h6 {
+  font-weight: 650;
+  line-height: 1.3;
+  margin: 1.6em 0 0.6em;
+}
+.contract-body h1 { font-size: 1.35em; }
+.contract-body h2 { font-size: 1.18em; }
+.contract-body h3 { font-size: 1.05em; }
+.contract-body h4,
+.contract-body h5,
+.contract-body h6 { font-size: 1em; }
+.contract-body ul,
+.contract-body ol { margin: 0 0 0.85em; padding-left: 1.4em; }
+.contract-body ul { list-style: disc; }
+.contract-body ol { list-style: decimal; }
+.contract-body li { margin: 0.25em 0; }
+.contract-body li::marker { color: hsl(var(--muted-foreground)); }
+.contract-body blockquote {
+  margin: 0 0 0.85em;
+  padding-left: 0.9em;
+  border-left: 3px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+}
+.contract-body a { color: hsl(var(--primary)); text-decoration: underline; }
+.contract-body strong { font-weight: 650; }
+.contract-body hr { margin: 1.4em 0; border: 0; border-top: 1px solid hsl(var(--border)); }
+/* A pasted table must not push the signing page sideways on a phone. */
+.contract-body table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 0 0 0.85em;
+}
+.contract-body th,
+.contract-body td {
+  border: 1px solid hsl(var(--border));
+  padding: 0.45em 0.6em;
+  text-align: left;
+}
+.contract-body th { background: hsl(var(--muted) / 0.4); font-weight: 600; }

--- a/src/app/portal/[token]/contract/[id]/page.tsx
+++ b/src/app/portal/[token]/contract/[id]/page.tsx
@@ -90,7 +90,7 @@ export default async function PortalContractPage({ params }: { params: Promise<{
           </Card>
         ) : (
           <Card className="p-6">
-            <div className="prose prose-sm max-w-none break-words" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+            <div className="contract-body max-w-none break-words" dangerouslySetInnerHTML={{ __html: bodyHtml }} />
           </Card>
         )}
 

--- a/src/app/portal/[token]/invoice/[id]/page.tsx
+++ b/src/app/portal/[token]/invoice/[id]/page.tsx
@@ -130,8 +130,16 @@ export default async function PortalInvoicePage({ params, searchParams }: {
         </Card>
 
         {/* Line items */}
-        <Card className="p-0 overflow-hidden">
-          <table className="w-full text-sm">
+        {/* overflow-x-auto, not overflow-hidden.
+            The three right-hand columns are w-16 + w-28 + w-28 = 288px of
+            FIXED width, plus 128px of cell padding, before the Item column is
+            given anything. On a 375px phone that has ~263px to work with, and
+            `overflow-hidden` clipped the difference — so the customer could
+            not see the Total column of the invoice they were being asked to
+            pay. Now it scrolls, and min-w keeps the columns readable rather
+            than crushing them into each other. */}
+        <Card className="p-0 overflow-x-auto">
+          <table className="w-full min-w-[30rem] text-sm">
             <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
               <tr>
                 <th className="text-left px-4 py-3 font-semibold">Item</th>

--- a/src/app/portal/[token]/quote/[id]/page.tsx
+++ b/src/app/portal/[token]/quote/[id]/page.tsx
@@ -110,8 +110,16 @@ export default async function PortalQuotePage({ params }: { params: Promise<{ to
         </Card>
 
         {/* Line items */}
-        <Card className="p-0 overflow-hidden">
-          <table className="w-full text-sm">
+        {/* overflow-x-auto, not overflow-hidden.
+            The three right-hand columns are w-16 + w-28 + w-28 = 288px of
+            FIXED width, plus 128px of cell padding, before the Item column is
+            given anything. On a 375px phone that has ~263px to work with, and
+            `overflow-hidden` clipped the difference — so the customer could
+            not see the Total column of the invoice they were being asked to
+            pay. Now it scrolls, and min-w keeps the columns readable rather
+            than crushing them into each other. */}
+        <Card className="p-0 overflow-x-auto">
+          <table className="w-full min-w-[30rem] text-sm">
             <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
               <tr>
                 <th className="text-left px-4 py-3 font-semibold">Item</th>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,4 +1,22 @@
+import type { Metadata } from "next";
 import { CustomerSurface } from "@/components/layout/customer-surface";
+
+/**
+ * Nothing under here should ever appear in a search result.
+ *
+ * These pages are reachable by URL — that is the whole point of a token link —
+ * and they carry a named customer's address, what they were charged and what
+ * they still owe. A token in a crawled referrer, a link pasted into a public
+ * thread, and an invoice is indexed under someone's name. /book already set
+ * this; the surfaces with the money on them did not.
+ *
+ * On the layout so it covers every current and future route beneath it, rather
+ * than relying on each page to remember.
+ */
+export const metadata: Metadata = {
+  robots: { index: false, follow: false, nocache: true,
+            googleBot: { index: false, follow: false } },
+};
 
 /** Customer-facing: pinned light, never the operator's dashboard theme. */
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/src/components/customer-portal/accept-quote-button.tsx
+++ b/src/components/customer-portal/accept-quote-button.tsx
@@ -13,17 +13,29 @@ export function AcceptQuoteButton({ token, quoteId }: { token: string; quoteId: 
   const { refresh } = useTrackedRefresh();
   const [pending, start] = useTransition();
   const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const accept = () => {
+    setError(null);
     start(async () => {
-      const res = await fetch(`/api/portal/${token}/quote/${quoteId}/accept`, { method: "POST" });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        alert(err.error || "Failed to accept");
-        return;
+      try {
+        const res = await fetch(`/api/portal/${token}/quote/${quoteId}/accept`, { method: "POST" });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          // Was a native alert(): an OS dialog with the page's hostname on it,
+          // landing on a customer who is mid-way through accepting a quote from
+          // a tradesperson. It reads like something has gone wrong with their
+          // browser rather than with the request, and on iOS it can be
+          // suppressed entirely — leaving the button looking simply dead.
+          setError(err.error || "We couldn't accept the quote. Please try again.");
+          return;
+        }
+        setDone(true);
+        refresh();
+      } catch {
+        // fetch itself failed — almost always the customer's connection.
+        setError("Couldn't reach us just then. Check your connection and try again.");
       }
-      setDone(true);
-      refresh();
     });
   };
 
@@ -36,9 +48,16 @@ export function AcceptQuoteButton({ token, quoteId }: { token: string; quoteId: 
   }
 
   return (
-    <Button onClick={accept} disabled={pending} size="lg" className="bg-emerald-600 hover:bg-emerald-700">
-      {pending ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Check className="w-4 h-4 mr-2" />}
-      Accept quote
-    </Button>
+    <div className="flex flex-col items-start gap-2">
+      <Button onClick={accept} disabled={pending} size="lg" className="bg-emerald-600 hover:bg-emerald-700">
+        {pending ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Check className="w-4 h-4 mr-2" />}
+        Accept quote
+      </Button>
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Tier (b) of the interface audit, starting where it says to: **the only surface an outsider ever sees.** Four of its items were already done (portal and `/f` 404 pages, `CustomerSurface` pinning light) — verified rather than re-fixed.

## Portal pages were indexable

`/book` sets `robots: noindex`. The routes carrying **a named customer's address, what they were charged, and what they still owe** did not. A token in a crawled referrer, or a link pasted into a public thread, is enough to get an invoice indexed under someone's name.

Set on the **layout**, so it covers every route beneath it — current and future — rather than relying on each page to remember. `/embed` too: an iframe target indexed on its own is a chrome-less form on a blank page with no indication whose business it belongs to.

**`/f` is deliberately excluded** — that's the hosted form a business shares and may well want found. The audit said "portal routes"; I didn't extend it to a page someone may be driving traffic to.

## The line-item tables were unreadable on a phone

Three right-hand columns at `w-16` + `w-28` + `w-28` = **288px of fixed width**, plus 128px of cell padding, before the Item column is given anything — inside the ~263px a 375px phone has. And `overflow-hidden` on the Card **clipped the difference**, so the customer could not see the **Total column of the invoice they were being asked to pay**.

Now scrolls horizontally, with a `min-w` so columns stay readable rather than crushing into each other. Both the invoice and quote pages.

## Accepting a quote failed through `alert()`

A native OS dialog, with the page's hostname on it, in front of a customer mid-way through accepting work from a tradesperson. It reads as a *browser* problem rather than a request problem — and iOS can suppress it entirely, leaving the button looking simply dead.

Now an inline `role="alert"` message. Also added a `catch` around the fetch itself, which had none: a customer on a dropped connection previously got no feedback at all.

## Contract bodies were rendering unstyled

The signing page marked the block `prose prose-sm`, but **`@tailwindcss/typography` isn't installed** — those classes match nothing. Headings the same size as body text, no paragraph spacing, no list markers. On the document someone reads immediately before typing their legal name under it.

A scoped `.contract-body` block rather than adding the dependency: the allowed tag set is fixed by `sanitizeContractHtml`, so it only has to style what can actually appear. Pasted tables scroll instead of widening the whole page.

## Verification

`npx tsc --noEmit` clean · 432 tests pass · `npm run build` succeeded · `.contract-body` confirmed present in the built CSS chunk (29 rules), not just in source — the dev server serves stale CSS after a `globals.css` append and will tell you otherwise.

Not clicked through: portal pages need a live customer token.

## Still open in tier (b)

The shared `PortalShell` (the four detail pages still each build their own header/footer), the signature canvas, the Kirei logo fallback, and then items 2–8: quote→work-order converter, the `work_order_id` drops, `DetailHero`→`BackButton`, `<ListTable>`, mobile search, `friendlyError`, and pointing the header Bot button at `/assistant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
