### PR TITLE
fix(pdf): an SVG logo silently produced blank invoices and quotes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ const nextConfig: NextConfig = {
   // @sentry/nextjs is server-only here (dynamically imported inside
   // src/instrumentation.ts, gated on SENTRY_DSN) — keep it external so it never
   // gets bundled/transpiled into route chunks and stays out of the client build.
-  serverExternalPackages: ["@react-pdf/renderer", "@sentry/nextjs"],
+  serverExternalPackages: ["@react-pdf/renderer", "@sentry/nextjs", "sharp"],
   // RFC 8414 / 9728 discovery lives at /.well-known/* by spec, but App Router
   // dot-folders are flaky — serve them from plain API routes via rewrites so
   // the public URL stays correct.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "recharts": "^3.8.1",
         "resend": "^4.5.1",
         "sanitize-html": "^2.17.6",
+        "sharp": "^0.34.5",
         "sonner": "^2.0.7",
         "stripe": "^22.2.1",
         "svix": "^1.92.2",
@@ -753,7 +754,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -7196,7 +7196,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -12498,7 +12497,6 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "recharts": "^3.8.1",
     "resend": "^4.5.1",
     "sanitize-html": "^2.17.6",
+    "sharp": "^0.34.5",
     "sonner": "^2.0.7",
     "stripe": "^22.2.1",
     "svix": "^1.92.2",

--- a/src/lib/actions/business.ts
+++ b/src/lib/actions/business.ts
@@ -189,10 +189,46 @@ export async function uploadLogo(formData: FormData): Promise<string> {
   const file = formData.get("logo") as File;
   if (!file) throw new Error("No file provided");
 
-  const ext = file.name.split(".").pop();
+  /**
+   * Store something every consumer can actually read.
+   *
+   * The file input accepts `image/*`, so an SVG went straight to storage — and
+   * @react-pdf/renderer decodes JPEG and PNG only. The web app rendered the
+   * logo perfectly (it's an <img>), so nothing looked wrong, while every
+   * invoice and quote PDF silently shipped with no logo on it. Crown Roofers
+   * had exactly this: a logo.svg, and blank PDFs for months.
+   *
+   * WebP and AVIF are the same trap — a browser shows them, react-pdf can't.
+   * So anything that isn't already PNG or JPEG is rasterised to PNG here, at
+   * the one place a logo enters the system, rather than at the ten places that
+   * render a document from it.
+   */
+  const RASTER_OK = ["image/png", "image/jpeg"];
+  let body: Blob = file;
+  let ext = (file.name.split(".").pop() ?? "png").toLowerCase();
+
+  if (!RASTER_OK.includes(file.type)) {
+    try {
+      const sharp = (await import("sharp")).default;
+      const png = await sharp(Buffer.from(await file.arrayBuffer()))
+        // A logo is placed at ~108pt in the PDFs; 512 wide is crisp at print
+        // density without storing something enormous.
+        .resize({ width: 512, height: 512, fit: "inside", withoutEnlargement: true })
+        .png()
+        .toBuffer();
+      body = new Blob([new Uint8Array(png)], { type: "image/png" });
+      ext = "png";
+    } catch (e) {
+      // Don't fail the upload — a logo that shows on screen but not on PDFs is
+      // still better than no logo at all, and the user gets to keep working.
+      console.error("[uploadLogo] could not rasterise:", e instanceof Error ? e.message : e);
+    }
+  }
+
   const path = `${user.id}/${businessId}/logo.${ext}`;
 
-  const { error: uploadError } = await supabase.storage.from("logos").upload(path, file, { upsert: true });
+  const { error: uploadError } = await supabase.storage.from("logos")
+    .upload(path, body, { upsert: true, contentType: ext === "png" ? "image/png" : file.type });
   if (uploadError) throw uploadError;
 
   const { data: urlData } = supabase.storage.from("logos").getPublicUrl(path);


### PR DESCRIPTION
## The cause

Crown Roofers' `logo_url` ends in **`.svg`**. `@react-pdf/renderer` decodes **JPEG and PNG only**.

Confirmed directly rather than inferred — rendering their actual logo through react-pdf:

```
Not valid image extension
SVG render returned, bytes: 1207     ← empty page
remote PNG render OK, bytes: 117641  ← same document, PNG logo
```

Connected Studio's logo is a `.png`, which is why only one business saw the problem.

## Why nothing looked broken

The file input accepts `image/*`, storage accepts anything, and the web app renders the SVG perfectly — it's an `<img>`. Only the PDFs, the one artefact that reaches the customer, quietly lost the logo. **WebP and AVIF are the same trap** for the same reason.

## The fix

At the single point a logo **enters** the system rather than the ten places that render a document from one: `uploadLogo` now rasterises anything that isn't already PNG or JPEG to a 512px PNG via sharp.

The alternative was threading a data-URL prop through all ten render sites (`/api/pdf/invoice`, `/api/pdf/quote`, draft-preview, template-preview, the scheduled-send cron, `/api/v1/agent`, and the two `lib/actions` send paths). Missing one would have silently reproduced this exact bug.

`sharp` was only resolving transitively, so it's now an explicit dependency and listed in `serverExternalPackages`. Verified on the real file: their SVG rasterises to a clean 512×155 PNG.

A rasterising failure is logged, not thrown — a logo that shows on screen but not on PDFs still beats a failed upload.

## Checked and ruled out

The report PDF route carries a note that react-pdf "can't reliably load remote images during a server-rendered stream". I tested it: a **remote PNG loads fine** here. So that doesn't apply to logos and no pre-fetch is needed — worth knowing before someone adds one on the strength of that comment.

## Action needed after merge

The conversion is on the upload path, so **existing logos are unaffected until re-uploaded**. Crown Roofers needs one re-upload in Settings → Business for its PDFs to carry the logo. Everything after that is automatic.

## Verification

`npx tsc --noEmit` clean · 432 tests pass · `npm run build` succeeded · lockfile updated so `npm ci` stays in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
