### PR TITLE
fix(leads): converting a lead made a duplicate customer and a $0 quote

### DIFF
--- a/src/lib/__tests__/lead-customer-match.test.ts
+++ b/src/lib/__tests__/lead-customer-match.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Phone normalisation for the lead → customer match.
+ *
+ * A lead that isn't already linked to a customer used to mint a new one
+ * unconditionally, which is how one contact ended up with two records sharing
+ * an email and a phone — her history on the first, a new quote on the second.
+ * The match now runs on email, then phone.
+ *
+ * Phones are free text in this database, so the comparison has to survive the
+ * ways people actually type them. It also has to be strict enough that two
+ * different people never collapse into one record: a wrong merge is far worse
+ * than the duplicate it prevents.
+ */
+import { describe, it, expect } from "vitest";
+
+// Mirrors normalisePhone in lib/actions/leads.ts and lib/mcp/register-tools.ts.
+const normalisePhone = (v: string | null | undefined) =>
+  String(v ?? "").replace(/\D/g, "").replace(/^61/, "0");
+
+describe("normalisePhone", () => {
+  it("treats the formats one person's number gets typed in as equal", () => {
+    const forms = ["0485542633", "0485 542 633", "+61 485 542 633", "(0485) 542-633", "0485-542-633"];
+    const normalised = forms.map(normalisePhone);
+    expect(new Set(normalised).size).toBe(1);
+    expect(normalised[0]).toBe("0485542633");
+  });
+
+  it("keeps different numbers different", () => {
+    expect(normalisePhone("0485542633")).not.toBe(normalisePhone("0485542634"));
+    expect(normalisePhone("0400000000")).not.toBe(normalisePhone("0400000001"));
+  });
+
+  it("returns empty for junk, so the caller's length guard skips matching", () => {
+    // Guarding on length >= 8 is what stops "n/a" or "-" matching each other
+    // and merging two unrelated customers.
+    for (const junk of ["", "n/a", "-", "  ", "tbc"]) {
+      expect(normalisePhone(junk).length).toBeLessThan(8);
+    }
+  });
+
+  it("does not fold a short extension into a real mobile", () => {
+    expect(normalisePhone("1234")).not.toBe(normalisePhone("0485542633"));
+    expect(normalisePhone("1234").length).toBeLessThan(8);
+  });
+});

--- a/src/lib/actions/leads.ts
+++ b/src/lib/actions/leads.ts
@@ -9,7 +9,7 @@ import { emitAutomationEvent } from "@/lib/automations/emit";
 import { createCustomer } from "@/lib/actions/customers";
 import { createQuote } from "@/lib/actions/quotes";
 import { createWorkOrder } from "@/lib/actions/work-orders";
-import type { Lead, LeadStatus, LeadNote, LeadTagPreset } from "@/types/database";
+import type { Lead, LeadStatus, LeadNote, LeadTagPreset, LineItem } from "@/types/database";
 
 import { getUser } from "@/lib/auth";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -285,8 +285,48 @@ export async function deleteLeadNote(noteId: string): Promise<void> {
  * marked as still being a lead"; the marking was never wired up, so the Lead
  * tag it exists to drive could never appear anywhere.
  */
+/** Digits only, so "0485 542 633" and "+61485542633" compare equal. */
+function normalisePhone(v: string | null | undefined): string {
+  return String(v ?? "").replace(/\D/g, "").replace(/^61/, "0");
+}
+
+/**
+ * The customer a lead belongs to — reusing the existing record wherever there
+ * is one.
+ *
+ * This only checked `lead.customer_id`, so a lead captured without that link
+ * minted a NEW customer even when the same person was already on file. That is
+ * how one contact ended up with two records sharing an email and a phone, her
+ * history on the first and a new quote on the second. Undoing it is expensive:
+ * quotes, invoices, reports and portal tokens all hang off the id.
+ *
+ * Matches on email first, then phone, both normalised. Deliberately NOT on
+ * name — two different Smiths are common, and wrongly merging them is worse
+ * than the duplicate this prevents.
+ */
 async function ensureCustomerForLead(lead: Lead): Promise<string> {
   if (lead.customer_id) return lead.customer_id;
+
+  const supabase = await createClient();
+  const user = await getUser();
+  const businessId = await getActiveBizId(supabase, user.id);
+
+  const email = (lead.email ?? "").trim();
+  if (email) {
+    const { data } = await tbl(supabase, "customers")
+      .select("id").eq("business_id", businessId).eq("archived", false)
+      .ilike("email", email).limit(1).maybeSingle();
+    if (data?.id) return data.id as string;
+  }
+  const wanted = normalisePhone(lead.phone);
+  if (wanted.length >= 8) {
+    const { data: rows } = await tbl(supabase, "customers")
+      .select("id, phone").eq("business_id", businessId).eq("archived", false)
+      .not("phone", "is", null).limit(500);
+    const hit = (rows ?? []).find((r: { phone: string | null }) => normalisePhone(r.phone) === wanted);
+    if (hit) return hit.id as string;
+  }
+
   const customer = await createCustomer({
     lifecycle_stage: "lead",
     name: lead.name,
@@ -316,25 +356,37 @@ export async function convertLeadToCustomer(leadId: string): Promise<{ customer_
 
 export async function convertLeadToQuote(
   leadId: string,
-  options: { expiry_days?: number; notes?: string | null } = {},
+  options: {
+    expiry_days?: number;
+    notes?: string | null;
+    /** Price the quote in the same step. Omitted, it stays a $0 draft. */
+    line_items?: LineItem[];
+  } = {},
 ): Promise<{ quote_id: string; quote_number: string; customer_id: string }> {
   const lead = await getLead(leadId);
   const customerId = await ensureCustomerForLead(lead);
   const issueDate = new Date().toISOString().split("T")[0];
   const expiryDate = new Date(Date.now() + (options.expiry_days ?? 30) * 86400000).toISOString().split("T")[0];
 
+  const items = options.line_items ?? [];
+  const subtotal = items.reduce((s, i) => s + Number(i.subtotal ?? 0), 0);
+  const taxTotal = items.reduce((s, i) => s + Number(i.tax_amount ?? 0), 0);
+  const total = subtotal + taxTotal;
+
   const quote = await createQuote({
     status: "draft",
     customer_id: customerId,
     issue_date: issueDate,
     expiry_date: expiryDate,
-    line_items: [],
-    subtotal: 0,
+    // Was hardcoded empty, so a converted lead always produced a $0 quote that
+    // had to be re-keyed by hand before it could be sent.
+    line_items: items,
+    subtotal,
     discount_type: null,
     discount_value: 0,
     discount_amount: 0,
-    tax_total: 0,
-    total: 0,
+    tax_total: taxTotal,
+    total,
     notes: options.notes ?? lead.notes ?? null,
     terms: null,
     invoice_id: null,

--- a/src/lib/mcp/register-tools.ts
+++ b/src/lib/mcp/register-tools.ts
@@ -909,9 +909,12 @@ export function registerTools(register: ToolFn): void {
     });
 
   // ===== QUOTES (update / delete / status / convert) =====
-  tool("update_quote", "Update a quote's notes, terms, expiry, status or line items. Provide line_items to fully replace them (totals recomputed).",
+  tool("update_quote",
+    "Update a quote's notes, terms, expiry, status, line items or customer. Provide line_items to fully replace them (totals recomputed). " +
+    "customer_id reassigns the quote — use it when one was raised against the wrong record.",
     {
       quote_id: UUID, notes: z.string().optional(), terms: z.string().optional(),
+      customer_id: UUID.optional(),
       expiry_date: z.string().optional(), property_address: z.string().optional(),
       status: z.enum(["draft", "sent", "accepted", "rejected", "expired"]).optional(),
       line_items: z.array(z.object({ name: z.string(), description: z.string().optional(), quantity: z.number().optional(), unit_price: z.number(), tax_rate: z.number().optional(), discount_percent: z.number().optional() })).optional(),
@@ -921,6 +924,18 @@ export function registerTools(register: ToolFn): void {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const patch: any = {};
       for (const k of ["notes", "terms", "expiry_date", "property_address", "status"] as const) if (args[k] !== undefined) patch[k] = args[k];
+
+      // customer_id was not updatable, so a quote raised against the wrong
+      // record — which the duplicate-customer bug above made easy — could not
+      // be moved without deleting and re-raising it. Verified against this
+      // business so a quote can't be pushed onto another tenant's customer.
+      if (args.customer_id !== undefined) {
+        const { data: cust } = await t(ctx, "customers")
+          .select("id").eq("id", args.customer_id).eq("business_id", ctx.businessId).maybeSingle();
+        if (!cust) return errorText("Customer not found");
+        patch.customer_id = args.customer_id;
+      }
+
       if (args.line_items) {
         const { items, subtotal, tax_total, total } = buildLineItems(args.line_items);
         patch.line_items = items; patch.subtotal = subtotal; patch.tax_total = tax_total; patch.total = total;
@@ -1908,8 +1923,17 @@ export function registerTools(register: ToolFn): void {
     });
 
   // ===== LEADS — convert to quote / work order =====
-  tool("convert_lead_to_quote", "Create a customer (if not linked) + a draft quote from a lead, and link them (lead → quoted).",
-    { lead_id: UUID, expiry_days: z.number().int().optional() },
+  tool("convert_lead_to_quote",
+    "Create a customer (if not already linked or matched by email/phone) + a draft quote from a lead, and link them (lead → quoted). " +
+    "Pass line_items to price the quote in the same call — omitting them creates a $0 draft you have to fill in by hand afterwards.",
+    {
+      lead_id: UUID, expiry_days: z.number().int().optional(),
+      line_items: z.array(z.object({
+        name: z.string(), description: z.string().optional(), quantity: z.number().optional(),
+        unit_price: z.number(), tax_rate: z.number().optional(), discount_percent: z.number().optional(),
+      })).optional(),
+      notes: z.string().optional(), terms: z.string().optional(),
+    },
     async (args, extra) => {
       const ctx = ctxFrom(extra); assertScope(ctx, "leads:write"); assertScope(ctx, "quotes:write");
       const customerId = await ensureCustomerForLead(ctx, args.lead_id);
@@ -1917,10 +1941,18 @@ export function registerTools(register: ToolFn): void {
       const number = await mintNumber(ctx, "quote_prefix", "quote_next_number", "QT");
       const issue = new Date().toISOString().split("T")[0];
       const expiry = new Date(Date.now() + (args.expiry_days ?? 30) * 86_400_000).toISOString().split("T")[0];
+      // line_items was not a parameter at all, so this always wrote an empty
+      // array and a $0 total — every converted lead produced a quote that had
+      // to be re-keyed by hand before it could be sent. Same maths as
+      // update_quote, via the shared buildLineItems.
+      const priced = args.line_items?.length ? buildLineItems(args.line_items) : null;
       const { data: quote, error } = await t(ctx, "quotes").insert({
         business_id: ctx.businessId, user_id: ctx.userId, customer_id: customerId, number,
-        issue_date: issue, expiry_date: expiry, line_items: [], subtotal: 0,
-        discount_type: "fixed", discount_value: 0, discount_amount: 0, tax_total: 0, total: 0,
+        issue_date: issue, expiry_date: expiry,
+        line_items: priced?.items ?? [], subtotal: priced?.subtotal ?? 0,
+        discount_type: "fixed", discount_value: 0, discount_amount: 0,
+        tax_total: priced?.tax_total ?? 0, total: priced?.total ?? 0,
+        notes: args.notes ?? null, terms: args.terms ?? null,
         status: "draft", invoice_id: null,
       }).select().single();
       if (error) throw error;
@@ -2402,10 +2434,63 @@ export function registerTools(register: ToolFn): void {
 
 /** Find or create the customer for a lead (mirrors ensureCustomerForLead in
  *  the web app). Returns the customer id, or null if the lead is missing. */
+/**
+ * The customer a lead belongs to — reusing the existing record wherever there
+ * is one.
+ *
+ * This only ever checked `lead.customer_id`, so a lead captured without that
+ * link minted a NEW customer even when the same person was already on file.
+ * That is how Anne Sculley ended up with two records sharing an email and a
+ * phone number, her history stranded on the first and a new quote on the
+ * second. A duplicate customer is expensive to undo — quotes, invoices,
+ * reports and portal tokens all hang off the id.
+ *
+ * So before creating one, look for a live customer with the same email, or
+ * failing that the same phone. Both are normalised: emails case-insensitively,
+ * phones stripped of the spaces and punctuation people type inconsistently.
+ * Matching on name is deliberately NOT done — two different Smiths are common,
+ * and merging them would be worse than the duplicate this avoids.
+ */
+/** Digits only — "0485 542 633", "+61485542633" and "0485542633" are one number. */
+function normalisePhone(v: string | null | undefined): string {
+  return String(v ?? "").replace(/\D/g, "").replace(/^61/, "0");
+}
+
+/** An existing, non-archived customer matching this email or phone. */
+async function findCustomerByContact(
+  ctx: McpContext, email: string | null | undefined, phone: string | null | undefined,
+): Promise<string | null> {
+  const cleanEmail = String(email ?? "").trim();
+  if (cleanEmail) {
+    const { data } = await t(ctx, "customers")
+      .select("id").eq("business_id", ctx.businessId).eq("archived", false)
+      .ilike("email", cleanEmail).limit(1).maybeSingle();
+    if (data?.id) return data.id;
+  }
+  const wanted = normalisePhone(phone);
+  if (wanted.length >= 8) {
+    // Stored phones are free text, so compare normalised in app code rather
+    // than trusting the column to be in any one format.
+    const { data: rows } = await t(ctx, "customers")
+      .select("id, phone").eq("business_id", ctx.businessId).eq("archived", false)
+      .not("phone", "is", null).limit(500);
+    const hit = (rows ?? []).find((r: { phone: string | null }) => normalisePhone(r.phone) === wanted);
+    if (hit) return hit.id;
+  }
+  return null;
+}
+
 async function ensureCustomerForLead(ctx: McpContext, leadId: string): Promise<string | null> {
   const { data: lead } = await t(ctx, "leads").select("*").eq("id", leadId).eq("business_id", ctx.businessId).maybeSingle();
   if (!lead) return null;
   if (lead.customer_id) return lead.customer_id;
+
+  const existingId = await findCustomerByContact(ctx, lead.email, lead.phone);
+  if (existingId) {
+    await t(ctx, "leads").update({ customer_id: existingId }).eq("id", leadId).eq("business_id", ctx.businessId);
+    return existingId;
+  }
+
   const { data: customer, error } = await t(ctx, "customers").insert({
     business_id: ctx.businessId, user_id: ctx.userId, name: lead.name,
     email: lead.email ?? null, phone: lead.phone ?? null, city: lead.suburb ?? null,


### PR DESCRIPTION
Three things were reported. **Two are real Kirei bugs and came from the same call**; the third isn't a Kirei bug at all.

Anne Sculley's second customer record was written **0.5 seconds before QUO-0165**, which has zero line items and a $0.00 total. One `convert_lead_to_quote` produced both.

## 1. Duplicate customer

`ensureCustomerForLead` only ever checked `lead.customer_id`. A lead captured without that link minted a **new** customer even when the same person was already on file with the same email and the same phone. Her history stayed on the first record; the quote landed on the second.

It now matches a live customer by email, then by phone, and links the lead to it.

- Phones are normalised to digits — the column is free text, so `0485 542 633`, `+61485542633` and `(0485) 542-633` have to compare equal.
- **Name is deliberately not matched.** Two different Smiths are common, and wrongly merging two real people is far worse than the duplicate this prevents.
- A length guard stops `"n/a"`, `"-"` and `"tbc"` from matching each other and collapsing unrelated customers.

Fixed in **both** copies — the server action and the MCP tool carried the same logic.

## 2. The $0 quote

Not an array bug. `convert_lead_to_quote` **had no `line_items` parameter at all**, in either copy, and hardcoded `line_items: []` with `total: 0`. Every converted lead produced an empty draft that had to be re-keyed by hand — which is precisely what QUO-0165's own notes record:

> `>>> LINE ITEMS STILL TO BE KEYED IN BY HAND — quote total reads $0 until this is done <<<`

QUO-0161 has the same shape. The tool now accepts `line_items` (plus `notes` and `terms`) and prices them through the same `buildLineItems` that `update_quote` already uses, so there's one implementation of the maths rather than two.

## 3. Reassigning a quote

`update_quote` could not set `customer_id`, so a quote raised against the wrong record — which bug 1 made easy — couldn't be moved without deleting and re-raising it. Now settable, and verified against the business so a quote can't be pushed onto another tenant's customer.

## Not changed: the HTML-escaping report

I checked rather than assumed. **No Kirei quote has HTML in its terms or notes** (`terms ~ '<[a-z]|&[a-z]+;'` is false across the board), and **QUO-0163 does not exist in this database** — the numbering runs 0162 → 0164, so that number was minted and the quote never landed. That bug was in the external tool's own PDF builder and was already patched there; there's nothing to fix on this side.

## Verification

4 new tests on phone normalisation, including the cases that must **not** match. 436 tests pass, `npx tsc --noEmit` clean, `npm run build` succeeded.

## Data still to clean up

Anne's two records still need merging, and QUO-0165 still needs its six line items — the fix prevents recurrence but doesn't retro-fill. Handling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
