### PR TITLE
fix(outreach): a running campaign that can never send now says so

### DIFF
--- a/src/components/outreach/outreach-client.tsx
+++ b/src/components/outreach/outreach-client.tsx
@@ -27,7 +27,7 @@ import { SEED_SEQUENCES } from "@/lib/outreach/seed-sequences";
 import { EMAIL_FONTS, type OutreachDesign } from "@/lib/outreach/render";
 import { EmailPreview } from "./email-preview";
 import { CampaignBranding } from "./campaign-branding";
-import type { OutreachStats } from "@/lib/actions/outreach";
+import type { OutreachStats, CampaignWithReach } from "@/lib/actions/outreach";
 import type {
   OutreachSettings, OutreachSequence, OutreachCampaign, OutreachMessage,
 } from "@/types/database";
@@ -54,7 +54,7 @@ export function OutreachClient({
 }: {
   settings: OutreachSettings;
   stats: OutreachStats;
-  campaigns: OutreachCampaign[];
+  campaigns: CampaignWithReach[];
   sequences: (OutreachSequence & { step_count: number })[];
   messages: OutreachMessage[];
   businessName: string;
@@ -255,7 +255,7 @@ function CampaignsTab({
   businessDesign: Partial<OutreachDesign>;
   businessName: string;
   businessLogoUrl?: string | null;
-  campaigns: OutreachCampaign[];
+  campaigns: CampaignWithReach[];
   sequences: (OutreachSequence & { step_count: number })[];
   onDone: () => void;
 }) {
@@ -339,8 +339,24 @@ function CampaignsTab({
                   <p className="truncate text-sm font-semibold">{c.name}</p>
                   <p className="text-xs text-muted-foreground">
                     {seq ? `${seq.name} · ${seq.step_count} steps` : "No sequence"}
+                    {" · "}{c.active_enrollments} enrolled
                     {c.auto_enroll ? " · auto-enrols new matches" : ""}
                   </p>
+                  {/* A running campaign with nobody in it is silent, and used to
+                      look identical to a working one. Say which of the two
+                      reasons it is, because they need different fixes. */}
+                  {c.status === "running" && c.active_enrollments === 0 && (
+                    <p className="mt-1 flex items-start gap-1.5 text-xs text-warn">
+                      <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span>
+                        {c.matching_prospects === 0
+                          ? "Running, but no prospect matches this filter — so nothing will send. Tag some prospects, or widen the filter."
+                          : c.auto_enroll
+                            ? `Running with ${c.matching_prospects} matching prospect${c.matching_prospects === 1 ? "" : "s"} — they'll be enrolled on the next hourly run.`
+                            : `Running, but nobody is enrolled. ${c.matching_prospects} prospect${c.matching_prospects === 1 ? "" : "s"} match — press Enrol matches, or turn on auto-enrol.`}
+                      </span>
+                    </p>
+                  )}
                 </div>
                 <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${
                   c.status === "running" ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"

--- a/src/lib/actions/outreach.ts
+++ b/src/lib/actions/outreach.ts
@@ -193,12 +193,52 @@ export async function runSourcingNow(limit?: number): Promise<SourcingResult> {
 
 // ── Campaigns ────────────────────────────────────────────────────────────────
 
-export async function listCampaigns(): Promise<OutreachCampaign[]> {
+/** A campaign plus the two numbers that decide whether it can send anything. */
+export type CampaignWithReach = OutreachCampaign & {
+  /** Enrollments still working through the sequence. */
+  active_enrollments: number;
+  /** Prospects with an email that match this campaign's filter right now. */
+  matching_prospects: number;
+};
+
+/**
+ * Campaigns, each with its reach.
+ *
+ * A campaign whose filter matches nobody looks exactly like a healthy one: the
+ * card says "running" and nothing else. A live one sat like that — filtering on
+ * a tag no prospect carried, with auto_enroll off so the cron would never enrol
+ * anyone either — and the only symptom was silence. These two counts are what
+ * the card needs to be able to say so.
+ */
+export async function listCampaigns(): Promise<CampaignWithReach[]> {
   const { supabase, businessId } = await ctx();
   const { data, error } = await tbl(supabase, "outreach_campaigns").select("*")
     .eq("business_id", businessId).order("created_at", { ascending: false });
   if (error) throw error;
-  return data as OutreachCampaign[];
+
+  const campaigns = (data ?? []) as OutreachCampaign[];
+
+  return Promise.all(campaigns.map(async (c) => {
+    const [{ count: enrolled }, matching] = await Promise.all([
+      tbl(supabase, "outreach_enrollments")
+        .select("id", { count: "exact", head: true })
+        .eq("business_id", businessId).eq("campaign_id", c.id).eq("status", "active"),
+      (async () => {
+        // Same filter the enroller applies, so the number on screen is the
+        // number that would actually be enrolled.
+        let q = tbl(supabase, "prospects")
+          .select("id", { count: "exact", head: true })
+          .eq("business_id", businessId).not("email", "is", null);
+        const f = c.filter ?? {};
+        if (f.status?.length) q = q.in("status", f.status);
+        if (f.sources?.length) q = q.in("source", f.sources);
+        if (f.tags?.length) q = q.overlaps("tags", f.tags);
+        const { count } = await q;
+        return count ?? 0;
+      })(),
+    ]);
+    return { ...c, active_enrollments: enrolled ?? 0, matching_prospects: matching };
+  }));
 }
 
 export async function createCampaign(input: {


### PR DESCRIPTION
Reported as *"I have one running and nothing is happening."* That was accurate, and nothing on screen could have explained it.

## What was actually wrong

The running campaign — **Insurance & claims — Sydney** — filters on `tags: ["insurance"]`. Crown Roofers has **one prospect, carrying no tags at all**, so the filter matches nobody. On top of that, `auto_enroll` is **false**, and the hourly cron only enrols campaigns where that flag is on.

Two independent reasons for silence. Neither was visible: the card said `running` and nothing else, which looks exactly like a campaign that's working.

## Everything else in the chain was fine

Checked rather than assumed, so this doesn't get re-diagnosed later:

| | |
|---|---|
| cron registered | ✅ `0 * * * * /api/cron/outreach` |
| route exists | ✅ |
| sending enabled | ✅ `true` |
| send window / days | ✅ 08:00–17:00, Mon–Fri, Australia/Sydney |
| sequence steps | ✅ 4 |
| **active enrollments** | ❌ **0** |

The engine simply had nothing to send.

## The fix

`listCampaigns` now returns two numbers per campaign: **active enrollments**, and **prospects matching the filter right now** — computed with the same filter the enroller applies, so the number on screen is the number that would actually enrol.

The card warns when a running campaign has nobody enrolled, and names which of three situations it is, because they need different fixes:

- **no prospect matches** → tag some prospects, or widen the filter
- **matches, auto-enrol on** → they'll be enrolled on the next hourly run
- **matches, auto-enrol off** → press *Enrol matches*, or turn auto-enrol on

No change to sending behaviour itself.

## Verification

`npx tsc --noEmit` clean · 436 tests pass · `npm run build` succeeded · `.text-warn` confirmed present in the built CSS so the warning renders in the right colour.

Not clicked through — the outreach page is behind auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
